### PR TITLE
project.get(): Accept non-list args (strings)

### DIFF
--- a/src/classes/exporters/edl.py
+++ b/src/classes/exporters/edl.py
@@ -46,8 +46,8 @@ def export_edl():
     edl_string = "%03d  %-9s%-6s%-9s%11s %11s %11s %11s\n"
 
     # Get FPS info
-    fps_num = get_app().project.get(["fps"]).get("num", 24)
-    fps_den = get_app().project.get(["fps"]).get("den", 1)
+    fps_num = get_app().project.get("fps").get("num", 24)
+    fps_den = get_app().project.get("fps").get("den", 1)
     fps_float = float(fps_num / fps_den)
 
     # Get EDL path
@@ -67,7 +67,7 @@ def export_edl():
     parent_path, file_name_with_ext = os.path.split(file_path)
     file_name, ext = os.path.splitext(file_name_with_ext)
 
-    all_tracks = get_app().project.get(["layers"])
+    all_tracks = get_app().project.get("layers")
     track_count = len(all_tracks)
     for track in reversed(sorted(all_tracks, key=itemgetter('number'))):
         existing_track = Track.get(number=track.get("number"))

--- a/src/classes/exporters/final_cut_pro.py
+++ b/src/classes/exporters/final_cut_pro.py
@@ -77,8 +77,8 @@ def export_xml():
     _ = app._tr
 
     # Get FPS info
-    fps_num = get_app().project.get(["fps"]).get("num", 24)
-    fps_den = get_app().project.get(["fps"]).get("den", 1)
+    fps_num = get_app().project.get("fps").get("num", 24)
+    fps_den = get_app().project.get("fps").get("den", 1)
     fps_float = float(fps_num / fps_den)
 
     # Ticks (final cut pro value)
@@ -116,10 +116,10 @@ def export_xml():
     xmldoc.getElementsByTagName("name")[0].childNodes[0].nodeValue = file_name_with_ext
     xmldoc.getElementsByTagName("uuid")[0].childNodes[0].nodeValue = str(uuid1())
     xmldoc.getElementsByTagName("duration")[0].childNodes[0].nodeValue = duration
-    xmldoc.getElementsByTagName("width")[0].childNodes[0].nodeValue = app.project.get(["width"])
-    xmldoc.getElementsByTagName("height")[0].childNodes[0].nodeValue = app.project.get(["height"])
-    xmldoc.getElementsByTagName("samplerate")[0].childNodes[0].nodeValue = app.project.get(["sample_rate"])
-    xmldoc.getElementsByTagName("sequence")[0].setAttribute("id", app.project.get(["id"]))
+    xmldoc.getElementsByTagName("width")[0].childNodes[0].nodeValue = app.project.get("width")
+    xmldoc.getElementsByTagName("height")[0].childNodes[0].nodeValue = app.project.get("height")
+    xmldoc.getElementsByTagName("samplerate")[0].childNodes[0].nodeValue = app.project.get("sample_rate")
+    xmldoc.getElementsByTagName("sequence")[0].setAttribute("id", app.project.get("id"))
     for childNode in xmldoc.getElementsByTagName("timebase"):
         childNode.childNodes[0].nodeValue = fps_float
 
@@ -127,7 +127,7 @@ def export_xml():
     parentAudioNode = xmldoc.getElementsByTagName("audio")[0]
 
     # Loop through tracks
-    all_tracks = get_app().project.get(["layers"])
+    all_tracks = get_app().project.get("layers")
     track_count = 1
     for track in sorted(all_tracks, key=itemgetter('number')):
         existing_track = Track.get(number=track.get("number"))

--- a/src/classes/importers/edl.py
+++ b/src/classes/importers/edl.py
@@ -55,8 +55,8 @@ def create_clip(context, track):
     _ = app._tr
 
     # Get FPS info
-    fps_num = get_app().project.get(["fps"]).get("num", 24)
-    fps_den = get_app().project.get(["fps"]).get("den", 1)
+    fps_num = get_app().project.get("fps").get("num", 24)
+    fps_den = get_app().project.get("fps").get("den", 1)
     fps_float = float(fps_num / fps_den)
 
     # Get clip path (and prompt user if path not found)
@@ -200,7 +200,7 @@ def import_edl():
         current_clip_index = ""
 
         # Get # of tracks
-        all_tracks = get_app().project.get(["layers"])
+        all_tracks = get_app().project.get("layers")
         track_number = list(reversed(sorted(all_tracks, key=itemgetter('number'))))[0].get("number") + 1000000
 
         # Create new track above existing layer(s)

