### PR TITLE
Remove simplejson fallback

### DIFF
--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -1,36 +1,33 @@
-""" 
+"""
  @file
  @brief This file loads and saves settings (as JSON)
  @author Noah Figg <eggmunkee@hotmail.com>
  @author Jonathan Thomas <jonathan@openshot.org>
  @author Olivier Girard <eolinwen@gmail.com>
- 
+
  @section LICENSE
- 
+
  Copyright (c) 2008-2018 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
+import json
 
 import copy
 import os
@@ -46,7 +43,7 @@ path_context = {}
 
 class JsonDataStore:
     """ This class which allows getting/setting of key/value settings, and loading and saving to json files.
-    Internal storage of a dictionary. Uses json or simplejson packages to serialize and deserialize from json to dictionary.
+    Internal storage of a dictionary. Uses json module to serialize and deserialize from json to dictionary.
     Keys are assumed to be strings, but subclasses which override get/set methods may use different key types.
     The write_to_file and read_from_file methods are key type agnostic."""
 

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -420,11 +420,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         from classes.query import File, Track, Clip, Transition
         from classes.app import get_app
         import openshot
-
-        try:
-            import json
-        except ImportError:
-            import simplejson as json
+        import json
 
         # Get translation method
         _ = get_app()._tr

--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -1,28 +1,28 @@
-""" 
+"""
  @file
  @brief This file contains the classes needed for tracking updates and distributing changes
  @author Noah Figg <eggmunkee@hotmail.com>
  @author Jonathan Thomas <jonathan@openshot.org>
  @author Olivier Girard <eolinwen@gmail.com>
- 
+
  @section LICENSE
- 
+
  Copyright (c) 2008-2018 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
@@ -31,12 +31,7 @@ from classes.logger import log
 from classes import info
 import copy
 import os
-
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class UpdateWatcher:
     """ Interface for classes that listen for 'undo' and 'redo' events. """

--- a/src/classes/version.py
+++ b/src/classes/version.py
@@ -30,11 +30,7 @@ import threading
 from classes.app import get_app
 from classes import info
 from classes.logger import log
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 def get_current_Version():
     """Get the current version """

--- a/src/tests/query_tests.py
+++ b/src/tests/query_tests.py
@@ -1,26 +1,26 @@
-""" 
+"""
  @file
  @brief This file contains unit tests for the Query class
  @author Jonathan Thomas <jonathan@openshot.org>
- 
+
  @section LICENSE
- 
+
  Copyright (c) 2008-2018 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
@@ -37,12 +37,7 @@ import uuid
 from classes.app import OpenShotApp
 from classes import info
 import openshot  # Python module for libopenshot (required video editing module installed separately)
-
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class TestQueryClass(unittest.TestCase):
     """ Unit test class for Query class """

--- a/src/windows/about.py
+++ b/src/windows/about.py
@@ -40,11 +40,7 @@ from classes.metrics import *
 from windows.views.credits_treeview import CreditsTreeView
 from windows.views.changelog_treeview import ChangelogTreeView
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 import datetime
 
 class About(QDialog):

--- a/src/windows/add_to_timeline.py
+++ b/src/windows/add_to_timeline.py
@@ -42,12 +42,7 @@ from classes.metrics import *
 from windows.views.add_to_timeline_treeview import TimelineTreeView
 
 import openshot
-
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class AddToTimeline(QDialog):
     """ Add To timeline Dialog """

--- a/src/windows/animated_title.py
+++ b/src/windows/animated_title.py
@@ -1,27 +1,27 @@
-""" 
+"""
  @file
  @brief This file loads the animated title dialog (i.e Blender animation automation)
  @author Noah Figg <eggmunkee@hotmail.com>
  @author Jonathan Thomas <jonathan@openshot.org>
- 
+
  @section LICENSE
- 
+
  Copyright (c) 2008-2018 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
@@ -49,11 +49,7 @@ from classes.query import File
 from classes.metrics import *
 from windows.views.blender_listview import BlenderListView
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class AnimatedTitle(QDialog):
     """ Animated Title Dialog """

