### PR TITLE
Make clip selection always visible

### DIFF
--- a/src/timeline/media/css/main.css
+++ b/src/timeline/media/css/main.css
@@ -83,8 +83,8 @@ img {
 .left_edge_stop { border-left: 2px solid #4b92ad; }
 .right_edge_stop { border-right: 2px solid #4b92ad; }
 .highlight_clip { border-color: #32b7ea; }
-.ui-selecting { border-left: 2px solid yellow!important; border-right: 2px solid yellow!important; box-sizing: border-box; }
-.ui-selected { border-left: 2px solid red!important; border-right: 2px solid red!important; box-sizing: border-box; }
+.ui-selecting { border: 1px solid yellow!important; border-left: 2px solid yellow!important; border-right: 2px solid yellow!important; box-sizing: border-box; }
+.ui-selected { border: 1px solid red!important; border-left: 2px solid red!important; border-right: 2px solid red!important; box-sizing: border-box; }
 .thumb { margin-left: 5px; width: 66px; height: 38px;}
 .thumb-start { float:left; }
 .thumb-end {float:right; }


### PR DESCRIPTION
Solves issue https://github.com/OpenShot/openshot-qt/issues/2816

Selection visibility shouldn't relay on zoom level or length of the clip.

The only change from previous attempt (https://github.com/OpenShot/openshot-qt/pull/1883) to improve the UI of OpenShot in this part - is that the `!important` rule was added. Without that change in some environments it is possible to notice slight delay when underlying blue border at top and bottom of the clip is drawn first and only then red (yellow) selection overwrites it.

Before (clip selected)
![Selection_clip_before_cropped](https://user-images.githubusercontent.com/19683044/59155174-679e6880-8a8c-11e9-818d-6bd99f0fe626.png)

After (clip selected)
![Selection_clip_after_cropped](https://user-images.githubusercontent.com/19683044/59155178-7127d080-8a8c-11e9-8c9a-de9fe4837831.png)

Screenshot of the UI for the rectangle selection is under the spoiler:
<details>
  <summary>Click to expand</summary>

Before (rectangle selection)
![Selection_rectangle_before_cropped](https://user-images.githubusercontent.com/19683044/59155180-7ab13880-8a8c-11e9-97f0-3d1b9db3eb68.png)

After (rectangle selection)
![Selection_rectangle_after_cropped](https://user-images.githubusercontent.com/19683044/59155181-800e8300-8a8c-11e9-8d39-1245b305bd70.png)

</details>