### PR TITLE
Update Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,7 +1,0 @@
-**System Details:**
-* Operating System / Distro: ?
-* OpenShot Version: ?
-* _Please attach log files if crash_
-
-**Issue Description and steps to reproduce:**
-

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve OpenShot
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**System Details (please complete the following information):**
+ - Operating System / Distro: [e.g. Windows 10, Linux Mint 17.1]
+ - OpenShot Version [e.g. 2.4.1]
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Logs**
+If you are experiencing a crash, please collect and attach logs of the problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for OpenShot
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Github has a new workflow for issue reporting (and pull requests, which can also be templated), now they allow multiple templates for different types of issue reports. The New Issue process starts off with a little chooser, like so:

![screenshot from 2018-05-03 09-54-02](https://user-images.githubusercontent.com/538020/39580876-2db4a05a-4eb8-11e8-93dc-bbd83d512868.png)

Then once you make your choice you're shown the appropriate template, along with a link at the top to change type if you selected the wrong thing.

So I used their little template-customization wizard to set up separate templates for bug reports and feature requests, and tuned the bug report template to both ask for the same details our previous template did, and to account for details of the project's organization. (For instance, we don't need to ask what web browser the user is running.)

Github stupidly decided to have the new templates live as `<filename>.md` files in a _directory_ named `.gitub/ISSUE_TEMPLATE/`, which means (I discovered, to my surprise and annoyance) if you have an existing old-style template saved to the _file_ `.github/ISSUE_TEMPLATE`, the attempt to save the new-format templates will break when it can't create the directory, and you will lose all your customization. ...No point to that, I'm just ranting because I ended up having to do everything twice, and it's totally their fault.

I kind of wish we could _turn off_ the "Don't see your issue here?" thing, because if you click to "open a regular issue" you'll be shown a completely-untemplated New Issue box. Though I suppose we could just copy the Bug Report template into the template for that "regular issue" link, as it can _also_ have its own template.