--- a/src/windows/animation.py
+++ b/src/windows/animation.py
@@ -38,11 +38,7 @@ from classes.app import get_app
 from classes.metrics import *
 from windows.views.credits_treeview import CreditsTreeView
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class Animation(QDialog):
     """ Animation Dialog """

--- a/src/windows/cutting.py
+++ b/src/windows/cutting.py
@@ -41,11 +41,7 @@ from classes.metrics import *
 from windows.preview_thread import PreviewParent
 from windows.video_widget import VideoWidget
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class Cutting(QDialog):
     """ Cutting Dialog """

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -41,11 +41,7 @@ from classes.query import File
 from classes.logger import log
 from classes.metrics import *
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class Export(QDialog):
     """ Export Dialog """

--- a/src/windows/file_properties.py
+++ b/src/windows/file_properties.py
@@ -39,11 +39,7 @@ from classes.app import get_app
 from classes.logger import log
 from classes.metrics import *
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class FileProperties(QDialog):
     """ File Properties Dialog """

--- a/src/windows/models/changelog_model.py
+++ b/src/windows/models/changelog_model.py
@@ -34,11 +34,7 @@ from classes import info
 from classes.logger import log
 from classes.app import get_app
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class ChangelogStandardItemModel(QStandardItemModel):
     def __init__(self, parent=None):

--- a/src/windows/models/credits_model.py
+++ b/src/windows/models/credits_model.py
@@ -34,11 +34,7 @@ from classes import info
 from classes.logger import log
 from classes.app import get_app
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class CreditsStandardItemModel(QStandardItemModel):
     def __init__(self, parent=None):

--- a/src/windows/models/effects_model.py
+++ b/src/windows/models/effects_model.py
@@ -36,11 +36,7 @@ from classes import info
 from classes.logger import log
 from classes.app import get_app
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class EffectsStandardItemModel(QStandardItemModel):
     def __init__(self, parent=None):

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -40,11 +40,7 @@ from classes.logger import log
 from classes.app import get_app
 from classes.thumbnail import GenerateThumbnail
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class FileStandardItemModel(QStandardItemModel):
     ModelRefreshed = pyqtSignal()

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -39,11 +39,7 @@ from classes.logger import log
 from classes.app import get_app
 import openshot
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class ClipStandardItemModel(QStandardItemModel):
     def __init__(self, parent=None):

--- a/src/windows/models/titles_model.py
+++ b/src/windows/models/titles_model.py
@@ -37,11 +37,7 @@ from classes import info
 from classes.logger import log
 from classes.app import get_app
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class TitleStandardItemModel(QStandardItemModel):
     def __init__(self, parent=None):

--- a/src/windows/models/transition_model.py
+++ b/src/windows/models/transition_model.py
@@ -36,11 +36,7 @@ from classes import info
 from classes.logger import log
 from classes.app import get_app
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class TransitionStandardItemModel(QStandardItemModel):
     def __init__(self, parent=None):

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -37,11 +37,7 @@ from classes.app import get_app
 from classes.logger import log
 from classes import settings
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class PreviewParent(QObject):
     """ Class which communicates with the PlayerWorker Class (running on a separate thread) """

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -48,11 +48,7 @@ from classes.query import File
 from classes.metrics import *
 from windows.views.titles_listview import TitlesListView
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class TitleEditor(QDialog):
     """ Title Editor Dialog """

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -34,11 +34,7 @@ from classes.logger import log
 from classes.app import get_app
 from classes.query import Clip
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class VideoWidget(QWidget):
     """ A QWidget used on the video display widget """

--- a/src/windows/views/add_to_timeline_treeview.py
+++ b/src/windows/views/add_to_timeline_treeview.py
@@ -32,11 +32,7 @@ from classes.logger import log
 from classes.app import get_app
 from windows.models.add_to_timeline_model import TimelineModel
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class TimelineTreeView(QTreeView):
     """ A TreeView QWidget used on the add to timeline window """

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -46,11 +46,7 @@ from classes.query import File
 from classes.app import get_app
 from windows.models.blender_model import BlenderModel
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class QBlenderEvent(QEvent):
     """ A custom Blender QEvent, which can safely be sent from the Blender thread to the Qt thread (to communicate) """

