### PR TITLE
Removing fractional values from X,Y coordinates on common transitions…

### DIFF
--- a/src/transitions/common/circle_in_to_out.svg
+++ b/src/transitions/common/circle_in_to_out.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -14,7 +15,7 @@
    height="576"
    id="svg2396"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="circle_in_to_out.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape">
   <metadata
@@ -44,18 +45,12 @@
      inkscape:zoom="1.0824912"
      inkscape:cx="466.71583"
      inkscape:cy="412.83934"
-     inkscape:window-x="0"
+     inkscape:window-x="65"
      inkscape:window-y="24"
-     inkscape:current-layer="layer1" />
+     inkscape:current-layer="layer1"
+     inkscape:window-maximized="0" />
   <defs
      id="defs2398">
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 288 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="720 : 288 : 1"
-       inkscape:persp3d-origin="360 : 192 : 1"
-       id="perspective5442" />
     <linearGradient
        id="linearGradient4649">
       <stop
@@ -68,11 +63,11 @@
          offset="1" />
     </linearGradient>
     <radialGradient
-       cx="360.00665"
-       cy="288.00635"
+       cx="360.0"
+       cy="288.0"
        r="360"
-       fx="360.00665"
-       fy="288.00635"
+       fx="360.0"
+       fy="288.0"
        id="radialGradient4655"
        xlink:href="#linearGradient4649"
        gradientUnits="userSpaceOnUse"
@@ -83,8 +78,8 @@
     <rect
        width="720"
        height="576"
-       x="0.0066374484"
-       y="0.006353823"
+       x="0.0"
+       y="0.0"
        id="rect2406"
        style="opacity:1;fill:url(#radialGradient4655);fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>

--- a/src/transitions/common/circle_out_to_in.svg
+++ b/src/transitions/common/circle_out_to_in.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -14,7 +15,7 @@
    height="576"
    id="svg2396"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="circle_out_to_in.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape">
   <metadata
@@ -44,18 +45,12 @@
      inkscape:zoom="1.0824912"
      inkscape:cx="466.71583"
      inkscape:cy="412.83934"
-     inkscape:window-x="0"
+     inkscape:window-x="65"
      inkscape:window-y="24"
-     inkscape:current-layer="layer1" />
+     inkscape:current-layer="layer1"
+     inkscape:window-maximized="0" />
   <defs
      id="defs2398">
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 288 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="720 : 288 : 1"
-       inkscape:persp3d-origin="360 : 192 : 1"
-       id="perspective5442" />
     <linearGradient
        id="linearGradient4649">
       <stop
@@ -68,11 +63,11 @@
          offset="1" />
     </linearGradient>
     <radialGradient
-       cx="360.00665"
-       cy="288.00635"
+       cx="360.0"
+       cy="288.0"
        r="360"
-       fx="360.00665"
-       fy="288.00635"
+       fx="360.0"
+       fy="288.0"
        id="radialGradient4655"
        xlink:href="#linearGradient4649"
        gradientUnits="userSpaceOnUse"
@@ -83,8 +78,8 @@
     <rect
        width="720"
        height="576"
-       x="0.0066374484"
-       y="0.006353823"
+       x="0.0"
+       y="0.0"
        id="rect2406"
        style="opacity:1;fill:url(#radialGradient4655);fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>

--- a/src/transitions/common/fade.svg
+++ b/src/transitions/common/fade.svg
@@ -38,11 +38,11 @@
          offset="1" />
     </linearGradient>
     <radialGradient
-       cx="360.00665"
-       cy="288.00635"
+       cx="360.0"
+       cy="288.0"
        r="360"
-       fx="360.00665"
-       fy="288.00635"
+       fx="360.0"
+       fy="288.0"
        id="radialGradient4655"
        xlink:href="#linearGradient4649"
        gradientUnits="userSpaceOnUse"
@@ -53,8 +53,8 @@
     <rect
        width="720"
        height="576"
-       x="0.0066374484"
-       y="0.006353823"
+       x="0.0"
+       y="0.0"
        id="rect2406"
        style="fill:url(#radialGradient4655);fill-opacity:1;stroke:none" />
   </g>

--- a/src/transitions/common/wipe_bottom_to_top.svg
+++ b/src/transitions/common/wipe_bottom_to_top.svg
@@ -23,10 +23,10 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="344.2374"
-       y1="-66.343071"
-       x2="344.2374"
-       y2="670.26086"
+       x1="344.0"
+       y1="-66.0"
+       x2="344.0"
+       y2="670.0"
        id="linearGradient5277"
        xlink:href="#linearGradient4649"
        gradientUnits="userSpaceOnUse" />
@@ -36,8 +36,8 @@
     <rect
        width="720"
        height="576"
