### PR TITLE
Scale keyframe coordinates when changing Profile or Exporting

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -358,6 +358,62 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         # Clear needs save flag
         self.has_unsaved_changes = False
 
+    def scale_keyframe_value(self, original_value, scale_factor):
+        """Scale keyframe X coordinate by some factor, except for 1 (leave that alone)"""
+        if original_value == 1.0:
+            # This represents the first frame of a clip (so we want to maintain that)
+            return original_value
+        else:
+            # Round to nearest INT
+            return round(original_value * scale_factor)
+
+    def rescale_keyframes(self, scale_factor):
+        """Adjust all keyframe coordinates from previous FPS to new FPS (using a scale factor)"""
+        log.info('Scale all keyframes by a factor of %s' % scale_factor)
+
+        # Loop through all clips (and look for Keyframe objects)
+        # Scale the X coordinate by factor (which represents the frame #)
+        for clip in self._data.get('clips', []):
+            for attribute in clip:
+                if type(clip.get(attribute)) == dict and "Points" in clip.get(attribute):
+                    for point in clip.get(attribute).get("Points"):
+                        if "co" in point:
+                            point["co"]["X"] = self.scale_keyframe_value(point["co"].get("X", 0.0), scale_factor)
+                if type(clip.get(attribute)) == dict and "red" in clip.get(attribute):
+                    for color in clip.get(attribute):
+                        for point in clip.get(attribute).get(color).get("Points"):
+                            if "co" in point:
+                                point["co"]["X"] = self.scale_keyframe_value(point["co"].get("X", 0.0), scale_factor)
+            for effect in clip.get("effects", []):
+                for attribute in effect:
+                    if type(effect.get(attribute)) == dict and "Points" in effect.get(attribute):
+                        for point in effect.get(attribute).get("Points"):
+                            if "co" in point:
+                                point["co"]["X"] = self.scale_keyframe_value(point["co"].get("X", 0.0), scale_factor)
+                    if type(effect.get(attribute)) == dict and "red" in effect.get(attribute):
+                        for color in effect.get(attribute):
+                            for point in effect.get(attribute).get(color).get("Points"):
+                                if "co" in point:
+                                    point["co"]["X"] = self.scale_keyframe_value(point["co"].get("X", 0.0), scale_factor)
+
+        # Loop through all effects/transitions (and look for Keyframe objects)
+        # Scale the X coordinate by factor (which represents the frame #)
+        for effect in self._data.get('effects',[]):
+            for attribute in effect:
+                if type(effect.get(attribute)) == dict and "Points" in effect.get(attribute):
+                    for point in effect.get(attribute).get("Points"):
+                        if "co" in point:
+                            point["co"]["X"] = self.scale_keyframe_value(point["co"].get("X", 0.0), scale_factor)
+                if type(effect.get(attribute)) == dict and "red" in effect.get(attribute):
+                    for color in effect.get(attribute):
+                        for point in effect.get(attribute).get(color).get("Points"):
+                            if "co" in point:
+                                point["co"]["X"] = self.scale_keyframe_value(point["co"].get("X", 0.0), scale_factor)
+
+        # Get app, and distribute all project data through update manager
+        from classes.app import get_app
+        get_app().updates.load(self._data)
+
     def read_legacy_project_file(self, file_path):
         """Attempt to read a legacy version 1.x openshot project file"""
         import sys, pickle

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -112,6 +112,9 @@ class Export(QDialog):
         channels = get_app().window.timeline_sync.timeline.info.channels
         channel_layout = get_app().window.timeline_sync.timeline.info.channel_layout
 
+        # No keyframe rescaling has happened yet (due to differences in FPS)
+        self.keyframes_rescaled = False
+
         # Create new "export" openshot.Timeline object
         self.timeline = openshot.Timeline(width, height, openshot.Fraction(fps.num, fps.den),
                                           sample_rate, channels, channel_layout)
@@ -350,6 +353,13 @@ class Export(QDialog):
         self.progressExportVideo.setMinimum(self.txtStartFrame.value())
         self.progressExportVideo.setMaximum(self.txtEndFrame.value())
         self.progressExportVideo.setValue(self.txtStartFrame.value())
