### PR TITLE
Track file-import path, the same way export path is tracked (issue #96)

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -893,9 +893,11 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
     def check_if_paths_are_valid(self):
         """Check if all paths are valid, and prompt to update them if needed"""
-        # Get project folder
+        # Get import path or project folder
         starting_folder = None
-        if self.current_filepath:
+        if self._data["import_path"]:
+            starting_folder = os.path.join(self._data["import_path"])
+        elif self.current_filepath:
             starting_folder = os.path.dirname(self.current_filepath)
 
         # Get translation method
@@ -914,9 +916,10 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                 starting_folder = QFileDialog.getExistingDirectory(None, _("Find directory that contains: %s" % file_name_with_ext), starting_folder)
                 log.info("Missing folder chosen by user: %s" % starting_folder)
                 if starting_folder:
-                    # Update file path
+                    # Update file path and import_path
                     path = os.path.join(starting_folder, file_name_with_ext)
                     file["path"] = path
+                    get_app().updates.update(["import_path"], os.path.dirname(path))
                 else:
                     log.info('Removed missing file: %s' % file_name_with_ext)
                     self._data["files"].remove(file)

--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -76,7 +76,7 @@ class TimelineSync(UpdateInterface):
         """ This method is invoked by the UpdateManager each time a change happens (i.e UpdateInterface) """
 
         # Ignore changes that don't affect libopenshot
-        if len(action.key) >= 1 and action.key[0].lower() in ["files", "history", "markers", "layers", "export_path", "scale"]:
+        if len(action.key) >= 1 and action.key[0].lower() in ["files", "history", "markers", "layers", "export_path", "import_path", "scale"]:
             return
 
         elif len(action.key) >= 1 and action.key[0].lower() in ["profile"]:

--- a/src/settings/_default.project
+++ b/src/settings/_default.project
@@ -13,6 +13,7 @@
   "clips": [],
   "effects": [],
   "export_path": "",
+  "import_path": "",
   "files": [],
   "duration": 300,
   "scale": 16,

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -582,13 +582,14 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
     def actionImportFiles_trigger(self, event):
         app = get_app()
         _ = app._tr
-        recommended_path = app.project.current_filepath
-        if not recommended_path:
+        recommended_path = app.project.get(["import_path"])
+        if not recommended_path or not os.path.exists(recommended_path):
             recommended_path = os.path.join(info.HOME_PATH)
         files = QFileDialog.getOpenFileNames(self, _("Import File..."), recommended_path)[0]
         for file_path in files:
             self.filesTreeView.add_file(file_path)
             self.filesTreeView.refresh_view()
+            app.updates.update(["import_path"], os.path.dirname(file_path))
             log.info("Imported media file {}".format(file_path))
 
     def actionAdd_to_Timeline_trigger(self, event):


### PR DESCRIPTION
OpenShot currently forces the open-file dialog for "Import files..." to open at the location of the project file every time. That's is fine for users who store their video files with the project file, which is probably good practice. But for users who don't, it creates frustration.

This change adds `import_path` tracking to the project file, the same way `export_path` is currently tracked, and attempts to use the stored `import_path` (if present) as the starting location of both "Import File..." and the  missing-file recovery process. So if the user imports from their project file location, nothing will really change for them. For other users, it will save them a lot of navigation.

Implements #96. 