### PR TITLE
Log length of metrics response, not (non-ascii) contents

### DIFF
--- a/src/classes/metrics.py
+++ b/src/classes/metrics.py
@@ -155,7 +155,7 @@ def send_metric(params):
         # Send metric HTTP data
         try:
             r = requests.get(url, headers={"user-agent": user_agent})
-            log.info("Track metric: [%s] %s | %s" % (r.status_code, r.url, r.text))
+            log.info("Track metric: [%s] %s | (%s bytes)" % (r.status_code, r.url, len(r.content)))
 
         except Exception as Ex:
             log.error("Failed to Track metric: %s" % (Ex))


### PR DESCRIPTION
The response to the Google Analytics HTTP request is apparently a GIF image, which was being dumped to the logfile and console output as raw bytes, corrupting the output. Instead we just log the length of the
response content, in bytes.

So, instead of this:
>metrics:INFO Track metric: [200] http://www.google-analytics.com/collect?cid=xxxxxxxxxxxxxx&an=OpenShot+Video+Editor&aip=1&aid=org.openshot.openshot-qt&av=2.4.1&ul=en&ua=Mozilla%2F5.0+%28X11%3B+Linux+x86_64%29+AppleWebKit%2F537.36+%28KHTML%2C+like+Gecko%29+Chrome%2F37.0.2062.120+Safari%2F537.36&cd1=0.1.9&cd2=3.6.4&cd3=5.9.4&cd4=5.9.1&cd5=Fedora-27-Twenty+Seven&t=screenview&sc=end&cd=close-app | GIF89a€ÿÿÿÿ,D;

We see/log this:
>metrics:INFO Track metric: [200] http://www.google-analytics.com/collect?cid=xxxxxxxxxxxxxx&an=OpenShot+Video+Editor&aip=1&aid=org.openshot.openshot-qt&av=2.4.1-dev1&ul=en&ua=Mozilla%2F5.0+%28X11%3B+Linux+x86_64%29+AppleWebKit%2F537.36+%28KHTML%2C+like+Gecko%29+Chrome%2F37.0.2062.120+Safari%2F537.36&cd1=0.1.9&cd2=3.6.4&cd3=5.9.4&cd4=5.9.1&cd5=Fedora-27-Twenty+Seven&t=screenview&sc=end&cd=close-app | (35 bytes)
```