### PR TITLE
 Don't skip loading translations in system locale

### DIFF
--- a/src/classes/language.py
+++ b/src/classes/language.py
@@ -74,8 +74,8 @@ def init_language():
 
     # Output all system languages detected
     log.info("Qt Detected Languages: {}".format(QLocale().system().uiLanguages()))
-    log.info("LANG Environment Variable: {}".format(os.environ.get('LANG', QLocale().system().name())))
-    log.info("LOCALE Environment Variable: {}".format(os.environ.get('LOCALE', QLocale().system().name())))
+    log.info("LANG Environment Variable: {}".format(os.environ.get('LANG', "")))
+    log.info("LOCALE Environment Variable: {}".format(os.environ.get('LOCALE', "")))
 
     # Default the locale to C, for number formatting
     locale.setlocale(locale.LC_ALL, 'C')

--- a/src/classes/language.py
+++ b/src/classes/language.py
@@ -84,11 +84,6 @@ def init_language():
     found_language = False
     for locale_name in locale_names:
 
-        # Don't try on default locale, since it fails to load what is the default language
-        if QLocale().system().name() in locale_name:
-            log.info("Skipping English language (no need for translation): {}".format(locale_name))
-            continue
-
         # Go through each translator and try to add for current locale
         for type in translator_types:
             trans = QTranslator(app)


### PR DESCRIPTION
PR #1332 sought to fix loading of English translations in non-English locales (see #1256) by removing a hardcoded `en_US` bypass in the translation file loading. In doing so, it inadvertently broke loading of translation files that match the system locale.

This removes the entire "skip loading" clause, because we can never assume that any translation shouldn't be loaded. English translations may need to be loaded and applied, if OpenShot's language is set to English in non-English locales. In contrast, we still need to load our OpenShot translations for the local language even if the selected language is the same as the system locale.

Fixes #1521. (I believe. It's not something I can test, since I'm not in a non-English locale.)

Also, the log messages for `$LANG` and `$LOCALE` no longer fall back to default strings, so
they will properly show when the corresponding variables are unset or set to the empty string.