### PR TITLE
Closing timeline object before Python kills the object itself

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -131,6 +131,10 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.preview_parent.background.exit()
         self.preview_parent.background.wait(5000)
 
+        # Close Timeline
+        self.timeline_sync.timeline.Close()
+        self.timeline_sync.timeline = None
+
         # Close & Stop libopenshot logger
         openshot.ZmqLogger.Instance().Close()
         get_app().logger_libopenshot.kill()


### PR DESCRIPTION
This is related to the libopenshot memory-fixes branch, and is required to prevent the ~Timeline() destructor from crashing openshot-qt.