### PR TITLE
More framerates for YouTube HD and Vimeo HD presets

### DIFF
--- a/src/presets/vimeo_HD.xml
+++ b/src/presets/vimeo_HD.xml
@@ -9,16 +9,22 @@
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate
-	 low="2 Mb/s"
-	 med="5 Mb/s"
-	 high="8 Mb/s"></videobitrate>
+	 low="4 Mb/s"
+	 med="8 Mb/s"
+	 high="12 Mb/s"></videobitrate>
 	<audiobitrate
 	 low="128 kb/s"
 	 med="256 kb/s"
 	 high="320 kb/s"></audiobitrate>
 	<samplerate>48000</samplerate>
+	<projectprofile>HD 720p 23.98 fps</projectprofile>
+	<projectprofile>HD 720p 24 fps</projectprofile>
 	<projectprofile>HD 720p 25 fps</projectprofile>
 	<projectprofile>HD 720p 29.97 fps</projectprofile>
+	<projectprofile>HD 720p 30 fps</projectprofile>
+	<projectprofile>HD 1080p 23.98 fps</projectprofile>
+	<projectprofile>HD 1080p 24 fps</projectprofile>
 	<projectprofile>HD 1080p 25 fps</projectprofile>
 	<projectprofile>HD 1080p 29.97 fps</projectprofile>
+	<projectprofile>HD 1080p 30 fps</projectprofile>
 </export-option>

--- a/src/presets/youtube_HD.xml
+++ b/src/presets/youtube_HD.xml
@@ -17,8 +17,14 @@
 	 med="256 kb/s"
 	 high="320 kb/s"></audiobitrate>
 	<samplerate>48000</samplerate>
+	<projectprofile>HD 720p 23.98 fps</projectprofile>
+	<projectprofile>HD 720p 24 fps</projectprofile>
 	<projectprofile>HD 720p 25 fps</projectprofile>
 	<projectprofile>HD 720p 29.97 fps</projectprofile>
+	<projectprofile>HD 720p 30 fps</projectprofile>
+	<projectprofile>HD 1080p 23.98 fps</projectprofile>
+	<projectprofile>HD 1080p 24 fps</projectprofile>
 	<projectprofile>HD 1080p 25 fps</projectprofile>
 	<projectprofile>HD 1080p 29.97 fps</projectprofile>
+	<projectprofile>HD 1080p 30 fps</projectprofile>
 </export-option>


### PR DESCRIPTION
[Youtube][1] and [Vimeo][2] both support upload of video at any frame rate.

Given OpenShot's sensitivity to framerate changes, it doesn't make sense that the presets only offer 25fps and 29.97fps choices for Video Profile, practically forcing the user to perform an unsupported frame-rate change on export. This change expands the profile list in both presets by adding 23.978fps, 24fps, and 30fps options in both 720p and 1080p.

I wanted to add the higher frame rates as well (50, 59.94, and 60 fps), but the "High" bitrate setting of 8Mbps doesn't meet either site's recommendations for higher frame rates, and there's currently no way to make export bitrate dependent on frame rate.

The Vimeo bitrates didn't even meet [their recommendations][2] for standard frame rate at 1080p, actually, so the bins in that preset get tweaked from 2/5/8 Mbps to 4/8/12 Mbps.

Given the increasing popularity of 60fps video on YouTube, a separate "YouTube-60fps" preset with higher video bitrates might be warranted.

[1]: https://support.google.com/youtube/answer/1722171
[2]:  https://vimeo.com/help/compression