### PR TITLE
Dragging an OSP file into the Project Files widget will open the project

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -168,7 +168,7 @@ class OpenShotApp(QApplication):
             path = args[0][1]
             if ".osp" in path:
                 # Auto load project passed as argument
-                self.window.open_project(path)
+                self.window.OpenProjectSignal.emit(path)
             else:
                 # Auto import media file
                 self.window.filesTreeView.add_file(path)

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -278,8 +278,14 @@ class FilesListView(QListView):
             filepath = uri.toLocalFile()
             if os.path.exists(filepath) and os.path.isfile(filepath):
                 log.info('Adding file: {}'.format(filepath))
-                if self.add_file(filepath):
+                if ".osp" in filepath:
+                    # Auto load project passed as argument
+                    self.win.OpenProjectSignal.emit(filepath)
                     event.accept()
+                else:
+                    # Auto import media file
+                    if self.add_file(filepath):
+                        event.accept()
 
     def clear_filter(self):
         if self:

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -277,8 +277,14 @@ class FilesTreeView(QTreeView):
             filepath = uri.toLocalFile()
             if os.path.exists(filepath) and os.path.isfile(filepath):
                 log.info('Adding file: {}'.format(filepath))
-                if self.add_file(filepath):
+                if ".osp" in filepath:
+                    # Auto load project passed as argument
+                    self.win.OpenProjectSignal.emit(filepath)
                     event.accept()
+                else:
+                    # Auto import media file
+                    if self.add_file(filepath):
+                        event.accept()
 
     def clear_filter(self):
         if self:


### PR DESCRIPTION
Dragging an OSP file into the Project Files widget will open the project file (and prompt to save unsaved changes)