### PR TITLE
WIP: Enable Blender GPU rendering

### DIFF
--- a/src/blender/scripts/gpu_enable.py
+++ b/src/blender/scripts/gpu_enable.py
@@ -1,0 +1,17 @@
+# Enable CYCLES renderer, using GPU (if found)
+bpy.context.scene.render.engine = 'CYCLES'
+bpy.context.scene.cycles.device = 'GPU'
+
+cprefs = bpy.context.user_preferences.addons['cycles'].preferences
+
+# Attempt to set GPU device types if available
+for compute_device_type in ('CUDA', 'OPENCL', 'NONE'):
+    try:
+        cprefs.compute_device_type = compute_device_type
+        break
+    except TypeError:
+        pass
+
+# Enable all CPU and GPU devices
+for device in cprefs.devices:
+    device.use = True

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -456,6 +456,14 @@
     "setting": "omp_threads_enabled"
   },
   {
+    "value": false,
+    "title": "Use Blender GPU rendering for Animated Titles (Experimental)",
+    "type": "bool",
+    "restart": false,
+    "category": "Performance",
+    "setting": "blender_gpu_enabled"
+  },
+  {
     "min": 0,
     "max": 128,
     "value": 12,

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -456,14 +456,6 @@
     "setting": "omp_threads_enabled"
   },
   {
-    "value": false,
-    "title": "Use Blender GPU rendering for Animated Titles (Experimental)",
-    "type": "bool",
-    "restart": false,
-    "category": "Performance",
-    "setting": "blender_gpu_enabled"
-  },
-  {
     "min": 0,
     "max": 128,
     "value": 12,
@@ -502,6 +494,14 @@
     "restart": true,
     "category": "Performance",
     "setting": "decode_hw_max_height"
+  },
+  {
+    "value": false,
+    "title": "Use Blender GPU rendering for Animated Titles (Experimental)",
+    "type": "bool",
+    "restart": false,
+    "category": "Performance",
+    "setting": "blender_gpu_enabled"
   },
   {
     "value": true,

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -738,7 +738,7 @@ class Worker(QObject):
                     # change cursor to "default" and stop running blender command
                     self.is_running = False
 
-                    # Wrong version of Blender.  Must be 2.62+:
+                    # Wrong version of Blender.
                     self.blender_version_error.emit(float(self.version[0]))
                     return
 
@@ -751,8 +751,8 @@ class Worker(QObject):
             self.process = subprocess.Popen(command_render, stdout=subprocess.PIPE, stderr=subprocess.PIPE, startupinfo=startupinfo)
 
         except:
-            # Error running command.  Most likely the blender executable path in the settings
-            # is not correct, or is not the correct version of Blender (i.e. 2.62+)
+            # Error running command.  Most likely the blender executable path in
+            # the settings is incorrect, or is not a supported Blender version
             self.is_running = False
             self.blender_error_nodata.emit()
             return

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -1,4 +1,4 @@
-""" 
+"""
  @file
  @brief This file contains the blender file listview, used by the 3d animated titles screen
  @author Jonathan Thomas <jonathan@openshot.org>
@@ -520,10 +520,26 @@ class BlenderListView(QListView):
 
         # Force the Frame to 1 frame (for previewing)
         if frame:
-            user_params += "\n\n#ONLY RENDER 1 FRAME FOR PREVIEW\n"
+            user_params += "\n#ONLY RENDER 1 FRAME FOR PREVIEW\n"
             user_params += "params['{}'] = {}\n".format("start_frame", frame)
             user_params += "params['{}'] = {}\n".format("end_frame", frame)
-            user_params += "\n\n#END ONLY RENDER 1 FRAME FOR PREVIEW\n"
+            user_params += "#END ONLY RENDER 1 FRAME FOR PREVIEW\n"
+
+        # If GPU rendering is selected, see if GPU enable code is available
+        s = settings.get_settings()
+        if s.get("blender_gpu_enabled"):
+            gpu_enable_py = os.path.join(info.PATH, "blender", "scripts", "gpu_enable.py")
+            try:
+                f = open(gpu_enable_py, 'r')
+                gpu_code_body = f.read()
+            except IOError as e:
+                log.error("Could not load GPU enable code! {}".format(e))
+
+        if gpu_code_body:
+            log.info("Injecting GPU enable code from {}".format(gpu_enable_py))
+            user_params += "\n#ENABLE GPU RENDERING\n"
+            user_params += gpu_code_body
+            user_params += "\n#END ENABLE GPU RENDERING\n"
 
         # Open new temp .py file, and inject the user parameters
         with open(path, 'r') as f:


### PR DESCRIPTION
This is work-in-progress (but functional) code to enable GPU rendering for the Animated Title editor, using the CYCLES renderer add-on that's part of the default Blender distribution, as requested in #2812. 

With assistance and testing from reporter @RafaelLinux , I've managed to condense the configs required to enable and activate CYCLES GPU rendering down to a single chunk of Python code, `src/blender/scripts/gpu_enable.py`, which will be automatically injected into the generated Blender Python script if the corresponding experimental preference is enabled.

The code is _mostly_ bulletproof, in the sense that if the user enables GPU rendering, but their system is not capable of using the GPU renderer, in the majority of cases CYCLES will simply fall back to CPU rendering silently, and still produce the rendered output. 

I say _mostly_, because there are configurations which can cause the render process to fail without generating frames (see #2812 for more detail); those cases can be handled by disabling the GPU rendering code injection, in which case the render pipeline will be completely identical to how it was before this PR. The need to handle those cases better is one of the reasons this PR remains in WIP status.

But, despite needing additional polish, the code is functional and can be enabled and tested today. Whether GPU rendering will provide any _benefit_ when enabled, that's a much larger question. Blender GPU rendering isn't like accelerated video de/encoding — it uses the GPU as a CUDA compute engine, and unless the GPU is sufficiently powerful the speed increase compared to the system CPU can be nonexistent or even negative. (My own low-end Nvidia GT 710 card, a < $50 model, renders between 0% and 20% _slower_ than my system's 4-core Intel Core i5 CPU, making GPU rendering completely pointless for me. But, for some users with high-end or multiple GPUs, CYCLES GPU rendering should offer significant speedups.)

### TODO items, to be ready for merge
- [ ] **Better failure handling:** If the render attempt results in an error, the sensible thing is to disable GPU rendering and try again using the CPU. That can be done one of two ways (our choice)...
  - [ ] Detect the issue automatically, switch off the setting, and try again automatically, with no user intervention.
  - [ ] In the error message dialog that comes up on render failure, if GPU rendering is enabled in the settings, add a button the user can click to turn off the setting and re-attempt the render. If that fails again, they'll get the same dialog _without_ that button, and they'll have to pursue other solutions.
- [ ] **Clean up the Preferences item:** I just stuck it in below the parallel-processing option, since they're both Experimental, but given how much has been added to Performance recently, it looks completely out of place there, and gets kind of lost. Also, the window needs to be taller if it's going to go in that tab.
- [ ] **Add documentation:** GPU rendering setup is complex _enough_ with Blender, that it's worth adding a section to the manual providing what information we can offer regarding proper configuration, along with the caveats I mentioned earlier (like how it might even be _slower_ than CPU rendering in many instances).

Fixes #2812 