-       x="0.0066374484"
-       y="0.006353823"
+       x="0.0"
+       y="0.0"
        id="rect2406"
        style="opacity:1;fill:url(#linearGradient5277);fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>

--- a/src/transitions/common/wipe_left_to_right.svg
+++ b/src/transitions/common/wipe_left_to_right.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,9 +14,10 @@
    height="576px"
    id="svg2396"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
-   sodipodi:docname="wipe_right_to_left.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="wipe_left_to_right.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
   <defs
      id="defs2398">
     <linearGradient
@@ -29,21 +31,14 @@
          offset="1"
          id="stop4653" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 288 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="720 : 288 : 1"
-       inkscape:persp3d-origin="360 : 192 : 1"
-       id="perspective2404" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4649"
        id="linearGradient4679"
-       x1="-103.86396"
-       y1="288.00635"
-       x2="822.8913"
-       y2="288.00635"
+       x1="-103.0"
+       y1="288.0"
+       x2="822.0"
+       y2="288.0"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
@@ -54,15 +49,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.04"
-     inkscape:cx="375.60555"
-     inkscape:cy="262.46374"
+     inkscape:cx="375"
+     inkscape:cy="262"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1680"
      inkscape:window-height="975"
-     inkscape:window-x="0"
-     inkscape:window-y="24" />
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0" />
   <metadata
      id="metadata2401">
     <rdf:RDF>
@@ -83,7 +79,7 @@
        id="rect2406"
        width="720"
        height="576"
-       x="0.0066374484"
-       y="0.006353823" />
+       x="0.0"
+       y="0.0" />
   </g>
 </svg>

--- a/src/transitions/common/wipe_right_to_left.svg
+++ b/src/transitions/common/wipe_right_to_left.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,9 +14,10 @@
    height="576px"
    id="svg2396"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
-   sodipodi:docname="wipe_left_to_right.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="wipe_right_to_left.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
   <defs
      id="defs2398">
     <linearGradient
@@ -29,21 +31,14 @@
          offset="1"
          id="stop4653" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 288 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="720 : 288 : 1"
-       inkscape:persp3d-origin="360 : 192 : 1"
-       id="perspective2404" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4649"
        id="linearGradient4679"
-       x1="-103.86396"
-       y1="288.00635"
-       x2="822.8913"
-       y2="288.00635"
+       x1="-103.0"
+       y1="288.0"
+       x2="822.0"
+       y2="288.0"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
@@ -54,15 +49,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.04"
-     inkscape:cx="375.60555"
-     inkscape:cy="262.46374"
+     inkscape:cx="375"
+     inkscape:cy="262"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1680"
      inkscape:window-height="975"
-     inkscape:window-x="0"
-     inkscape:window-y="24" />
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0" />
   <metadata
      id="metadata2401">
     <rdf:RDF>
@@ -83,7 +79,7 @@
        id="rect2406"
        width="720"
        height="576"
-       x="0.0066374484"
-       y="0.006353823" />
+       x="0.0"
+       y="0.0" />
   </g>
 </svg>

--- a/src/transitions/common/wipe_top_to_bottom.svg
+++ b/src/transitions/common/wipe_top_to_bottom.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -13,9 +14,10 @@
    height="576px"
    id="svg2396"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="wipe_top_to_bottom.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
   <defs
      id="defs2398">
     <linearGradient
@@ -29,21 +31,14 @@
          offset="1"
          id="stop4653" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 288 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="720 : 288 : 1"
-       inkscape:persp3d-origin="360 : 192 : 1"
-       id="perspective2404" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4649"
        id="linearGradient5277"
-       x1="344.2374"
-       y1="-66.343071"
-       x2="344.2374"
-       y2="670.26086"
+       x1="344.0"
+       y1="-66.0"
+       x2="344.0"
+       y2="670.0"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
@@ -54,15 +49,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.04"
-     inkscape:cx="362.14401"
-     inkscape:cy="280.02987"
+     inkscape:cx="362"
+     inkscape:cy="280"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1680"
      inkscape:window-height="975"
-     inkscape:window-x="0"
-     inkscape:window-y="24" />
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0" />
   <metadata
      id="metadata2401">
     <rdf:RDF>
@@ -83,7 +79,7 @@
        id="rect2406"
        width="720"
        height="576"
-       x="0.0066374484"
-       y="0.006353823" />
+       x="0.0"
+       y="0.0" />
   </g>
 </svg>


### PR DESCRIPTION
Removing fractional values from X,Y coordinates on common transitions (trying to prevent strange rendering issues with 1 pixel borders). This is a pretty harmless PR, but I have a feeling there are more tweaks needed to fully resolve this issue (especially related to caching / scaling for performance).

More discussion here: https://github.com/RazrFalcon/resvg/issues/153