### PR TITLE
Enable text wrapping in table cells (addresses #1262)

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,4 +1,5 @@
 {% extends "!layout.html" %}
+{% set css_files = css_files + ["_static/tablefix.css"] %}
 
 {% block footer %}
     {{ super() }}

--- a/doc/animation.rst
+++ b/doc/animation.rst
@@ -31,15 +31,18 @@ Overview
 
 .. image:: _static/animation-overview.jpg
 
-==  ==================  ============
-#   Name                Description
-==  ==================  ============
-1   Green Property      When the play-head is on a key frame, the property appears green
-1   Blue Property       When the play-head is on an interpolated value, the property appears blue
-2   Value Slider        Click and drag your mouse to adjust the value (this automatically creates a key frame if needed)
-3   Play-head           Position the play-head over a clip where you need a key frame
-4   Key frame Markers   Small green tick marks are drawn at all key frame positions (on a clip)
-==  ==================  ============
+.. table::
+     :widths: 5 32
+
+     ==  ==================  ============
+     #   Name                Description
+     ==  ==================  ============
+     1   Green Property      When the play-head is on a key frame, the property appears green
+     1   Blue Property       When the play-head is on an interpolated value, the property appears blue
+     2   Value Slider        Click and drag your mouse to adjust the value (this automatically creates a key frame if needed)
+     3   Play-head           Position the play-head over a clip where you need a key frame
+     4   Key frame Markers   Small green tick marks are drawn at all key frame positions (on a clip)
+     ==  ==================  ============
 
 Key Frames
 ----------
@@ -50,13 +53,16 @@ the properties again. All animations require at least 2 key frames, but can supp
 
 To adjust the **interpolation mode**, right click on the small graph icon next to a property value.
 
-==================  ============
-Name                Description
-==================  ============
-Bézier              Interpolated values use a quadratic curve, and ease-in and ease-out
-Linear              Interpolated values are calculated linear (each step value is equal)
-Constant            Interpolated values stay the same until the next key frame, and jump to the new value
-==================  ============
+.. table::
+     :widths: 12
+
+     ==================  ============
+     Name                Description
+     ==================  ============
+     Bézier              Interpolated values use a quadratic curve, and ease-in and ease-out
+     Linear              Interpolated values are calculated linear (each step value is equal)
+     Constant            Interpolated values stay the same until the next key frame, and jump to the new value
+     ==================  ============
 
 For more info on clip properties, see :ref:`clip_properties_ref`. For more info on preset animations, see :ref:`clip_presets_ref`.
 For more info on creating key frames for location and scale, see :ref:`clip_transform_ref`.
@@ -82,9 +88,13 @@ and adjust the frame rate. Once you have set the correct frame rate, drag the an
 
 .. image:: _static/file-properties.jpg
 
-==  ====================  ============
-#   Name                  Description
-==  ====================  ============
-1   File Properties       Select an image sequence in the **Project Files** panel, right click and choose **File Properties**
-2   Frame Rate            Adjust the frame rate of the animation. Typically, hand-drawn animations use 12 frames per second.
-==  ====================  ============
+.. table::
+     :widths: 5 25
+
+     ==  ====================  ============
+     #   Name                  Description
+     ==  ====================  ============
+     1   File Properties       Select an image sequence in the **Project Files** panel, right click and choose **File Properties**
+     2   Frame Rate            Adjust the frame rate of the animation. Typically, hand-drawn animations use 12 frames per second.
+     ==  ====================  ============
+

--- a/doc/clips.rst
+++ b/doc/clips.rst
@@ -32,28 +32,34 @@ Overview
 
 .. image:: _static/clip-overview.jpg
 
-==  ==================  ============
-#   Name                Description
-==  ==================  ============
-1   Clip 1              A video clip
-2   Transition          A gradual fade transition between the 2 clips
-3   Clip 2              An image clip
-==  ==================  ============
+.. table::
+     :widths: 5 10 35
+     
+     ==  ==================  ============
+     #   Name                Description
+     ==  ==================  ============
+     1   Clip 1              A video clip
+     2   Transition          A gradual fade transition between the 2 clips
+     3   Clip 2              An image clip
+     ==  ==================  ============
 
 Cutting & Slicing
 -----------------
 OpenShot has many easy ways to adjust the start and end positions of a clip (otherwise known as cutting). The most common
 method is simply grabbing the left (or right) edge of the clip and dragging. Here is a list of methods for cutting clips in OpenShot:
 
-==================  ============
-Name                Description
-==================  ============
-Slice               When the play-head (i.e. red playback line) is overlapping a clip, right click on the clip, and choose Slice
-Slice All           When the play-head is overlapping many clips, right click on the play-head, and choose Slice All (it will cut all intersecting clips)
-Resizing Edge       Mouse over the edge of a clip, and resize the edge
-Split Dialog        Right click on a file, and choose **Split Clip**. A dialog will appear which allows for creating lots of small cuts in a single video file.
-Razor Tool          The razor tool cuts a clip wherever you click, so be careful. Easy and dangerous.
-==================  ============
+.. table::
+     :widths: 30
+     
+     ==================  ============
+     Name                Description
+     ==================  ============
+     Slice               When the play-head (i.e. red playback line) is overlapping a clip, right click on the clip, and choose Slice
+     Slice All           When the play-head is overlapping many clips, right click on the play-head, and choose Slice All (it will cut all intersecting clips)
+     Resizing Edge       Mouse over the edge of a clip, and resize the edge
+     Split Dialog        Right click on a file, and choose **Split Clip**. A dialog will appear which allows for creating lots of small cuts in a single video file.
+     Razor Tool          The razor tool cuts a clip wherever you click, so be careful. Easy and dangerous.
+     ==================  ============
 
 Keep in mind that all of the above cutting methods also have :ref:`keyboard_shortcut_ref`, to save even more time.
 
@@ -66,23 +72,26 @@ These presets can be accessed by right clicking on a clip.
 
 .. image:: _static/clip-presets.jpg
 
-==================  ============
-Name                Description
-==================  ============
-Fade                Fade in or out a clip (often easier than using a transition)
-Animate             Zoom and slide a clip
-Rotate              Rotate or flip a video
-Layout              Make a video smaller or larger, and snap to any corner
-Time                Reverse and speed up or slow down video
-Volume              Fade in or out the volume for a clip
-Separate Audio      Create a clip for each audio track
-Slice               Cut the clip at the play-head position
-Transform           Enable transform mode
-Display             Show waveform or thumbnail for a clip
-Properties          Show the properties panel for a clip
-Copy / Paste        Copy and paste key frames or duplicate an entire clip (with all key frames)
-Remove Clip         Remove a clip from the timeline
-==================  ============
+.. table::
+     :widths: 20
+     
+     ==================  ============
+     Name                Description
+     ==================  ============
+     Fade                Fade in or out a clip (often easier than using a transition)
+     Animate             Zoom and slide a clip
+     Rotate              Rotate or flip a video
+     Layout              Make a video smaller or larger, and snap to any corner
+     Time                Reverse and speed up or slow down video
+     Volume              Fade in or out the volume for a clip
+     Separate Audio      Create a clip for each audio track
+     Slice               Cut the clip at the play-head position
+     Transform           Enable transform mode
+     Display             Show waveform or thumbnail for a clip
+     Properties          Show the properties panel for a clip
+     Copy / Paste        Copy and paste key frames or duplicate an entire clip (with all key frames)
+     Remove Clip         Remove a clip from the timeline
+     ==================  ============
 
 .. _clip_transform_ref:
 
@@ -114,28 +123,31 @@ right click and choose **Properties**. The property editor will appear, where yo
 close attention to where the play-head (i.e. red playback line) is. Key frames are automatically created at the current playback
 position, to help create animations.
 
-==================  ============
-Name                Description
-==================  ============
-Gravity Type        The gravity of a clip determines where it snaps to it's parent
-Scale Type          The scale determines how a clip should be resized to fit it's parent
-Frame Display Type  The format to display the frame number (if any)
-Scale X             Curve representing the horizontal scaling in percent (0 to 1)
-Scale Y             Curve representing the vertical scaling in percent (0 to 1)
-Location X          Curve representing the relative X position in percent based on the gravity (-1 to 1)
-Location Y          Curve representing the relative Y position in percent based on the gravity (-1 to 1)
-Rotation            Curve representing the rotation (0 to 360)
-Alpha               Curve representing the alpha (1 to 0)
-Time                Curve representing the frames over time to play (used for speed and direction of video)
-Volume              Curve representing the volume (0 to 1)
-Shear X             Curve representing X shear angle in degrees (-45.0=left, 45.0=right)
-Shear Y             Curve representing Y shear angle in degrees (-45.0=down, 45.0=up)
-Channel Filter      A number representing an audio channel to filter (clears all other channels)
-Channel Mapping     A number representing an audio channel to output (only works when filtering a channel)
-Has Audio           An optional override to determine if this clip has audio (-1=undefined, 0=no, 1=yes)
-Has Video           An optional override to determine if this clip has video (-1=undefined, 0=no, 1=yes)
-Waveform            Should a waveform be used instead of the clip's image
-Waveform Color      Curve representing the color of the audio wave form
-==================  ============
+.. table::
+     :widths: 20
+
+     ==================  ============
+     Name                Description
+     ==================  ============
+     Gravity Type        The gravity of a clip determines where it snaps to it's parent
+     Scale Type          The scale determines how a clip should be resized to fit it's parent
+     Frame Display Type  The format to display the frame number (if any)
+     Scale X             Curve representing the horizontal scaling in percent (0 to 1)
+     Scale Y             Curve representing the vertical scaling in percent (0 to 1)
+     Location X          Curve representing the relative X position in percent based on the gravity (-1 to 1)
+     Location Y          Curve representing the relative Y position in percent based on the gravity (-1 to 1)
+     Rotation            Curve representing the rotation (0 to 360)
+     Alpha               Curve representing the alpha (1 to 0)
+     Time                Curve representing the frames over time to play (used for speed and direction of video)
+     Volume              Curve representing the volume (0 to 1)
+     Shear X             Curve representing X shear angle in degrees (-45.0=left, 45.0=right)
+     Shear Y             Curve representing Y shear angle in degrees (-45.0=down, 45.0=up)
+     Channel Filter      A number representing an audio channel to filter (clears all other channels)
+     Channel Mapping     A number representing an audio channel to output (only works when filtering a channel)
+     Has Audio           An optional override to determine if this clip has audio (-1=undefined, 0=no, 1=yes)
+     Has Video           An optional override to determine if this clip has video (-1=undefined, 0=no, 1=yes)
+     Waveform            Should a waveform be used instead of the clip's image
+     Waveform Color      Curve representing the color of the audio wave form
+     ==================  ============
 
 For more info on key frames and animation, see :ref:`animation_ref`.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -155,7 +155,7 @@ html_favicon = "../xdg/openshot-qt.ico"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['images']
+html_static_path = ['images', 'css']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/doc/css/tablefix.css
+++ b/doc/css/tablefix.css
@@ -1,0 +1,11 @@
+/* override table width restrictions */
+.wy-table-responsive table td, .wy-table-responsive table th {
+    white-space: normal;
+}
+
+.wy-table-responsive {
+    margin-bottom: 24px;
+    max-width: 100%;
+    overflow: visible;
+}
+

--- a/doc/files.rst
+++ b/doc/files.rst
@@ -31,8 +31,8 @@ There are many ways to import media files into OpenShot.
 Name                  Description
 ====================  ============
 Drag and Drop         Drag and drop the files from your file manager (file explorer, finder, etc...)
-Right Click->Import   Right click in the **Project Files** panel, choose **Import Files...**
-File Menu->Import     File menu->Import Files...
+Right Click\→Import   Right click in the **Project Files** panel, choose **Import Files...**
+File Menu\→Import     File menu\→Import Files...
 Import Files Toolbar  Click the **Import Files...** toolbar button (on the top menu)
 ====================  ============
 

--- a/doc/files.rst
+++ b/doc/files.rst
@@ -27,14 +27,17 @@ Import Files
 ------------
 There are many ways to import media files into OpenShot.
 
-====================  ============
-Name                  Description
-====================  ============
-Drag and Drop         Drag and drop the files from your file manager (file explorer, finder, etc...)
-Right Click\→Import   Right click in the **Project Files** panel, choose **Import Files...**
-File Menu\→Import     File menu\→Import Files...
-Import Files Toolbar  Click the **Import Files...** toolbar button (on the top menu)
-====================  ============
+.. table::
+     :widths: 25
+
+     ====================  ============
+     Name                  Description
+     ====================  ============
+     Drag and Drop         Drag and drop the files from your file manager (file explorer, finder, etc...)
+     Right Click\→Import   Right click in the **Project Files** panel, choose **Import Files...**
+     File Menu\→Import     File menu\→Import Files...
+     Import Files Toolbar  Click the **Import Files...** toolbar button (on the top menu)
+     ====================  ============
 
 .. image:: _static/quick-start-drop-files.jpg
 
@@ -68,14 +71,17 @@ to repeat the steps for your next clip. When you are finished, simply close the 
 
 .. image:: _static/file-split-dialog.jpg
 
-==  ==================  ============
-#   Name                Description
-==  ==================  ============
-1   Start of Clip       Choose the starting frame of your clip by clicking this button
-2   End of Clip         Choose the ending frame of your clip by clicking this button
-3   Name of Clip        Enter an optional name
-4   Create Clip         Create the clip (which resets this dialog, so you can repeat these steps for each clip)
-==  ==================  ============
+.. table::
+     :widths: 5 20
+
+     ==  ==================  ============
+     #   Name                Description
+     ==  ==================  ============
+     1   Start of Clip       Choose the starting frame of your clip by clicking this button
+     2   End of Clip         Choose the ending frame of your clip by clicking this button
+     3   Name of Clip        Enter an optional name
+     4   Create Clip         Create the clip (which resets this dialog, so you can repeat these steps for each clip)
+     ==  ==================  ============
 
 Add to Timeline
 ---------------
@@ -85,16 +91,19 @@ all files you need to add, right click, and choose Add to Timeline.
 
 .. image:: _static/file-add-to-timeline.jpg
 
-==  ==================  ============
-#   Name                Description
-==  ==================  ============
-1   Selected Files      The list of selected files that need to be added to the timeline
-2   Order of Files      Use these buttons to reorder the list of files (move up, move down, randomize, remove)
-3   Timeline Position   Choose the starting position and track where these files need to be inserted on the timeline
-4   Fade Options        Fade in, fade out, both, or none
-5   Zoom Options        Zoom in, zoom out, or none
-6   Transitions         Choose a specific transition to use between files, random, or none
-==  ==================  ============
+.. table::
+     :widths: 5 28
+
+     ==  ==================  ============
+     #   Name                Description
+     ==  ==================  ============
+     1   Selected Files      The list of selected files that need to be added to the timeline
+     2   Order of Files      Use these buttons to reorder the list of files (move up, move down, randomize, remove)
+     3   Timeline Position   Choose the starting position and track where these files need to be inserted on the timeline
+     4   Fade Options        Fade in, fade out, both, or none
+     5   Zoom Options        Zoom in, zoom out, or none
+     6   Transitions         Choose a specific transition to use between files, random, or none
+     ==  ==================  ============
 
 Properties
 ----------
@@ -104,9 +113,13 @@ This will launch the file properties dialog, which displays information about yo
 
 .. image:: _static/file-properties.jpg
 
-==  ====================  ============
-#   Name                  Description
-==  ====================  ============
-1   File Properties       Select an image sequence in the **Project Files** panel, right click and choose **File Properties**
-2   Frame Rate            For image sequences, you can also adjust the frame rate of the animation
-==  ====================  ============
+.. table::
+     :widths: 5 24
+     
+     ==  ====================  ============
+     #   Name                  Description
+     ==  ====================  ============
+     1   File Properties       Select an image sequence in the **Project Files** panel, right click and choose **File Properties**
+     2   Frame Rate            For image sequences, you can also adjust the frame rate of the animation
+     ==  ====================  ============
+

--- a/doc/main_window.rst
+++ b/doc/main_window.rst
@@ -48,7 +48,7 @@ For step-by-step instructions on the basic usage of OpenShot, be sure to read th
 Built-in Tutorial
 -----------------
 When you first launch OpenShot, you will be presented with a friendly built-in tutorial. It will point out and explain
-the basics. Clicking **Next** will jump to the next topic. You can always view this tutorial again from the **Help->Tutorial** menu.
+the basics. Clicking **Next** will jump to the next topic. You can always view this tutorial again from the **Help\→Tutorial** menu.
 
 .. image:: _static/built-in-tutorial.jpg
 

--- a/doc/main_window.rst
+++ b/doc/main_window.rst
@@ -28,19 +28,22 @@ Overview
 
 .. image:: _static/main-window.jpg
 
-==  ==================  ============
-#   Name                Description
-==  ==================  ============
-1   Main Toolbar        Contains buttons to open, save, and export your video project.
-2   Function Tabs       Switch between Project Files, Transitions, and Effects.
-3   Project Files       All audio, video, and image files that have been imported into your project.
-4   Preview Window      This is the area that the video will playback on the screen.
-5   Edit Toolbar        This toolbar contains buttons used for snapping, inserting markers, and jumping between markers.
-6   Zoom Slider         This slider will adjust the time-scale of your timeline.
-7   Play-head / Ruler   The ruler shows the time-scale, and the red line is the play-head. The play-head represents the current playback position.
-8   Timeline            The timeline visualizes your video project, and each clip and transition in your project.
-9   Filter              Filter the list of items shown (project files, transitions, and effects) by using these buttons and filter textbox. Enter a few letters of what you are looking for, and the results will be shown.
-==  ==================  ============
+.. table::
+     :widths: 5 22 73
+     
+     ==  ==================  ============
+     #   Name                Description
+     ==  ==================  ============
+     1   Main Toolbar        Contains buttons to open, save, and export your video project.
+     2   Function Tabs       Switch between Project Files, Transitions, and Effects.
+     3   Project Files       All audio, video, and image files that have been imported into your project.
+     4   Preview Window      This is the area that the video will playback on the screen.
+     5   Edit Toolbar        This toolbar contains buttons used for snapping, inserting markers, and jumping between markers.
+     6   Zoom Slider         This slider will adjust the time-scale of your timeline.
+     7   Play-head / Ruler   The ruler shows the time-scale, and the red line is the play-head. The play-head represents the current playback position.
+     8   Timeline            The timeline visualizes your video project, and each clip and transition in your project.
+     9   Filter              Filter the list of items shown (project files, transitions, and effects) by using these buttons and filter textbox. Enter a few letters of what you are looking for, and the results will be shown.
+     ==  ==================  ============
 
 For step-by-step instructions on the basic usage of OpenShot, be sure to read the
 :ref:`quick_tutorial_ref`.
@@ -65,13 +68,16 @@ For example, imagine a 3 track video project
 
 .. image:: _static/tracks.jpg
 
-==  ==================  ============
-#   Name                Description
-==  ==================  ============
-1   Top Track           Clips on this track will always be on top and visible
-2   Middle Track        Clips in the middle (might or might not be visible, depending on what is above them)
-3   Bottom Track        Clips on this track will always be on the bottom
-==  ==================  ============
+.. table::
+     :widths: 5 18 77
+     
+     ==  ==================  ============
+     #   Name                Description
+     ==  ==================  ============
+     1   Top Track           Clips on this track will always be on top and visible
+     2   Middle Track        Clips in the middle (might or might not be visible, depending on what is above them)
+     3   Bottom Track        Clips on this track will always be on the bottom
+     ==  ==================  ============
 
 .. _keyboard_shortcut_ref:
 

--- a/doc/titles.rst
+++ b/doc/titles.rst
@@ -29,14 +29,17 @@ Overview
 
 .. image:: _static/title-editor.jpg
 
-==  ==================  ============
-#   Name                Description
-==  ==================  ============
-1   Choose a Template   Choose from any available vector title template
-2   Preview Title       Preview your title as you make changes
-3   Title Properties    Change the text, colors, or edit in an advanced SVG image editor (such as Inkscape)
-3   Save                Save and add the title to your project
-==  ==================  ============
+.. table::
+     :widths: 5 26
+
+     ==  ==================  ============
+     #   Name                Description
+     ==  ==================  ============
+     1   Choose a Template   Choose from any available vector title template
+     2   Preview Title       Preview your title as you make changes
+     3   Title Properties    Change the text, colors, or edit in an advanced SVG image editor (such as Inkscape)
+     3   Save                Save and add the title to your project
+     ==  ==================  ============
 
 Custom Titles
 -------------

--- a/doc/transitions.rst
+++ b/doc/transitions.rst
@@ -51,14 +51,17 @@ Cutting & Slicing
 OpenShot has many easy ways to adjust the start and end positions of a transition (otherwise known as cutting). The most common
 method is simply grabbing the left (or right) edge of the transition and dragging. Here is a list of methods for cutting transitions in OpenShot:
 
-==================  ============
-Name                Description
-==================  ============
-Slice               When the play-head (i.e. red playback line) is overlapping a transition, right click on the transition, and choose Slice
-Slice All           When the play-head is overlapping many transitions, right click on the play-head, and choose Slice All (it will cut all intersecting transitions)
-Resizing Edge       Mouse over the edge of a transition, and resize the edge
-Razor Tool          The razor tool cuts a transition wherever you click, so be careful. Easy and dangerous.
-==================  ============
+.. table::
+     :widths: 32
+
+     ==================  ============
+     Name                Description
+     ==================  ============
+     Slice               When the play-head (i.e. red playback line) is overlapping a transition, right click on the transition, and choose Slice
+     Slice All           When the play-head is overlapping many transitions, right click on the play-head, and choose Slice All (it will cut all intersecting transitions)
+     Resizing Edge       Mouse over the edge of a transition, and resize the edge
+     Razor Tool          The razor tool cuts a transition wherever you click, so be careful. Easy and dangerous.
+     ==================  ============
 
 Keep in mind that all of the above cutting methods also have :ref:`keyboard_shortcut_ref`.
 
@@ -80,10 +83,14 @@ right click and choose **Properties**. The property editor will appear, where yo
 close attention to where the play-head (i.e. red playback line) is. Key frames are automatically created at the current playback
 position, to help create animations.
 
-==================  ============
-Name                Description
-==================  ============
-Brightness          Curve representing the brightness of the transition image, which affects the fade/wipe (-1 to 1)
-Contrast            Curve representing the contrast of the transition image, which affects the softness/hardness of the fade/wipe (0 to 20)
-Replace Image       For debugging a problem, this property displays the transition image (instead of becoming a transparency)
-==================  ============
+.. table::
+     :widths: 28
+
+     ==================  ============
+     Name                Description
+     ==================  ============
+     Brightness          Curve representing the brightness of the transition image, which affects the fade/wipe (-1 to 1)
+     Contrast            Curve representing the contrast of the transition image, which affects the softness/hardness of the fade/wipe (0 to 20)
+     Replace Image       For debugging a problem, this property displays the transition image (instead of becoming a transparency)
+     ==================  ============
+


### PR DESCRIPTION
Here's the change promised in #1262, to enable text wrapping in table cells (disabled by default in the Read The Docs theme for Sphinx). It's two simple changes and one... not so simple. It turns out, having table cells wrap is a deceptively complex thing. (And I now understand the theme's reluctance to just enable wrapping by default, though I can't say I like their solution of forcing side-scrolling tables everywhere any better.)

The issue, basically, is how the cell widths are balanced by Sphinx. Sometimes it makes OK decisions. Other times, the columns are wildly imbalanced, requiring intervention by the author to get the tables sized correctly. So, after enabling wrapping, I went through the entire manual, looked at all of the tables, and manually adjusted them to what I felt was a reasonable balance by manually specifying widths for some or all columns.

Doing that is the difference between this (the default output, with wrapping enabled):

![screenshot from 2018-02-11 22-28-13](https://user-images.githubusercontent.com/538020/36082981-58892b0a-0f7c-11e8-88de-0a2bd103127b.png)

And this (manually adjusted to make the second column wider):

![screenshot from 2018-02-11 22-28-26](https://user-images.githubusercontent.com/538020/36082991-66b05550-0f7c-11e8-9970-297266c62991.png)

Note that that's the "full-width" formatting, or the "starting point" for column sizing. Even with explicit column widths, Sphinx's tables are flexible and will resize. With the browser window reduced to half the screen width, those become (respectively):

![screenshot from 2018-02-11 22-28-45](https://user-images.githubusercontent.com/538020/36083015-963abcd4-0f7c-11e8-8efd-157fb4463746.png)

![screenshot from 2018-02-11 22-28-52](https://user-images.githubusercontent.com/538020/36083024-ac257c1e-0f7c-11e8-9873-244c784a63d7.png)

On my phone (Samsung Galaxy S6, Chrome browser) they end up looking identical, because the columns compress to the same state regardless of the specified widths.

(Honestly, while I know that one of these is a screenshot from my "unadjusted" export of the docs, and the other is the output with my column-width fixes applied, I'm really not sure _which_ of these is which! They are, as I said, identical.)

![screenshot_20180211-224233](https://user-images.githubusercontent.com/538020/36083144-c55d9e5e-0f7d-11e8-91cc-8130de27ca51.png)

![screenshot_20180211-224211](https://user-images.githubusercontent.com/538020/36083146-c855602e-0f7d-11e8-9c88-dfbaa68f81c8.png)

Really, I think it does quite a good job, especially once the widths are tweaked as needed.

Now, here's the slightly bad news. The trick to doing this, as I explain in the commit message for the third (large) commit, is to use reStructuredText's explicit `.. table:` directive, as it can be provided with a `:widths:` argument specifying column widths. When using `.. table:`, the table syntax is the same, but the table gets nested below the directive, requiring a 5-space indent. So this table (from the repo HEAD):

```rst
==  ==================  ============
#   Name                Description
==  ==================  ============
1   Main Toolbar        Contains buttons to open, save, and export your video project.
2   Function Tabs       Switch between Project Files, Transitions, and Effects.
3   Project Files       All audio, video, and image files that have been imported into your project.
4   Preview Window      This is the area that the video will playback on the screen.
5   Edit Toolbar        This toolbar contains buttons used for snapping, inserting markers, and jumping between markers.
6   Zoom Slider         This slider will adjust the time-scale of your timeline.
7   Play-head / Ruler   The ruler shows the time-scale, and the red line is the play-head. The play-head represents the current playback position.
8   Timeline            The timeline visualizes your video project, and each clip and transition in your project.
9   Filter              Filter the list of items shown (project files, transitions, and effects) by using these buttons and filter textbox. Enter a few letters of what you are looking for, and the results will be shown.
==  ==================  ============
```

Becomes this (after my patch):

```rst
.. table::
     :widths: 5 22 73
     
     ==  ==================  ============
     #   Name                Description
     ==  ==================  ============
     1   Main Toolbar        Contains buttons to open, save, and export your video project.
     2   Function Tabs       Switch between Project Files, Transitions, and Effects.
     3   Project Files       All audio, video, and image files that have been imported into your project.
     4   Preview Window      This is the area that the video will playback on the screen.
     5   Edit Toolbar        This toolbar contains buttons used for snapping, inserting markers, and jumping between markers.
     6   Zoom Slider         This slider will adjust the time-scale of your timeline.
     7   Play-head / Ruler   The ruler shows the time-scale, and the red line is the play-head. The play-head represents the current playback position.
     8   Timeline            The timeline visualizes your video project, and each clip and transition in your project.
     9   Filter              Filter the list of items shown (project files, transitions, and effects) by using these buttons and filter textbox. Enter a few letters of what you are looking for, and the results will be shown.
     ==  ==================  ============
```
It's not ideal, but it's not unworkable. Using `.. table::` does also give us the option of converting to `.. list-table::` format, which dumps the ASCII art and turns that code into:

```rst
.. list-table::
     :widths: 5 22 73
     :header-rows: 1

     * - #
       - Name
       - Description
     * - 1
       - Main Toolbar
       - Contains buttons to open, save, and export your video project.
     * - 2
       - Function Tabs
       - Switch between Project Files, Transitions, and Effects.
```
...and so on.

There are definite advantages to that format, especially as the column contents get more complex, and _especially_ especially if they end up containing RST markup. (That's something else I'd like to explore at a later date, as I have some thoughts in that area.) So, if we want to convert the doc tables to `.. list-table::` formatting, then that's a possibility for a future PR. The rendered table is the same, so it's purely an issue of source readability.

Oh, I made one other change (as you'll see in the second commit), to replace the ASCII arrows (`->`) used at a couple of points in the tables (and body text) with real Unicode → arrows. That was purely an aesthetic decision, as word-wrapping would cause the ASCII arrows to get split in half sometimes. (e.g:)
> File menu -
> \> Import Media...

which will instead now be (worst-case):

> File menu →
> Import Media...
