### PR TITLE
Retain track parameters during add/remove track

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -885,7 +885,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Get # of tracks
         track_number = len(get_app().project.get(["layers"]))
 
-        # Look for existing Marker
+        # Create new track above existing layer(s)
         track = Track()
         track.data = {"number": track_number, "y": 0, "label": "", "lock": False}
         track.save()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -910,11 +910,16 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             existing_track.data["number"] = existing_layer + 1
             existing_track.save()
 
-            # Loop through clips for track, moving up to new layer
+            # Loop through clips and transitions for track, moving up to new layer
             for clip in Clip.filter(layer=existing_layer):
                 # log.info("Moving clip id {} from layer {} to {}".format(clip.data["id"], int(clip.data["layer"]), int(clip.data["layer"])+1))
                 clip.data["layer"] = int(clip.data["layer"]) + 1
                 clip.save()
+
+            for trans in Transition.filter(layer=existing_layer):
+                # log.info("Moving transition id {} from layer {} to {}".format(trans.data["id"], int(trans.data["layer"]), int(trans.data["layer"])+1))
+                trans.data["layer"] = int(trans.data["layer"]) + 1
+                trans.save()
 
         # Create new track at vacated layer
         track = Track()
@@ -942,11 +947,16 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             existing_track.data["number"] = existing_layer + 1
             existing_track.save()
 
-            # Loop through clips for track, moving up to new layer
+            # Loop through clips and transitions for track, moving up to new layer
             for clip in Clip.filter(layer=existing_layer):
                 # log.info("Moving clip id {} from layer {} to {}".format(clip.data["id"], int(clip.data["layer"]), int(clip.data["layer"])+1))
                 clip.data["layer"] = int(clip.data["layer"]) + 1
                 clip.save()
+
+            for trans in Transition.filter(layer=existing_layer):
+                # log.info("Moving transition id {} from layer {} to {}".format(trans.data["id"], int(trans.data["layer"]), int(trans.data["layer"])+1))
+                trans.data["layer"] = int(trans.data["layer"]) + 1
+                trans.save()
 
         # Create new track at vacated layer
         track = Track()
@@ -1447,9 +1457,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Remove track
         selected_track.delete()
 
-        # Loop through all tracks, and renumber (to keep thing in numerical order)
+        # Loop through all layers above, and renumber elements (to keep thing in numerical order)
         for existing_layer in list(range(selected_track_number + 1, max_track_number)):
-            # Update existing layer #
+            # Update existing layer number
             track = Track.get(number=existing_layer)
             track.data["number"] = existing_layer - 1
             track.save()
@@ -1457,6 +1467,11 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             for clip in Clip.filter(layer=existing_layer):
                 clip.data["layer"] = int(clip.data["layer"]) - 1
                 clip.save()
+
+            for trans in Transition.filter(layer=existing_layer):
+                trans.data["layer"] = int(trans.data["layer"]) - 1
+                trans.save()
+
 
         # Clear selected track
         self.selected_tracks = []


### PR DESCRIPTION
Previously, actionAddTrackAbove()/Below() would always create the new track at the very top of the layer stack (above all existing tracks), then walk the list of those tracks' clips and slide them up one layer.

This caused _track_-level parameters (name, lock status) to be left behind (in the case of lock status) or intentionally discarded (in the case of track-name, which was blanked on all tracks which were moved). Lock status was thus left behind on the "wrong track", relative to the clips that track previously contained.

With this new code, the list of _tracks_ is walked during an add operation, starting from the topmost track, and each track is moved upwards one layer (with all of its properties intact). As each track is moved, all of the clips and transitions on that track are pushed up along with it. Then, a new track is created and slotted into the space vacated by the lowermost moved track.

This method preserves all track parameters, because each track's data in the project file is the _same_ after being moved as it was before. Only the layer numbers change.

All of the label-blanking code was removed from both add methods, as well as from the renumbering (in the other direction) performed during actionRemoveTrack().

Fixes issues #1531 , #321 ; Addresses part of rant #454 