### PR TITLE
Exponential zoom levels (and only 14 of them, instead of 800)

### DIFF
--- a/src/classes/conversion.py
+++ b/src/classes/conversion.py
@@ -1,0 +1,49 @@
+"""
+ @file
+ @brief This file deals with value conversions
+ @author Jonathan Thomas <jonathan@openshot.org>
+ @author Frank Dana <ferdnyc AT gmail com>
+
+ @section LICENSE
+
+ Copyright (c) 2008-2018 OpenShot Studios, LLC
+ (http://www.openshotstudios.com). This file is part of
+ OpenShot Video Editor (http://www.openshot.org), an open-source project
+ dedicated to delivering high quality video editing and animation solutions
+ to the world.
+
+ OpenShot Video Editor is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenShot Video Editor is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
+ """
+
+import math
+
+def zoomToSeconds(zoomValue):
+    """ Convert zoom factor (slider position) into scale-seconds """
+
+    if (zoomValue <= 5):
+        # Under 1 minute, convert to seconds (exponential)
+        return 2**zoomValue
+    elif (zoomValue <= 11):
+        # convert to N minutes (exponential), in seconds
+        return 60 * (2**(zoomValue-6))
+    else:
+        # Over 1 hour, convert to N hours (exponential), in seconds
+        return 3600 * (2**(zoomValue-12))
+
+
+def secondsToZoom(scaleValue):
+    """ Convert a number of seconds to a timeline zoom factor """
+
+    return int(math.log(scaleValue,2))
+

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -48,6 +48,7 @@ from classes.timeline import TimelineSync
 from classes.query import File, Clip, Transition, Marker, Track
 from classes.metrics import *
 from classes.version import *
+from classes.conversion import zoomToSeconds, secondsToZoom
 from images import openshot_rc
 from windows.views.files_treeview import FilesTreeView
 from windows.views.files_listview import FilesListView
@@ -1963,17 +1964,19 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.timelineToolbar.addSeparator()
 
         # Get project's initial zoom value
-        initial_scale = get_app().project.get(["scale"]) or 20
+        initial_scale = get_app().project.get(["scale"]) or 16
+        # Round non-exponential scale down to next lowest power of 2
+        initial_zoom = secondsToZoom(initial_scale)
 
         # Setup Zoom slider
         self.sliderZoom = QSlider(Qt.Horizontal, self)
         self.sliderZoom.setPageStep(2)
-        self.sliderZoom.setRange(1, 800)
-        self.sliderZoom.setValue(initial_scale)
+        self.sliderZoom.setRange(0, 15)
+        self.sliderZoom.setValue(initial_zoom)
         self.sliderZoom.setInvertedControls(True)
         self.sliderZoom.resize(100, 16)
 
-        self.zoomScaleLabel = QLabel(_("{} seconds").format(self.sliderZoom.value()))
+        self.zoomScaleLabel = QLabel( _("{} seconds").format(zoomToSeconds(self.sliderZoom.value())) )
 
         # add zoom widgets
         self.timelineToolbar.addAction(self.actionTimelineZoomIn)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1971,7 +1971,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Setup Zoom slider
         self.sliderZoom = QSlider(Qt.Horizontal, self)
         self.sliderZoom.setPageStep(2)
-        self.sliderZoom.setRange(0, 15)
+        self.sliderZoom.setRange(0, 13)
         self.sliderZoom.setValue(initial_zoom)
         self.sliderZoom.setInvertedControls(True)
         self.sliderZoom.resize(100, 16)


### PR DESCRIPTION
This patch reins in the vast, and not _entirely_ beneficial, number of zoom levels in OpenShot, by making the zoom level roughly exponential: each zoom-in halves the previous scale, each zoom-out doubles it — _except_ that whole numbers of seconds, minutes, and hours are used, rather than exponential numbers of seconds each time.

Long and short, there are now 14 zoom levels: 
* 1, 2, 4, 8, 16, 32 seconds; followed by
* 1, 2, 4, 8, 16, 32 minutes; followed by
* 1, 2 hours 
...which is now the maximum zoom. 

(Previous maximum was 800 seconds, so it also allows zooming out _much_ farther than before. Handy if, say, you've tossed a 2-hour-long movie file onto the timeline as a single clip.)

All conversions between zoom-factor and scale (in seconds) are done in the utility functions `zoomToSeconds()` and `secondsToZoom()`, found in new file `src/classes/conversion.py`. This file imports the math library as it has to compute logarithms (base 2) in `secondsToZoom()`.

Honestly, while it _feels_ like the zoom levels "should be" too coarse now, and that going from 800 fine-grained settings to only 14 big jumps would be limiting, in practice it just... isn't, at least in my testing.

There really doesn't seem to be _any_ reason why zooming in at 45 seconds is preferable to either 32 seconds or 60 seconds, in practice. For the most part, you either want to be zoomed in _suuuper_-close, or you want to be able to back out as quickly as possible. Which is exactly what exponential zooming provides.

Oh, yes, I locked the zoom levels in to whole units (minutes, hours) instead of just jumping by exponential seconds continuously, for two reasons:
1. The timescale ruler formats nicely.
    (Tickmarks will be at 00:01:00, 00:02:00, etc., for example, instead of 00:01:04, 00:01:08 like they would be if the scale jumped to 64 seconds.)
2. The scale factors can _potentially_ be expressed as "1 minute", "8 minutes", "1 hour", etc.
    **HOWEVER**, this is not currently done in this patch, so after "32 seconds" it goes to "60 seconds", etc. and the final zoom level (2 hours) will be displayed as "7200 seconds".