### PR TITLE
CONTRIBUTING.md: Where to find daily installers

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
   _Please download our latest daily installer:_
 
-  1. www.openshot.org/download - grab the newest one from the '**Daily Build Installer**' list.
+  1. www.openshot.org/download - click the '**Daily Builds**' button, then grab the latest build from the list.
      (Use the buttons below to download installers for a different Operating System.)
   2. Then enable 'Debug Mode (Verbose)' in the Preferences
   3. Quit OpenShot and delete both log files:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,8 @@
 
   _Please download our latest daily installer:_
 
-  1. www.openshot.org/download - click '**Other Downloads**' link and grab the newest one
+  1. www.openshot.org/download - grab the newest one from the '**Daily Build Installer**' list.
+     (Use the buttons below to download installers for a different Operating System.)
   2. Then enable 'Debug Mode (Verbose)' in the Preferences
   3. Quit OpenShot and delete both log files:
       * **Windows**: OpenShot stores its logs in your user profile directory (`%USERPROFILE%`, e.g. `C:\Users\username\`)


### PR DESCRIPTION
There isn't actually an "Other Downloads" link on the referenced page anymore, so the previous description was confusing.

(The presence of the "Daily Installers" button on that download page is also confusing, as it does nothing and should probably go away. But that's an issue for the website, not the code.) 
**ETA:** Crap, that's not true. You _do_ have to hit the "Daily Installers" button **once** to get the list shown. After that, you can switch operating systems at will, and the button no longer does anything. I'll have to update this slightly and push in another commit.
**Update 2:** Done.