### PR TITLE
Fix author string in __init__.py

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,7 +1,7 @@
 """
  @file openshot_qt/__init__.py
  @brief Initialization code used when running OpenShot installed as a Python module
- @author FeRD (Frank Dana) <ferdnyc AT gmail com>
+ @author Jonathan Thomas <jonathan@openshot.org>
 
  @section LICENSE
 


### PR DESCRIPTION
I happen to have written `src/__init__.py`, which is all of two lines of code and a comment. But as it's the core file for the entire Python module, its header comment is **also** the first thing you see from `pydoc3 openshot_qt` and the like, on an installed `openshot_qt`. Which means I inadvertently created the following misleading situation:
```console
$ pydoc3 openshot_qt|head -n20 
Help on package openshot_qt:

NAME
    openshot_qt

DESCRIPTION
    @file openshot_qt/__init__.py
    @brief Initialization code used when running OpenShot installed as a Python module
    @author FeRD (Frank Dana) <ferdnyc AT gmail com>
    
    @section LICENSE
    
    Copyright (c) 2008-2018 OpenShot Studios, LLC
    (http://www.openshotstudios.com). This file is part of
    OpenShot Video Editor (http://www.openshot.org), an open-source project
    dedicated to delivering high quality video editing and animation solutions
    to the world.
    
    OpenShot Video Editor is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
```

...Certainly not my intention. So, this commit restores @jonoomph as the author of record.

(Might be worth sticking a more general application-level overview in there, really, but that's not currently the focus of this PR. Just correcting my glaring faux pas.)