### PR TITLE
Add checks for invalid file names before file export

### DIFF
--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -605,6 +605,37 @@ class Export(QDialog):
         self.export_button.setEnabled(False)
         self.exporting = True
 
+        # Check if file name contains invalid characters
+        invalidFileChars = set("\\/:*?\"<>|")
+        if any((char in invalidFileChars) for char in self.txtFileName.text()):
+            # Alert user
+            msg = QMessageBox()
+            msg.setWindowTitle("Export Error")
+            msg.setText("File name can't contain any of the the following characters: \\ / : * ? \" < > |")
+            msg.exec_()
+            # Cancel export
+            self.txtFileName.setEnabled(True)
+            self.txtExportFolder.setEnabled(True)
+            self.tabWidget.setEnabled(True)
+            self.export_button.setEnabled(True)
+            self.exporting = False
+            return
+        
+        # Check if file name is just an empty string
+        if self.txtFileName.text() == "":
+            # Alert user
+            msg = QMessageBox()
+            msg.setWindowTitle("Export Error")
+            msg.setText("You must set a name for the file being exported.")
+            msg.exec_()
+            # Cancel export
+            self.txtFileName.setEnabled(True)
+            self.txtExportFolder.setEnabled(True)
+            self.tabWidget.setEnabled(True)
+            self.export_button.setEnabled(True)
+            self.exporting = False
+            return
+        
         # Determine type of export (video+audio, video, audio, image sequences)
         # _("Video & Audio"), _("Video Only"), _("Audio Only"), _("Image Sequence")
         export_type = self.cboExportTo.currentText()


### PR DESCRIPTION
• Check if the user is trying to save the file with a name which contains invalid characters \/:*?"<>|
• Check if the user is trying to save a file without any name/empty string (Whilst technically not a problem, it can lead to files which cause problems for other programs, so not a good idea to let it through).

NOTE: been a while since I used python, but it compiles without error, so I think I got that right (couldn't find the unit tests referred to in the contributing guidelines though). Also, I've only had limited time to understand how the project is coded, so there's a chance I've done something slightly differently from how it should be done.