### PR TITLE
Use QUrl.toLocalFile() to convert dropped URIs

### DIFF
--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -273,17 +273,13 @@ class FilesListView(QListView):
         # Reset list of ignored image sequences paths
         self.ignore_image_sequence_paths = []
 
-        # log.info('Dropping file(s) on files tree.')
         for uri in event.mimeData().urls():
-            file_url = urlparse(uri.toString())
-            if file_url.scheme == "file":
-                filepath = file_url.path
-                if sys.platform == "win32":
-                    filepath = filepath[1:] # Remove / at beginning of path (just for Windows)
-                if os.path.exists(filepath.encode('UTF-8')) and os.path.isfile(filepath.encode('UTF-8')):
-                    log.info('Adding file: {}'.format(filepath))
-                    if self.add_file(filepath):
-                        event.accept()
+            log.info('Processing drop event for {}'.format(uri))
+            filepath = uri.toLocalFile()
+            if os.path.exists(filepath) and os.path.isfile(filepath):
+                log.info('Adding file: {}'.format(filepath))
+                if self.add_file(filepath):
+                    event.accept()
 
     def clear_filter(self):
         if self:

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -272,17 +272,13 @@ class FilesTreeView(QTreeView):
         # Reset list of ignored image sequences paths
         self.ignore_image_sequence_paths = []
 
-        # log.info('Dropping file(s) on files tree.')
         for uri in event.mimeData().urls():
-            file_url = urlparse(uri.toString())
-            if file_url.scheme == "file":
-                filepath = file_url.path
-                if sys.platform == "win32":
-                    filepath = filepath[1:] # Remove / at beginning of path (just for Windows)
-                if os.path.exists(filepath.encode('UTF-8')) and os.path.isfile(filepath.encode('UTF-8')):
-                    log.info('Adding file: {}'.format(filepath))
-                    if self.add_file(filepath):
-                        event.accept()
+            log.info('Processing drop event for {}'.format(uri))
+            filepath = uri.toLocalFile()
+            if os.path.exists(filepath) and os.path.isfile(filepath):
+                log.info('Adding file: {}'.format(filepath))
+                if self.add_file(filepath):
+                    event.accept()
 
     def clear_filter(self):
         if self:

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -2734,16 +2734,13 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
             # Add clips for each file dropped
             for uri in event.mimeData().urls():
-                file_url = urlparse(uri.toString())
-                if file_url.scheme == "file":
-                    filepath = file_url.path
-                    if sys.platform == "win32":
-                        filepath = filepath[1:]  # Remove / at beginning of path (just for Windows)
-                    if os.path.exists(filepath.encode('UTF-8')) and os.path.isfile(filepath.encode('UTF-8')):
-                        # Valid file, so create clip for it
-                        for file in File.filter(path=filepath):
-                            # Insert clip for this file at this position
-                            self.addClip([file.id], pos)
+                filepath = uri.toLocalFile()
+                if os.path.exists(filepath) and os.path.isfile(filepath):
+                    # Valid file, so create clip for it
+                    log.info('Adding clip for {}'.format(os.path.basename(filepath)))
+                    for file in File.filter(path=filepath):
+                        # Insert clip for this file at this position
+                        self.addClip([file.id], pos)
 
         # Clear new clip
         self.new_item = False


### PR DESCRIPTION
This is tested on Linux, still does the right thing. I can't currently test it on Windows (which it targets) because I'm still working on getting an OpenShot build environment working there, but I'm hopeful that it will fix the filename-handing issues that have been plaguing drag-and-drop imports on that platform. The previous method of forcing UTF-8 was clearly causing problems with paths containing non-ASCII characters (on Windows).

There are also some `log.info()` calls that should probably be commented out once this has been tested on Windows and Mac.

Addresses #1526, #880, #677; possibly #1084, #923, #888 (not enough detail in reports); maybe #1288 (but probably not?)