### PR TITLE
Correct variable name typo to initialize properly

### DIFF
--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -40,7 +40,7 @@ var track_container_height = -1;
 // 1: can be dragged
 // 2: can be resized
 // 3: class change when hovered over
-var dragLog = null;
+var dragLoc = null;
 
 App.directive('tlClip', function($timeout){
 	return {

--- a/src/timeline/js/directives/transition.js
+++ b/src/timeline/js/directives/transition.js
@@ -40,7 +40,7 @@ var track_container_height = -1;
 // 1: can be dragged
 // 2: can be resized
 // 3: class change when hovered over
-var dragLog = null;
+var dragLoc = null;
 
 App.directive('tlTransition', function(){
 	return {


### PR DESCRIPTION
Both `clip.js` and `transition.js` were using the variable `dragLoc` uninitialized, because the top of each file contained the following initialization:

```js
var dragLog = null
```