### PR TITLE
title_editor.py: Don't import unused QWebView

### DIFF
--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -1,27 +1,27 @@
-""" 
+"""
  @file
  @brief This file loads the title editor dialog (i.e SVG creator)
  @author Jonathan Thomas <jonathan@openshot.org>
  @author Andy Finch <andy@openshot.org>
- 
+
  @section LICENSE
- 
+
  Copyright (c) 2008-2018 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
@@ -38,7 +38,6 @@ from PyQt5.QtCore import *
 from PyQt5.QtGui import QIcon, QStandardItemModel, QStandardItem, QFont
 from PyQt5.QtWidgets import *
 from PyQt5 import uic, QtSvg, QtGui
-from PyQt5.QtWebKitWidgets import QWebView
 import openshot
 
 from classes import info, ui_util, settings, qt_types, updates


### PR DESCRIPTION
So, turns out `src/windows/title_editor.py` was importing `QWebView` from `PyQt5.QtWebKitWidgets`. 

"But the title editor doesn't have any web components!" I hear you cry.

Well-spotted. And that's why `src/windows/title_editor.py` shouldn't be importing anything from `PyQt5.QtWebKitWidgets`. 

So, after this change, `PyQt5.QtWebKitWidgets` will only appear at one place in the source: an import statement at the top of `src/windows/views/timeline_webview.py`. As it should be.