### PR TITLE
Support for both utf-8 and utf-16-le Changelog

### DIFF
--- a/src/windows/about.py
+++ b/src/windows/about.py
@@ -71,10 +71,16 @@ class About(QDialog):
         for project in ['openshot-qt', 'libopenshot', 'libopenshot-audio']:
             changelog_path = os.path.join(info.PATH, 'settings', '%s.log' % project)
             if os.path.exists(changelog_path):
-                with codecs.open(changelog_path, 'r', 'utf-8') as changelog_file:
-                    if changelog_file.read():
-                        self.btnchangelog.setVisible(True)
-                        break
+                # Attempt to open changelog with utf-8, and then utf-16-le (for unix / windows support)
+                for encoding_name in ('utf-8', 'utf_16_le'):
+                    try:
+                        with codecs.open(changelog_path, 'r', encoding=encoding_name) as changelog_file:
+                            if changelog_file.read():
+                                self.btnchangelog.setVisible(True)
+                                break
+                    except:
+                        # Ignore decoding errors
+                        pass
 
         create_text = _('Create &amp; Edit Amazing Videos and Movies')
         description_text = _('OpenShot Video Editor 2.x is the next generation of the award-winning <br/>OpenShot video editing platform.')
@@ -255,12 +261,18 @@ class Changelog(QDialog):
         changelog_list = []
         changelog_path = os.path.join(info.PATH, 'settings', 'openshot-qt.log')
         if os.path.exists(changelog_path):
-            with codecs.open(changelog_path, 'r', 'utf-8') as changelog_file:
-                for line in changelog_file:
-                    changelog_list.append({'hash': line[:9].strip(),
-                                           'date': line[9:20].strip(),
-                                           'author': line[20:45].strip(),
-                                           'subject': line[45:].strip() })
+            # Attempt to open changelog with utf-8, and then utf-16-le (for unix / windows support)
+            for encoding_name in ('utf-8', 'utf_16_le'):
+                try:
+                    with codecs.open(changelog_path, 'r', encoding=encoding_name) as changelog_file:
+                        for line in changelog_file:
+                            changelog_list.append({'hash': line[:9].strip(),
+                                                   'date': line[9:20].strip(),
+                                                   'author': line[20:45].strip(),
+                                                   'subject': line[45:].strip() })
+                except:
+                    # Ignore decoding errors
+                    pass
         self.openshot_qt_ListView = ChangelogTreeView(commits=changelog_list, commit_url="https://github.com/OpenShot/openshot-qt/commit/%s/")
         self.vbox_openshot_qt.addWidget(self.openshot_qt_ListView)
         self.txtChangeLogFilter_openshot_qt.textChanged.connect(partial(self.Filter_Triggered, self.txtChangeLogFilter_openshot_qt, self.openshot_qt_ListView))
@@ -269,12 +281,18 @@ class Changelog(QDialog):
         changelog_list = []
         changelog_path = os.path.join(info.PATH, 'settings', 'libopenshot.log')
         if os.path.exists(changelog_path):
-            with codecs.open(changelog_path, 'r', 'utf-8') as changelog_file:
-                for line in changelog_file:
-                    changelog_list.append({'hash': line[:9].strip(),
-                                           'date': line[9:20].strip(),
-                                           'author': line[20:45].strip(),
-                                           'subject': line[45:].strip() })
+            # Attempt to open changelog with utf-8, and then utf-16-le (for unix / windows support)
+            for encoding_name in ('utf-8', 'utf_16_le'):
+                try:
+                    with codecs.open(changelog_path, 'r', encoding=encoding_name) as changelog_file:
+                        for line in changelog_file:
+                            changelog_list.append({'hash': line[:9].strip(),
+                                                   'date': line[9:20].strip(),
+                                                   'author': line[20:45].strip(),
+                                                   'subject': line[45:].strip() })
+                except:
+                    # Ignore decoding errors
+                    pass
         self.libopenshot_ListView = ChangelogTreeView(commits=changelog_list, commit_url="https://github.com/OpenShot/libopenshot/commit/%s/")
         self.vbox_libopenshot.addWidget(self.libopenshot_ListView)
         self.txtChangeLogFilter_libopenshot.textChanged.connect(partial(self.Filter_Triggered, self.txtChangeLogFilter_libopenshot, self.libopenshot_ListView))
