### PR TITLE
WIP*: Reduce logspam

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -123,7 +123,6 @@ class OpenShotApp(QApplication):
         if self.settings.get("theme") != "No Theme":
             # Load embedded font
             try:
-                log.info("Setting font to %s" % os.path.join(info.IMAGES_PATH, "fonts", "Ubuntu-R.ttf"))
                 font_id = QFontDatabase.addApplicationFont(os.path.join(info.IMAGES_PATH, "fonts", "Ubuntu-R.ttf"))
                 font_family = QFontDatabase.applicationFontFamilies(font_id)[0]
                 font = QFont(font_family)
@@ -135,7 +134,6 @@ class OpenShotApp(QApplication):
         # Set Experimental Dark Theme
         if self.settings.get("theme") == "Humanity: Dark":
             # Only set if dark theme selected
-            log.info("Setting custom dark theme")
             self.setStyle(QStyleFactory.create("Fusion"))
 
             darkPalette = self.palette()
@@ -163,7 +161,7 @@ class OpenShotApp(QApplication):
         self.updates.reset()
         self.window.updateStatusChanged(False, False)
 
-        log.info('Process command-line arguments: %s' % args)
+        log.debug('Process command-line arguments: %s' % args)
         if len(args[0]) == 2:
             path = args[0][1]
             if ".osp" in path:

--- a/src/classes/language.py
+++ b/src/classes/language.py
@@ -104,7 +104,12 @@ def init_language():
     found_language = False
     for locale_name in locale_names:
 
-        # Go through each translator and try to add for current locale
+        # Don't try on default locale, since it fails to load what is the default language
+        if QLocale().system().name() in locale_name:
+            log.info("Skipping English language (no need for translation): {}".format(locale_name))
+            continue
+
+         # Go through each translator and try to add for current locale
         for type in translator_types:
             trans = QTranslator(app)
             if find_language_match(type["prefix"], type["path"], trans, locale_name):

--- a/src/classes/language.py
+++ b/src/classes/language.py
@@ -104,12 +104,7 @@ def init_language():
     found_language = False
     for locale_name in locale_names:
 
-        # Don't try on default locale, since it fails to load what is the default language
-        if QLocale().system().name() in locale_name:
-            log.info("Skipping English language (no need for translation): {}".format(locale_name))
-            continue
-
-         # Go through each translator and try to add for current locale
+        # Go through each translator and try to add for current locale
         for type in translator_types:
             trans = QTranslator(app)
             if find_language_match(type["prefix"], type["path"], trans, locale_name):

--- a/src/classes/language.py
+++ b/src/classes/language.py
@@ -128,7 +128,6 @@ def find_language_match(prefix, path, translator, locale_name):
     """ Match all combinations of locale, language, and country """
 
     filename = prefix + locale_name
-    log.debug('Attempting to load {} in \'{}\''.format(filename,path))
     success = translator.load(filename, path)
     if success:
         log.debug('Successfully loaded {} in \'{}\''.format(filename, path))

--- a/src/classes/logger.py
+++ b/src/classes/logger.py
@@ -50,29 +50,45 @@ class StreamToLogger(object):
         pass
 
 # Initialize logging module, give basic formats and level we want to report
-logging.basicConfig(format="%(module)12s:%(levelname)s %(message)s",
-                    datefmt='%H:%M:%S',
-                    level=logging.INFO)
+#logging.basicConfig(format="%(module)12s:%(levelname)s %(message)s",
+#                    datefmt='%H:%M:%S',
+#                    level=logging.INFO)
 
 # Create a formatter
 formatter = logging.Formatter('%(module)12s:%(levelname)s %(message)s')
 
 # Get logger instance & set level
 log = logging.getLogger('OpenShot')
-log.setLevel(logging.INFO)
+log.setLevel(logging.DEBUG)
+
+# create console handler, set level to INFO, add formatter
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+ch.setFormatter(formatter)
+log.addHandler(ch)
 
 # Add rotation file handler
 fh = RotatingFileHandler(
     os.path.join(info.USER_PATH, 'openshot-qt.log'), encoding="utf-8", maxBytes=25*1024*1024, backupCount=3)
+fh.setLevel(logging.INFO)
 fh.setFormatter(formatter)
 log.addHandler(fh)
 
 def reroute_output():
     """Route stdout and stderr to logger (custom handler)"""
     if not getattr(sys, 'frozen', False):
-        so = StreamToLogger(log, logging.INFO)
+        so = StreamToLogger(log, logging.DEBUG)
         sys.stdout = so
 
         se = StreamToLogger(log, logging.ERROR)
         sys.stderr = se
+
+def debug_logging(enable=True):
+    """Enable/disable debug logging to the logfile"""
+    if enable:
+        fh.setLevel(logging.DEBUG)
+        #log.info("Enabled DEBUG message logging")
+    else:
+        fh.setLevel(logging.INFO)
+        #log.info("Disabled DEBUG message logging")
 

--- a/src/classes/logger_libopenshot.py
+++ b/src/classes/logger_libopenshot.py
@@ -27,7 +27,7 @@
 
 from threading import Thread
 from classes import settings, info
-from classes.logger import log
+from classes.logger import log, debug_logging
 import openshot
 import os
 import zmq
@@ -55,8 +55,9 @@ class LoggerLibOpenShot(Thread):
         # Set filepath for ZmqLogger also
         openshot.ZmqLogger.Instance().Path(os.path.join(info.USER_PATH, 'libopenshot.log'))
 
-        # Enable / Disable logger
+        # Enable / Disable debug loggers
         openshot.ZmqLogger.Instance().Enable(debug_enabled)
+        debug_logging(debug_enabled)
 
         # Socket to talk to server
         context = zmq.Context()
@@ -80,4 +81,4 @@ class LoggerLibOpenShot(Thread):
 
             # Log the message (if any)
             if msg:
-                log.info(msg.strip().decode('UTF-8'))
+                log.debug(msg.strip().decode('UTF-8'))

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -633,11 +633,9 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         openshot_version = self._data["version"]["openshot-qt"]
         libopenshot_version = self._data["version"]["libopenshot"]
 
-        log.info(openshot_version)
-        log.info(libopenshot_version)
-
         if openshot_version == "0.0.0":
             # If version = 0.0.0, this is the beta of OpenShot
+            log.info('Upgrading OpenShot 0.0.0 project data')
             # Fix alpha values (they are now flipped)
             for clip in self._data["clips"]:
                 # Loop through keyframes for alpha
@@ -651,6 +649,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                         point["handle_right"]["Y"] = 1.0 - point["handle_right"]["Y"]
 
         elif openshot_version <= "2.1.0-dev":
+            log.info('Upgrading OpenShot 2.1.0-dev project data')
             # Fix handle_left and handle_right coordinates and default to ease in/out bezier curve
             # using the new percent based keyframes
             for clip_type in ["clips", "effects"]:
@@ -737,7 +736,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
                 # Find any temp BLENDER file paths
                 if info.BLENDER_PATH in path or info.ASSETS_PATH in path:
-                    log.info("Temp blender file path detected in file")
 
                     # Get folder of file
                     folder_path, file_name = os.path.split(path)
@@ -770,7 +768,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
                 # Find any temp BLENDER file paths
                 if info.BLENDER_PATH in path or info.ASSETS_PATH in path:
-                    log.info("Temp blender file path detected in clip")
 
                     # Get folder of file
                     folder_path, file_name = os.path.split(path)
@@ -787,7 +784,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
                 # Find any temp BLENDER file paths
                 if info.BLENDER_PATH in path or info.ASSETS_PATH in path:
-                    log.info("Temp blender file path detected in clip thumbnail")
 
                     # Get folder of file
                     folder_path, file_name = os.path.split(path)
@@ -911,18 +907,18 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             path = file["path"]
             parent_path, file_name_with_ext = os.path.split(path)
             while not os.path.exists(path) and "%" not in path:
-                # File already exists! Prompt user to find missing file
+                # Prompt user to find missing media file
                 QMessageBox.warning(None, _("Missing File (%s)") % file["id"], _("%s cannot be found.") % file_name_with_ext)
                 starting_folder = QFileDialog.getExistingDirectory(None, _("Find directory that contains: %s" % file_name_with_ext), starting_folder)
-                log.info("Missing folder chosen by user: %s" % starting_folder)
                 if starting_folder:
                     # Update file path and import_path
                     path = os.path.join(starting_folder, file_name_with_ext)
                     file["path"] = path
                     get_app().updates.update(["import_path"], os.path.dirname(path))
+                    log.info('Updated File path: {}'.format(path))
                 else:
-                    log.info('Removed missing file: %s' % file_name_with_ext)
                     self._data["files"].remove(file)
+                    log.info('Removed missing file: {}'.format(file_name_with_ext))
                     break
 
         # Loop through each clip (in reverse order)
@@ -930,16 +926,16 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             path = clip["reader"]["path"]
             parent_path, file_name_with_ext = os.path.split(path)
             while not os.path.exists(path) and "%" not in path:
-                # Clip already exists! Prompt user to find missing file
-                QMessageBox.warning(None, _("Missing File in Clip (%s)") % clip["id"], _("%s cannot be found.") % file_name_with_ext)
+                # Prompt user to find missing file for Clip
+                QMessageBox.warning(None, _("Missing file in Clip (%s)") % clip["id"], _("%s cannot be found.") % file_name_with_ext)
                 starting_folder = QFileDialog.getExistingDirectory(None, _("Find directory that contains: %s" % file_name_with_ext), starting_folder)
-                log.info("Missing folder chosen by user: %s" % starting_folder)
                 if starting_folder:
                     # Update clip path
                     path = os.path.join(starting_folder, file_name_with_ext)
                     clip["reader"]["path"] = path
+                    log.info('Updated file path for Clip: {}'.format(path))
                 else:
-                    log.info('Removed missing clip: %s' % file_name_with_ext)
+                    log.info('Removed missing Clip: {}'.format(file_name_with_ext))
                     self._data["clips"].remove(clip)
                     break
 

--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -103,15 +103,12 @@ class TimelineSync(UpdateInterface):
                 self.timeline.ApplyJsonDiff(action.json(is_array=True))
 
         except Exception as e:
-            log.info("Error applying JSON to timeline object in libopenshot: %s. %s" % (e, action.json(is_array=True)))
+            log.error("Error applying JSON to timeline object in libopenshot: %s. %s" % (e, action.json(is_array=True)))
 
     def MaxSizeChangedCB(self, new_size):
         """Callback for max sized change (i.e. max size of video widget)"""
         while not self.window.initialized:
