### PR TITLE
Use source path for images, not destination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea
 .settings
 idea/*
+doc/_build
+**/__pycache__/

--- a/doc/animation.rst
+++ b/doc/animation.rst
@@ -29,7 +29,7 @@ values at certain points on a clip, and OpenShot does the hard work of interpola
 Overview
 --------
 
-.. image:: _static/animation-overview.jpg
+.. image:: images/animation-overview.jpg
 
 .. table::
      :widths: 5 32
@@ -76,7 +76,7 @@ the expected value and then back (producing a bounce effect).
 
 To choose a curve preset, right click on the small graph icon next to a key frame.
 
-.. image:: _static/curve-presets.jpg
+.. image:: images/curve-presets.jpg
 
 Image Sequences
 ---------------
@@ -86,7 +86,7 @@ drag and drop one of them into OpenShot, and you will be prompted to import the 
 To adjust the frame rate of the animation, right click and choose **File Properties** in the **Project Files** panel,
 and adjust the frame rate. Once you have set the correct frame rate, drag the animation onto the timeline.
 
-.. image:: _static/file-properties.jpg
+.. image:: images/file-properties.jpg
 
 .. table::
      :widths: 5 25

--- a/doc/clips.rst
+++ b/doc/clips.rst
@@ -30,7 +30,7 @@ and when combined together, can create some amazing effects.
 Overview
 --------
 
-.. image:: _static/clip-overview.jpg
+.. image:: images/clip-overview.jpg
 
 .. table::
      :widths: 5 10 35
@@ -70,7 +70,7 @@ Preset Menu
 OpenShot has tons of great preset animations and clip properties, such as fading, sliding, zooming, etc...
 These presets can be accessed by right clicking on a clip.
 
-.. image:: _static/clip-presets.jpg
+.. image:: images/clip-presets.jpg
 
 .. table::
      :widths: 20
@@ -102,7 +102,7 @@ Grab any of the small blue handles to adjust scale, and grab the middle circle t
 attention to where the play-head (i.e. red playback line) is. Key frames are automatically created at the current playback
 position, to help create animations.
 
-.. image:: _static/clip-transform.jpg
+.. image:: images/clip-transform.jpg
 
 For more info on key frames and animation, see :ref:`animation_ref`.
 
@@ -112,7 +112,7 @@ In addition to the many clip properties which can be animated and adjusted, you 
 a clip. Each effect is represented by a small letter icon. Clicking the effect icon will populate the properties of that
 effect, and allow you to edit (and animate) them.
 
-.. image:: _static/clip-effects.jpg
+.. image:: images/clip-effects.jpg
 
 .. _clip_properties_ref:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -155,7 +155,7 @@ html_favicon = "../xdg/openshot-qt.ico"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['images', 'css']
+html_static_path = ['css']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/doc/files.rst
+++ b/doc/files.rst
@@ -39,14 +39,14 @@ There are many ways to import media files into OpenShot.
      Import Files Toolbar  Click the **Import Files...** toolbar button (on the top menu)
      ====================  ============
 
-.. image:: _static/quick-start-drop-files.jpg
+.. image:: images/quick-start-drop-files.jpg
 
 File Menu
 ---------
 To view the file menu, right click on a file (in the **Project Files** panel). Here are the actions you can use from the
 file menu.
 
-.. image:: _static/file-menu.jpg
+.. image:: images/file-menu.jpg
 
 ====================  ============
 Name                  Description
@@ -69,7 +69,7 @@ purpose. Right click on a file, and choose Split Clip... from the file menu. Thi
 dialog to quickly cut out as many small clips as you need. The dialog stays open after you create a clip, to allow you
 to repeat the steps for your next clip. When you are finished, simply close the dialog.
 
-.. image:: _static/file-split-dialog.jpg
+.. image:: images/file-split-dialog.jpg
 
 .. table::
      :widths: 5 20
@@ -89,7 +89,7 @@ In certain cases, you might need to add many files to the timeline at the same t
 or a large number of short video clips. The **Add to Timeline** dialog can automate this task for you. First, select
 all files you need to add, right click, and choose Add to Timeline.
 
-.. image:: _static/file-add-to-timeline.jpg
+.. image:: images/file-add-to-timeline.jpg
 
 .. table::
      :widths: 5 28