@@ -283,12 +301,18 @@ class Changelog(QDialog):
         changelog_list = []
         changelog_path = os.path.join(info.PATH, 'settings', 'libopenshot-audio.log')
         if os.path.exists(changelog_path):
-            with codecs.open(changelog_path, 'r', 'utf-8') as changelog_file:
-                for line in changelog_file:
-                    changelog_list.append({'hash': line[:9].strip(),
-                                           'date': line[9:20].strip(),
-                                           'author': line[20:45].strip(),
-                                           'subject': line[45:].strip() })
+            # Attempt to open changelog with utf-8, and then utf-16-le (for unix / windows support)
+            for encoding_name in ('utf-8', 'utf_16_le'):
+                try:
+                    with codecs.open(changelog_path, 'r', encoding=encoding_name) as changelog_file:
+                        for line in changelog_file:
+                            changelog_list.append({'hash': line[:9].strip(),
+                                                   'date': line[9:20].strip(),
+                                                   'author': line[20:45].strip(),
+                                                   'subject': line[45:].strip() })
+                except:
+                    # Ignore decoding errors
+                    pass
         self.libopenshot_audio_ListView = ChangelogTreeView(commits=changelog_list, commit_url="https://github.com/OpenShot/libopenshot-audio/commit/%s/")
         self.vbox_libopenshot_audio.addWidget(self.libopenshot_audio_ListView)
         self.txtChangeLogFilter_libopenshot_audio.textChanged.connect(partial(self.Filter_Triggered, self.txtChangeLogFilter_libopenshot_audio, self.libopenshot_audio_ListView))

--- a/src/windows/models/blender_model.py
+++ b/src/windows/models/blender_model.py
@@ -28,7 +28,7 @@
 import os
 import xml.dom.minidom as xml
 
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QSize
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import QMessageBox
 import openshot  # Python module for libopenshot (required video editing module installed separately)
@@ -108,7 +108,9 @@ class BlenderModel():
 
                 # Append thumbnail
                 col = QStandardItem()
-                col.setIcon(QIcon(thumb_path))
+                icon_pixmap = QPixmap(thumb_path)
+                scaled_pixmap = icon_pixmap.scaled(QSize(93, 62), Qt.IgnoreAspectRatio, Qt.SmoothTransformation)
+                col.setIcon(QIcon(scaled_pixmap))
                 col.setText(self.app._tr(title))
                 col.setToolTip(self.app._tr(title))
                 col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)

--- a/src/windows/models/blender_model.py
+++ b/src/windows/models/blender_model.py
@@ -148,5 +148,5 @@ class BlenderModel():
         # Create standard model
         self.app = get_app()
         self.model = QStandardItemModel()
-        self.model.setColumnCount(4)
+        self.model.setColumnCount(3)
         self.model_paths = {}

--- a/src/windows/models/titles_model.py
+++ b/src/windows/models/titles_model.py
@@ -28,7 +28,7 @@
 import os
 import fnmatch
 
-from PyQt5.QtCore import QMimeData, Qt
+from PyQt5.QtCore import QMimeData, Qt, QSize
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import QMessageBox
 import openshot  # Python module for libopenshot (required video editing module installed separately)
@@ -153,7 +153,9 @@ class TitlesModel():
 
             # Append thumbnail
             col = QStandardItem()
-            col.setIcon(QIcon(thumb_path))
+            icon_pixmap = QPixmap(thumb_path)
+            scaled_pixmap = icon_pixmap.scaled(QSize(93, 62), Qt.IgnoreAspectRatio, Qt.SmoothTransformation)
+            col.setIcon(QIcon(scaled_pixmap))
             col.setText(title_name)
             col.setToolTip(title_name)
             col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)

--- a/src/windows/ui/animated-title.ui
+++ b/src/windows/ui/animated-title.ui
@@ -57,7 +57,7 @@
       </property>
       <property name="maximumSize">
        <size>
