### PR TITLE
Add Makefile to compile .qrc file

### DIFF
--- a/src/images/Makefile
+++ b/src/images/Makefile
@@ -1,0 +1,4 @@
+ALL: openshot_rc.py
+
+openshot_rc.py: openshot.qrc
+	pyrcc5 openshot.qrc -o openshot_rc.py

--- a/src/images/README
+++ b/src/images/README
@@ -1,6 +1,8 @@
 To compile a Qt resource file with new icons, follow these steps:
 
 1) Edit the resource file, and add files to it (the *.qrc files) using QtCreator
-2) Compile this into a Python file:
-   $ pyrcc5 openshot.qrc -o openshot_rc.py
+2) Compile this into a Python file, either:
+     $ make
+   or, if make is unavailable:
+     $ pyrcc5 openshot.qrc -o openshot_rc.py
 


### PR DESCRIPTION
I added a simple `Makefile` in `src/images/` so that `openshot_rc.py`
can be recompiled from `openshot.qrc` with just a simple `make` command.
Make will also handle recompiling only when the output file is older
than the input `.qrc`.

Also updated `src/images/README` accordingly.