### PR TITLE
Widen Export window

### DIFF
--- a/src/windows/ui/export.ui
+++ b/src/windows/ui/export.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>453</width>
-    <height>479</height>
+    <width>520</width>
+    <height>480</height>
    </rect>
   </property>
   <property name="sizePolicy">


### PR DESCRIPTION
The Export window, at least on my system, is not wide enough for its contents in the Advanced tab's Profile subtab. The width seems to be governed by the longest label in the Profile: dropbox, and "DV/DVD Widescreen PAL (Anamorphic) (720x576)" is a really long label.

The window auto-extends its height to compensate for longer content (like the Profile subtab, which is actually longer than the starting height), but it doesn't do the same for the window width.

This change increases the window dimensions from 453×479 pixels to 520×480 pixels, leaving a comfortable margin for the profile-name dropbox.

### Before
![image](https://user-images.githubusercontent.com/538020/48694363-1e4b0200-ebaa-11e8-85c9-667a922eaeb0.png)


### After
![image](https://user-images.githubusercontent.com/538020/48694417-39b60d00-ebaa-11e8-8246-e768c590f678.png)