-        <width>340</width>
+        <width>400</width>
         <height>16777215</height>
        </size>
       </property>

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -618,7 +618,6 @@ class BlenderListView(QListView):
         self.setUniformItemSizes(True)
         self.setWordWrap(True)
         self.setTextElideMode(Qt.ElideRight)
-        self.setStyleSheet('QListView::item { padding-top: 10px; }')
 
         # Hook up button
         self.win.btnRefresh.clicked.connect(functools.partial(self.btnRefresh_clicked))

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -30,6 +30,7 @@ import os
 import uuid
 import shutil
 import subprocess
+import sys
 import re
 import xml.dom.minidom as xml
 import functools
@@ -614,10 +615,10 @@ class BlenderListView(QListView):
         self.setGridSize(QSize(102, 92))
         self.setViewMode(QListView.IconMode)
         self.setResizeMode(QListView.Adjust)
-        self.setUniformItemSizes(False)
+        self.setUniformItemSizes(True)
         self.setWordWrap(True)
         self.setTextElideMode(Qt.ElideRight)
-        self.setStyleSheet('QTreeView::item { padding-top: 2px; }')
+        self.setStyleSheet('QListView::item { padding-top: 2px; }')
 
         # Hook up button
         self.win.btnRefresh.clicked.connect(functools.partial(self.btnRefresh_clicked))
@@ -719,11 +720,16 @@ class Worker(QObject):
         self.is_running = True
         _ = get_app()._tr
 
+        startupinfo = None
+        if sys.platform == 'win32':
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
         try:
             # Shell the blender command to create the image sequence
             command_get_version = [self.blender_exec_path, '-v']
             command_render = [self.blender_exec_path, '-b', self.blend_file_path, '-P', self.target_script]
-            self.process = subprocess.Popen(command_get_version, stdout=subprocess.PIPE)
+            self.process = subprocess.Popen(command_get_version, stdout=subprocess.PIPE, stderr=subprocess.PIPE, startupinfo=startupinfo)
 
             # Check the version of Blender
             self.version = self.blender_version.findall(str(self.process.stdout.readline()))
@@ -743,7 +749,7 @@ class Worker(QObject):
                                                              command_render[3], command_render[4]))
 
             # Run real command to render Blender project
-            self.process = subprocess.Popen(command_render, stdout=subprocess.PIPE)
+            self.process = subprocess.Popen(command_render, stdout=subprocess.PIPE, stderr=subprocess.PIPE, startupinfo=startupinfo)
 
         except:
             # Error running command.  Most likely the blender executable path in the settings

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -618,7 +618,7 @@ class BlenderListView(QListView):
         self.setUniformItemSizes(True)
         self.setWordWrap(True)
         self.setTextElideMode(Qt.ElideRight)
-        self.setStyleSheet('QListView::item { padding-top: 2px; }')
+        self.setStyleSheet('QListView::item { padding-top: 10px; }')
 
         # Hook up button
         self.win.btnRefresh.clicked.connect(functools.partial(self.btnRefresh_clicked))

--- a/src/windows/views/titles_listview.py
+++ b/src/windows/views/titles_listview.py
@@ -89,7 +89,6 @@ class TitlesListView(QListView):
         self.setUniformItemSizes(True)
         self.setWordWrap(True)
         self.setTextElideMode(Qt.ElideRight)
-        self.setStyleSheet('QListView::item { padding-top: 10px; }')
 
         # Refresh view
         self.refresh_view()

--- a/src/windows/views/titles_listview.py
+++ b/src/windows/views/titles_listview.py
@@ -89,7 +89,7 @@ class TitlesListView(QListView):
         self.setUniformItemSizes(True)
         self.setWordWrap(True)
         self.setTextElideMode(Qt.ElideRight)
-        self.setStyleSheet('QListView::item { padding-top: 2px; }')
+        self.setStyleSheet('QListView::item { padding-top: 10px; }')
 
         # Refresh view
         self.refresh_view()


### PR DESCRIPTION
Support for both utf-8 and utf-16-le Changelog support. Windows builders always encode the changelog in utf-16-le, and after many hours of failure to output utf-8, I decided that supporting both is not that big of a deal.