### PR TITLE
Improve Title duplication counting

### DIFF
--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -28,6 +28,7 @@
 
 import sys
 import os
+import re
 import shutil
 import functools
 import subprocess
@@ -205,11 +206,26 @@ class TitleEditor(QDialog):
             self.txtFileName.setText(os.path.split(self.edit_file_path)[1])
             self.txtFileName.setEnabled(False)
         else:
+            name = _("TitleFileName-%d")
+            offset = 0
+            if self.duplicate and self.edit_file_path:
+                # Re-use current name
+                name = os.path.split(self.edit_file_path)[1]
+                # Splits the filename into (base-part)(optional "-")(number)(.svg)
+                match = re.match(r"^(.*?)(-?)([0-9]*)(\.svg)?$", name)
+                # Make sure the new title ends with "-%d" by default
+                name = match.group(1) + "-%d"
+                if match.group(3):
+                    # Filename already contained a number -> start counting from there
+                    offset = int(match.group(3))
+                    # -> only use "-" if it was there before
+                    name = match.group(1) + match.group(2) + "%d"
             # Find an unused file name
             for i in range(1, 1000):
-                possible_path = os.path.join(info.ASSETS_PATH, "%s.svg" % _("TitleFileName-%d") % i)
+                curname = name % (offset + i)
+                possible_path = os.path.join(info.ASSETS_PATH, "%s.svg" % curname)
                 if not os.path.exists(possible_path):
-                    self.txtFileName.setText(_("TitleFileName-%d") % i)
+                    self.txtFileName.setText(curname)
                     break
         self.txtFileName.setFixedHeight(28)
         self.settingsContainer.layout().addRow(label, self.txtFileName)


### PR DESCRIPTION
Keep the users name when duplicating a title;
Increment number if existing; add if not yet existing

When duplicating, Title names will now be changed in the following way:

* `<name>-1`  
  `<name>-2`
* `<name>`  
  `<name>-1`
* `<name>-`  
  `<name>-1`
* `<name>----`  
  `<name>----1`
* `<name>1`  
  `<name>2`

=
* Increase number if already exists;
* add `-<number>` if it doesn't exist
* except when the title already ends in a `-`; then just add `<number>`

Old behavior:
* `TitleFileName-1`  
  `TitleFileName-2`
* `<name>`  
  `TitleFileName-1`
* `<name>-`  
  `TitleFileName-1`
* `<name>----`  
  `TitleFileName-1`
* `<name>1`  
  `TitleFileName-1`

While doing this PR, I was trying to mitigate #2004;
Which I wasn't able to do.
But at least I figured out the exact reason for it:
See #2041