### PR TITLE
Reverting back to ac3 temporarily (as the default codec)

### DIFF
--- a/src/presets/format_mov_x264.xml
+++ b/src/presets/format_mov_x264.xml
@@ -5,7 +5,7 @@
 	<title translatable="True">MOV (h.264)</title>
 	<videoformat>mov</videoformat>
 	<videocodec>libx264</videocodec>
-	<audiocodec>aac</audiocodec>
+	<audiocodec>ac3</audiocodec>
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate

--- a/src/presets/format_mp4_x264.xml
+++ b/src/presets/format_mp4_x264.xml
@@ -5,7 +5,7 @@
 	<title translatable="True">MP4 (h.264)</title>
 	<videoformat>mp4</videoformat>
 	<videocodec>libx264</videocodec>
-	<audiocodec>aac</audiocodec>
+	<audiocodec>ac3</audiocodec>
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate


### PR DESCRIPTION
Reverting back to ac3 temporarily (as the default codec), since not all builds support aac. We need to find a better way to choose the best audio codec for each user, but this needs more work.