--- a/src/windows/views/changelog_treeview.py
+++ b/src/windows/views/changelog_treeview.py
@@ -39,11 +39,7 @@ from classes.logger import log
 from classes.app import get_app
 from windows.models.changelog_model import ChangelogModel
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class ChangelogTreeView(QTreeView):
     """ A ListView QWidget used on the changelog window """

--- a/src/windows/views/credits_treeview.py
+++ b/src/windows/views/credits_treeview.py
@@ -36,11 +36,7 @@ from classes.logger import log
 from classes.app import get_app
 from windows.models.credits_model import CreditsModel
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class CreditsTreeView(QTreeView):
     """ A ListView QWidget used on the credits window """

--- a/src/windows/views/effects_listview.py
+++ b/src/windows/views/effects_listview.py
@@ -32,11 +32,7 @@ from PyQt5.QtWidgets import QListView, QMenu
 from classes.app import get_app
 from windows.models.effects_model import EffectsModel
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class EffectsListView(QListView):
     """ A TreeView QWidget used on the main window """

--- a/src/windows/views/effects_treeview.py
+++ b/src/windows/views/effects_treeview.py
@@ -32,11 +32,7 @@ from PyQt5.QtWidgets import QTreeView, QAbstractItemView, QMenu, QSizePolicy
 from classes.app import get_app
 from windows.models.effects_model import EffectsModel
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class EffectsTreeView(QTreeView):
     """ A TreeView QWidget used on the main window """

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -42,11 +42,7 @@ from classes.logger import log
 from classes.query import File
 from windows.models.files_model import FilesModel
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class FilesListView(QListView):
     """ A ListView QWidget used on the main window """

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -43,11 +43,7 @@ from classes.logger import log
 from classes.app import get_app
 from windows.models.files_model import FilesModel
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class FilesTreeView(QTreeView):
     """ A TreeView QWidget used on the main window """

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -42,11 +42,7 @@ from windows.models.files_model import FilesModel
 
 import openshot
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class PropertyDelegate(QItemDelegate):
     def __init__(self, parent=None, *args):

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -50,10 +50,7 @@ from classes.waveform import get_audio_data
 from classes.thumbnail import GenerateThumbnail
 from classes.conversion import zoomToSeconds, secondsToZoom
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
+import json
 
 # Constants used by this file
 JS_SCOPE_SELECTOR = "$('body').scope()"

--- a/src/windows/views/titles_listview.py
+++ b/src/windows/views/titles_listview.py
@@ -32,11 +32,7 @@ from PyQt5.QtWidgets import QListView, QMenu
 from classes.app import get_app
 from windows.models.titles_model import TitlesModel
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class TitlesListView(QListView):
     """ A QListView QWidget used on the title editor window """

--- a/src/windows/views/transitions_listview.py
+++ b/src/windows/views/transitions_listview.py
@@ -32,11 +32,7 @@ from PyQt5.QtWidgets import QListView, QMenu
 from classes.app import get_app
 from windows.models.transition_model import TransitionsModel
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class TransitionsListView(QListView):
     """ A QListView QWidget used on the main window """

--- a/src/windows/views/transitions_treeview.py
+++ b/src/windows/views/transitions_treeview.py
@@ -32,11 +32,7 @@ from PyQt5.QtWidgets import QTreeView, QAbstractItemView, QMenu, QSizePolicy
 from classes.app import get_app
 from windows.models.transition_model import TransitionsModel
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
+import json
 
 class TransitionsTreeView(QTreeView):
     """ A TreeView QWidget used on the main window """


### PR DESCRIPTION
The json module has been standard since Python 2.6, and OpenShot only supports Python 3.0+, so `import json` will never fail. The code to use simplejson as a fallback is outdated and unnecessary.

(My editor also did some blank-line and end-of-file newline cleanup that got sucked in.)