### PR TITLE
Improved Tracks (simpler numbering, faster inserting, prevent deletion of locked tracks)

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -231,7 +231,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             # Add or Full Update
             # For adds to list perform an insert to index or the end if not specified
             if add and isinstance(parent, list):
-                # log.info("adding to list")
                 parent.append(values)
 
             # Otherwise, set the given index

--- a/src/classes/ui_util.py
+++ b/src/classes/ui_util.py
@@ -220,7 +220,6 @@ def init_ui(window):
 
         # Loop through all actions
         for action in window.findChildren(QAction):
-            # log.info('Initializing element: {}'.format(action))
             init_element(window, action)
     except:
         log.info('Failed to initialize an element on {}'.format(window.objectName()))

--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -233,8 +233,6 @@ class UpdateManager:
     # caused by actions.
     def get_reverse_action(self, action):
         """ Convert an UpdateAction into the opposite type (i.e. 'insert' becomes an 'delete') """
-
-        # log.info("Reversing action: {}, {}, {}, {}".format(action.type, action.key, action.values, action.partial_update))
         reverse = UpdateAction(action.type, action.key, action.values, action.partial_update)
         # On adds, setup remove
         if action.type == "insert":
@@ -256,7 +254,6 @@ class UpdateManager:
         reverse.old_values = action.values
         reverse.values = action.old_values
 
-        # log.info("Reversed values: {}, {}, {}, {}".format(reverse.type, reverse.key, reverse.values, reverse.partial_update))
         return reverse
 
     def undo(self):

