### PR TITLE
Fix a crash while clicking properties

### DIFF
--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -511,7 +511,10 @@ class PropertiesModel(updates.UpdateInterface):
                 points = property[1]["points"]
                 interpolation = property[1]["interpolation"]
                 closest_point_x = property[1]["closest_point_x"]
-                choices = property[1]["choices"]
+                if 'choices' in property[1]:
+                    choices = property[1]["choices"]
+                else:
+                    choices = None
 
                 # Adding Transparency to translation file
                 transparency_label = _("Transparency")


### PR DESCRIPTION
It was impossible to click the "Properties" button (see the arrow on the screenshot):
![screenshot](http://i.imgur.com/Nvikb3F.png)
Now it works.

I'm actually not a python developer, also it's my first experience with the OpenShot's source. I guess it might be better to ensure the `choices` property is always present. But although it's quick'n'dirty fix, it works.