### PR TITLE
Lower scroll area minimum height for Preferences

### DIFF
--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -144,7 +144,7 @@ class Preferences(QDialog):
                     scroll_area.setWidgetResizable(True)
                     scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
                     scroll_area.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-                    scroll_area.setMinimumSize(675, 350)
+                    scroll_area.setMinimumSize(675, 100)
 
                     # Create tab widget and layout
                     layout = QVBoxLayout()


### PR DESCRIPTION
In preferences.ui the default widget's size of the Preferences
window is set to 350, thus few items at bottom of the main
menu Edit > Preferences > Keyboard_tab is not visible when
scrolled down until Preferences window resized.

This change ensures that scroll area always fits into parent
widget by default, without needs to enlarge the window.

This PR doesn't changes size of the Preferences window itself.