### PR TITLE
Time-index conversion isues

### DIFF
--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -91,7 +91,7 @@
 						</div>
 
 						<!-- CLIP KEYFRAME POINTS -->
-						<img ng-repeat="(point, value) in getKeyframes(clip)" id="point_{{point}}_{{$index}}" style="position: absolute; bottom: 0px; left: {{((point / (project.fps.num / project.fps.den) - clip.start) * pixelsPerSecond) - keyframePointOffset}}px;" class="point_icon" ng-src="media/images/keyframes/point.png"/>
+						<img ng-repeat="(point, value) in getKeyframes(clip)" id="point_{{point}}_{{$index}}" style="position: absolute; bottom: 0px; left: {{(((point - 1) / (project.fps.num / project.fps.den) - clip.start) * pixelsPerSecond) - keyframePointOffset}}px;" class="point_icon" ng-src="media/images/keyframes/point.png"/>
 
 						<!-- CLIP LABEL -->
 						<div class="clip_label" ng-class="getClipLabelStyle(clip)" tooltip-enable="!enable_razor" tooltip="{{clip.title}}" tooltip-placement="bottom" tooltip-popup-delay="400">{{clip.title}}</div>
@@ -112,7 +112,7 @@
 						<div tl-clip-menu class="transition_menu" ng-show="!enable_razor" ng-mousedown="ShowTransitionMenu(transition.id, $event)"></div>
 						<!-- TRANSITION KEYFRAME POINTS -->
 						<span class="keyframe_point" id="points_for_{{transition.id}}" ng-show="transition.selected">
-							<img ng-repeat="(point, value) in getKeyframes(transition)" id="point_{{point}}_{{$index}}" style="position: absolute; bottom: 0px; left: {{((point / (project.fps.num / project.fps.den) - clip.start) * pixelsPerSecond) - keyframePointOffset}}px;" class="point_icon" ng-src="media/images/keyframes/point.png"/>
+							<img ng-repeat="(point, value) in getKeyframes(transition)" id="point_{{point}}_{{$index}}" style="position: absolute; bottom: 0px; left: {{(((point - 1) / (project.fps.num / project.fps.den) - clip.start) * pixelsPerSecond) - keyframePointOffset}}px;" class="point_icon" ng-src="media/images/keyframes/point.png"/>
 						</span>
 						<!--div class="transition_label">{{transition.title}}</div-->
 						<br class="cleared">

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -963,7 +963,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         fps_float = float(fps["num"]) / float(fps["den"])
 
         # Calculate position in seconds
-        position = player.Position() / fps_float
+        position = (player.Position() - 1) / fps_float
 
         # Look for existing Marker
         marker = Marker()
@@ -976,7 +976,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Calculate current position (in seconds)
         fps = get_app().project.get(["fps"])
         fps_float = float(fps["num"]) / float(fps["den"])
-        current_position = self.preview_thread.current_frame / fps_float
+        current_position = (self.preview_thread.current_frame - 1) / fps_float
         all_marker_positions = []
 
         # Get list of marker and important positions (like selected clip bounds)
@@ -1029,7 +1029,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Calculate current position (in seconds)
         fps = get_app().project.get(["fps"])
         fps_float = float(fps["num"]) / float(fps["den"])
-        current_position = self.preview_thread.current_frame / fps_float
+        current_position = (self.preview_thread.current_frame - 1) / fps_float
         all_marker_positions = []
 
         # Get list of marker and important positions (like selected clip bounds)
@@ -1113,7 +1113,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Get framerate
         fps = get_app().project.get(["fps"])
         fps_float = float(fps["num"]) / float(fps["den"])
-        playhead_position = float(self.preview_thread.current_frame) / fps_float
+        playhead_position = float(self.preview_thread.current_frame - 1) / fps_float
 
         # Basic shortcuts i.e just a letter
         if key.matches(self.getShortcutByName("seekPreviousFrame")) == QKeySequence.ExactMatch:


