### PR TITLE
Rewrite conversion of relative and absolute path support in OpenShot

### DIFF
--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -147,15 +147,16 @@ class UpdateManager:
         history = project.get(["history"])
 
         # Loop through each, and load serialized data into updateAction objects
+        # Ignore any load actions or history update actions
         for actionDict in history.get("redo", []):
             action = UpdateAction()
             action.load_json(json.dumps(actionDict))
-            if action.type != "load":
+            if action.type != "load" and action.key[0] != "history":
                 self.redoHistory.append(action)
         for actionDict in history.get("undo", []):
             action = UpdateAction()
             action.load_json(json.dumps(actionDict))
-            if action.type != "load":
+            if action.type != "load" and action.key[0] != "history":
                 self.actionHistory.append(action)
 
         # Notify watchers of new status
@@ -166,14 +167,15 @@ class UpdateManager:
         redo_list = []
         undo_list = []
 
-        # Loop through each, and serialize
+        # Loop through each updateAction object and serialize
+        # Ignore any load actions or history update actions
         history_length_int = int(history_length)
         for action in self.redoHistory[-history_length_int:]:
-            if action.type != "load":
+            if action.type != "load" and action.key[0] != "history":
                 actionDict = json.loads(action.json())
                 redo_list.append(actionDict)
         for action in self.actionHistory[-history_length_int:]:
-            if action.type != "load":
+            if action.type != "load" and action.key[0] != "history":
                 actionDict = json.loads(action.json())
                 undo_list.append(actionDict)
 

--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -149,15 +149,11 @@ class UpdateManager:
         # Loop through each, and load serialized data into updateAction objects
         for actionDict in history.get("redo", []):
             action = UpdateAction()
-            self.convert_paths_to_absolute(actionDict.get("value"))
-            self.convert_paths_to_absolute(actionDict.get("old_values"))
             action.load_json(json.dumps(actionDict))
             if action.type != "load":
                 self.redoHistory.append(action)
         for actionDict in history.get("undo", []):
             action = UpdateAction()
-            self.convert_paths_to_absolute(actionDict.get("value"))
-            self.convert_paths_to_absolute(actionDict.get("old_values"))
             action.load_json(json.dumps(actionDict))
             if action.type != "load":
                 self.actionHistory.append(action)
@@ -175,54 +171,16 @@ class UpdateManager:
         for action in self.redoHistory[-history_length_int:]:
             if action.type != "load":
                 actionDict = json.loads(action.json())
-                self.convert_paths_to_relative(actionDict.get("value"))
-                self.convert_paths_to_relative(actionDict.get("old_values"))
                 redo_list.append(actionDict)
         for action in self.actionHistory[-history_length_int:]:
             if action.type != "load":
                 actionDict = json.loads(action.json())
-                self.convert_paths_to_relative(actionDict.get("value"))
-                self.convert_paths_to_relative(actionDict.get("old_values"))
                 undo_list.append(actionDict)
 
         # Set history data in project
         self.ignore_history = True
         self.update(["history"], { "redo": redo_list, "undo": undo_list})
         self.ignore_history = False
-
-    def convert_paths_to_relative(self, action_value):
-        """Convert transition paths to relative placeholders (if found)"""
-        if type(action_value) != dict:
-            return action_value
-        # Update reader path
-        path = action_value.get("reader", {}).get("path")
-
-        # Determine if this path is the official transition path
-        if path:
-            folder_path, file_path = os.path.split(path)
-            if os.path.join(info.PATH, "transitions") in folder_path:
-                # Yes, this is an OpenShot transitions
-                folder_path, category_path = os.path.split(folder_path)
-
-                # Convert path to @transitions/ path
-                action_value["reader"]["path"] = os.path.join("@transitions", category_path, file_path)
-        return action_value
-
-    def convert_paths_to_absolute(self, action_value):
-        """ Convert all transition paths to absolute (if found) """
-        if type(action_value) != dict:
-            return action_value
-        # Update reader path
-        path = action_value.get("reader", {}).get("path")
-
-        # Determine if this path is the official transition path
-        if path:
-            # Determine if @transitions path is found
-            if "@transitions" in path:
-                path = path.replace("@transitions", os.path.join(info.PATH, "transitions"))
-            # Convert absolute path to relavite
-            action_value["reader"]["path"] = path
-        return action_value
 
     def reset(self):
         """ Reset the UpdateManager, and clear all UpdateActions and History. This does not clear listeners and watchers. """


### PR DESCRIPTION
I have done a complete rewrite of relative and absolute path support in OpenShot, to work as the JSON is read and write. It uses regex to quickly find all mentions of "path": or "image": , and converts the paths as needed: absolute when loading a project, and relative when saving. Even better, it also catches all paths in the undo/redo history, and fully supports @transitions relative paths. 

I've done quite a bit of testing on Linux, and this seems to work much better than the previous approach. I need to now test on Windows and Mac, to verify this has no OS dependencies.