### PR TITLE
launch.py: Exit using sys.exit()

### DIFF
--- a/src/launch.py
+++ b/src/launch.py
@@ -74,20 +74,20 @@ def main():
     # Display version and exit (if requested)
     if args.version:
         print("OpenShot version %s" % info.SETUP['version'])
-        exit()
+        sys.exit()
 
     if args.list_languages:
         print("Supported Languages:")
         for lang in get_all_languages():
             print("  {:>12}  {}".format(lang[0],lang[1]))
-        exit()
+        sys.exit()
 
     if args.lang:
         if args.lang in info.SUPPORTED_LANGUAGES:
             info.CMDLINE_LANGUAGE = args.lang
         else:
             print("Unsupported language '{}'! (See --list-languages)".format(args.lang))
-            exit(-1)
+            sys.exit(-1)
 
     reroute_output()
 


### PR DESCRIPTION
cx_freeze doesn't like it if we quit OpenShot with `exit()`, triggering a traceback and complaining:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/cx_Freeze-4.3.4-py3.4-linux-x86_64.egg/cx_Freeze/initscripts/Console.py", line 27, in <module>
  File "openshot_qt/launch.py", line 105, in <module>
    main()
  File "openshot_qt/launch.py", line 76, in main
    exit()
NameError: name 'exit' is not defined
```
Using `sys.exit()` is more correct, and should appease cx_freeze.