### PR TITLE
Use actual import source for PYQT_VERSION_STR

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -35,7 +35,7 @@ from PyQt5.QtWidgets import QApplication, QStyleFactory, QMessageBox
 from PyQt5.QtGui import QPalette, QColor, QFontDatabase, QFont
 from PyQt5.QtCore import Qt
 from PyQt5.QtCore import QT_VERSION_STR
-from PyQt5.Qt import PYQT_VERSION_STR
+from PyQt5.QtCore import PYQT_VERSION_STR
 
 try:
     # Enable High-DPI resolutions

--- a/src/classes/metrics.py
+++ b/src/classes/metrics.py
@@ -39,7 +39,7 @@ from classes import settings
 import openshot
 
 from PyQt5.QtCore import QT_VERSION_STR
-from PyQt5.Qt import PYQT_VERSION_STR
+from PyQt5.QtCore import PYQT_VERSION_STR
 
 
 # Get libopenshot version


### PR DESCRIPTION
Resolve the PYQT_VERSION_STR import error
The error appear if minimum of PyQt5 is installed (--no-sip-files key etc.).
This changes the source of the string during the import to ensure that
the string is always reachable.