-            log.info('Waiting for main window to initialize before calling SetMaxSize')
             time.sleep(0.5)
-
-        log.info("Adjusting max size of preview image: %s" % new_size)
 
         # Clear timeline preview cache (since our video size has changed)
         self.timeline.ClearAllCache()

--- a/src/classes/ui_util.py
+++ b/src/classes/ui_util.py
@@ -129,8 +129,6 @@ def get_icon(theme_name):
 
     if theme_name:
         has_icon = QIcon.hasThemeIcon(theme_name)
-        if not has_icon:
-            log.warn('Icon theme {} not found. Will use backup icon.'.format(theme_name))
         fallback_icon, fallback_path = get_default_icon(theme_name)
         # log.info('Fallback icon path for {} is {}'.format(theme_name, fallback_path))
         if has_icon or fallback_icon:

--- a/src/classes/ui_util.py
+++ b/src/classes/ui_util.py
@@ -194,13 +194,11 @@ def connect_auto_events(window, elem, name):
         func_name = name + "_trigger"
         if hasattr(window, func_name) and callable(getattr(window, func_name)):
             func = getattr(window, func_name)
-            log.info("Binding event {}:{}".format(window.objectName(), func_name))
             elem.triggered.connect(getattr(window, func_name))
     if hasattr(elem, 'click'):
         func_name = name + "_click"
         if hasattr(window, func_name) and callable(getattr(window, func_name)):
             func = getattr(window, func_name)
-            log.info("Binding event {}:{}".format(window.objectName(), func_name))
             elem.clicked.connect(getattr(window, func_name))
 
 
@@ -239,3 +237,4 @@ def center(window):
 
 def transfer_children(from_widget, to_widget):
     log.info("Transferring children from '{}' to '{}'".format(from_widget.objectName(), to_widget.objectName()))
+

