### PR TITLE
Converting to new Settings class, instead of the old ENV VAR method. …

### DIFF
--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -29,7 +29,7 @@ import os
 
 from PyQt5.QtCore import QDir
 
-VERSION = "2.4.3-dev2"
+VERSION = "2.4.3-dev3"
 MINIMUM_LIBOPENSHOT_VERSION = "0.2.2"
 DATE = "20180922000000"
 NAME = "openshot-qt"

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -326,7 +326,7 @@
     "setting": "send_metrics"
   },
   {
-    "value": true,
+    "value": false,
     "title": "Enable Hardware Decode",
     "type": "hidden",
     "restart": true,
@@ -334,10 +334,18 @@
     "setting": "hardware_decode"
   },
   {
+    "value": false,
+    "title": "Enable Hardware Encode",
+    "type": "hidden",
+    "restart": true,
+    "category": "Performance",
+    "setting": "hardware_encode"
+  },
+  {
     "value": true,
     "title": "Process Video Frames in Parallel (Experimental)",
     "type": "bool",
-    "restart": true,
+    "restart": false,
     "category": "Performance",
     "setting": "omp_threads_enabled"
   },

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -101,7 +101,8 @@ class Export(QDialog):
         self.txtChannels.setVisible(False)
 
         # Set OMP thread disabled flag (for stability)
-        os.environ['OS2_OMP_THREADS'] = "0"
+        openshot.Settings.Instance().WAIT_FOR_VIDEO_PROCESSING_TASK = True
+        openshot.Settings.Instance().HIGH_QUALITY_SCALING = True
 
         # Get the original timeline settings
         width = get_app().window.timeline_sync.timeline.info.width
@@ -813,9 +814,12 @@ class Export(QDialog):
 
         # Re-set OMP thread enabled flag
         if self.s.get("omp_threads_enabled"):
-            os.environ['OS2_OMP_THREADS'] = "1"
+            openshot.Settings.Instance().WAIT_FOR_VIDEO_PROCESSING_TASK = False
         else:
-            os.environ['OS2_OMP_THREADS'] = "0"
+            openshot.Settings.Instance().WAIT_FOR_VIDEO_PROCESSING_TASK = True
+
+            # Return scale mode to lower quality scaling (for faster previews)
+        openshot.Settings.Instance().HIGH_QUALITY_SCALING = False
 
         # Accept dialog
         super(Export, self).accept()
@@ -823,9 +827,12 @@ class Export(QDialog):
     def reject(self):
         # Re-set OMP thread enabled flag
         if self.s.get("omp_threads_enabled"):
-            os.environ['OS2_OMP_THREADS'] = "1"
+            openshot.Settings.Instance().WAIT_FOR_VIDEO_PROCESSING_TASK = False
         else:
-            os.environ['OS2_OMP_THREADS'] = "0"
+            openshot.Settings.Instance().WAIT_FOR_VIDEO_PROCESSING_TASK = True
+
+        # Return scale mode to lower quality scaling (for faster previews)
+        openshot.Settings.Instance().HIGH_QUALITY_SCALING = False
 
         # Cancel dialog
         self.exporting = False

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2476,17 +2476,26 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         if s.get("enable-auto-save"):
             self.auto_save_timer.start()
 
-        # Set hardware decode environment variable
+        # Set hardware decode
         if s.get("hardware_decode"):
-            os.environ['OS2_DECODE_HW'] = "1"
+            openshot.Settings.Instance().HARDWARE_DECODE = True
         else:
-            os.environ['OS2_DECODE_HW'] = "0"
+            openshot.Settings.Instance().HARDWARE_DECODE = False
+
+        # Set hardware encode
+        if s.get("hardware_encode"):
+            openshot.Settings.Instance().HARDWARE_ENCODE = True
+        else:
+            openshot.Settings.Instance().HARDWARE_ENCODE = False
 
         # Set OMP thread enabled flag (for stability)
         if s.get("omp_threads_enabled"):
-            os.environ['OS2_OMP_THREADS'] = "1"
+            openshot.Settings.Instance().WAIT_FOR_VIDEO_PROCESSING_TASK = False
         else:
-            os.environ['OS2_OMP_THREADS'] = "0"
+            openshot.Settings.Instance().WAIT_FOR_VIDEO_PROCESSING_TASK = True
+
+        # Set scaling mode to lower quality scaling (for faster previews)
+        openshot.Settings.Instance().HIGH_QUALITY_SCALING = False
 
         # Create lock file
         self.create_lock_file()

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -300,19 +300,27 @@ class Preferences(QDialog):
 
         elif param["setting"] == "hardware_decode":
             if (state == Qt.Checked):
-                # Enable hardware decode environment variable
-                os.environ['OS2_DECODE_HW'] = "1"
+                # Enable hardware decode
+                openshot.Settings.Instance().HARDWARE_DECODE = True
             else:
-                # Disable hardware decode environment variable
-                os.environ['OS2_DECODE_HW'] = "0"
+                # Disable hardware decode
+                openshot.Settings.Instance().HARDWARE_DECODE = False
+
+        elif param["setting"] == "hardware_encode":
+            if (state == Qt.Checked):
+                # Enable hardware encode
+                openshot.Settings.Instance().HARDWARE_ENCODE = True
+            else:
+                # Disable hardware encode
+                openshot.Settings.Instance().HARDWARE_ENCODE = False
 
         elif param["setting"] == "omp_threads_enabled":
             if (state == Qt.Checked):
                 # Enable OMP multi-threading
-                os.environ['OS2_OMP_THREADS'] = "1"
+                openshot.Settings.Instance().WAIT_FOR_VIDEO_PROCESSING_TASK = False
             else:
                 # Disable OMP multi-threading
-                os.environ['OS2_OMP_THREADS'] = "0"
+                openshot.Settings.Instance().WAIT_FOR_VIDEO_PROCESSING_TASK = True
 
         # Check for restart
         self.check_for_restart(param)


### PR DESCRIPTION
…This requires the latest build of libopenshot to be installed, otherwise these new Settings options will not be found in Python. Also adding in a few hidden settings, for development work (related to hardware decode and encode)

The biggest improvement when running this new version of OpenShot is a faster (and lower quality) scale mode during realtime previews, and a higher quality (and slower) scale mode during final renders.