### PR TITLE
Adding new preference for `omp taskwait` (i.e. Multiple Threads Support)

### DIFF
--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -329,8 +329,17 @@
     "value": true,
     "title": "Enable Hardware Decode",
     "type": "hidden",
+    "restart": true,
     "category": "Performance",
     "setting": "hardware_decode"
+  },
+  {
+    "value": true,
+    "title": "Enable Multiple Threads",
+    "type": "bool",
+    "restart": true,
+    "category": "Performance",
+    "setting": "omp_threads_enabled"
   },
   {
     "value": true,

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2396,6 +2396,12 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         else:
             os.environ['OS2_DECODE_HW'] = "0"
 
+        # Set hardware decode environment variable
+        if s.get("omp_threads_enabled"):
+            os.environ['OS2_OMP_THREADS'] = "1"
+        else:
+            os.environ['OS2_OMP_THREADS'] = "0"
+
         # Create lock file
         self.create_lock_file()
 

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -286,6 +286,14 @@ class Preferences(QDialog):
                 # Disable hardware decode environment variable
                 os.environ['OS2_DECODE_HW'] = "0"
 
+        elif param["setting"] == "omp_threads_enabled":
+            if (state == Qt.Checked):
+                # Enable OMP multi-threading
+                os.environ['OS2_OMP_THREADS'] = "1"
+            else:
+                # Disable OMP multi-threading
+                os.environ['OS2_OMP_THREADS'] = "0"
+
         # Check for restart
         self.check_for_restart(param)
 


### PR DESCRIPTION
Many crashes are related to race conditions due to OMP task collisions. This preference allows a user to disable support for high performance threading support, in hope that it will be more stable. This is a bit experimental, and might go away at some point.