--- a/src/timeline/app.js
+++ b/src/timeline/app.js
@@ -53,7 +53,7 @@ var App = angular.module('openshot-timeline', ['ui.bootstrap','ngAnimate']);
 	
 	// Check for Qt Integration
 	if(typeof timeline != 'undefined') {
-		timeline.qt_log("Qt Found!");
+		timeline.qt_debug("Qt Found!");
 		$('body').scope().EnableQt();
 		timeline.page_ready();
 	} else {

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -958,7 +958,7 @@ $scope.SetTrackLabel = function (label){
  $scope.UpdateLayerIndex = function(){
 
 	 if ($scope.Qt)
-		 timeline.qt_log('UpdateLayerIndex');
+		 timeline.qt_debug('UpdateLayerIndex');
 
 	var vert_scroll_offset = $("#scrolling_tracks").scrollTop();
 	var horz_scroll_offset = $("#scrolling_tracks").scrollLeft();
@@ -994,7 +994,7 @@ $scope.SetTrackLabel = function (label){
 		 return;
 
 	 if ($scope.Qt)
-		 timeline.qt_log('SortItems');
+		 timeline.qt_debug('SortItems');
 
 	 $scope.$apply(function(){
 		 // Sort by position second

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -252,7 +252,7 @@ App.controller('TimelineCtrl',function($scope) {
   $scope.Qt = false;
   $scope.EnableQt = function() { 
 	  	$scope.Qt = true;
-	  	timeline.qt_log("$scope.Qt = true;"); 
+	  	timeline.qt_debug("$scope.Qt = true;");
   };
 
   // Move the playhead to a specific time
@@ -431,7 +431,7 @@ App.controller('TimelineCtrl',function($scope) {
 				$scope.project.clips[clip_index].audio_data = audio_data;
 				$scope.project.clips[clip_index].show_audio = true;
 			});
-			timeline.qt_log("Audio data successful set on clip JSON");
+			timeline.qt_debug("Audio data successful set on clip JSON");
 			break;
 		}
 
@@ -724,7 +724,7 @@ App.controller('TimelineCtrl',function($scope) {
  // Show clip context menu
  $scope.ShowClipMenu = function(clip_id, event) {
  	if ($scope.Qt) {
-	 	timeline.qt_log("$scope.ShowClipMenu");
+	 	timeline.qt_debug("$scope.ShowClipMenu");
 	 	$scope.SelectClip(clip_id, false, event);
 	 	timeline.ShowClipMenu(clip_id);
  	}
@@ -733,7 +733,7 @@ App.controller('TimelineCtrl',function($scope) {
  // Show clip context menu
  $scope.ShowEffectMenu = function(effect_id) {
  	if ($scope.Qt) {
-	 	timeline.qt_log("$scope.ShowEffectMenu");
+	 	timeline.qt_debug("$scope.ShowEffectMenu");
 	 	timeline.ShowEffectMenu(effect_id);
  	}
  };
@@ -741,7 +741,7 @@ App.controller('TimelineCtrl',function($scope) {
  // Show transition context menu
  $scope.ShowTransitionMenu = function(tran_id, event) {
  	if ($scope.Qt) {
-	 	timeline.qt_log("$scope.ShowTransitionMenu");
+	 	timeline.qt_debug("$scope.ShowTransitionMenu");
 	 	$scope.SelectTransition(tran_id, false, event);
 	 	timeline.ShowTransitionMenu(tran_id);
  	}
@@ -750,7 +750,7 @@ App.controller('TimelineCtrl',function($scope) {
  // Show track context menu
  $scope.ShowTrackMenu = function(layer_id) {
  	if ($scope.Qt) {
-	 	timeline.qt_log("$scope.ShowTrackMenu");
+	 	timeline.qt_debug("$scope.ShowTrackMenu");
 	 	timeline.ShowTrackMenu(layer_id);
  	}
  };
@@ -758,7 +758,7 @@ App.controller('TimelineCtrl',function($scope) {
  // Show marker context menu
  $scope.ShowMarkerMenu = function(marker_id) {
  	if ($scope.Qt) {
-	 	timeline.qt_log("$scope.ShowMarkerMenu");
+	 	timeline.qt_debug("$scope.ShowMarkerMenu");
 	 	timeline.ShowMarkerMenu(marker_id);
  	}
  };
@@ -766,7 +766,7 @@ App.controller('TimelineCtrl',function($scope) {
   // Show playhead context menu
  $scope.ShowPlayheadMenu = function(position) {
  	if ($scope.Qt) {
-	 	timeline.qt_log("$scope.ShowPlayheadMenu");
+	 	timeline.qt_debug("$scope.ShowPlayheadMenu");
 	 	timeline.ShowPlayheadMenu(position);
 	 }
  };

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1064,7 +1064,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             get_app().window.propertyTableView.select_frame(frame_to_seek)
 
     def actionNextMarker_trigger(self, event):
-        log.info(self.preview_thread.current_frame)
+        log.debug("Next Marker called from frame {}".format(self.preview_thread.current_frame))
 
         # Calculate current position (in seconds)
         fps = get_app().project.get(["fps"])
@@ -1450,11 +1450,11 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             QMessageBox.warning(self, _("Error Removing Track"), _("You must keep at least 1 track"))
             return
 
-        # Revove all clips on this track first
+        # Remove all clips on this track first
         for clip in Clip.filter(layer=selected_track_number):
             clip.delete()
 
-        # Revove all transitions on this track first
+        # Remove all transitions on this track first
         for trans in Transition.filter(layer=selected_track_number):
             trans.delete()
 
@@ -1775,7 +1775,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     # Add to the selected items
     def addSelection(self, item_id, item_type, clear_existing=False):
-        log.debug('main::addSelection: {}[{}], clear_existing: {}' % (item_type.capitalize(), item_id, clear_existing))
+        log.debug('main::addSelection: {}[{}], clear_existing: {}'.format(item_type.capitalize(), item_id, clear_existing))
 
         # Clear existing selection (if needed)
         if clear_existing:

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -94,7 +94,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # Prompt user to save (if needed)
         if get_app().project.needs_save() and not self.mode == "unittest":
-            log.info('Prompt user to save project')
             # Translate object
             _ = get_app()._tr
 
@@ -136,13 +135,12 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     def recover_backup(self):
         """Recover the backup file (if any)"""
-        log.info("recover_backup")
         # Check for backup.osp file
         recovery_path = os.path.join(info.BACKUP_PATH, "backup.osp")
 
         # Load recovery project
         if os.path.exists(recovery_path):
-            log.info("Recovering backup file: %s" % recovery_path)
+            log.info("Recovering backup file: {}".format(recovery_path))
             self.open_project(recovery_path, clear_thumbnails=False)
 
             # Clear the file_path (which is set by saving the project)
@@ -235,7 +233,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 last_log_line = ""
 
             # Throw exception (with last libopenshot line... if found)
-            log.error("Unhandled crash detected... will attempt to recover backup project: %s" % info.BACKUP_PATH)
+            log.error("Unhandled crash detected... will attempt to recover backup project: {}".format(info.BACKUP_PATH))
             track_metric_error("unhandled-crash%s" % last_log_line, True)
 
             # Remove file
@@ -315,10 +313,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         win = AnimatedTitle()
         # Run the dialog event loop - blocking interaction on this window during that time
         result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('animated title add confirmed')
-        else:
-            log.info('animated title add cancelled')
 
     def actionAnimation_trigger(self, event):
         # show dialog
@@ -326,10 +320,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         win = Animation()
         # Run the dialog event loop - blocking interaction on this window during that time
         result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('animation confirmed')
-        else:
-            log.info('animation cancelled')
 
     def actionTitle_trigger(self, event):
         # show dialog
@@ -337,10 +327,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         win = TitleEditor()
         # Run the dialog event loop - blocking interaction on this window during that time
         result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('title editor add confirmed')
-        else:
-            log.info('title editor add cancelled')
 
     def actionEditTitle_trigger(self, event):
 
@@ -384,16 +370,12 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         win = ImportImageSeq()
         # Run the dialog event loop - blocking interaction on this window during that time
         result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('Import image sequence add confirmed')
-        else:
-            log.info('Import image sequence add cancelled')
 
     def actionClearHistory_trigger(self, event):
         """Clear history for current project"""
         app = get_app()
         app.updates.reset()
-        log.info('History cleared')
+        log.info('History cleared.')
 
     def save_project(self, file_path):
         """ Save a project to a file path, and refresh the screen """
@@ -417,7 +399,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             log.info("Saved project {}".format(file_path))
 
         except Exception as ex:
-            log.error("Couldn't save project %s. %s" % (file_path, str(ex)))
+            log.error("Failed to save project {}: {}".format(file_path, str(ex)))
             QMessageBox.warning(self, _("Error Saving Project"), str(ex))
 
     def open_project(self, file_path, clear_thumbnails=True):
@@ -457,7 +439,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 log.info("Loaded project {}".format(file_path))
 
         except Exception as ex:
-            log.error("Couldn't open project {}".format(file_path))
+            log.error("Couldn't open project {}: {}".format(file_path, str(ex)))
             QMessageBox.warning(self, _("Error Opening Project"), str(ex))
 
         # Restore normal cursor
@@ -465,9 +447,10 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     def clear_all_thumbnails(self):
         """Clear all user thumbnails"""
+        log.info("Clearing OpenShot working file spaces")
         try:
             if os.path.exists(info.THUMBNAIL_PATH):
-                log.info("Clear all thumbnails: %s" % info.THUMBNAIL_PATH)
+                log.debug("Clear all thumbnails: %s" % info.THUMBNAIL_PATH)
                 # Remove thumbnail folder
                 shutil.rmtree(info.THUMBNAIL_PATH)
                 # Create thumbnail folder
@@ -475,7 +458,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
             # Clear any blender animations
             if os.path.exists(info.BLENDER_PATH):
-                log.info("Clear all animations: %s" % info.BLENDER_PATH)
+                log.debug("Clear all animations: %s" % info.BLENDER_PATH)
                 # Remove blender folder
                 shutil.rmtree(info.BLENDER_PATH)
                 # Create blender folder
@@ -483,7 +466,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
             # Clear any assets folder
             if os.path.exists(info.ASSETS_PATH):
-                log.info("Clear all assets: %s" % info.ASSETS_PATH)
+                log.debug("Clear all assets: %s" % info.ASSETS_PATH)
                 # Remove assets folder
                 shutil.rmtree(info.ASSETS_PATH)
                 # Create assets folder
@@ -491,13 +474,13 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
             # Clear any backups
             if os.path.exists(info.BACKUP_PATH):
-                log.info("Clear all backups: %s" % info.BACKUP_PATH)
+                log.debug("Clear all backups: %s" % info.BACKUP_PATH)
                 # Remove backup folder
                 shutil.rmtree(info.BACKUP_PATH)
                 # Create backup folder
                 os.mkdir(info.BACKUP_PATH)
-        except:
-            log.info("Failed to clear thumbnails: %s" % info.THUMBNAIL_PATH)
+        except Exception as ex:
+            log.error("Failed to clear working file space: {}".format(str(ex)))
 
     def actionOpen_trigger(self, event):
         app = get_app()
@@ -542,7 +525,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     def auto_save_project(self):
         """Auto save the project"""
-        log.info("auto_save_project")
 
         # Get current filepath (if any)
         file_path = get_app().project.current_filepath
@@ -554,13 +536,13 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                     file_path = "%s.osp" % file_path
 
                 # Save project
-                log.info("Auto save project file: %s" % file_path)
+                log.info("Autosaving project file: {}".format(file_path))
                 self.save_project(file_path)
 
             else:
                 # No saved project found
                 recovery_path = os.path.join(info.BACKUP_PATH, "backup.osp")
-                log.info("Creating backup of project file: %s" % recovery_path)
+                log.info("Saving project recovery file: {}".format(recovery_path))
                 get_app().project.save(recovery_path, move_temp_files=False, make_paths_relative=False)
 
                 # Clear the file_path (which is set by saving the project)
@@ -614,10 +596,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         win = AddToTimeline(files, pos)
         # Run the dialog event loop - blocking interaction on this window during this time
         result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('confirmed')
-        else:
-            log.info('canceled')
 
     def actionUploadVideo_trigger(self, event):
         # show window
@@ -625,10 +603,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         win = UploadVideo()
         # Run the dialog event loop - blocking interaction on this window during this time
         result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('Upload Video add confirmed')
-        else:
-            log.info('Upload Video add cancelled')
 
     def actionExportVideo_trigger(self, event):
         # show window
@@ -636,13 +610,8 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         win = Export()
         # Run the dialog event loop - blocking interaction on this window during this time
         result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('Export Video add confirmed')
-        else:
-            log.info('Export Video add cancelled')
 
     def actionUndo_trigger(self, event):
-        log.info('actionUndo_trigger')
         app = get_app()
         app.updates.undo()
 
@@ -650,7 +619,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.refreshFrameSignal.emit()
 
     def actionRedo_trigger(self, event):
-        log.info('actionRedo_trigger')
         app = get_app()
         app.updates.redo()
 
@@ -668,10 +636,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         win = Preferences()
         # Run the dialog event loop - blocking interaction on this window during this time
         result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('Preferences add confirmed')
-        else:
-            log.info('Preferences add cancelled')
 
         # Save settings
         s = settings.get_settings()
@@ -698,7 +662,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
     def actionHelpContents_trigger(self, event):
         try:
             webbrowser.open("http://%s.openshot.org/files/user-guide/?app-menu" % info.website_language())
-            log.info("Help Contents is open")
+            log.debug("Help Contents is open")
         except:
             QMessageBox.information(self, "Error !", "Unable to open the Help Contents. Please ensure the openshot-doc package is installed.")
             log.info("Unable to open the Help Contents")
@@ -709,15 +673,11 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         win = About()
         # Run the dialog event loop - blocking interaction on this window during this time
         result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('About Openshot add confirmed')
-        else:
-            log.info('About Openshot add cancelled')
 
     def actionReportBug_trigger(self, event):
         try:
             webbrowser.open("https://github.com/OpenShot/openshot-qt/issues/?app-menu-bug")
-            log.info("Open the Bug Report GitHub Issues web page with success")
+            log.debug("Open the Bug Report GitHub Issues web page with success")
         except:
             QMessageBox.information(self, "Error !", "Unable to open the Bug Report GitHub Issues web page")
             log.info("Unable to open the Bug Report GitHub Issues web page")
@@ -725,7 +685,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
     def actionAskQuestion_trigger(self, event):
         try:
             webbrowser.open("https://github.com/OpenShot/openshot-qt/issues/?app-menu-question")
-            log.info("Open the Questions GitHub Issues web page with success")
+            log.debug("Open the Questions GitHub Issues web page with success")
         except:
             QMessageBox.information(self, "Error !", "Unable to open the Questions GitHub Issues web page")
             log.info("Unable to open the Questions GitHub Issues web page")
@@ -733,7 +693,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
     def actionTranslate_trigger(self, event):
         try:
             webbrowser.open("https://translations.launchpad.net/openshot/2.0")
-            log.info("Open the Translate launchpad web page with success")
+            log.debug("Open the Translate launchpad web page with success")
         except:
             QMessageBox.information(self, "Error !", "Unable to open the Translation web page")
             log.info("Unable to open the Translation web page")
@@ -741,7 +701,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
     def actionDonate_trigger(self, event):
         try:
             webbrowser.open("http://%s.openshot.org/donate/?app-menu" % info.website_language())
-            log.info("Open the Donate web page with success")
+            log.debug("Open the Donate web page with success")
         except:
             QMessageBox.information(self, "Error !", "Unable to open the Donate web page")
             log.info("Unable to open the Donate web page")
@@ -749,7 +709,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
     def actionUpdate_trigger(self, event):
         try:
             webbrowser.open("http://%s.openshot.org/download/?app-toolbar" % info.website_language())
-            log.info("Open the Download web page with success")
+            log.debug("Open the Download web page with success")
         except:
             QMessageBox.information(self, "Error !", "Unable to open the Download web page")
             log.info("Unable to open the Download web page")
@@ -784,7 +744,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     def actionPreview_File_trigger(self, event):
         """ Preview the selected media file """
-        log.info('actionPreview_File_trigger')
 
         # Loop through selected files (set 1 selected file if more than 1)
         f = None
@@ -794,7 +753,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # Bail out if no file selected
         if not f:
-            log.info(self.selected_files)
+            log.info("Preview failed, no file selected: {}".format(self.selected_files))
             return
 
         # show dialog
@@ -846,13 +805,11 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             self.actionPlay.trigger()
 
     def actionJumpStart_trigger(self, event):
-        log.info("actionJumpStart_trigger")
 
         # Seek to the 1st frame
         self.SeekSignal.emit(1)
 
     def actionJumpEnd_trigger(self, event):
-        log.info("actionJumpEnd_trigger")
 
         # Determine max frame (based on clips)
         timeline_length = 0.0
@@ -871,7 +828,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.SeekSignal.emit(timeline_length_int)
 
     def actionSaveFrame_trigger(self, event):
-        log.info("actionSaveFrame_trigger")
 
         # Translate object
         _ = get_app()._tr
@@ -890,7 +846,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             recommended_path = get_app().project.get(["export_path"])
 
         framePath = _("%s/Frame-%05d.png" % (recommended_path, self.preview_thread.current_frame))
-        #log.info("Saving frame to %" % framePath)
 
         # Ask user to confirm or update framePath
         framePath, file_type = QFileDialog.getSaveFileName(self, _("Save Frame..."), framePath, _("Image files (*.png)"))
@@ -905,7 +860,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             return
 
         get_app().updates.update(["export_path"], os.path.dirname(framePath))
-        log.info(_("Saving frame to %s" % framePath ))
+        log.debug("Saving frame to {}".format(framePath))
 
         # Pause playback (to prevent crash since we are fixing to change the timeline's max size)
         get_app().window.actionPlay_trigger(None, force="pause")
@@ -928,9 +883,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 	# Get and Save the frame (return is void, so we cannot check for success/fail here - must use file modification timestamp)
         openshot.Timeline.GetFrame(self.timeline_sync.timeline,self.preview_thread.current_frame).Save(framePath, 1.0)
 
-        #log.info("orig framePathTime %s" % framePathTime.toString("yyMMdd hh:mm:ss.zzz") )
-        #log.info("new framePathTime %s" % QFileInfo(framePath).lastModified().toString("yyMMdd hh:mm:ss.zzz") )
-
 	# Show message to user
         if os.path.exists(framePath) and (QFileInfo(framePath).lastModified() > framePathTime): 
             #QMessageBox.information(self, _("Save Frame Successful"), _("Saved image to %s" % framePath))
@@ -949,7 +901,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         new_cache_object = None
 
     def actionAddTrack_trigger(self, event):
-        log.info("actionAddTrack_trigger")
 
         # Get # of tracks
         track_number = len(get_app().project.get(["layers"]))
@@ -960,7 +911,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         track.save()
 
     def actionAddTrackAbove_trigger(self, event):
-        log.info("actionAddTrackAbove_trigger")
 
         # Get # of tracks
         max_track_number = len(get_app().project.get(["layers"]))
@@ -970,23 +920,23 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         existing_track = Track.get(id=selected_layer_id)
         selected_layer_number = int(existing_track.data["number"])
 
-        # log.info("Adding track above #{} (id {})".format(selected_layer_number, selected_layer_id))
+        # log.debug("Adding track above #{} (id {})".format(selected_layer_number, selected_layer_id))
 
         # Loop through tracks above insert point (in descending order), renumbering layers
         for existing_layer in list(reversed(range(selected_layer_number+1, max_track_number))):
             existing_track = Track.get(number=existing_layer)
-            # log.info("Renumbering track id {} from {} to {}".format(existing_track.data["id"], existing_layer, existing_layer+1))
+            # log.debug("Renumbering track id {} from {} to {}".format(existing_track.data["id"], existing_layer, existing_layer+1))
             existing_track.data["number"] = existing_layer + 1
             existing_track.save()
 
             # Loop through clips and transitions for track, moving up to new layer
             for clip in Clip.filter(layer=existing_layer):
-                # log.info("Moving clip id {} from layer {} to {}".format(clip.data["id"], int(clip.data["layer"]), int(clip.data["layer"])+1))
+                # log.debug("Moving clip id {} from layer {} to {}".format(clip.data["id"], int(clip.data["layer"]), int(clip.data["layer"])+1))
                 clip.data["layer"] = int(clip.data["layer"]) + 1
                 clip.save()
 
             for trans in Transition.filter(layer=existing_layer):
-                # log.info("Moving transition id {} from layer {} to {}".format(trans.data["id"], int(trans.data["layer"]), int(trans.data["layer"])+1))
+                # log.debug("Moving transition id {} from layer {} to {}".format(trans.data["id"], int(trans.data["layer"]), int(trans.data["layer"])+1))
                 trans.data["layer"] = int(trans.data["layer"]) + 1
                 trans.save()
 
@@ -994,10 +944,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         track = Track()
         track.data = {"number": selected_layer_number+1, "y": 0, "label": "", "lock": False}
         track.save()
-        # log.info("Created new track id {} at layer number {}".format(track.data["id"], track.data["number"]))
+        # log.debug("Created new track id {} at layer number {}".format(track.data["id"], track.data["number"]))
 
     def actionAddTrackBelow_trigger(self, event):
-        log.info("actionAddTrackBelow_trigger")
 
         # Get # of tracks
         max_track_number = len(get_app().project.get(["layers"]))
@@ -1007,23 +956,23 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         existing_track = Track.get(id=selected_layer_id)
         selected_layer_number = int(existing_track.data["number"])
 
-        # log.info("Adding track below #{} (id {})".format(selected_layer_number, selected_layer_id))
+        # log.debug("Adding track below #{} (id {})".format(selected_layer_number, selected_layer_id))
 
         # Loop through tracks from insert point up (in descending order), renumbering layers
         for existing_layer in list(reversed(range(selected_layer_number, max_track_number))):
             existing_track = Track.get(number=existing_layer)
-            # log.info("Renumbering track id {} from {} to {}".format(existing_track.data["id"], existing_layer, existing_layer+1))
+            # log.debug("Renumbering track id {} from {} to {}".format(existing_track.data["id"], existing_layer, existing_layer+1))
             existing_track.data["number"] = existing_layer + 1
             existing_track.save()
 
             # Loop through clips and transitions for track, moving up to new layer
             for clip in Clip.filter(layer=existing_layer):
-                # log.info("Moving clip id {} from layer {} to {}".format(clip.data["id"], int(clip.data["layer"]), int(clip.data["layer"])+1))
+                # log.debug("Moving clip id {} from layer {} to {}".format(clip.data["id"], int(clip.data["layer"]), int(clip.data["layer"])+1))
                 clip.data["layer"] = int(clip.data["layer"]) + 1
                 clip.save()
 
             for trans in Transition.filter(layer=existing_layer):
-                # log.info("Moving transition id {} from layer {} to {}".format(trans.data["id"], int(trans.data["layer"]), int(trans.data["layer"])+1))
+                # log.debug("Moving transition id {} from layer {} to {}".format(trans.data["id"], int(trans.data["layer"]), int(trans.data["layer"])+1))
                 trans.data["layer"] = int(trans.data["layer"]) + 1
                 trans.save()
 
@@ -1031,27 +980,22 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         track = Track()
         track.data = {"number": selected_layer_number, "y": 0, "label": "", "lock": False}
         track.save()
-        # log.info("Created new track id {} at layer number {}".format(track.data["id"], track.data["number"]))
+        # log.debug("Created new track id {} at layer number {}".format(track.data["id"], track.data["number"]))
 
     def actionArrowTool_trigger(self, event):
-        log.info("actionArrowTool_trigger")
+        return
 
     def actionSnappingTool_trigger(self, event):
-        log.info("actionSnappingTool_trigger")
-        log.info(self.actionSnappingTool.isChecked())
-
         # Enable / Disable snapping mode
         self.timeline.SetSnappingMode(self.actionSnappingTool.isChecked())
 
     def actionRazorTool_trigger(self, event):
         """Toggle razor tool on and off"""
-        log.info('actionRazorTool_trigger')
 
         # Enable / Disable razor mode
         self.timeline.SetRazorMode(self.actionRazorTool.isChecked())
 
     def actionAddMarker_trigger(self, event):
-        log.info("actionAddMarker_trigger")
 
         # Get player object
         player = self.preview_thread.player
@@ -1069,7 +1013,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         marker.save()
 
     def actionPreviousMarker_trigger(self, event):
-        log.info("actionPreviousMarker_trigger")
 
         # Calculate current position (in seconds)
         fps = get_app().project.get(["fps"])
@@ -1121,7 +1064,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             get_app().window.propertyTableView.select_frame(frame_to_seek)
 
     def actionNextMarker_trigger(self, event):
-        log.info("actionNextMarker_trigger")
         log.info(self.preview_thread.current_frame)
 
         # Calculate current position (in seconds)
@@ -1203,7 +1145,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             return
 
         # Debug
-        log.info("keyPressEvent: %s" % (key.toString()))
+        log.debug("keyPressEvent: %s" % (key.toString()))
 
         # Get the video player object
         player = self.preview_thread.player
@@ -1387,12 +1329,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         win = Profile()
         # Run the dialog event loop - blocking interaction on this window during this time
         result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('Profile add confirmed')
 
 
     def actionSplitClip_trigger(self, event):
-        log.info("actionSplitClip_trigger")
 
         # Loop through selected files (set 1 selected file if more than 1)
         f = None
@@ -1402,7 +1341,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # Bail out if no file selected
         if not f:
-            log.info(self.selected_files)
+            log.info("Split failed, no file selected: {}".format(self.selected_files))
             return
 
         # show dialog
@@ -1410,13 +1349,8 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         win = Cutting(f)
         # Run the dialog event loop - blocking interaction on this window during that time
         result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('Cutting Finished')
-        else:
-            log.info('Cutting Cancelled')
 
     def actionRemove_from_Project_trigger(self, event):
-        log.info("actionRemove_from_Project_trigger")
 
         # Loop through selected files
         for file_id in self.selected_files:
@@ -1436,7 +1370,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.selected_files = []
 
     def actionRemoveClip_trigger(self, event):
-        log.info('actionRemoveClip_trigger')
 
         # Loop through selected clips
         for clip_id in deepcopy(self.selected_clips):
@@ -1450,25 +1383,22 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 c.delete()
 
     def actionProperties_trigger(self, event):
-        log.info('actionProperties_trigger')
 
         # Show properties dock
         if not self.dockProperties.isVisible():
             self.dockProperties.show()
 
     def actionRemoveEffect_trigger(self, event):
-        log.info('actionRemoveEffect_trigger')
 
         # Loop through selected clips
         for effect_id in deepcopy(self.selected_effects):
-            log.info("effect id: %s" % effect_id)
 
             # Find matching file
             clips = Clip.filter()
             found_effect = None
             for c in clips:
                 found_effect = False
-                log.info("c.data[effects]: %s" % c.data["effects"])
+                log.debug("Clip[{}].effects: {}".format(c.data["id"], c.data["effects"]))
 
                 for effect in c.data["effects"]:
                     if effect["id"] == effect_id:
@@ -1476,6 +1406,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                         break
 
                 if found_effect:
+                    log.info("Clip[{}]: Removing Effect[{}]".format(c.data["id"], found_effect["id"]))
                     # Remove found effect from clip data and save clip
                     c.data["effects"].remove(found_effect)
 
@@ -1489,7 +1420,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                     self.removeSelection(effect_id, "effect")
 
     def actionRemoveTransition_trigger(self, event):
-        log.info('actionRemoveTransition_trigger')
 
         # Loop through selected clips
         for tran_id in deepcopy(self.selected_transitions):
@@ -1503,7 +1433,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 t.delete()
 
     def actionRemoveTrack_trigger(self, event):
-        log.info('actionRemoveTrack_trigger')
 
         # Get translation function
         _ = get_app()._tr
@@ -1553,7 +1482,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     def actionLockTrack_trigger(self, event):
         """Callback for locking a track"""
-        log.info('actionLockTrack_trigger')
 
         # Get details of track
         track_id = self.selected_tracks[0]
@@ -1565,7 +1493,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     def actionUnlockTrack_trigger(self, event):
         """Callback for unlocking a track"""
-        log.info('actionUnlockTrack_trigger')
 
         # Get details of track
         track_id = self.selected_tracks[0]
@@ -1577,7 +1504,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     def actionRenameTrack_trigger(self, event):
         """Callback for renaming track"""
-        log.info('actionRenameTrack_trigger')
 
         # Get translation function
         _ = get_app()._tr
@@ -1594,7 +1520,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             selected_track.save()
 
     def actionRemoveMarker_trigger(self, event):
-        log.info('actionRemoveMarker_trigger')
 
         for marker_id in self.selected_markers:
             marker = Marker.filter(id=marker_id)
@@ -1616,7 +1541,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             self.showNormal()
 
     def actionFile_Properties_trigger(self, event):
-        log.info("Show file properties")
 
         # Loop through selected files (set 1 selected file if more than 1)
         f = None
@@ -1629,13 +1553,8 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         win = FileProperties(f)
         # Run the dialog event loop - blocking interaction on this window during that time
         result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('File Properties Finished')
-        else:
-            log.info('File Properties Cancelled')
 
     def actionDetailsView_trigger(self, event):
-        log.info("Switch to Details View")
 
         # Get settings
         app = get_app()
@@ -1673,7 +1592,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             self.tabEffects.layout().addWidget(self.effectsTreeView)
 
     def actionThumbnailView_trigger(self, event):
-        log.info("Switch to Thumbnail View")
 
         # Get settings
         app = get_app()
@@ -1851,14 +1769,13 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     # Update undo and redo buttons enabled/disabled to available changes
     def updateStatusChanged(self, undo_status, redo_status):
-        log.info('updateStatusChanged')
         self.actionUndo.setEnabled(undo_status)
         self.actionRedo.setEnabled(redo_status)
         self.SetWindowTitle()
 
     # Add to the selected items
     def addSelection(self, item_id, item_type, clear_existing=False):
-        log.info('main::addSelection: item_id: %s, item_type: %s, clear_existing: %s' % (item_id, item_type, clear_existing))
+        log.debug('main::addSelection: {}[{}], clear_existing: {}' % (item_type.capitalize(), item_id, clear_existing))
 
         # Clear existing selection (if needed)
         if clear_existing:
@@ -2107,7 +2024,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     def foundCurrentVersion(self, version):
         """Handle the callback for detecting the current version on openshot.org"""
-        log.info('foundCurrentVersion: Found the latest version: %s' % version)
         _ = get_app()._tr
 
         # Compare versions (alphabetical compare of version strings should work fine)
@@ -2167,9 +2083,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         """Set the correct cache settings for the timeline"""
         # Load user settings
         s = settings.get_settings()
-        log.info("InitCacheSettings")
-        log.info("cache-mode: %s" % s.get("cache-mode"))
-        log.info("cache-limit-mb: %s" % s.get("cache-limit-mb"))
+        log.info("Cache initialized: mode: {}, limit-mb: {}".format(s.get("cache-mode"), s.get("cache-limit-mb")))
 
         # Get MB limit of cache (and convert to bytes)
         cache_limit = s.get("cache-limit-mb") * 1024 * 1024 # Convert MB to Bytes
@@ -2178,13 +2092,13 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         new_cache_object = None
         if s.get("cache-mode") == "CacheMemory":
             # Create CacheMemory object, and set on timeline
-            log.info("Creating CacheMemory object with %s byte limit" % cache_limit)
+            log.debug("Creating CacheMemory object with {} byte limit".format(cache_limit))
             new_cache_object = openshot.CacheMemory(cache_limit)
             self.timeline_sync.timeline.SetCache(new_cache_object)
 
         elif s.get("cache-mode") == "CacheDisk":
             # Create CacheDisk object, and set on timeline
-            log.info("Creating CacheDisk object with %s byte limit at %s" % (cache_limit, info.PREVIEW_CACHE_PATH))
+            log.debug("Creating CacheDisk object with {} byte limit at {}".format(cache_limit, info.PREVIEW_CACHE_PATH))
             image_format = s.get("cache-image-format")
             image_quality = s.get("cache-quality")
             image_scale = s.get("cache-scale")

--- a/src/windows/models/add_to_timeline_model.py
+++ b/src/windows/models/add_to_timeline_model.py
@@ -37,7 +37,6 @@ from classes.app import get_app
 
 class TimelineModel():
     def update_model(self, files=[], clear=True):
-        log.info("updating timeline model.")
         app = get_app()
 
         # Get window to check filters
@@ -46,7 +45,7 @@ class TimelineModel():
 
         # Set files list (if found)
         if files:
-            log.info('set files to %s' % files)
+            log.debug('Adding to timeline: {}'.format(files))
             self.files = files
 
         # Clear all items
@@ -55,8 +54,6 @@ class TimelineModel():
 
         # Add Headers
         self.model.setHorizontalHeaderLabels([_("Thumb"), _("Name")])
-
-        log.info(self.files)
 
         for file in self.files:
             # Get attributes from file

--- a/src/windows/models/blender_model.py
+++ b/src/windows/models/blender_model.py
@@ -40,7 +40,6 @@ from classes.app import get_app
 
 class BlenderModel():
     def update_model(self, clear=True):
-        log.info("updating effects model.")
         app = get_app()
 
         # Get window to check filters

--- a/src/windows/models/credits_model.py
+++ b/src/windows/models/credits_model.py
@@ -54,7 +54,6 @@ class CreditsModel():
     developer_icon = QIcon(os.path.join(info.IMAGES_PATH, "python-icon.png"))
 
     def update_model(self, filter=None, clear=True):
-        log.info("updating credits model.")
         app = get_app()
         _ = app._tr
 
@@ -63,7 +62,6 @@ class CreditsModel():
 
         # Clear all items
         if clear:
-            log.info('cleared credits model')
             self.model.clear()
 
         # Add Headers

--- a/src/windows/models/effects_model.py
+++ b/src/windows/models/effects_model.py
@@ -64,7 +64,6 @@ class EffectsStandardItemModel(QStandardItemModel):
 
 class EffectsModel():
     def update_model(self, clear=True):
-        log.info("updating effects model.")
         app = get_app()
 
         # Get window to check filters

--- a/src/windows/models/effects_model.py
+++ b/src/windows/models/effects_model.py
@@ -105,8 +105,6 @@ class EffectsModel():
             elif effect_info["has_video"] and not effect_info["has_audio"]:
                 category = "Video"
 
-            log.info("category: %s" % category)
-
             # Filter out effect (if needed)
             if win.effectsFilter.text() != "":
                 if not win.effectsFilter.text().lower() in self.app._tr(title).lower() and not win.effectsFilter.text().lower() in self.app._tr(description).lower():

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -83,7 +83,6 @@ class FilesModel(updates.UpdateInterface):
                 self.update_model(clear=True)
 
     def update_model(self, clear=True):
-        log.info("updating files model.")
         app = get_app()
 
         # Get window to check filters

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -188,8 +188,7 @@ class PropertiesModel(updates.UpdateInterface):
             if self.frame_number > max_frame_number:
                 self.frame_number = max_frame_number
 
-            log.debug("{}[{}] update frame to {}".format(
-                     item_type.capitalize(), clip_id, self.frame_number))
+            log.debug("Update frame to {}".format(self.frame_number))
 
             # Update the model data
             if reload_model:

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -68,7 +68,7 @@ class PropertiesModel(updates.UpdateInterface):
 
         # Handle change
         if action.key and action.key[0] in ["clips", "effects"] and action.type in ["update", "insert"]:
-            log.info(action.values)
+            log.debug(action.values)
             # Update the model data
             self.update_model(get_app().window.txtPropertyFilter.text())
 
@@ -90,8 +90,6 @@ class PropertiesModel(updates.UpdateInterface):
         # Clear previous selection
         self.selected = []
         self.filter_base_properties = []
-
-        log.info("Update item: %s" % item_type)
 
         if item_type == "clip":
             c = None
@@ -190,7 +188,8 @@ class PropertiesModel(updates.UpdateInterface):
             if self.frame_number > max_frame_number:
                 self.frame_number = max_frame_number
 
-            log.info("Update frame to %s" % self.frame_number)
+            log.debug("{}[{}] update frame to {}".format(
+                     item_type.capitalize(), clip_id, self.frame_number))
 
             # Update the model data
             if reload_model:
@@ -225,7 +224,8 @@ class PropertiesModel(updates.UpdateInterface):
         if c:
             # Update clip attribute
             if property_key in c.data:
-                log.info("remove keyframe: %s" % c.data)
+                log.debug("{}[{}] remove keyframe: {}".format(
+                          item_type.capitalize(), clip_id, c.data))
 
                 # Determine type of keyframe (normal or color)
                 keyframe_list = []
@@ -257,7 +257,8 @@ class PropertiesModel(updates.UpdateInterface):
                     # Delete point (if needed)
                     if point_to_delete:
                         clip_updated = True
-                        log.info("Found point to delete at X=%s" % point_to_delete["co"]["X"])
+                        log.debug("{}[{}] found point to delete at X={}".format(
+                                  item_type.capitalize(), clip_id, point_to_delete["co"]["X"]))
                         keyframe["Points"].remove(point_to_delete)
 
                 # Reduce # of clip properties we are saving (performance boost)
@@ -303,7 +304,7 @@ class PropertiesModel(updates.UpdateInterface):
             if c:
                 # Update clip attribute
                 if property_key in c.data:
-                    log.info("color update: %s" % c.data)
+                    log.debug("{}[{}] color update: {}".format(item_type.capitalize(), clip_id, c.data))
 
                     # Loop through each keyframe (red, blue, and green)
                     for color, new_value in [("red", new_color.red()), ("blue", new_color.blue()),  ("green", new_color.green())]:
@@ -312,14 +313,14 @@ class PropertiesModel(updates.UpdateInterface):
                         # Loop through points, find a matching points on this frame
                         found_point = False
                         for point in c.data[property_key][color]["Points"]:
-                            log.info("looping points: co.X = %s" % point["co"]["X"])
                             if interpolation == -1 and point["co"]["X"] == self.frame_number:
                                 # Found point, Update value
                                 found_point = True
                                 clip_updated = True
                                 # Update point
                                 point["co"]["Y"] = new_value
-                                log.info("updating point: co.X = %s to value: %s" % (point["co"]["X"], float(new_value)))
+                                log.debug("{}[{}].frame[{}] new color value: {}".format(
+                                          item_type.capitalize(), clip_id, point["co"]["X"], float(new_value)))
                                 break
 
                             elif interpolation > -1 and point["co"]["X"] == previous_point_x:
@@ -332,8 +333,9 @@ class PropertiesModel(updates.UpdateInterface):
                                     point["handle_right"]["X"] = interpolation_details[0]
                                     point["handle_right"]["Y"] = interpolation_details[1]
 
-                                log.info("updating interpolation mode point: co.X = %s to %s" % (point["co"]["X"], interpolation))
-                                log.info("use interpolation preset: %s" % str(interpolation_details))
+                                log.debug("{}[{}].frame[{}] update color interpolation: {} (preset {})".format(
+                                          item_type.capitalize(), clip_id, point["co"]["X"], interpolation,
+                                          str(interpolation_details)))
 
                             elif interpolation > -1 and point["co"]["X"] == closest_point_x:
                                 # Only update interpolation type (and the RIGHT side of the curve)
@@ -345,13 +347,15 @@ class PropertiesModel(updates.UpdateInterface):
                                     point["handle_left"]["X"] = interpolation_details[2]
                                     point["handle_left"]["Y"] = interpolation_details[3]
 
-                                log.info("updating interpolation mode point: co.X = %s to %s" % (point["co"]["X"], interpolation))
-                                log.info("use interpolation preset: %s" % str(interpolation_details))
+                                log.debug("{}[{}].frame[{}] update color interpolation: {} (preset {})".format(
+                                          item_type.capitalize(), clip_id, point["co"]["X"], interpolation,
+                                          str(interpolation_details)))
 
                         # Create new point (if needed)
                         if not found_point:
                             clip_updated = True
-                            log.info("Created new point at X=%s" % self.frame_number)
+                            log.debug("{}[{}].frame[{}] color point created".format(
+                                      item_type.capitalize(), clip_id, self.frame_number))
                             c.data[property_key][color]["Points"].append({'co': {'X': self.frame_number, 'Y': new_value}, 'interpolation': 1})
 
                 # Reduce # of clip properties we are saving (performance boost)
@@ -410,7 +414,9 @@ class PropertiesModel(updates.UpdateInterface):
         else:
             new_value = None
 
-        log.info("%s for %s changed to %s at frame %s with interpolation: %s at closest x: %s" % (property_key, clip_id, new_value, self.frame_number, interpolation, closest_point_x))
+        log.debug("{}[{}].frame[{}]: set {} = {} with interpolation: {} at nearest x: {}".format(
+                  item_type.capitalize(), clip_id, self.frame_number, property_key, new_value,
+                  interpolation, closest_point_x))
 
 
         # Find this clip
@@ -430,7 +436,7 @@ class PropertiesModel(updates.UpdateInterface):
         if c:
             # Update clip attribute
             if property_key in c.data:
-                log.info("value updated: %s" % c.data)
+                log.debug("{}[{}]: value update: {}".format(item_type.capitalize(), clip_id, c.data))
 
                 # Check the type of property (some are keyframe, and some are not)
                 if type(c.data[property_key]) == dict:
@@ -439,7 +445,6 @@ class PropertiesModel(updates.UpdateInterface):
                     found_point = False
                     point_to_delete = None
                     for point in c.data[property_key]["Points"]:
-                        log.info("looping points: co.X = %s" % point["co"]["X"])
                         if interpolation == -1 and point["co"]["X"] == self.frame_number:
                             # Found point, Update value
                             found_point = True
@@ -447,7 +452,8 @@ class PropertiesModel(updates.UpdateInterface):
                             # Update or delete point
                             if new_value != None:
                                 point["co"]["Y"] = float(new_value)
-                                log.info("updating point: co.X = %s to value: %s" % (point["co"]["X"], float(new_value)))
+                                log.debug("{}[{}].frame[{}] new point value: {}".format(
+                                          item_type.capitalize(), clip_id, point["co"]["X"], float(new_value)))
                             else:
                                 point_to_delete = point
                             break
@@ -462,8 +468,9 @@ class PropertiesModel(updates.UpdateInterface):
                                 point["handle_right"]["X"] = interpolation_details[0]
                                 point["handle_right"]["Y"] = interpolation_details[1]
 
-                            log.info("updating interpolation mode point: co.X = %s to %s" % (point["co"]["X"], interpolation))
-                            log.info("use interpolation preset: %s" % str(interpolation_details))
+                            log.debug("{}[{}].frame[{}] update value interpolation: {} (preset {})".format(
+                                      item_type.capitalize(), clip_id, point["co"]["X"], interpolation,
+                                      str(interpolation_details)))
 
                         elif interpolation > -1 and point["co"]["X"] == closest_point_x:
                             # Only update interpolation type (and the RIGHT side of the curve)
@@ -475,19 +482,23 @@ class PropertiesModel(updates.UpdateInterface):
                                 point["handle_left"]["X"] = interpolation_details[2]
                                 point["handle_left"]["Y"] = interpolation_details[3]
 
-                            log.info("updating interpolation mode point: co.X = %s to %s" % (point["co"]["X"], interpolation))
-                            log.info("use interpolation preset: %s" % str(interpolation_details))
+                            log.debug("{}[{}].frame[{}] update value interpolation: {} (preset {})".format(
+                                      item_type.capitalize(), clip_id, point["co"]["X"], interpolation,
+                                      str(interpolation_details)))
+
 
                     # Delete point (if needed)
                     if point_to_delete:
                         clip_updated = True
-                        log.info("Found point to delete at X=%s" % point_to_delete["co"]["X"])
+                        log.debug("{}[{}].frame[{}] found point to delete".format(
+                                  item_type.capitalize(), clip_id, point_to_delete["co"]["X"]))
                         c.data[property_key]["Points"].remove(point_to_delete)
 
                     # Create new point (if needed)
                     elif not found_point and new_value != None:
                         clip_updated = True
-                        log.info("Created new point at X=%s" % self.frame_number)
+                        log.debug("{}[{}].frame[{}] value point created".format(
+                                  item_type.capitalize(), clip_id, self.frame_number))
                         c.data[property_key]["Points"].append({'co': {'X': self.frame_number, 'Y': new_value}, 'interpolation': 1})
 
             if not clip_updated:
@@ -528,7 +539,6 @@ class PropertiesModel(updates.UpdateInterface):
             self.parent.clearSelection()
 
     def update_model(self, filter=""):
-        log.info("updating clip properties model.")
         app = get_app()
         _ = app._tr
 
@@ -547,7 +557,8 @@ class PropertiesModel(updates.UpdateInterface):
             # Get raw unordered JSON properties
             raw_properties = json.loads(c.PropertiesJSON(self.frame_number))
             all_properties = OrderedDict(sorted(raw_properties.items(), key=lambda x: x[1]['name']))
-            log.info("Getting properties for frame %s: %s" % (self.frame_number, str(all_properties)))
+            log.debug("Getting {} properties for frame {}: {}".format(
+                      item_type.capitalize(), self.frame_number, str(all_properties)))
 
             # Check if filter was changed (if so, wipe previous model data)
             if self.previous_filter != filter:

--- a/src/windows/models/titles_model.py
+++ b/src/windows/models/titles_model.py
@@ -65,7 +65,6 @@ class TitleStandardItemModel(QStandardItemModel):
 
 class TitlesModel():
     def update_model(self, clear=True):
-        log.info("updating title model.")
         app = get_app()
 
         # Get window to check filters

--- a/src/windows/models/transition_model.py
+++ b/src/windows/models/transition_model.py
@@ -64,7 +64,6 @@ class TransitionStandardItemModel(QStandardItemModel):
 
 class TransitionsModel():
     def update_model(self, clear=True):
-        log.info("updating transitions model.")
         app = get_app()
 
         # Get window to check filters

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -38,7 +38,7 @@ from PyQt5 import uic
 from classes import info, ui_util, settings, qt_types, updates
 from classes.app import get_app
 from classes.language import get_all_languages
-from classes.logger import log
+from classes.logger import log, debug_logging
 from classes.metrics import *
 import openshot
 
@@ -266,7 +266,10 @@ class Preferences(QDialog):
             log.info("Setting debug-mode to %s" % (state == Qt.Checked))
             debug_enabled = (state == Qt.Checked)
 
-            # Enable / Disable logger
+            # Enable/disable debug logging to our logfile
+            debug_logging(debug_enabled)
+
+            # Enable / Disable libopenshot debug logger
             openshot.ZmqLogger.Instance().Enable(debug_enabled)
 
         elif param["setting"] == "enable-auto-save":

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -292,7 +292,7 @@ class Preferences(QDialog):
     def spinner_value_changed(self, param, value):
         # Save setting
         self.s.set(param["setting"], value)
-        log.info(value)
+        log.debug('{} set to {}'.format(param["setting"], value))
 
         if param["setting"] == "autosave-interval":
             # Update autosave interval (# of minutes)
@@ -317,11 +317,11 @@ class Preferences(QDialog):
         if param.get("category") == "Keyboard":
             previous_value = value
             value = QKeySequence(value).toString()
-            log.info("Parsing keyboard mapping via QKeySequence from %s to %s" % (previous_value, value))
+            log.debug("Parsing keyboard mapping via QKeySequence from %s to %s" % (previous_value, value))
 
         # Save setting
         self.s.set(param["setting"], value)
-        log.info(value)
+        log.debug('{} set to {}'.format(param["setting"], value))
 
         # Check for restart
         self.check_for_restart(param)
@@ -330,7 +330,7 @@ class Preferences(QDialog):
         # Save setting
         value = widget.itemData(index)
         self.s.set(param["setting"], value)
-        log.info(value)
+        log.debug('{} set to {}'.format(param["setting"], value))
 
         # Apply cache settings (if needed)
         if param["setting"] in ["cache-mode", "cache-image-format"]:

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -53,8 +53,6 @@ class FilesListView(QListView):
     drag_item_size = 48
 
     def updateSelection(self):
-        log.info('updateSelection')
-
         # Track selected items
         self.selected = self.selectionModel().selectedIndexes()
 
@@ -250,7 +248,6 @@ class FilesListView(QListView):
                 is_sequence = False
 
             if is_sequence and dirName not in self.ignore_image_sequence_paths:
-                log.info('Prompt user to import image sequence')
                 # Ignore this path (temporarily)
                 self.ignore_image_sequence_paths.append(dirName)
 
@@ -274,10 +271,10 @@ class FilesListView(QListView):
         self.ignore_image_sequence_paths = []
 
         for uri in event.mimeData().urls():
-            log.info('Processing drop event for {}'.format(uri))
+            log.debug('Processing drop event for {}'.format(uri))
             filepath = uri.toLocalFile()
             if os.path.exists(filepath) and os.path.isfile(filepath):
-                log.info('Adding file: {}'.format(filepath))
+                log.debug('Adding file: {}'.format(filepath))
                 if self.add_file(filepath):
                     event.accept()
 
@@ -297,7 +294,6 @@ class FilesListView(QListView):
         self.files_model.update_model()
 
     def currentChanged(self, selected, deselected):
-        log.info('currentChanged')
         self.updateSelection()
 
     def resize_contents(self):

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -249,7 +249,6 @@ class FilesTreeView(QTreeView):
                 is_sequence = False
 
             if is_sequence and dirName not in self.ignore_image_sequence_paths:
-                log.info('Prompt user to import image sequence')
                 # Ignore this path (temporarily)
                 self.ignore_image_sequence_paths.append(dirName)
 
@@ -273,10 +272,10 @@ class FilesTreeView(QTreeView):
         self.ignore_image_sequence_paths = []
 
         for uri in event.mimeData().urls():
-            log.info('Processing drop event for {}'.format(uri))
+            log.debug('Processing drop event for {}'.format(uri))
             filepath = uri.toLocalFile()
             if os.path.exists(filepath) and os.path.isfile(filepath):
-                log.info('Adding file: {}'.format(filepath))
+                log.debug('Adding file: {}'.format(filepath))
                 if self.add_file(filepath):
                     event.accept()
 
@@ -319,7 +318,6 @@ class FilesTreeView(QTreeView):
         self.header().setSectionResizeMode(2, QHeaderView.Interactive)
 
     def currentChanged(self, selected, deselected):
-        log.info('currentChanged')
         self.updateSelection()
 
     def value_updated(self, item):

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -338,10 +338,12 @@ class PropertiesTableView(QTableView):
             property_key = property[0]
             clip_id, item_type = selected_value.data()
 
-            log.info("Context menu shown for %s (%s) for clip %s on frame %s" % (
-                property_name, property_key, clip_id, frame_number))
-            log.info("Points: %s" % points)
-            log.info("Property: %s" % str(property))
+            log.debug("Clip[{}].frame[{}].{}: Show context menu for {} ({} points)".format(
+                      clip_id, frame_number, property_key, property_name, points))
+            # log.info("Context menu shown for %s (%s) for clip %s on frame %s" % (
+            #     property_name, property_key, clip_id, frame_number))
+            # log.info("Points: %s" % points)
+            log.info("Clip[{}].frame[{}].{}: {}".format(clip_id, frame_number, property_key, str(property)))
 
             # Define bezier presets
             bezier_presets = [
@@ -422,7 +424,7 @@ class PropertiesTableView(QTableView):
                 menu.popup(QCursor.pos())
 
     def Bezier_Action_Triggered(self, preset=[]):
-        log.info("Bezier_Action_Triggered: %s" % str(preset))
+        log.debug("Bezier_Action_Triggered, preset: {}".format(str(preset)))
         if self.property_type != "color":
             # Update keyframe interpolation mode
             self.clip_properties_model.value_updated(self.selected_item, interpolation=0, interpolation_details=preset)
@@ -431,7 +433,6 @@ class PropertiesTableView(QTableView):
             self.clip_properties_model.color_update(self.selected_item, QColor("#000"), interpolation=0, interpolation_details=preset)
 
     def Linear_Action_Triggered(self, event):
-        log.info("Linear_Action_Triggered")
         if self.property_type != "color":
             # Update keyframe interpolation mode
             self.clip_properties_model.value_updated(self.selected_item, interpolation=1)
@@ -440,7 +441,6 @@ class PropertiesTableView(QTableView):
             self.clip_properties_model.color_update(self.selected_item, QColor("#000"), interpolation=1, interpolation_details=[])
 
     def Constant_Action_Triggered(self, event):
-        log.info("Constant_Action_Triggered")
         if self.property_type != "color":
             # Update keyframe interpolation mode
             self.clip_properties_model.value_updated(self.selected_item, interpolation=2)
@@ -449,17 +449,14 @@ class PropertiesTableView(QTableView):
             self.clip_properties_model.color_update(self.selected_item, QColor("#000"), interpolation=2, interpolation_details=[])
 
     def Insert_Action_Triggered(self, event):
-        log.info("Insert_Action_Triggered")
         if self.selected_item:
             current_value = QLocale().system().toDouble(self.selected_item.text())[0]
             self.clip_properties_model.value_updated(self.selected_item, value=current_value)
 
     def Remove_Action_Triggered(self, event):
-        log.info("Remove_Action_Triggered")
         self.clip_properties_model.remove_keyframe(self.selected_item)
 
     def Choice_Action_Triggered(self, event):
-        log.info("Choice_Action_Triggered")
         choice_value = self.sender().data()
 
         # Update value of dropdown item
@@ -592,7 +589,7 @@ class SelectionLabel(QFrame):
         # Switch selection
         item_id = self.sender().data()['item_id']
         item_type = self.sender().data()['item_type']
-        log.info('switch selection to %s:%s' % (item_id, item_type))
+        log.debug('switch selection to {}:{}'.format(item_id, item_type))
 
         # Set the property tableview to the new item
         get_app().window.propertyTableView.loadProperties.emit(item_id, item_type)

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -2537,6 +2537,10 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
     def qt_log(self, message=None):
         log.info(message)
 
+    @pyqtSlot(str)
+    def qt_debug(self, message=None):
+        log.debug(message)
+
     # Handle changes to zoom level, update js
     def update_zoom(self, newValue):
         _ = get_app()._tr

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -169,7 +169,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         # Check if document.Ready has fired in JS
         if not self.document_is_ready:
             # Not ready, try again in a few milliseconds
-            log.error("TimelineWebView::eval_js() called before document ready event. Script queued: %s" % code)
+            log.debug("TimelineWebView::eval_js() called before document ready event. Script queued: %s" % code)
             QTimer.singleShot(50, partial(self.eval_js, code))
             return None
         else:
@@ -261,7 +261,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
         # Determine thumb path
         thumb_path = os.path.join(info.THUMBNAIL_PATH, "{}-{}.png".format(clip_data["id"], start_frame))
-        log.info('Updating thumbnail image: %s' % thumb_path)
+        log.debug('Clip[{}]: Updating thumbnail image: {}'.format(clip_data["id"], thumb_path))
 
         # Check if thumb exists
         if not os.path.exists(thumb_path):
@@ -385,8 +385,8 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
             existing_item.data["start"] = transition_data["start"]
             existing_item.data["end"] = transition_data["end"]
 
-            log.info('transition start: %s' % transition_data["start"])
-            log.info('transition end: %s' % transition_data["end"])
+            log.debug('Transition[{}]: start: {}, end: {}'.format(transition_data["id"],
+                      transition_data["start"], transition_data["end"]))
 
             if brightness:
                 existing_item.data["brightness"] = brightness
@@ -407,7 +407,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
     # Javascript callable function to show clip or transition content menus, passing in type to show
     @pyqtSlot(float)
     def ShowPlayheadMenu(self, position=None):
-        log.info('ShowPlayheadMenu: %s' % position)
+        log.debug('ShowPlayheadMenu: %s' % position)
 
         # Get translation method
         _ = get_app()._tr
@@ -438,7 +438,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     @pyqtSlot(str)
     def ShowEffectMenu(self, effect_id=None):
-        log.info('ShowEffectMenu: %s' % effect_id)
+        log.debug('ShowEffectMenu: %s' % effect_id)
 
         # Set the selected clip (if needed)
         self.window.addSelection(effect_id, 'effect', True)
@@ -454,7 +454,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     @pyqtSlot(float, int)
     def ShowTimelineMenu(self, position, layer_id):
-        log.info('ShowTimelineMenu: position: %s, layer: %s' % (position, layer_id))
+        log.debug('ShowTimelineMenu: position: %s, layer: %s' % (position, layer_id))
 
         # Get translation method
         _ = get_app()._tr
@@ -476,7 +476,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     @pyqtSlot(str)
     def ShowClipMenu(self, clip_id=None):
-        log.info('ShowClipMenu: %s' % clip_id)
+        log.debug('ShowClipMenu: %s' % clip_id)
 
         # Get translation method
         _ = get_app()._tr
@@ -910,7 +910,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def Waveform_Ready(self, clip_id, audio_data):
         """Callback when audio waveform is ready"""
-        log.info("Waveform_Ready for clip ID: %s" % (clip_id))
+        log.debug("Waveform_Ready for clip ID: %s" % (clip_id))
 
         # Convert waveform data to JSON
         serialized_audio_data = json.dumps(audio_data)
@@ -924,7 +924,6 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def Split_Audio_Triggered(self, action, clip_ids):
         """Callback for split audio context menus"""
-        log.info("Split_Audio_Triggered")
 
         # Get translation method
         _ = get_app()._tr
@@ -986,7 +985,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
                 # Loop through each channel
                 for channel in range(0, channels):
-                    log.info("Adding clip for channel %s" % channel)
+                    log.debug("Adding clip for channel {}".format(channel))
 
                     # Each clip is filtered to a different channel
                     p = openshot.Point(1, channel, openshot.CONSTANT)
@@ -1033,7 +1032,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def Layout_Triggered(self, action, clip_ids):
         """Callback for the layout context menus"""
-        log.info(action)
+        log.debug('Clip(s)[{}]: Layout action {}'.format(clip_ids, action))
 
         # Loop through each selected clip
         for clip_id in clip_ids:
@@ -1109,7 +1108,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def Animate_Triggered(self, action, clip_ids, position="Entire Clip"):
         """Callback for the animate context menus"""
-        log.info(action)
+        log.debug(action)
 
         # Loop through each selected clip
         for clip_id in clip_ids:
@@ -1279,7 +1278,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def Copy_Triggered(self, action, clip_ids, tran_ids):
         """Callback for copy context menus"""
-        log.info(action)
+        log.debug(action)
 
         # Empty previous clipboard
         self.copy_clipboard = {}
@@ -1351,7 +1350,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def Paste_Triggered(self, action, position, layer_id, clip_ids, tran_ids):
         """Callback for paste context menus"""
-        log.info(action)
+        log.debug(action)
 
         # Get list of clipboard items (that are complete clips or transitions)
         # i.e. ignore partial clipboard items (keyframes / effects / etc...)
@@ -1463,7 +1462,6 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def Nudge_Triggered(self, action, clip_ids, tran_ids):
         """Callback for clip nudges"""
-        log.info("Nudging clip(s) and/or transition(s)")
         left_edge = -1.0
         right_edge = -1.0
 
@@ -1474,7 +1472,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         nudgeDistance /= 2.0	# 1/2 frame
         if abs(nudgeDistance) < 0.01:
             nudgeDistance = 0.01 * action	# nudge is less than the minimum of +/- 0.01s
-        log.info("Nudging by %s sec" % nudgeDistance)
+        log.debug("Nudging {} by {} sec".format(clip_ids+tran_ids, nudgeDistance))
 
         # Loop through each selected clip (find furthest left and right edge)
         for clip_id in clip_ids:
@@ -1495,7 +1493,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
             # Do not nudge beyond the start of the timeline
             if left_edge + nudgeDistance < 0.0:
-                log.info("Cannot nudge beyond start of timeline")
+                log.debug("Clip[{}]: Cannot nudge beyond start of timeline".format(clip.data["id"]))
                 nudgeDistance = 0
 
         # Loop through each selected transition (find furthest left and right edge)
@@ -1517,7 +1515,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
             # Do not nudge beyond the start of the timeline
             if left_edge + nudgeDistance < 0.0:
-                log.info("Cannot nudge beyond start of timeline")
+                log.debug("Transition[{}]: Cannot nudge beyond start of timeline".format(tran.data["id"]))
                 nudgeDistance = 0
 
         # Loop through each selected clip (update position to align clips)
@@ -1551,7 +1549,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def Align_Triggered(self, action, clip_ids, tran_ids):
         """Callback for alignment context menus"""
-        log.info(action)
+        log.debug(action)
         prop_name = "position"
         left_edge = -1.0
         right_edge = -1.0
@@ -1635,7 +1633,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def Fade_Triggered(self, action, clip_ids, position="Entire Clip"):
         """Callback for fade context menus"""
-        log.info(action)
+        log.debug(action)
         prop_name = "alpha"
 
         # Get FPS from project
@@ -1806,7 +1804,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
                 if has_audio_data:
                     # Re-generate waveform since volume curve has changed
-                    log.info("Generate right splice waveform for clip id: %s" % right_clip.id)
+                    log.debug("Clip[{}]: Generate right splice waveform".format(right_clip.id))
                     self.Show_Waveform_Triggered(right_clip.id)
 
             # Save changes
@@ -1814,7 +1812,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
             if has_audio_data:
                 # Re-generate waveform since volume curve has changed
-                log.info("Generate left splice waveform for clip id: %s" % clip.id)
+                log.debug("Clip[{}]: Generate left splice waveform".format(clip.id))
                 self.Show_Waveform_Triggered(clip.id)
 
 
@@ -1875,7 +1873,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def Volume_Triggered(self, action, clip_ids, position="Entire Clip"):
         """Callback for volume context menus"""
-        log.info(action)
+        log.debug(action)
         prop_name = "volume"
 
         # Get FPS from project
@@ -1974,7 +1972,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def Rotate_Triggered(self, action, clip_ids, position="Start of Clip"):
         """Callback for rotate context menus"""
-        log.info(action)
+        log.debug(action)
         prop_name = "rotation"
 
         # Get FPS from project
@@ -2019,7 +2017,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def Time_Triggered(self, action, clip_ids, speed="1X", playhead_position=0.0):
         """Callback for rotate context menus"""
-        log.info(action)
+        log.debug(action)
         prop_name = "time"
 
         # Get FPS from project
@@ -2285,8 +2283,8 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
                     y_object = json.loads(y_point.Json())
                     selected_clip.data["location_y"] = { "Points" : [y_object]}
 
-                    log.info('Updating clip id: %s' % selected_clip.data["id"])
-                    log.info('width: %s, height: %s' % (width, height))
+                    log.debug('Clip[{}]: Updating width: {}, height: {}'.format(
+                              selected_clip.data["id"], width, height))
 
                     # Increment Clip Index
                     clip_index += 1
@@ -2296,7 +2294,6 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def Reverse_Transition_Triggered(self, tran_ids):
         """Callback for reversing a transition"""
-        log.info("Reverse_Transition_Triggered")
 
         # Loop through all selected transitions
         for tran_id in tran_ids:
@@ -2322,8 +2319,6 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     @pyqtSlot(str)
     def ShowTransitionMenu(self, tran_id=None):
-        log.info('ShowTransitionMenu: %s' % tran_id)
-
         # Get translation method
         _ = get_app()._tr
 
@@ -2431,8 +2426,6 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     @pyqtSlot(str)
     def ShowTrackMenu(self, layer_id=None):
-        log.info('ShowTrackMenu: %s' % layer_id)
-
         if layer_id not in self.window.selected_tracks:
             self.window.selected_tracks = [layer_id]
 
@@ -2453,8 +2446,6 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     @pyqtSlot(str)
     def ShowMarkerMenu(self, marker_id=None):
-        log.info('ShowMarkerMenu: %s' % marker_id)
-
         if marker_id not in self.window.selected_markers:
             self.window.selected_markers = [marker_id]
 
@@ -2723,8 +2714,6 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     # Add Transition
     def addTransition(self, file_ids, position):
-        log.info("addTransition...")
-
         # Find the closest track (from javascript)
         top_layer = int(self.eval_js(JS_SCOPE_SELECTOR + ".GetJavaScriptTrack(" + str(position.y()) + ");"))
 
@@ -2770,7 +2759,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     # Add Effect
     def addEffect(self, effect_names, position):
-        log.info("addEffect: %s at %s" % (effect_names, position))
+        log.debug("addEffect: %s at %s" % (effect_names, position))
         # Get name of effect
         name = effect_names[0]
 
@@ -2785,8 +2774,8 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         for clip in possible_clips:
             if js_position == 0 or (clip.data["position"] <= js_position <= clip.data["position"] + (
                         clip.data["end"] - clip.data["start"])):
-                log.info("Applying effect to clip")
-                log.info(clip)
+                log.info("Clip[{}].frame[{}]: Applying effect {}",format(clip.data["id"], position, effect_names))
+                log.debug("Clip[{}]: {}".format(clip.data["id"], clip))
 
                 # Create Effect
                 effect = openshot.EffectInfo().CreateEffect(name)
@@ -2816,16 +2805,16 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     # Drop an item on the timeline
     def dropEvent(self, event):
-        log.info("Dropping item on timeline - item_id: %s, item_type: %s" % (self.item_id, self.item_type))
-
         # Get position of cursor
         pos = event.posF()
 
         if self.item_type in ["clip", "transition"] and self.item_id:
+            log.debug("{}[{}] dropped on timeline".format(self.item_type.capitalize(), self.item_id))
             # Update most recent clip
             self.eval_js(JS_SCOPE_SELECTOR + ".UpdateRecentItemJSON('" + self.item_type + "', '" + self.item_id + "');")
 
         elif self.item_type == "effect":
+            log.debug("{}[{}] dropped on timeline".format(self.item_type.capitalize(), self.item_id))
             # Add effect only on drop
             data = json.loads(event.mimeData().text())
             self.addEffect(data, pos)
@@ -2839,7 +2828,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
                 filepath = uri.toLocalFile()
                 if os.path.exists(filepath) and os.path.isfile(filepath):
                     # Valid file, so create clip for it
-                    log.info('Adding clip for {}'.format(os.path.basename(filepath)))
+                    log.info('Adding Clip for {}'.format(os.path.basename(filepath)))
                     for file in File.filter(path=filepath):
                         # Insert clip for this file at this position
                         self.addClip([file.id], pos)
@@ -2858,7 +2847,6 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def dragLeaveEvent(self, event):
         """A drag is in-progress and the user moves mouse outside of timeline"""
-        log.info('dragLeaveEvent - Undo drop')
         if self.item_type == "clip":
             get_app().window.actionRemoveClip.trigger()
         elif self.item_type == "transition":
@@ -2874,7 +2862,6 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
     def redraw_audio_onTimeout(self):
         """Timer is ready to redraw audio (if any)"""
-        log.info('redraw_audio_onTimeout')
 
         # Stop timer
         self.redraw_audio_timer.stop()

--- a/src/windows/views/tutorial.py
+++ b/src/windows/views/tutorial.py
@@ -74,7 +74,6 @@ class TutorialDialog(QWidget):
     def eventFilter(self, object, e):
         if e.type() == QEvent.WindowActivate:
             # Raise parent window, and then this tutorial
-            #log.info("Raising main app and tutorial popup")
             get_app().window.show()
             get_app().window.raise_()
             self.moveWidget()
@@ -191,7 +190,6 @@ class TutorialManager(object):
 
     def process(self, parent_name=None):
         """ Process and show the first non-completed tutorial """
-        log.info("process tutorial dialogs")
 
         # Do nothing if a tutorial is already visible
         if self.current_dialog:
@@ -222,6 +220,8 @@ class TutorialManager(object):
             tutorial_dialog.btn_next_tip.clicked.connect(functools.partial(self.next_tip, tutorial_id))
             tutorial_dialog.btn_close_tips.clicked.connect(functools.partial(self.hide_tips, tutorial_id, True))
 
+            log.debug("Showing tutorial {}".format(tutorial_id))
+
             # Show dialog
             self.current_dialog = tutorial_dialog
             self.current_dialog.show()
@@ -250,7 +250,6 @@ class TutorialManager(object):
 
     def next_tip(self, tid):
         """ Mark the current tip completed, and show the next one """
-        log.info("next_tip")
 
         # Hide matching tutorial
         self.hide_tips(tid)
@@ -260,7 +259,6 @@ class TutorialManager(object):
 
     def hide_tips(self, tid, user_clicked=False):
         """ Hide the current tip, and don't show anymore """
-        log.info("hide_tips")
         s = get_settings()
 
         # Loop through and find current tid
@@ -315,7 +313,6 @@ class TutorialManager(object):
 
     def minimize(self):
         """ Minimize any visible tutorial dialog """
-        log.info("minimize tutorial")
         if self.current_dialog:
             self.current_dialog.showMinimized()
 


### PR DESCRIPTION
OpenShot outputs a staggering number of unnecessary, redundant, or generic messages to its log while running, especially on startup.

(A log message every time a fallback icon is used; every time an interface binding is created; every time an effect is loaded — that one just says "effects_model:INFO category: Video" every time, so super useless; every time the preview is resized; etc...)

The user doesn't care about any of these, and honestly they're of no help to developers either. They're just the equivalent of debug `printf()`s being left in the code. So, this PR aims to wipe them out.

Along the way, I'm fixing the type of some other messages (lowering some from log.info() to log.debug(), promoting others from `log.info()` to `log.error()`, etc.) and updating the formatting of any that use Python %-string formatting to instead use str.format.

I've also made the logging asymmetrical between the console output and the logfile, and hooked the `debug-mode` preference up to OpenShot's (file-based) logging. So, `openshot-qt.log` will get INFO and higher messages normally, but DEBUG-and-higher when the debugging switch is enabled.

(Replacement for PR #1772)

### IMPORTANT:
\* — This is very much WIP for real, please _do **NOT** merge_ in current state. There are a lot of commits in here I was holding back on my local system, not pushing to my fork / the previous PR, to keep what _was_ in the PR relatively harmless to merge. The changes here are extensive and no longer harmless, and they are not ready to go in yet.