### PR TITLE
Install icons to hicolor/NxN instead of hicolor/N

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,9 @@ os_files = [
     ('share/pixmaps', ['xdg/openshot-qt.svg']),
     # XDG Freedesktop icon paths
     ('share/icons/hicolor/scalable/apps', ['xdg/openshot-qt.svg']),
-    ('share/icons/hicolor/64/apps', ['xdg/icon/64/openshot-qt.png']),
-    ('share/icons/hicolor/256/apps', ['xdg/icon/256/openshot-qt.png']),
-    ('share/icons/hicolor/512/apps', ['xdg/icon/512/openshot-qt.png']),
+    ('share/icons/hicolor/64x64/apps', ['xdg/icon/64/openshot-qt.png']),
+    ('share/icons/hicolor/256x256/apps', ['xdg/icon/256/openshot-qt.png']),
+    ('share/icons/hicolor/512x512/apps', ['xdg/icon/512/openshot-qt.png']),
     # XDG desktop mime types cache
     ('share/mime/packages', ['xdg/openshot-qt.xml']),
     # launcher (mime.types)


### PR DESCRIPTION
Nearly all other Arch Linux packages also follow this pattern and the Freedesktop specification also only uses this pattern when providing examples.

References:
https://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html
https://bugs.archlinux.org/task/62900

Note: I didn't verify how this behaves in GUI file managers/GUI application launchers since I do not use any of them. I created this patch just based on the bug report and the icon theme spec.