### PR TITLE
Fix web links to question template

### DIFF
--- a/.github/ISSUE_TEMPLATE/i-have-a-question.md
+++ b/.github/ISSUE_TEMPLATE/i-have-a-question.md
@@ -1,0 +1,1 @@
+question.md


### PR DESCRIPTION
Simple hack to fix the website "Ask a Question" link, by symlinking the old filename to the current one.

Didn't cause any side effects, in testing on my fork. (No duplicate options in the Issue-type list or anything like that.)

Fixes #2728 