--- a/src/classes/importers/final_cut_pro.py
+++ b/src/classes/importers/final_cut_pro.py
@@ -46,8 +46,8 @@ def import_xml():
     _ = app._tr
 
     # Get FPS info
-    fps_num = get_app().project.get(["fps"]).get("num", 24)
-    fps_den = get_app().project.get(["fps"]).get("den", 1)
+    fps_num = get_app().project.get("fps").get("num", 24)
+    fps_den = get_app().project.get("fps").get("den", 1)
     fps_float = float(fps_num / fps_den)
 
     # Get XML path
@@ -83,7 +83,7 @@ def import_xml():
 
                 # Get # of tracks
                 track_index += 1
-                all_tracks = get_app().project.get(["layers"])
+                all_tracks = get_app().project.get("layers")
                 track_number = list(reversed(sorted(all_tracks, key=itemgetter('number'))))[0].get("number") + 1000000
 
                 # Create new track above existing layer(s)

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -66,12 +66,11 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         """ Get copied value of a given key in data store """
 
         # Verify key is valid type
-        if not isinstance(key, list):
-            log.warning("get() key must be a list. key: {}".format(key))
-            return None
         if not key:
             log.warning("Cannot get empty key.")
             return None
+        if not isinstance(key, list):
+            key = [key]
 
         # Get reference to internal data structure
         obj = self._data

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -441,7 +441,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
         # Get FPS from project
         from classes.app import get_app
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
 
         # Import legacy openshot classes (from version 1.X)

--- a/src/classes/query.py
+++ b/src/classes/query.py
@@ -322,7 +322,7 @@ class Effect(QueryObject):
         """ Take any arguments given as filters, and find a list of matching objects """
 
         # Get a list of clips
-        clips = project.get(["clips"])
+        clips = project.get("clips")
         matching_objects = []
 
         # Loop through all clips

--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -44,12 +44,12 @@ class TimelineSync(UpdateInterface):
         s = settings.get_settings()
 
         # Get some settings from the project
