### PR TITLE
Bump version to RC6

### DIFF
--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -27,7 +27,7 @@
 
 import os
 
-VERSION = "2.4.2-rc5"
+VERSION = "2.4.2-rc6"
 MINIMUM_LIBOPENSHOT_VERSION = "0.2.0"
 DATE = "20180530000000"
 NAME = "openshot-qt"


### PR DESCRIPTION
Bump version to RC6, to get latest libopenshot in installer (which has fixes for blur effect)