### PR TITLE
Windows Installer: Remove invalid files (system32/zlib1.dll)

### DIFF
--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -79,7 +79,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 ; Remove previous installed versions of OpenShot
 Type: filesandordirs; Name: "{app}\*"
 Type: dirifempty; Name: "{app}\*"
-Type: files; Name: "{group}\OpenShot Video Editor"
+Type: files; Name: "{group}\OpenShot Video Editor"; BeforeInstall: DeleteInvalidFiles
 
 [Registry]
 ; Remove previously installed registry keys (no longer needed)
@@ -97,3 +97,12 @@ Name: "{commondesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: 
 [Run]
 ; Launch after installation
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+
+[Code]
+procedure DeleteInvalidFiles();
+begin
+  if (FileExists (ExpandConstant('{sys}\zlib1.dll'))) then
+  begin
+    RenameFile(ExpandConstant('{sys}\zlib1.dll'), ExpandConstant('{sys}\zlib1.DELETE'));
+  end;
+end;

--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -105,4 +105,12 @@ begin
   begin
     RenameFile(ExpandConstant('{sys}\zlib1.dll'), ExpandConstant('{sys}\zlib1.DELETE'));
   end;
+  if (FileExists (ExpandConstant('{win}\system32\zlib1.dll'))) then
+  begin
+    RenameFile(ExpandConstant('{win}\system32\zlib1.dll'), ExpandConstant('{win}\system32\zlib1.DELETE'));
+  end;
+  if (FileExists (ExpandConstant('{syswow64}\zlib1.dll'))) then
+  begin
+    RenameFile(ExpandConstant('{syswow64}\zlib1.dll'), ExpandConstant('{syswow64}\zlib1.DELETE'));
+  end;
 end;


### PR DESCRIPTION
Some Windows systems fail to launch OpenShot due to an invalid file installed by some 3rd party application: C:\Windows\System32\zlib1.dll. The OpenShot installer will now rename that file so OpenShot will not have any conflicts during launch. There could also be additional files we need to rename as well, but this one has consistently come up as a problem.