### PR TITLE
Color picker: Never use native dialog

### DIFF
--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -219,6 +219,9 @@ class BlenderListView(QListView):
         log.info('New value of param: %s' % value)
 
     def color_button_clicked(self, widget, param, index):
+        # Get translation object
+        _ = get_app()._tr
+
         # Show color dialog
         log.info('Animation param being changed: %s' % param["name"])
         color_value = self.params[param["name"]]
@@ -227,7 +230,8 @@ class BlenderListView(QListView):
         if len(color_value) == 3:
             #currentColor = QColor(color_value[0], color_value[1], color_value[2])
             currentColor.setRgbF(color_value[0], color_value[1], color_value[2])
-        newColor = QColorDialog.getColor(currentColor)
+        newColor = QColorDialog.getColor(currentColor, self, _("Select a Color"),
+                                         QColorDialog.DontUseNativeDialog)
         if newColor.isValid():
             widget.setStyleSheet("background-color: {}".format(newColor.name()))
             self.params[param["name"]] = [newColor.redF(), newColor.greenF(), newColor.blueF()]

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -272,6 +272,10 @@ class PropertiesTableView(QTableView):
 
     def doubleClickedCB(self, model_index):
         """Double click handler for the property table"""
+
+        # Get translation object
+        _ = get_app()._tr
+
         # Get data model and selection
         model = self.clip_properties_model.model
 
@@ -291,7 +295,8 @@ class PropertiesTableView(QTableView):
 
                 # Show color dialog
                 currentColor = QColor(red, green, blue)
-                newColor = QColorDialog.getColor(currentColor)
+                newColor = QColorDialog.getColor(currentColor, self, _("Select a Color"),
+                                                 QColorDialog.DontUseNativeDialog)
 
                 # Set the new color keyframe
                 self.clip_properties_model.color_update(self.selected_item, newColor)


### PR DESCRIPTION
This change modifies the color picker invocations in `blender_listview.py` and `properties_tableview.py` to exclude use of the (inferior) native color picker dialog, the way `title_editor.py` was already doing.

Dialog without this change, on some systems running under Gnome Shell:

![image](https://user-images.githubusercontent.com/538020/49413625-88cd7780-f73e-11e8-81b1-8c2a50f61fff.png)

Dialog after this change, on **all** supported systems/platforms:

![image](https://user-images.githubusercontent.com/538020/49413661-a69adc80-f73e-11e8-9477-fe7c6802b5c3.png)

Fixes #2326 