### PR TITLE
Improve Title Editor to use libopenshot for Preview

### DIFF
--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -32,6 +32,7 @@ import re
 import shutil
 import functools
 import subprocess
+import tempfile
 from xml.dom import minidom
 
 from PyQt5.QtCore import *
@@ -149,9 +150,26 @@ class TitleEditor(QDialog):
         self.display_svg()
 
     def display_svg(self):
+        # Create a temp file for this thumbnail image
+        new_file, tmp_filename = tempfile.mkstemp()
+        tmp_filename = "%s.png" % tmp_filename
+
+        # Create a clip object and get the reader
+        clip = openshot.Clip(self.filename)
+        reader = clip.Reader()
+
+        # Open reader
+        reader.Open()
+
+        # Save thumbnail image and close readers
+        reader.GetFrame(1).Thumbnail(tmp_filename, self.graphicsView.width(), self.graphicsView.height(), "", "", "#000", False, "png", 100, 0.0)
+        reader.Close()
+        clip.Close()
+
+        # Display temp image
         scene = QGraphicsScene(self)
         view = self.graphicsView
-        svg = QtGui.QPixmap(self.filename)
+        svg = QtGui.QPixmap(tmp_filename)
         svg_scaled = svg.scaled(self.graphicsView.size(), Qt.KeepAspectRatio, Qt.SmoothTransformation)
         scene.addPixmap(svg_scaled)
         view.setScene(scene)


### PR DESCRIPTION
Instead of defaulting to Qt's built-in SVG parsing for title previews, use libopenshot instead to generate the preview images. This allows resvg to render them (if compiled and available), otherwise it falls back to Qt.