+
+        # Calculate differences between editing/preview FPS and export FPS
+        current_fps = get_app().project.get(["fps"])
+        current_fps_float = float(current_fps["num"]) / float(current_fps["den"])
+        new_fps_float = float(self.txtFrameRateNum.value()) / float(self.txtFrameRateDen.value())
+        self.export_fps_factor = new_fps_float / current_fps_float
+        self.original_fps_factor = current_fps_float / new_fps_float
 
     def cboSimpleProjectType_index_changed(self, widget, index):
         selected_project = widget.itemData(index)
@@ -715,6 +725,18 @@ class Export(QDialog):
         export_cache_object = openshot.CacheMemory(250)
         self.timeline.SetCache(export_cache_object)
 
+        # Rescale all keyframes and reload project
+        if self.export_fps_factor != 1.0:
+            self.keyframes_rescaled = True
+            get_app().project.rescale_keyframes(self.export_fps_factor)
+
+            # Load the "export" Timeline reader with the JSON from the real timeline
+            json_timeline = json.dumps(get_app().project._data)
+            self.timeline.SetJson(json_timeline)
+
+            # Re-update the timeline FPS again (since the timeline just got clobbered)
+            self.updateFrameRate()
+
         # Create FFmpegWriter
         try:
             w = openshot.FFmpegWriter(export_file_path)
@@ -842,8 +864,12 @@ class Export(QDialog):
         else:
             openshot.Settings.Instance().WAIT_FOR_VIDEO_PROCESSING_TASK = True
 
-            # Return scale mode to lower quality scaling (for faster previews)
+        # Return scale mode to lower quality scaling (for faster previews)
         openshot.Settings.Instance().HIGH_QUALITY_SCALING = False
+
+        # Return keyframes to preview scaling
+        if self.keyframes_rescaled:
+            get_app().project.rescale_keyframes(self.original_fps_factor)
 
         # Accept dialog
         super(Export, self).accept()
@@ -857,6 +883,10 @@ class Export(QDialog):
 
         # Return scale mode to lower quality scaling (for faster previews)
         openshot.Settings.Instance().HIGH_QUALITY_SCALING = False
+
+        # Return keyframes to preview scaling
+        if self.keyframes_rescaled:
+            get_app().project.rescale_keyframes(self.original_fps_factor)
 
         # Cancel dialog
         self.exporting = False

--- a/src/windows/profile.py
+++ b/src/windows/profile.py
@@ -123,11 +123,21 @@ class Profile(QDialog):
         self.lblFPS.setText("%0.2f" % (profile.info.fps.num / profile.info.fps.den))
         self.lblOther.setText("DAR: %s/%s, SAR: %s/%s, Interlaced: %s" % (profile.info.display_ratio.num, profile.info.display_ratio.den, profile.info.pixel_ratio.num, profile.info.pixel_ratio.den, profile.info.interlaced_frame))
 
+        # Get current FPS (prior to changing)
+        current_fps = get_app().project.get(["fps"])
+        current_fps_float = float(current_fps["num"]) / float(current_fps["den"])
+        new_fps_float = float(profile.info.fps.num) / float(profile.info.fps.den)
+        fps_factor = new_fps_float / current_fps_float
+
         # Update timeline settings
         get_app().updates.update(["profile"], profile.info.description)
         get_app().updates.update(["width"], profile.info.width)
         get_app().updates.update(["height"], profile.info.height)
         get_app().updates.update(["fps"], {"num" : profile.info.fps.num, "den" : profile.info.fps.den})
+
+        # Rescale all keyframes and reload project
+        if fps_factor != 1.0:
+            get_app().project.rescale_keyframes(fps_factor)
 
         # Force ApplyMapperToClips to apply these changes
         get_app().window.timeline_sync.timeline.ApplyMapperToClips()


### PR DESCRIPTION
Scale keyframe coordinates when changing Profile or Exporting using a different FPS (compared to the preview/editing Profile). This has been a long-time issue with OpenShot 2.x. Essentially changing the framerate during editing (or exporting as a different framerate) causes all Keyframe objects in OpenShot to be incorrect, since they use actual Frame numbers, and not percentages.

This MR introduces a new rescale method, used when changing Profile or Exporting using a different profile, and scales coordinates between different FPS rates. Although this fixes most issues users have reported with respects to Exports not using the correct Keyframe values, it can introduce some rounding errors when switching from a high framerate used during editing, then exporting at a low framerate, and then switching back to the original rate (which can change values and lose precision).

It is still highly recommended to edit and export using the same FPS and same width/height ratio. This is somewhat experimental, but it's ready for some testing now.