### PR TITLE
Docs: fence filenames containing wildcards

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -141,7 +141,7 @@ to run. To launch openshot-qt from the source code, use the following commands:
    python3 src/launch.py
 
 This should launch the OpenShot user interface, and include any changes you have made to the source code
-files (*.py Python files, *.ui PyQt UI files, etc...). This requires the `libopenshot-audio` and
+files (`*.py` Python files, `*.ui` PyQt UI files, etc...). This requires the `libopenshot-audio` and
 `libopenshot` libraries, and if anything went wrong with the steps above, OpenShot will likely not launch.
 
 If OpenShot launches at this point, congratulations, you now have a working local version of OpenShot,


### PR DESCRIPTION
The Sphinx compiler caught a couple of unfenced wildcards in the new `developers.rst`, which will be interpreted as emphasis characters.

```
% make SPHINXBUILD=sphinx-build-3 html
sphinx-build-3 -b html -d _build/doctrees   . _build/html
Running Sphinx v1.6.6
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 12 source files that are out of date
updating environment: 2 added, 10 changed, 0 removed
reading sources... [100%] transitions                                           
/home/ferd/rpmbuild/REPOS/openshot-qt.ferd/doc/developers.rst:143: WARNING: Inline emphasis start-string without end-string.
/home/ferd/rpmbuild/REPOS/openshot-qt.ferd/doc/developers.rst:143: WARNING: Inline emphasis start-string without end-string.
```