### PR TITLE
Default to three tracks for new projects

### DIFF
--- a/src/settings/_default.project
+++ b/src/settings/_default.project
@@ -49,20 +49,6 @@
       "number": 3000000,
       "y": 0,
       "lock": false
-    },
-    {
-      "id": "L4",
-      "label" : "",
-      "number": 4000000,
-      "y": 0,
-      "lock": false
-    },
-    {
-      "id": "L5",
-      "label" : "",
-      "number": 5000000,
-      "y": 0,
-      "lock": false
     }
   ],
   "markers": [  ],

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -177,9 +177,7 @@ App.controller('TimelineCtrl',function($scope) {
 	  	layers : [
   				{id: 'L0', number:0, y:0, label: '', lock: false},
 				{id: 'L1', number:1, y:0, label: '', lock: false},
-				{id: 'L2', number:2, y:0, label: '', lock: false},
-				{id: 'L3', number:3, y:0, label: '', lock: false},
-				{id: 'L4', number:4, y:0, label: '', lock: false}
+				{id: 'L2', number:2, y:0, label: '', lock: false}
              ],
 	  	markers : [],
               // [


### PR DESCRIPTION
Five tracks is excessive as a starting configuration. Few users will ever create projects that complex, and with the current default window geometry not even able to fit _two_ tracks, it's just a waste of space. This reduces the default track count to three for both new projects and the debugging interface.