### PR DESCRIPTION
This is a ~work-in-progress~ first-attempt PR, which I believe is complete as to the changes needed for the Marker/Keyframe positioning issue, but is _certainly_ incomplete in terms of addressing all timing/frame-sync issues. (See below for considerable further discussion/developments, but long-and-short I think this fixes the problem of Markers being positioned off by 1 frame, and Keyframe tickmarks being _drawn_ one frame off from where they actually are.)

I'm posting where I'm at so that others might have a chance to test the changes so far, confirm that things seem to be moving in the right _direction_, and identify remaining issues stemming from time-index off-by-one errors.

The issues that have been reported with marker/keyframe positioning, clip boundaries, and etc. seem to _mostly_ be manifestations of two issues:

#### Conversion between frame# and time index is performed inconsistently in the code.
Because time-indexes originate at 0 seconds, but frames are counted from 1, _every_ conversion from time-based position to linear (counted) position, in either direction, has to account for this. And the code contains _dozens_ of separate places where this conversion is performed, ad hoc. 
1. In the python code:
     * When going forwards,
        ```python
        # If frames-per-second is expressed as the fraction
        fps_float = float(fps["num"]) / float(fps["den"])
        # Anytime a time index is converted to a frame#, the formula is:
        frame = (time_pos * fps_float) + 1
        ```
        ...this appears to be done consistently, so time indexes are always converted to the correct frame.
     * But when going backwards,
        ```python
        # Anytime a frame# is converted to a time index, the formula is reversed:
        time_pos = (frame - 1 / fps_float)
        ```
        ...**multiple** locations were failing to subtract 1 from the frame number, causing time indexes to be computed and stored one frame too **high** (once they were properly converted back to frame numbers).
2. In the Timeline HTML:
    * Several places compute the location of display elements in terms of `pixelsPerSecond`, after computing that based on the zoom level. When the math is being done from a time index, or uses a time duration, frames-per-second is uninvolved and you get math such as:
        ```html
        <div style="width:{{(clip.end - clip.start) * pixelsPerSecond}}px;
         left:{{clip.position * pixelsPerSecond}}px;">
        ```
    * But when the position is frame-based, as it is with keyframe parameters, it's instead e.g.:
        ```html
        <img style="position: absolute;
         left: {{(((point - 1) /
                   (project.fps.num / project.fps.den) - clip.start)
                  * pixelsPerSecond) - keyframePointOffset}}px;"
         class="point_icon" ng-src="media/images/keyframes/point.png"/>
        ```
        ...again, the necessary subtraction `(point - 1)` was not being performed.

This PR thus contains, so far, one commit which patches two files, attempting to ensure that the code will "**Always compute time as (frame# - 1) / fps**".

#### Interpolated parameters store keyframe positions as frame numbers
This issue is the source of much of the above complexity. While it's in some senses _easier_ to store raw frame numbers, when positioning timeline elements, the problem is that frame number is dependent on the frame rate of the video, so altering the frames-per-second value changes the position of every frame except the first. Most users working with video want frame _accuracy_ in operations, but they want **positioning** to be independent of frame rate so that, if they place a timeline element at the 1-second mark, that's automatically adjusted to frame 25 @ 24fps, frame 30 @ 29.97 fps, frame 31 @ 30fps, and frame 61 @ 60fps.

This PR does not address, or even attempt to address, this more-fundamental issue. (See bug #1034, and others, for reports of problems related to frame-based positioning.)

### Other, possibly-related, issues
There are other time-indexing issues still present in the code.
1. @peanutbutterandcrackers reported #1369 where the Split Clip tool seems to be off by a frame when bounding clips created from project files.
2. Using the "Slice: Keep both sides" timeline tool doubles a frame. (I'm not sure whether this issue has been reported, as such.) The last frame in the left clip will be the same frame as the first frame in the right clip.
    This is because the `Start` parameter of the right clip is set to the same time-index as the left clip's `End` parameter, when `right.Start` _should_ be `left.End + (1 / fps)` (or both `left.End` and `left.Duration` should be decreased by `1/fps`). My changes here don't address this, though with the keyframe-positioning updates I believe they may make the incorrect slice positioning more obvious.