--- a/src/settings/_default.project
+++ b/src/settings/_default.project
@@ -22,37 +22,37 @@
   "profile": "HD 720p 30 fps",
   "layers": [
     {
-      "id": "L0",
-      "label" : "",
-      "number": 0,
-      "y": 0,
-      "lock": false
-    },
-    {
       "id": "L1",
       "label" : "",
-      "number": 1,
+      "number": 1000000,
       "y": 0,
       "lock": false
     },
     {
       "id": "L2",
       "label" : "",
-      "number": 2,
+      "number": 2000000,
       "y": 0,
       "lock": false
     },
     {
       "id": "L3",
       "label" : "",
-      "number": 3,
+      "number": 3000000,
       "y": 0,
       "lock": false
     },
     {
       "id": "L4",
       "label" : "",
-      "number": 4,
+      "number": 4000000,
+      "y": 0,
+      "lock": false
+    },
+    {
+      "id": "L5",
+      "label" : "",
+      "number": 5000000,
       "y": 0,
       "lock": false
     }

--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -65,7 +65,7 @@
 			<div ng-repeat="layer in project.layers.slice().reverse()" id="track_static_{{layer.number}}" ng-right-click="ShowTrackMenu(layer.id)" class="track_name">
 				<div class="track_top">
 					<div tl-clip-menu class="track_menu" ng-mousedown="ShowTrackMenu(layer.id)"></div>
-					<span class="track_label">{{GetTrackName(layer.label, layer.number)}}</span><span ng-show="layer.lock" class="track_lock"></span>
+					<span class="track_label">{{GetTrackName(layer.label, project.layers.length - $index)}}</span><span ng-show="layer.lock" class="track_lock"></span>
 				</div>
 			</div>
 			<br>

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -32,6 +32,7 @@ import sys
 import platform
 import shutil
 import webbrowser
+from operator import itemgetter
 from uuid import uuid4
 from copy import deepcopy
 from time import sleep
@@ -987,7 +988,8 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         log.info("actionAddTrack_trigger")
 
         # Get # of tracks
-        track_number = len(get_app().project.get(["layers"]))
+        all_tracks = get_app().project.get(["layers"])
+        track_number = list(reversed(sorted(all_tracks, key=itemgetter('number'))))[0].get("number") + 1000000
 
         # Create new track above existing layer(s)
         track = Track()
@@ -998,7 +1000,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         log.info("actionAddTrackAbove_trigger")
 
         # Get # of tracks
-        max_track_number = len(get_app().project.get(["layers"]))
+        all_tracks = get_app().project.get(["layers"])
         selected_layer_id = self.selected_tracks[0]
 
         # Get selected track data
@@ -1009,35 +1011,52 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             return
         selected_layer_number = int(existing_track.data["number"])
 
-        # Loop through tracks above insert point (in descending order), renumbering layers
-        for existing_layer in list(reversed(range(selected_layer_number+1, max_track_number))):
-            existing_track = Track.get(number=existing_layer)
-            if not existing_track:
-                # Log error and fail silently, and continue
-                log.error('No track object found with number: %s' % existing_layer)
-                continue
-            existing_track.data["number"] = existing_layer + 1
-            existing_track.save()
+        # Get track above selected track (if any)
+        previous_track_number = 0
+        track_number_delta = 0
+        for track in reversed(sorted(all_tracks, key=itemgetter('number'))):
+            if track.get("number") == selected_layer_number:
+                track_number_delta = previous_track_number - selected_layer_number
+                break
+            previous_track_number = track.get("number")
 
-            # Loop through clips and transitions for track, moving up to new layer
-            for clip in Clip.filter(layer=existing_layer):
-                clip.data["layer"] = int(clip.data["layer"]) + 1
-                clip.save()
+        # Calculate new track number (based on gap delta)
+        new_track_number = selected_layer_number + 1000000
+        if track_number_delta > 2:
+            # New track number (pick mid point in track number gap)
+            new_track_number = selected_layer_number + int(round(track_number_delta / 2.0))
+        else:
+            # Loop through tracks above insert point
+            for track in reversed(sorted(all_tracks, key=itemgetter('number'))):
+                if track.get("number") > selected_layer_number:
+                    existing_track = Track.get(number=track.get("number"))
+                    if not existing_track:
+                        # Log error and fail silently, and continue
+                        log.error('No track object found with number: %s' % track.get("number"))
+                        continue
+                    existing_layer = existing_track.data["number"]
+                    existing_track.data["number"] = existing_layer + 1000000
+                    existing_track.save()
 
-            for trans in Transition.filter(layer=existing_layer):
-                trans.data["layer"] = int(trans.data["layer"]) + 1
-                trans.save()
+                    # Loop through clips and transitions for track, moving up to new layer
+                    for clip in Clip.filter(layer=existing_layer):
+                        clip.data["layer"] = int(clip.data["layer"]) + 1000000
+                        clip.save()
+
+                    for trans in Transition.filter(layer=existing_layer):
+                        trans.data["layer"] = int(trans.data["layer"]) + 1000000
+                        trans.save()
 
         # Create new track at vacated layer
         track = Track()
-        track.data = {"number": selected_layer_number+1, "y": 0, "label": "", "lock": False}
+        track.data = {"number": new_track_number, "y": 0, "label": "", "lock": False}
         track.save()
 
     def actionAddTrackBelow_trigger(self, event):
         log.info("actionAddTrackBelow_trigger")
 
         # Get # of tracks
-        max_track_number = len(get_app().project.get(["layers"]))
+        all_tracks = get_app().project.get(["layers"])
         selected_layer_id = self.selected_tracks[0]
 
         # Get selected track data
@@ -1048,28 +1067,49 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             return
         selected_layer_number = int(existing_track.data["number"])
 
-        # Loop through tracks from insert point up (in descending order), renumbering layers
-        for existing_layer in list(reversed(range(selected_layer_number, max_track_number))):
-            existing_track = Track.get(number=existing_layer)
-            if not existing_track:
-                # Log error and fail silently, and continue
-                log.error('No track object found with number: %s' % existing_layer)
+        # Get track below selected track (if any)
+        next_track_number = 0
+        track_number_delta = 0
+        found_track = False
+        for track in reversed(sorted(all_tracks, key=itemgetter('number'))):
+            if found_track:
+                next_track_number = track.get("number")
+                track_number_delta = selected_layer_number - next_track_number
+                break
+            if track.get("number") == selected_layer_number:
+                found_track = True
                 continue
-            existing_track.data["number"] = existing_layer + 1
-            existing_track.save()
 
-            # Loop through clips and transitions for track, moving up to new layer
-            for clip in Clip.filter(layer=existing_layer):
-                clip.data["layer"] = int(clip.data["layer"]) + 1
-                clip.save()
+        # Calculate new track number (based on gap delta)
+        new_track_number = selected_layer_number
+        if track_number_delta > 2:
+            # New track number (pick mid point in track number gap)
+            new_track_number = selected_layer_number - int(round(track_number_delta / 2.0))
+        else:
+            # Loop through tracks from insert point and above
+            for track in reversed(sorted(all_tracks, key=itemgetter('number'))):
+                if track.get("number") >= selected_layer_number:
+                    existing_track = Track.get(number=track.get("number"))
+                    if not existing_track:
+                        # Log error and fail silently, and continue
+                        log.error('No track object found with number: %s' % track.get("number"))
+                        continue
+                    existing_layer = existing_track.data["number"]
+                    existing_track.data["number"] = existing_layer + 1000000
+                    existing_track.save()
 
-            for trans in Transition.filter(layer=existing_layer):
-                trans.data["layer"] = int(trans.data["layer"]) + 1
-                trans.save()
+                    # Loop through clips and transitions for track, moving up to new layer
+                    for clip in Clip.filter(layer=existing_layer):
+                        clip.data["layer"] = int(clip.data["layer"]) + 1000000
+                        clip.save()
+
+                    for trans in Transition.filter(layer=existing_layer):
+                        trans.data["layer"] = int(trans.data["layer"]) + 1000000
+                        trans.save()
 
         # Create new track at vacated layer
         track = Track()
-        track.data = {"number": selected_layer_number, "y": 0, "label": "", "lock": False}
+        track.data = {"number": new_track_number, "y": 0, "label": "", "lock": False}
         track.save()
 
     def actionArrowTool_trigger(self, event):
@@ -1571,22 +1611,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Remove track
         selected_track.delete()
 
-        # Loop through all layers above, and renumber elements (to keep thing in numerical order)
-        for existing_layer in list(range(selected_track_number + 1, max_track_number)):
-            # Update existing layer number
-            track = Track.get(number=existing_layer)
-            track.data["number"] = existing_layer - 1
-            track.save()
-
-            for clip in Clip.filter(layer=existing_layer):
-                clip.data["layer"] = int(clip.data["layer"]) - 1
-                clip.save()
-
-            for trans in Transition.filter(layer=existing_layer):
-                trans.data["layer"] = int(trans.data["layer"]) - 1
-                trans.save()
-
-
         # Clear selected track
         self.selected_tracks = []
 
@@ -1624,7 +1648,16 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Get details of track
         track_id = self.selected_tracks[0]
         selected_track = Track.get(id=track_id)
-        track_name = selected_track.data["label"] or _("Track %s") % selected_track.data["number"]
+
+        # Find display track number
+        all_tracks = get_app().project.get(["layers"])
+        display_count = len(all_tracks)
+        for track in reversed(sorted(all_tracks, key=itemgetter('number'))):
+            if track.get("id") == track_id:
+                break
+            display_count -= 1
+
+        track_name = selected_track.data["label"] or _("Track %s") % display_count
 
         text, ok = QInputDialog.getText(self, _('Rename Track'), _('Track Name:'), text=track_name)
         if ok:

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -912,7 +912,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Translate object
         _ = get_app()._tr
 
-	    # Prepare to use the status bar
+        # Prepare to use the status bar
         self.statusBar = QStatusBar()
         self.setStatusBar(self.statusBar)
 
@@ -926,7 +926,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             recommended_path = get_app().project.get(["export_path"])
 
         framePath = _("%s/Frame-%05d.png" % (recommended_path, self.preview_thread.current_frame))
-        #log.info("Saving frame to %" % framePath)
 
         # Ask user to confirm or update framePath
         framePath, file_type = QFileDialog.getSaveFileName(self, _("Save Frame..."), framePath, _("Image files (*.png)"))
@@ -961,21 +960,16 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         else:
             framePathTime = QDateTime()
 
-	# Get and Save the frame (return is void, so we cannot check for success/fail here - must use file modification timestamp)
+        # Get and Save the frame (return is void, so we cannot check for success/fail here - must use file modification timestamp)
         openshot.Timeline.GetFrame(self.timeline_sync.timeline,self.preview_thread.current_frame).Save(framePath, 1.0)
 
-        #log.info("orig framePathTime %s" % framePathTime.toString("yyMMdd hh:mm:ss.zzz") )
-        #log.info("new framePathTime %s" % QFileInfo(framePath).lastModified().toString("yyMMdd hh:mm:ss.zzz") )
-
-	# Show message to user
+        # Show message to user
         if os.path.exists(framePath) and (QFileInfo(framePath).lastModified() > framePathTime):
-            #QMessageBox.information(self, _("Save Frame Successful"), _("Saved image to %s" % framePath))
             self.statusBar.showMessage(_("Saved Frame to %s" % framePath), 5000)
         else:
-            #QMessageBox.warning(self, _("Save Frame Failed"), _("Failed to save image to %s" % framePath))
             self.statusBar.showMessage( _("Failed to save image to %s" % framePath), 5000)
 
-	# Reset the MaxSize to match the preview and reset the preview cache
+        # Reset the MaxSize to match the preview and reset the preview cache
         viewport_rect = self.videoPreview.centeredViewport(self.videoPreview.width(), self.videoPreview.height())
         self.timeline_sync.timeline.SetMaxSize(viewport_rect.width(), viewport_rect.height())
         self.cache_object.Clear()

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -667,12 +667,10 @@ class BlenderListView(QListView):
 
     # Signal when to update progress bar (1005)
     def onUpdateProgress(self, current_frame, current_part, max_parts):
-        # log.info ('onUpdateProgress')
         self.update_progress_bar(current_frame, current_part, max_parts)
 
     # Signal when to update preview image (1006)
     def onUpdateImage(self, image_path):
-        # log.info ('onUpdateImage: %s' % image_path)
         self.update_image(image_path)
 
     # Signal error from blender (with custom message) (1007)

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -2441,15 +2441,18 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
         # Get track object
         track = Track.get(id=layer_id)
+        locked = track.data.get("lock", False)
 
         menu = QMenu(self)
         menu.addAction(self.window.actionAddTrackAbove)
         menu.addAction(self.window.actionAddTrackBelow)
         menu.addAction(self.window.actionRenameTrack)
-        if track.data.get("lock", False):
+        if locked:
             menu.addAction(self.window.actionUnlockTrack)
+            self.window.actionRemoveTrack.setEnabled(False)
         else:
             menu.addAction(self.window.actionLockTrack)
+            self.window.actionRemoveTrack.setEnabled(True)
         menu.addSeparator()
         menu.addAction(self.window.actionRemoveTrack)
         return menu.popup(QCursor.pos())

--- a/src/windows/views/tutorial.py
+++ b/src/windows/views/tutorial.py
@@ -205,7 +205,6 @@ class TutorialManager(object):
             self.dock.adjustSize()
             self.dock.setEnabled(True)
             self.re_position_dialog()
-            #self.current_dialog.show()
             self.dock.show()
             break
 


### PR DESCRIPTION
This is a pretty big re-write of the Track / Layers logic, with respects to how we number them, and how we insert, add, and remove them. The tracks numbering is now spread out:
Track 5 (number: 5,000,000)
Track 4 (number: 4,000,000)
Track 3 (number: 3,000,000)
Track 2 (number: 2,000,000)
Track 1 (number: 1,000,000)

Inserting a new track now simply picks a number halfway between the gap... for example:
Track 5 (number: 5,000,000)
Track 4 (number: 4,000,000)
Inserted Track (number 3,500,000)
Track 3 (number: 3,000,000)
Track 2 (number: 2,000,000)
Track 1 (number: 1,000,000)

With this logic, no other data is required to change, and it all magically works. However, if a user inserts around 30 tracks at the exact same spot, the 1/2'ing will eventually run out of a gap, and will then renumber things that conflict (similar to the current logic).

Also, disabled tracks are now blocked from the "Delete" context menu. 

Otherwise, the behavior of Tracks is identical to before, just faster, simpler, and more stable.