### PR TITLE
Useless logs

### DIFF
--- a/src/classes/ui_util.py
+++ b/src/classes/ui_util.py
@@ -196,13 +196,11 @@ def connect_auto_events(window, elem, name):
         func_name = name + "_trigger"
         if hasattr(window, func_name) and callable(getattr(window, func_name)):
             func = getattr(window, func_name)
-            log.info("Binding event {}:{}".format(window.objectName(), func_name))
             elem.triggered.connect(getattr(window, func_name))
     if hasattr(elem, 'click'):
         func_name = name + "_click"
         if hasattr(window, func_name) and callable(getattr(window, func_name)):
             func = getattr(window, func_name)
-            log.info("Binding event {}:{}".format(window.objectName(), func_name))
             elem.clicked.connect(getattr(window, func_name))
 
 

--- a/src/classes/ui_util.py
+++ b/src/classes/ui_util.py
@@ -129,10 +129,7 @@ def get_icon(theme_name):
 
     if theme_name:
         has_icon = QIcon.hasThemeIcon(theme_name)
-        if not has_icon:
-            log.warn('Icon theme {} not found. Will use backup icon.'.format(theme_name))
         fallback_icon, fallback_path = get_default_icon(theme_name)
-        # log.info('Fallback icon path for {} is {}'.format(theme_name, fallback_path))
         if has_icon or fallback_icon:
             return QIcon.fromTheme(theme_name, fallback_icon)
     return None

--- a/src/windows/models/effects_model.py
+++ b/src/windows/models/effects_model.py
@@ -105,8 +105,6 @@ class EffectsModel():
             elif effect_info["has_video"] and not effect_info["has_audio"]:
                 category = "Video"
 
-            log.info("category: %s" % category)
-
             # Filter out effect (if needed)
             if win.effectsFilter.text() != "":
                 if not win.effectsFilter.text().lower() in self.app._tr(title).lower() and not win.effectsFilter.text().lower() in self.app._tr(description).lower():


### PR DESCRIPTION
On more than one previous occasion I've started larger, more ambitious efforts in this regard... and ultimately got nowhere with them. So, this time I decided to just make a quick, targeted strike against some of the worst offenders: The log messages that are output _every_ time, on _**every**_ launch of OpenShot, and exactly the _same_ each time... messages which serve no purpose except to clutter the logs and obscure _useful_ data. 

These are those, and this PR eliminates them with prejudice. See individual commit messages for details.