@@ -111,7 +111,7 @@ To view the properties of any imported file in your video project, right click o
 This will launch the file properties dialog, which displays information about your media file. For certain types of images
 (i.e. image sequences), you can adjust the frame rate on this dialog also.
 
-.. image:: _static/file-properties.jpg
+.. image:: images/file-properties.jpg
 
 .. table::
      :widths: 5 24

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -47,7 +47,7 @@ Features
 
 Screenshot
 ----------
-.. image:: _static/ui-example.jpg
+.. image:: images/ui-example.jpg
 
 System Requirements
 -------------------

--- a/doc/main_window.rst
+++ b/doc/main_window.rst
@@ -26,7 +26,7 @@ and menus needed to edit your video project.
 Overview
 --------
 
-.. image:: _static/main-window.jpg
+.. image:: images/main-window.jpg
 
 .. table::
      :widths: 5 22 73
@@ -53,7 +53,7 @@ Built-in Tutorial
 When you first launch OpenShot, you will be presented with a friendly built-in tutorial. It will point out and explain
 the basics. Clicking **Next** will jump to the next topic. You can always view this tutorial again from the **Help\→Tutorial** menu.
 
-.. image:: _static/built-in-tutorial.jpg
+.. image:: images/built-in-tutorial.jpg
 
 
 Tracks & Layers
@@ -66,7 +66,7 @@ typically a video project will not need more than 10 (or so) tracks.
 
 For example, imagine a 3 track video project
 
-.. image:: _static/tracks.jpg
+.. image:: images/tracks.jpg
 
 .. table::
      :widths: 5 18 77

--- a/doc/profiles.rst
+++ b/doc/profiles.rst
@@ -32,7 +32,7 @@ The project profile is used when previewing your project and editing. The defaul
 It is best practice to always switch to your target profile before you begin editing. For example, if you are targeting
 1080p 30fps, switch to that profile before you begin editing your project.
 
-.. image:: _static/profiles.jpg
+.. image:: images/profiles.jpg
 
 ==  ==================  ============
 #   Name                Description
@@ -47,7 +47,7 @@ Export Profile
 
 The export profile always defaults to your current project profile, but can be changed to target different profiles.
 
-.. image:: _static/export-profiles.jpg
+.. image:: images/export-profiles.jpg
 
 ==  ==================  ============
 #   Name                Description

