### PR TITLE
Override file version for win32

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -281,9 +281,19 @@ build_exe_options["include_files"] = src_files + external_so_files
 # Set options
 build_options["build_exe"] = build_exe_options
 
+infoVersion = info.VERSION
+
+# Override version for win32 (in pywin32 module, used by cx_Freeze, only int numbers: a.b.c.d allowed)
+if sys.platform == "win32":
+    # for example, infoVersion = "2.4.4-dev1"
+    import re
+    infoVersion = infoVersion.replace("-", ".")
+    infoVersion = re.sub("[^0-9.]", "", infoVersion)
+    # here infoVersion = "2.4.4.1"
+
 # Create distutils setup object
 setup(name=info.PRODUCT_NAME,
-      version=info.VERSION,
+      version=infoVersion,
       description=info.DESCRIPTION,
       author=info.COMPANY_NAME,
       options=build_options,


### PR DESCRIPTION
The _pywin32_ module, when used by _cx_Freeze_ in Windows doesn't allow not integer versioning of the files in the first 4 numbers.

This change allows "freeze" while versioning style may be kept.

It doesn't changes logging info of the OpenShot, only file description is affected.