### PR TITLE
Default to AAC audio codec & Bump to RC9

### DIFF
--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -27,7 +27,7 @@
 
 import os
 
-VERSION = "2.4.2-rc8"
+VERSION = "2.4.2-rc9"
 MINIMUM_LIBOPENSHOT_VERSION = "0.2.0"
 DATE = "20180530000000"
 NAME = "openshot-qt"

--- a/src/presets/apple_tv.xml
+++ b/src/presets/apple_tv.xml
@@ -5,7 +5,7 @@
 	<title translatable="True">Apple TV</title>
 	<videoformat>mp4</videoformat>
 	<videocodec>libx264</videocodec>
-	<audiocodec>ac3</audiocodec>
+	<audiocodec>aac</audiocodec>
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate

--- a/src/presets/avchd.xml
+++ b/src/presets/avchd.xml
@@ -5,7 +5,7 @@
 	<title translatable="True">AVCHD Disks</title>
 	<videoformat>mp4</videoformat>
 	<videocodec>libx264</videocodec>
-	<audiocodec>ac3</audiocodec>
+	<audiocodec>aac</audiocodec>
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate

--- a/src/presets/dvd_ntsc.xml
+++ b/src/presets/dvd_ntsc.xml
@@ -5,7 +5,7 @@
 	<title translatable="True">DVD-NTSC</title>
 	<videoformat>dvd</videoformat>
 	<videocodec>mpeg2video</videocodec>
-	<audiocodec>ac3</audiocodec>
+	<audiocodec>aac</audiocodec>
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate

--- a/src/presets/dvd_pal.xml
+++ b/src/presets/dvd_pal.xml
@@ -5,7 +5,7 @@
 	<title translatable="True">DVD-PAL</title>
 	<videoformat>dvd</videoformat>
 	<videocodec>mpeg2video</videocodec>
-	<audiocodec>ac3</audiocodec>
+	<audiocodec>aac</audiocodec>
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate

--- a/src/presets/flickr_HD.xml
+++ b/src/presets/flickr_HD.xml
@@ -5,7 +5,7 @@
 	<title translatable="True">Flickr-HD</title>
 	<videoformat>mov</videoformat>
 	<videocodec>libx264</videocodec>
-	<audiocodec>ac3</audiocodec>
+	<audiocodec>aac</audiocodec>
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate

--- a/src/presets/format_avi_x264.xml
+++ b/src/presets/format_avi_x264.xml
@@ -5,7 +5,7 @@
 	<title translatable="True">AVI (h.264)</title>
 	<videoformat>avi</videoformat>
 	<videocodec>libx264</videocodec>
-	<audiocodec>mp2</audiocodec>
+	<audiocodec>aac</audiocodec>
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate

--- a/src/presets/format_mov_x264.xml
+++ b/src/presets/format_mov_x264.xml
@@ -5,7 +5,7 @@
 	<title translatable="True">MOV (h.264)</title>
 	<videoformat>mov</videoformat>
 	<videocodec>libx264</videocodec>
-	<audiocodec>ac3</audiocodec>
+	<audiocodec>aac</audiocodec>
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate

--- a/src/presets/format_mp4_x264.xml
+++ b/src/presets/format_mp4_x264.xml
@@ -5,7 +5,7 @@
 	<title translatable="True">MP4 (h.264)</title>
 	<videoformat>mp4</videoformat>
 	<videocodec>libx264</videocodec>
-	<audiocodec>ac3</audiocodec>
+	<audiocodec>aac</audiocodec>
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate

--- a/src/presets/format_mp4_xvid.xml
+++ b/src/presets/format_mp4_xvid.xml
@@ -5,7 +5,7 @@
 	<title translatable="True">MP4 (Xvid)</title>
 	<videoformat>mp4</videoformat>
 	<videocodec>libxvid</videocodec>
-	<audiocodec>ac3</audiocodec>
+	<audiocodec>aac</audiocodec>
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate

--- a/src/presets/nokia_nHD.xml
+++ b/src/presets/nokia_nHD.xml
@@ -5,7 +5,7 @@
 	<title translatable="True">Nokia nHD</title>
 	<videoformat>avi</videoformat>
 	<videocodec>libxvid</videocodec>
-	<audiocodec>ac3</audiocodec>
+	<audiocodec>aac</audiocodec>
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate

--- a/src/presets/xbox360.xml
+++ b/src/presets/xbox360.xml
@@ -5,7 +5,7 @@
 	<title translatable="True">Xbox 360</title>
 	<videoformat>avi</videoformat>
 	<videocodec>libxvid</videocodec>
-	<audiocodec>ac3</audiocodec>
+	<audiocodec>aac</audiocodec>
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -477,13 +477,29 @@ class Export(QDialog):
                     self.txtVideoFormat.setText(vf[0].childNodes[0].data)
                     vc = xmldoc.getElementsByTagName("videocodec")
                     self.txtVideoCodec.setText(vc[0].childNodes[0].data)
-                    ac = xmldoc.getElementsByTagName("audiocodec")
-                    self.txtAudioCodec.setText(ac[0].childNodes[0].data)
                     sr = xmldoc.getElementsByTagName("samplerate")
                     self.txtSampleRate.setValue(int(sr[0].childNodes[0].data))
                     c = xmldoc.getElementsByTagName("audiochannels")
                     self.txtChannels.setValue(int(c[0].childNodes[0].data))
                     c = xmldoc.getElementsByTagName("audiochannellayout")
+
+                    # check for compatible audio codec
+                    ac = xmldoc.getElementsByTagName("audiocodec")
+                    audio_codec_name = ac[0].childNodes[0].data
+                    if audio_codec_name == "aac":
+                        # Determine which version of AAC encoder is available
+                        if openshot.FFmpegWriter.IsValidCodec("libfaac"):
+                            self.txtAudioCodec.setText("libfaac")
+                        elif openshot.FFmpegWriter.IsValidCodec("libvo_aacenc"):
+                            self.txtAudioCodec.setText("libvo_aacenc")
+                        elif openshot.FFmpegWriter.IsValidCodec("aac"):
+                            self.txtAudioCodec.setText("aac")
+                        else:
+                            # fallback audio codec
+                            self.txtAudioCodec.setText("ac3")
+                    else:
+                        # fallback audio codec
+                        self.txtAudioCodec.setText(audio_codec_name)
 
                     layout_index = 0
                     for layout in self.channel_layout_choices:


### PR DESCRIPTION
Using the new FFmpegWriter::IsValidCodec static function, to properly fallback when aac is not installed on a user's system. There are a few different encoder names we check, in order to find a compatible one. Many presets have been updated from AC3 to AAC, for wider playback compatibility. Bump to RC9.