### PR TITLE
Separating FFmpegWriter::Open() from PrepareStreams()

### DIFF
--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -611,6 +611,14 @@ class Export(QDialog):
                     measurement = "mb"
                     bit_rate_bytes = raw_number * 1000.0 * 1000.0
 
+                elif "crf" in raw_measurement:
+                    measurement = "crf"
+                    if raw_number > 63:
+                        raw_number = 63
+                    if raw_number < 0:
+                        raw_number = 0
+                    bit_rate_bytes = raw_number
+
         except:
             pass
 
@@ -734,28 +742,18 @@ class Export(QDialog):
                                   audio_settings.get("channel_layout"),
                                   audio_settings.get("audio_bitrate"))
 
-            # Open the writer
-            w.Open()
+            # Prepare the streams
+            w.PrepareStreams()
+
             # These extra options should be set in an extra method
             # No feedback is given to the user
             # TODO: Tell user if option is not avaliable
             # Set the quality in case crf was selected
-            crf_bitrate = self.txtVideoBitRate.text()
-            s = crf_bitrate.lower().split(" ")
-            if len(s) >= 2:
-                raw_number_string = s[0]
-                raw_measurement = s[1]
-                raw_number = locale.atof(raw_number_string)
-                # Only the range for all crf settings is checked here
-                # The main check is in libopenshot FFmpegWriter.cpp
-                if "crf" in raw_measurement:
-                    measurement = "crf"
-                    if raw_number > 63:
-                        raw_number = 63
-                    if raw_number < 0:
-                        raw_number = 0
-                    bit_rate_bytes = raw_number
-                    w.SetOption(openshot.VIDEO_STREAM, "crf", str(int(bit_rate_bytes)) )
+            if "crf" in self.txtVideoBitRate.text():
+                w.SetOption(openshot.VIDEO_STREAM, "crf", str(int(video_settings.get("video_bitrate"))) )
+
+            # Open the writer
+            w.Open()
 
             # Notify window of export started
             export_file_path = ""


### PR DESCRIPTION
This allows SetOption to work by setting both the video bit_rate and options for CRF... and goes along with a refactor in libopenshot: https://github.com/OpenShot/libopenshot/pull/193