### PR TITLE
WIP: win32: Add metadata to launcher executable

### DIFF
--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -431,6 +431,23 @@ try:
         if windows_32bit:
             only_64_bit = ""
 
+        # Add version metadata to frozen app launcher
+        launcher_exe = os.path.join(exe_path, "launch.exe")
+        verpatch_success = True
+        verpatch_command = '"C:\Program Files (x86)\Verpatch\verpatch.exe" "{}" /va /high "{}" /pv "{}" /s product "{}" /s company "{}" /s copyright "{}" /s desc "{}"'.format(launcher_exe, info.VERSION, info.VERSION, info.PRODUCT_NAME, info.COMPANY_NAME, info.COPYRIGHT, info.PRODUCT_NAME)
+        verpatch_output = ""
+        # version-stamp executable
+        for line in run_command(verpatch_command):
+            output(line)
+            if line:
+                verpatch_success = False
+                verpatch_output = line
+                
+        # Was the verpatch command successful
+        if not verpatch_success:
+            # Verpatch failed (not fatal)
+            error("Verpatch Error: Had output when none was expected (%s)" % verpatch_output)
+
         # Copy uninstall files into build folder
         for file in os.listdir(os.path.join("c:/", "InnoSetup")):
             shutil.copyfile(os.path.join("c:/", "InnoSetup", file), os.path.join(PATH, "build", file))


### PR DESCRIPTION
This isn't actually a WIP, but it's tagged that way because it has external dependencies (explained below) before it can be merged. 

Inspired by the information @SuslikV provided in #2772 re: attaching Windows metadata to the OpenShot launcher executable, this PR adds code to do so, using an external Win32 binary tool which should be placed on the Windows builder hosts.

**PREREQUISITE:** Before this PR can be merged, a change to the Windows builders @ GitLab is required, to install the `verpatch.exe` executable referenced in this PR. The binary ZIP (attached) was [downloaded from CodeProject](https://www.codeproject.com/KB/install/VerPatch.aspx?msg=3207401). Before extracting, create the directory `C:\Program Files (x86)\Verpatch`, then extract the `verpatch.exe` from the zip file into that directory.

Verpatch binary: 
[verpatch-bin-1.0.10.zip](https://github.com/OpenShot/openshot-qt/files/3230112/verpatch-bin-1.0.10.zip)

The new code will run `c:\program files (x86)\verpatch\verpatch.exe` to add metadata to the Windows `launch.exe` program. This will affect both the Properties dialog, and the Task Manager listing:

![Screenshot from 2019-05-28 19-22-49](https://user-images.githubusercontent.com/538020/58518787-98be9500-817e-11e9-9027-264176b36498.png)
![Screenshot from 2019-05-28 19-23-02](https://user-images.githubusercontent.com/538020/58518791-9eb47600-817e-11e9-8cb1-836301fe0860.png)


Fixes: #2762