### PR TITLE
Docs: Add Contributing doc

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -1,0 +1,60 @@
+How to contribute to OpenShot Video Editor
+------------------------------------------
+
+**Did you find a bug?**
+^^^^^^^^^^^^^^^^^^^^^^^
+
+-  **Please check if this bug was already reported** by searching on
+   GitHub under
+   `Issues <https://github.com/OpenShot/openshot-qt/issues>`__.
+
+-  If you're unable to find an open issue addressing the problem, `open
+   a new one <https://github.com/OpenShot/openshot-qt/issues/new>`__. Be
+   sure to include a **title and clear description**, as much relevant
+   information as possible, and the steps to reproduce the crash or
+   issue.
+
+-  Please **attach log files** if you are reporting a crash. Otherwise,
+   we will not be able to determine the cause of the crash.
+
+*Please download our latest daily installer:*
+
+1. www.openshot.org/download - click '**Other Downloads**' link and grab
+   the newest one
+2. Then enable 'Debug Mode (Verbose)' in the Preferences
+3. Quit OpenShot and delete both log files:
+
+   -  **Windows**: OpenShot stores its logs in your user profile
+      directory (``%USERPROFILE%``, e.g. ``C:\Users\username\``)
+
+      -  **``%USERPROFILE%/.openshot_qt/openshot_qt.log``**
+      -  **``%USERPROFILE%/.openshot_qt/libopenshot.log``**
+
+   -  **Linux/MacOS**: OpenShot stores its logs in your home directory
+      (``$HOME``, e.g. ``/home/username/``)
+
+      -  **``$HOME/.openshot_qt/openshot_qt.log``**
+      -  **``$HOME/.openshot_qt/libopenshot.log``**
+
+4. Re-launch OpenShot and trigger the crash as quickly as possible (to
+   keep the log files small)
+5. Attach **both** log files
+
+**Did you write a patch that fixes a bug?**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  Open a new GitHub pull request with the patch.
+
+-  Ensure the PR description clearly describes the problem and solution.
+   Include the relevant issue number if applicable.
+
+-  Before submitting, please ensure your PR passes all build /
+   compilation / and unit tests.
+
+OpenShot Video Editor is a volunteer effort, and a labor of love. Please
+be patient with any issues you find, and feel free to get involved and
+help us fix them!
+
+Thanks!
+
+OpenShot Team

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -39,7 +39,8 @@ Did you find a bug?
 
 Please download our latest daily installer:
 """""""""""""""""""""""""""""""""""""""""""
-1. `www.openshot.org/download <https://www.openshot.org/download>`__ - grab the newest one from the 'Daily Build Installer' list. (Use the buttons below to download installers for a different Operating System.)
+1. `www.openshot.org/download <https://www.openshot.org/download>`__ - click the '**DAILY BUILDS**' button, then grab the latest build from the list.
+   (Use the buttons below to download installers for a different Operating System.)
 2. Then enable 'Debug Mode (Verbose)' in the Preferences
 3. Quit OpenShot and delete both log files:
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -1,8 +1,28 @@
-How to contribute to OpenShot Video Editor
-------------------------------------------
+.. Copyright (c) 2008-2018 OpenShot Studios, LLC
+ (http://www.openshotstudios.com). This file is part of
+ OpenShot Video Editor (http://www.openshot.org), an open-source project
+ dedicated to delivering high quality video editing and animation solutions
+ to the world.
 
-**Did you find a bug?**
-^^^^^^^^^^^^^^^^^^^^^^^
+.. OpenShot Video Editor is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+.. OpenShot Video Editor is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+.. You should have received a copy of the GNU General Public License
+ along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
+
+
+Contributing
+============
+
+Did you find a bug?
+-------------------
 
 -  **Please check if this bug was already reported** by searching on
    GitHub under
@@ -17,31 +37,30 @@ How to contribute to OpenShot Video Editor
 -  Please **attach log files** if you are reporting a crash. Otherwise,
    we will not be able to determine the cause of the crash.
 
-*Please download our latest daily installer:*
-
-1. www.openshot.org/download - click '**Other Downloads**' link and grab
-   the newest one
+Please download our latest daily installer:
+"""""""""""""""""""""""""""""""""""""""""""
+1. `www.openshot.org/download <https://www.openshot.org/download>`__ - grab the newest one from the 'Daily Build Installer' list. (Use the buttons below to download installers for a different Operating System.)
 2. Then enable 'Debug Mode (Verbose)' in the Preferences
 3. Quit OpenShot and delete both log files:
 
    -  **Windows**: OpenShot stores its logs in your user profile
       directory (``%USERPROFILE%``, e.g. ``C:\Users\username\``)
 
-      -  **``%USERPROFILE%/.openshot_qt/openshot_qt.log``**
-      -  **``%USERPROFILE%/.openshot_qt/libopenshot.log``**
+      -  ``%USERPROFILE%/.openshot_qt/openshot_qt.log``
+      -  ``%USERPROFILE%/.openshot_qt/libopenshot.log``
 
    -  **Linux/MacOS**: OpenShot stores its logs in your home directory
       (``$HOME``, e.g. ``/home/username/``)
 
-      -  **``$HOME/.openshot_qt/openshot_qt.log``**
-      -  **``$HOME/.openshot_qt/libopenshot.log``**
+      -  ``$HOME/.openshot_qt/openshot_qt.log``
+      -  ``$HOME/.openshot_qt/libopenshot.log``
 
 4. Re-launch OpenShot and trigger the crash as quickly as possible (to
    keep the log files small)
 5. Attach **both** log files
 
-**Did you write a patch that fixes a bug?**
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Did you write a patch that fixes a bug?
+---------------------------------------
 
 -  Open a new GitHub pull request with the patch.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -44,4 +44,5 @@ Table of Contents:
    titles
    profiles
    developers
+   contributing
    learn_more


### PR DESCRIPTION
Converted from `.github/CONTRIBUTING.md` with pandoc, then cleaned up by hand.

It's a _little_ redundant with the new Developer doc page, but I think it's still useful to have the same contents as `CONTRIBUTING.md` in there directly (and we should endeavor to keep them in sync).

The main thrust for this was @theelectricsoul pointing out in #1443 that the word "crash" doesn't actually appear anywhere in the documentation, when you search for it. Now it does, and the docs provide information on collecting crash logs and submitting them.