### PR TITLE
Use track names in "Add To Timeline" window

### DIFF
--- a/src/windows/add_to_timeline.py
+++ b/src/windows/add_to_timeline.py
@@ -485,7 +485,8 @@ class AddToTimeline(QDialog):
         tracks = Track.filter()
         for track in reversed(tracks):
             # Add to dropdown
-            self.cmbTrack.addItem(_('Track %s' % track.data['number']), track.data['number'])
+            track_name = track.data['label'] or _("Track %s") % track.data['number']
+            self.cmbTrack.addItem(track_name, track.data['number'])
 
         # Add all fade options
         self.cmbFade.addItem(_('None'), None)


### PR DESCRIPTION
I happened to notice that the track selector in the "Add To Timeline" window (right-click a Project Files entry, select "Add To Timeline...') didn't use the user-defined track labels, it always showed "Track _"
numbered labels even when a custom label was set. There was no reason _not_ to use the user's track names, so now it does.