-        fps = project.get(["fps"])
-        width = project.get(["width"])
-        height = project.get(["height"])
-        sample_rate = project.get(["sample_rate"])
-        channels = project.get(["channels"])
-        channel_layout = project.get(["channel_layout"])
+        fps = project.get("fps")
+        width = project.get("width")
+        height = project.get("height")
+        sample_rate = project.get("sample_rate")
+        channels = project.get("channels")
+        channel_layout = project.get("channel_layout")
 
         # Create an instance of a libopenshot Timeline object
         self.timeline = openshot.Timeline(width, height, openshot.Fraction(fps["num"], fps["den"]), sample_rate, channels,

--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -139,7 +139,7 @@ class UpdateManager:
         self.actionHistory.clear()
 
         # Get history from project data
-        history = project.get(["history"])
+        history = project.get("history")
 
         # Loop through each, and load serialized data into updateAction objects
         # Ignore any load actions or history update actions

--- a/src/windows/add_to_timeline.py
+++ b/src/windows/add_to_timeline.py
@@ -170,7 +170,7 @@ class AddToTimeline(QDialog):
             random_transition = True
 
         # Get frames per second
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
 
         # Loop through each file (in the current order)
@@ -401,7 +401,7 @@ class AddToTimeline(QDialog):
             total += duration
 
         # Get frames per second
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
 
         # Update label
         total_parts = time_parts.secondsToTime(total, fps["num"], fps["den"])
@@ -457,7 +457,7 @@ class AddToTimeline(QDialog):
         self.txtTransitionLength.valueChanged.connect(self.updateTotal)
 
         # Find display track number
-        all_tracks = get_app().project.get(["layers"])
+        all_tracks = get_app().project.get("layers")
         display_count = len(all_tracks)
         for track in reversed(sorted(all_tracks, key=itemgetter('number'))):
             # Add to dropdown

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -140,7 +140,7 @@ class Export(QDialog):
         if app.project.current_filepath:
             recommended_path = os.path.dirname(app.project.current_filepath)
 
-        export_path = get_app().project.get(["export_path"])
+        export_path = get_app().project.get("export_path")
         if os.path.exists(export_path):
             # Use last selected export path
             self.txtExportFolder.setText(export_path)
@@ -354,7 +354,7 @@ class Export(QDialog):
         self.txtEndFrame.setValue(self.timeline_length_int)
 
         # Calculate differences between editing/preview FPS and export FPS
-        current_fps = get_app().project.get(["fps"])
+        current_fps = get_app().project.get("fps")
         current_fps_float = float(current_fps["num"]) / float(current_fps["den"])
         new_fps_float = float(self.txtFrameRateNum.value()) / float(self.txtFrameRateDen.value())
         self.export_fps_factor = new_fps_float / current_fps_float

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -655,7 +655,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
     def actionImportFiles_trigger(self, event):
         app = get_app()
         _ = app._tr
-        recommended_path = app.project.get(["import_path"])
+        recommended_path = app.project.get("import_path")
         if not recommended_path or not os.path.exists(recommended_path):
             recommended_path = os.path.join(info.HOME_PATH)
         files = QFileDialog.getOpenFileNames(self, _("Import File..."), recommended_path)[0]
@@ -674,7 +674,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             files.append(File.get(id=file_id))
 
         # Get current position of playhead
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
         pos = (self.preview_thread.player.Position() - 1) / fps_float
 
@@ -966,8 +966,8 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             recommended_path = os.path.dirname(get_app().project.current_filepath)
 
         # Determine path for saved frame - Project's export path
-        if get_app().project.get(["export_path"]):
-            recommended_path = get_app().project.get(["export_path"])
+        if get_app().project.get("export_path"):
+            recommended_path = get_app().project.get("export_path")
 
         framePath = "%s/Frame-%05d.png" % (recommended_path, self.preview_thread.current_frame)
 
@@ -995,7 +995,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.timeline_sync.timeline.SetCache(new_cache_object)
 
         # Set MaxSize to full project resolution and clear preview cache so we get a full resolution frame
-        self.timeline_sync.timeline.SetMaxSize(get_app().project.get(["width"]), get_app().project.get(["height"]))
+        self.timeline_sync.timeline.SetMaxSize(get_app().project.get("width"), get_app().project.get("height"))
         self.cache_object.Clear()
 
         # Check if file exists, if it does, get the lastModified time
@@ -1026,7 +1026,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         log.info("actionAddTrack_trigger")
 
         # Get # of tracks
-        all_tracks = get_app().project.get(["layers"])
+        all_tracks = get_app().project.get("layers")
         track_number = list(reversed(sorted(all_tracks, key=itemgetter('number'))))[0].get("number") + 1000000
 
         # Create new track above existing layer(s)
@@ -1038,7 +1038,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         log.info("actionAddTrackAbove_trigger")
 
         # Get # of tracks
-        all_tracks = get_app().project.get(["layers"])
+        all_tracks = get_app().project.get("layers")
         selected_layer_id = self.selected_tracks[0]
 
         # Get selected track data
@@ -1094,7 +1094,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         log.info("actionAddTrackBelow_trigger")
 
         # Get # of tracks
-        all_tracks = get_app().project.get(["layers"])
+        all_tracks = get_app().project.get("layers")
         selected_layer_id = self.selected_tracks[0]
 
         # Get selected track data
@@ -1174,7 +1174,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         player = self.preview_thread.player
 
         # Calculate frames per second
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
 
         # Calculate position in seconds
@@ -1189,7 +1189,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         log.info("actionPreviousMarker_trigger")
 
         # Calculate current position (in seconds)
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
         current_position = (self.preview_thread.current_frame - 1) / fps_float
         all_marker_positions = []
@@ -1242,7 +1242,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         log.info(self.preview_thread.current_frame)
 
         # Calculate current position (in seconds)
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
         current_position = (self.preview_thread.current_frame - 1) / fps_float
         all_marker_positions = []
@@ -1326,7 +1326,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         player = self.preview_thread.player
 
         # Get framerate
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
         playhead_position = float(self.preview_thread.current_frame - 1) / fps_float
 
@@ -1638,7 +1638,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         _ = get_app()._tr
 
         track_id = self.selected_tracks[0]
-        max_track_number = len(get_app().project.get(["layers"]))
+        max_track_number = len(get_app().project.get("layers"))
 
         # Get details of selected track
         selected_track = Track.get(id=track_id)
@@ -1703,7 +1703,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         selected_track = Track.get(id=track_id)
 
         # Find display track number
-        all_tracks = get_app().project.get(["layers"])
+        all_tracks = get_app().project.get("layers")
         display_count = len(all_tracks)
         for track in reversed(sorted(all_tracks, key=itemgetter('number'))):
             if track.get("id") == track_id:
@@ -1965,7 +1965,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         _ = get_app()._tr
 
         if not profile:
-            profile = get_app().project.get(["profile"])
+            profile = get_app().project.get("profile")
 
         # Determine if the project needs saving (has any unsaved changes)
         save_indicator = ""
@@ -2216,7 +2216,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.timelineToolbar.addSeparator()
 
         # Get project's initial zoom value
-        initial_scale = get_app().project.get(["scale"]) or 15
+        initial_scale = get_app().project.get("scale") or 15
         # Round non-exponential scale down to next lowest power of 2
         initial_zoom = secondsToZoom(initial_scale)
 

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -168,7 +168,7 @@ class PropertiesModel(updates.UpdateInterface):
                         break
 
             # Get FPS from project
-            fps = get_app().project.get(["fps"])
+            fps = get_app().project.get("fps")
             fps_float = float(fps["num"]) / float(fps["den"])
 
             # Requested time
@@ -654,7 +654,7 @@ class PropertiesModel(updates.UpdateInterface):
                         col.setText(fileName)
                     elif type == "int" and label == "Track":
                         # Find track display name
-                        all_tracks = get_app().project.get(["layers"])
+                        all_tracks = get_app().project.get("layers")
                         display_count = len(all_tracks)
                         display_label = None
                         for track in reversed(sorted(all_tracks, key=itemgetter('number'))):
@@ -733,7 +733,7 @@ class PropertiesModel(updates.UpdateInterface):
                         col.setText("")
                     elif type == "int" and label == "Track":
                         # Find track display name
-                        all_tracks = get_app().project.get(["layers"])
+                        all_tracks = get_app().project.get("layers")
                         display_count = len(all_tracks)
                         display_label = None
                         for track in reversed(sorted(all_tracks, key=itemgetter('number'))):

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -247,12 +247,12 @@ class PlayerWorker(QObject):
             project = get_app().project
 
             # Get some settings from the project
-            fps = project.get(["fps"])
-            width = project.get(["width"])
-            height = project.get(["height"])
-            sample_rate = project.get(["sample_rate"])
-            channels = project.get(["channels"])
-            channel_layout = project.get(["channel_layout"])
+            fps = project.get("fps")
+            width = project.get("width")
+            height = project.get("height")
+            sample_rate = project.get("sample_rate")
+            channels = project.get("channels")
+            channel_layout = project.get("channel_layout")
 
             # Create an instance of a libopenshot Timeline object
             self.clip_reader = openshot.Timeline(width, height, openshot.Fraction(fps["num"], fps["den"]), sample_rate, channels, channel_layout)

--- a/src/windows/profile.py
+++ b/src/windows/profile.py
@@ -132,7 +132,7 @@ class Profile(QDialog):
         self.lblOther.setText("DAR: %s/%s, SAR: %s/%s, Interlaced: %s" % (profile.info.display_ratio.num, profile.info.display_ratio.den, profile.info.pixel_ratio.num, profile.info.pixel_ratio.den, profile.info.interlaced_frame))
 
         # Get current FPS (prior to changing)
-        current_fps = get_app().project.get(["fps"])
+        current_fps = get_app().project.get("fps")
         current_fps_float = float(current_fps["num"]) / float(current_fps["den"])
         new_fps_float = float(profile.info.fps.num) / float(profile.info.fps.den)
         fps_factor = new_fps_float / current_fps_float

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -101,7 +101,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         if self.transforming_clip:
             # Draw transform handles on top of video preview
             # Get framerate
-            fps = get_app().project.get(["fps"])
+            fps = get_app().project.get("fps")
             fps_float = float(fps["num"]) / float(fps["den"])
 
             # Determine frame # of clip
@@ -336,7 +336,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
         if self.transforming_clip:
             # Get framerate
-            fps = get_app().project.get(["fps"])
+            fps = get_app().project.get("fps")
             fps_float = float(fps["num"]) / float(fps["den"])
 
             # Get current clip's position

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -441,9 +441,9 @@ class BlenderListView(QListView):
         project_params = {}
 
         # Append on some project settings
-        project_params["fps"] = project.get(["fps"])
-        project_params["resolution_x"] = project.get(["width"])
-        project_params["resolution_y"] = project.get(["height"])
+        project_params["fps"] = project.get("fps")
+        project_params["resolution_x"] = project.get("width")
+        project_params["resolution_y"] = project.get("height")
 
         if is_preview:
             project_params["resolution_percentage"] = 50

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -387,7 +387,7 @@ class PropertiesTableView(QTableView):
             if property_name =="Track" and self.property_type == "int" and not self.choices:
                 # Populate all display track names
                 track_choices = []
-                all_tracks = get_app().project.get(["layers"])
+                all_tracks = get_app().project.get("layers")
                 display_count = len(all_tracks)
                 for track in reversed(sorted(all_tracks, key=itemgetter('number'))):
                     # Append track choice

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -196,7 +196,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         # Reset the scale when loading new JSON
         if action.type == "load":
             # Set the scale again (to project setting)
-            initial_scale = get_app().project.get(["scale"]) or 15
+            initial_scale = get_app().project.get("scale") or 15
             get_app().window.sliderZoom.setValue(secondsToZoom(initial_scale))
 
     # Javascript callable function to update the project data when a clip changes
@@ -296,7 +296,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         transition_details = json.loads(transition_json)
 
         # Get FPS from project
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
 
         # Open up QtImageReader for transition Image
@@ -351,7 +351,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         existing_item.data = transition_data
 
         # Get FPS from project
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
         duration = existing_item.data["end"] - existing_item.data["start"]
 
@@ -498,7 +498,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         tran_ids = self.window.selected_transitions
 
         # Get framerate
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
 
         # Get playhead position
@@ -954,7 +954,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
                 continue
 
             # Get # of tracks
-            all_tracks = get_app().project.get(["layers"])
+            all_tracks = get_app().project.get("layers")
 
             # Clear audio override
             p = openshot.Point(1, -1.0, openshot.CONSTANT) # Override has_audio keyframe to False
@@ -1160,7 +1160,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
                 continue
 
             # Get framerate
-            fps = get_app().project.get(["fps"])
+            fps = get_app().project.get("fps")
             fps_float = float(fps["num"]) / float(fps["den"])
 
             # Get existing clip object
@@ -1507,7 +1507,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         right_edge = -1.0
 
         # Determine how far we're going to nudge (1/2 frame or 0.01s, whichever is larger)
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
         nudgeDistance = float(action) / float(fps_float)
         nudgeDistance /= 2.0	# 1/2 frame
@@ -1678,7 +1678,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         prop_name = "alpha"
 
         # Get FPS from project
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
 
         # Loop through each selected clip
@@ -1770,7 +1770,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
     def Slice_Triggered(self, action, clip_ids, trans_ids, playhead_position=0):
         """Callback for slice context menus"""
         # Get FPS from project
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_num = float(fps["num"])
         fps_den = float(fps["den"])
         fps_float = fps_num / fps_den
@@ -1914,7 +1914,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         prop_name = "volume"
 
         # Get FPS from project
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
 
         # Loop through each selected clip
@@ -2013,7 +2013,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         prop_name = "rotation"
 
         # Get FPS from project
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
 
         # Loop through each selected clip
@@ -2058,7 +2058,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         prop_name = "time"
 
         # Get FPS from project
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
 
         # Loop through each selected clip
@@ -2377,7 +2377,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         clip_ids = self.window.selected_clips
 
         # Get framerate
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
 
         # Get playhead position
@@ -2601,7 +2601,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         self.redraw_audio_timer.start()
 
         # Only update scale if different
-        current_scale = get_app().project.get(["scale"])
+        current_scale = get_app().project.get("scale")
 
         # Save current zoom
         if newScale != current_scale:
@@ -2773,7 +2773,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         js_position = self.eval_js(JS_SCOPE_SELECTOR + ".GetJavaScriptPosition(" + str(position.x()) + ");")
 
         # Get FPS from project
-        fps = get_app().project.get(["fps"])
+        fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
 
         # Open up QtImageReader for transition Image


### PR DESCRIPTION
This is another entry in my award-ineligible series, "Don't make programmers write awkward code" (see OpenShot/libopenshot#266). The target today is `project.get()` in `classes.project_data`.

### Don't make programmers write awkward code

All over the source tree, there are requests for project data like this:
https://github.com/OpenShot/openshot-qt/blob/eef69337e077162c589f2580c2503a218875f844/src/classes/timeline.py#L46-L52

Unlike any other lookup method, `ProjectDataStore.get()` _requires_ that it be passed a list, or it will fail with a warning:
https://github.com/OpenShot/openshot-qt/blob/eef69337e077162c589f2580c2503a218875f844/src/classes/project_data.py#L68-L71

But that just makes the calling code awkward. So, with this change, a non-empty, non-list arg is simply promoted to a single-item list by the _code_, instead of by the _coder_:
```python
        if not key:
            log.warning("Cannot get empty key.")
            return None
        if not isinstance(key, list):
            key = [key]
```

That allows `project.get("fps")`, `project.get("width")`, etc. to do what's expected, and makes the code easier to write and to read.