### PR TITLE
Disconnect path detection from classes.info

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,32 @@
+"""
+ @file openshot_qt/__init__.py
+ @brief Initialization code used when running OpenShot installed as a Python module
+ @author FeRD (Frank Dana) <ferdnyc AT gmail com>
+
+ @section LICENSE
+
+ Copyright (c) 2008-2018 OpenShot Studios, LLC
+ (http://www.openshotstudios.com). This file is part of
+ OpenShot Video Editor (http://www.openshot.org), an open-source project
+ dedicated to delivering high quality video editing and animation solutions
+ to the world.
+
+ OpenShot Video Editor is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenShot Video Editor is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
+ """
+
+import sys
+import os
+
+# Determine path to this module
+OPENSHOT_PATH = os.path.dirname(os.path.realpath(__file__))

--- a/src/launch.py
+++ b/src/launch.py
@@ -47,8 +47,9 @@ try:
     from classes import info
     print("Loaded modules from current directory: %s" % info.PATH)
 except ImportError:
-    from openshot_qt.classes import info
-    sys.path.append(info.PATH)
+    import openshot_qt
+    sys.path.append(openshot_qt.OPENSHOT_PATH)
+    from classes import info
     print("Loaded modules from installed directory: %s" % info.PATH)
 
 from classes.app import OpenShotApp


### PR DESCRIPTION
I detail in #2148 an issue caused by OpenShot importing `classes.info` _differently_ in `launch.py` than it does in other modules. When running from an installed `openshot_qt` Python package, this causes two instances of the `info` module to exist in memory (one imported as `openshot_qt.classes.info`, the other imported as `classes.info` after the `openshot_qt` dir is added to `sys.path`), and prevents the passing of data from `launch.py` to the rest of OpenShot by storing it in `classes.info` variables.

This change adds a `src/__init__.py` file which has only **one** purpose: To perform the path-detection duties that allow `launch.py` to add the `openshot_qt` directory to `sys.path`, after which point it can then use `from classes import info` to import the same `classes.info` instance that all the rest of the code will be using. Data can thus be passed from class to class using variables stored in `classes.info`. Specifically, this makes the `--lang` command-line option function in an installed `openshot-qt` the same way it does when running in the AppImage or from the source tree.

I've tested this in the installed and running-from-the-source tree scenarios, and encountered no problems, nor do I expect there will be any. The `__init__.py` file should have no effect anywhere _other_ than the system-installed case, since all it does (even if it ends up being executed) is create a single variable and store the detected path to the OpenShot Python code there. (It's `launch.py` that handles updating `sys.path`, still.)

Fixes #2418 