### PR TITLE
Disable SSl verification on metrics and version requests

### DIFF
--- a/src/classes/metrics.py
+++ b/src/classes/metrics.py
@@ -154,7 +154,7 @@ def send_metric(params):
 
         # Send metric HTTP data
         try:
-            r = requests.get(url, headers={"user-agent": user_agent})
+            r = requests.get(url, headers={"user-agent": user_agent}, verify=False)
             log.info("Track metric: [%s] %s | (%s bytes)" % (r.status_code, r.url, len(r.content)))
 
         except Exception as Ex:
@@ -174,7 +174,7 @@ def send_exception(stacktrace, source):
 
         # Send exception HTTP data
         try:
-            r = requests.post(url, data=data, headers={"user-agent": user_agent, "content-type": "application/x-www-form-urlencoded"})
+            r = requests.post(url, data=data, headers={"user-agent": user_agent, "content-type": "application/x-www-form-urlencoded"}, verify=False)
             log.info("Track exception: [%s] %s | %s" % (r.status_code, r.url, r.text))
 
         except Exception as Ex:

--- a/src/classes/version.py
+++ b/src/classes/version.py
@@ -48,7 +48,7 @@ def get_version_from_http():
 
     # Send metric HTTP data
     try:
-        r = requests.get(url, headers={"user-agent": "openshot-qt-%s" % info.VERSION})
+        r = requests.get(url, headers={"user-agent": "openshot-qt-%s" % info.VERSION}, verify=False)
         log.info("Found current version: %s" % r.text)
 
         # Parse version


### PR DESCRIPTION
Disable SSl verification on metrics and version requests, since we don't package the python cacert.pem, and these are public info reports and not secure by nature. In the future, we can always turn back on SSL and package and configure the location of cacert.pem, but for now, it isn't important.