--- a/doc/quick_tutorial.rst
+++ b/doc/quick_tutorial.rst
@@ -33,7 +33,7 @@ drop a few images (\*.JPG, \*.PNG, etc...) and a music file (most formats will w
 from your Desktop to OpenShot. Be sure to drop the files where the
 arrow in the illustration is pointing to.
 
-.. image:: _static/quick-start-drop-files.jpg
+.. image:: images/quick-start-drop-files.jpg
 
 Step 2 – Arrange Photos on Timeline
 ------------------------------------
@@ -43,7 +43,7 @@ video. If you overlap two clips, OpenShot will automatically create a smooth fad
 displayed by blue rounded rectangles between the clips. Remember, you can rearrange the clips
 as many times as needed by simply dragging and dropping them.
 
-.. image:: _static/quick-start-timeline-drop.jpg
+.. image:: images/quick-start-timeline-drop.jpg
 
 Step 3 – Add Music to Timeline
 ------------------------------
@@ -51,7 +51,7 @@ To make our photo slide-show more interesting, we need to add some music. You sh
 imported a music file in step 1. Click on the music file, and drag it onto the timeline. If
 the song is too long, grab the right edge of your music clip, and resize it smaller.
 
-.. image:: _static/quick-start-music.jpg
+.. image:: images/quick-start-music.jpg
 
 Step 4 – Preview your Project
 ------------------------------
@@ -59,7 +59,7 @@ To preview what our video looks & sounds like, click the Play button under the p
 You can also pause, rewind, and fast-forward your video project by clicking the corresponding
 buttons.
 
-.. image:: _static/quick-start-play.jpg
+.. image:: images/quick-start-play.jpg
 
 Step 5 – Export your Video
 ---------------------------
@@ -70,7 +70,7 @@ media players (such as VLC) or websites (such as YouTube, Vimeo, etc...).
 Click on the Export Video icon at the top of the screen (or use the **File > Export Video** menu).
 Choose from one of the many preset export options, and click the *Export Video* button.
 
-.. image:: _static/quick-start-export.jpg
+.. image:: images/quick-start-export.jpg
 
 You should now have a basic understanding of how OpenShot works. Importing, Arranging,
 Previewing, and Exporting. Hopefully this tutorial took less than 5 minutes for you to

--- a/doc/titles.rst
+++ b/doc/titles.rst
@@ -27,7 +27,7 @@ the Title menu (located in the main menu of OpenShot) to launch the Title Editor
 Overview
 --------
 
-.. image:: _static/title-editor.jpg
+.. image:: images/title-editor.jpg
 
 .. table::
      :widths: 5 26
@@ -52,7 +52,7 @@ files in your **Project Files** panel, and choose **Edit Title** or **Duplicate 
 Adding a 3D animated title is just as easy, using our **Animated Title** dialog. Use the Title menu (located
 in the main menu of OpenShot) to launch the Animated Title editor. You can also use the keyboard shortcut **Ctrl+B**.
 
-.. image:: _static/animated-title.jpg
+.. image:: images/animated-title.jpg
 
 ==  ==================  ============
 #   Name                Description

--- a/doc/transitions.rst
+++ b/doc/transitions.rst
@@ -28,7 +28,7 @@ with the most common location being the beginning or end.
 Overview
 --------
 
-.. image:: _static/clip-overview.jpg
+.. image:: images/clip-overview.jpg
 
 ==  ==================  ============
 #   Name                Description
@@ -44,7 +44,7 @@ Transitions adjust the alpha/transparency of the clip below it, and can either f
 to opaque. Right click and choose **Reverse Transition** to change the direction of the fade. You can also manually adjust
 the **Brightness** curve, animating the fade in any way you wish.
 
-.. image:: _static/transition-reverse.jpg
+.. image:: images/transition-reverse.jpg
 
 Cutting & Slicing
 -----------------


### PR DESCRIPTION
Before I get to the table changes, a tweak I made in building the docs locally.

Currently, the docs source references images using their output location in the `_build` directory, which only becomes valid _after_ the build process is complete, when the `html_static_path` directive in `conf.py` causes `sphinx-build` to copy the image files into `_build/html/_static`. This means that, during build time, `sphinx-build` will spew tons of error messages about missing image files:

>% make html
>sphinx-build-3 -b html -d _build/doctrees   . _build/html
>Running Sphinx v1.6.6
>loading pickled environment... done
>building [mo]: targets for 0 po files that are out of date
>building [html]: targets for 12 source files that are out of date
>updating environment: 0 added, 9 changed, 0 removed
>reading sources... [100%] transitions                                           
>**$PWD/animation.rst:33: WARNING: image file not readable: _static/animation-overview.jpg
>$PWD/animation.rst:80: WARNING: image file not readable: _static/curve-presets.jpg
>$PWD/animation.rst:90: WARNING: image file not readable: _static/file-properties.jpg**

...and so on, for every image in the docs. The abundance of these (expected, ignorable) errors can make it difficult to spot any _genuine_, problematic errors output during the build process, as they get lost in the noise.

I originally worked around the issue by symlinking `_static` to `_build/html/_static` in the documentation directory, but that caused _two_ copies of every image to be written into the output directory when building the docs.

The reason for that was, when images are referenced using a _valid_ source path, `sphinx-build` will **automatically** copy them into to `_build/html/_images/` (rather than `_build/html/_static/`). It also adjusts the path in the generated output HTML accordingly. So, as soon as I made `_static` a valid source path, `sphinx-build` started duplicating all of the images, and the copies in `_build/html/_static/` became redundant.

So, this patch leaves `sphinx-build` to do its thing automatically, by specifying the path to all images as `images/filename.png` instead of `_static/filename.png`. `images` is removed from the `html_static_paths` list, so that they are not also copied into `_build/html/_static/`.

Beyond allowing for a cleaner build process with better error-checking (since the existence of all referenced image files will be verified during the copying process, and any missing images reported), the only effect of this change is the migration of non-theme images (screenshots, figures) from the `_static` subdirectory to the `_images` subdirectory, in the generated output HTML. This may potentially require minor adjustment to existing webserver configs when serving the docs.