### PR TITLE
Nudge clips

### DIFF
--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -735,5 +735,21 @@
     "setting": "actionInsertKeyframe",
     "value": "Ctrl+Shift+E",
     "type": "text"
+  },
+  {
+    "category": "Keyboard",
+    "title": "Nudge left",
+    "restart": true,
+    "setting": "nudgeLeft",
+    "value": "Shift+Left",
+    "type": "text"
+  },
+  {
+    "category": "Keyboard",
+    "title": "Nudge right",
+    "restart": true,
+    "setting": "nudgeRight",
+    "value": "Shift+Right",
+    "type": "text"
   }
 ]

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1294,6 +1294,10 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             self.timeline.Copy_Triggered(-1, self.selected_clips, self.selected_transitions)
         elif key.matches(self.getShortcutByName("pasteAll")) == QKeySequence.ExactMatch:
             self.timeline.Paste_Triggered(9, float(playhead_position), -1, [], [])
+        elif key.matches(self.getShortcutByName("nudgeLeft")) == QKeySequence.ExactMatch:
+            self.timeline.Nudge_Triggered(-1, self.selected_clips, self.selected_transitions)
+        elif key.matches(self.getShortcutByName("nudgeRight")) == QKeySequence.ExactMatch:
+            self.timeline.Nudge_Triggered(1, self.selected_clips, self.selected_transitions)
 
         # Select All / None
         elif key.matches(self.getShortcutByName("selectAll")) == QKeySequence.ExactMatch:

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -1467,13 +1467,13 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         left_edge = -1.0
         right_edge = -1.0
 
-        # Determine how far we're going to nudge (1 frame or 0.01s, whichever is larger)
+        # Determine how far we're going to nudge (1/2 frame or 0.01s, whichever is larger)
         fps = get_app().project.get(["fps"])
         fps_float = float(fps["num"]) / float(fps["den"])
-        nudgeDistance = action / fps_float	# result is milliseconds
-        nudgeDistance /= 1000.0			# convert milliseconds to seconds
+        nudgeDistance = float(action) / float(fps_float)
+        nudgeDistance =/ 2.0	# 1/2 frame
         if abs(nudgeDistance) < 0.01:
-            nudgeDistance = 0.01 * action
+            nudgeDistance = 0.01 * action	# nudge is less than the minimum of +/- 0.01s
         log.info("Nudging by %s sec" % nudgeDistance)
 
         # Loop through each selected clip (find furthest left and right edge)

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -1471,7 +1471,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         fps = get_app().project.get(["fps"])
         fps_float = float(fps["num"]) / float(fps["den"])
         nudgeDistance = float(action) / float(fps_float)
-        nudgeDistance =/ 2.0	# 1/2 frame
+        nudgeDistance /= 2.0	# 1/2 frame
         if abs(nudgeDistance) < 0.01:
             nudgeDistance = 0.01 * action	# nudge is less than the minimum of +/- 0.01s
         log.info("Nudging by %s sec" % nudgeDistance)

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -1461,6 +1461,94 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
                 # Save changes
                 tran.save()
 
+    def Nudge_Triggered(self, action, clip_ids, tran_ids):
+        """Callback for clip nudges"""
+        log.info("Nudging clip(s) and/or transition(s)")
+        left_edge = -1.0
+        right_edge = -1.0
+
+        # Determine how far we're going to nudge (1 frame or 0.01s, whichever is larger)
+        fps = get_app().project.get(["fps"])
+        fps_float = float(fps["num"]) / float(fps["den"])
+        nudgeDistance = action / fps_float	# result is milliseconds
+        nudgeDistance /= 1000.0			# convert milliseconds to seconds
+        if abs(nudgeDistance) < 0.01:
+            nudgeDistance = 0.01 * action
+        log.info("Nudging by %s sec" % nudgeDistance)
+
+        # Loop through each selected clip (find furthest left and right edge)
+        for clip_id in clip_ids:
+            # Get existing clip object
+            clip = Clip.get(id=clip_id)
+            if not clip:
+                # Invalid clip, skip to next item
+                continue
+
+            position = float(clip.data["position"])
+            start_of_clip = float(clip.data["start"])
+            end_of_clip = float(clip.data["end"])
+
+            if position < left_edge or left_edge == -1.0:
+                left_edge = position
+            if position + (end_of_clip - start_of_clip) > right_edge or right_edge == -1.0:
+                right_edge = position + (end_of_clip - start_of_clip)
+
+            # Do not nudge beyond the start of the timeline
+            if left_edge + nudgeDistance < 0.0:
+                log.info("Cannot nudge beyond start of timeline")
+                nudgeDistance = 0
+
+        # Loop through each selected transition (find furthest left and right edge)
+        for tran_id in tran_ids:
+            # Get existing transition object
+            tran = Transition.get(id=tran_id)
+            if not tran:
+                # Invalid transition, skip to next item
+                continue
+
+            position = float(tran.data["position"])
+            start_of_tran = float(tran.data["start"])
+            end_of_tran = float(tran.data["end"])
+
+            if position < left_edge or left_edge == -1.0:
+                left_edge = position
+            if position + (end_of_tran - start_of_tran) > right_edge or right_edge == -1.0:
+                right_edge = position + (end_of_tran - start_of_tran)
+
+            # Do not nudge beyond the start of the timeline
+            if left_edge + nudgeDistance < 0.0:
+                log.info("Cannot nudge beyond start of timeline")
+                nudgeDistance = 0
+
+        # Loop through each selected clip (update position to align clips)
+        for clip_id in clip_ids:
+            # Get existing clip object
+            clip = Clip.get(id=clip_id)
+            if not clip:
+                # Invalid clip, skip to next item
+                continue
+
+            # Do the nudge
+            clip.data['position'] += nudgeDistance
+
+            # Save changes
+            self.update_clip_data(clip.data, only_basic_props=False, ignore_reader=True)
+
+        # Loop through each selected transition (update position to align clips)
+        for tran_id in tran_ids:
+            # Get existing transition object
+            tran = Transition.get(id=tran_id)
+            if not tran:
+                # Invalid transition, skip to next item
+                continue
+
+            # Do the nudge
+            tran.data['position'] += nudgeDistance
+
+            # Save changes
+            self.update_transition_data(tran.data, only_basic_props=False)
+
+
     def Align_Triggered(self, action, clip_ids, tran_ids):
         """Callback for alignment context menus"""
         log.info(action)


### PR DESCRIPTION
Resubmission of the "Nudge clips" PR to the develop branch.

This replaces PR #1512 .

Nudging of clips can now be performed by selecting the clip(s) on the timeline and using <kbd>Shift</kbd>+<kbd>Left</kbd> or <kbd>Shift</kbd>+<kbd>Right</kbd>.

Minimum nudge amount is 0.01s or 1/2 frame duration, whichever is more.  

For instance, a  15 FPS project will nudge clips by 1/2 a frame or ~0.03s (1/15 * 1/2), but a 60 FPS project will nudge clips by 0.01s because 1/2 frame is 0.008s (1/60 * 1/2).

I know I saw an email or issue or something where this was requested, and I know that I will use it all the time, but I can't find the issue to reference here.  