### PR TITLE
preferences: Tweak layout builder

### DIFF
--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -247,7 +247,9 @@ class Preferences(QDialog):
                     layout_hbox = QHBoxLayout()
                     layout_hbox.addWidget(label)
                     layout_hbox.addWidget(widget)
-                    layout_hbox.addWidget(extraWidget)
+
+                    if (extraWidget):
+                        layout_hbox.addWidget(extraWidget)
 
                     # Add widget to layout
                     tabWidget.layout().addLayout(layout_hbox)


### PR DESCRIPTION
The code for building the preferences window layout from the available settings items was always trying to add `extraWidget` to the item's `layout_hbox`, but since `extraWidget` is only set on `param["type"] == "browse"` items, most of the time `extraWidget` is undefined. This was causing a flurry of (harmless) log messages whenever the prefs window was opened:
```
QLayout: Cannot add a null widget to QHBoxLayout/
QLayout: Cannot add a null widget to QHBoxLayout/
QLayout: Cannot add a null widget to QHBoxLayout/
QLayout: Cannot add a null widget to QHBoxLayout/
QLayout: Cannot add a null widget to QHBoxLayout/
QLayout: Cannot add a null widget to QHBoxLayout/
QLayout: Cannot add a null widget to QHBoxLayout/
QLayout: Cannot add a null widget to QHBoxLayout/
```

This change wraps an `if(extraWidget):` around the code adding it to the layout, so it will only be attempted when the `extraWidget` exists.