### PR TITLE
Change default multiplexing preset for mp4, mov

### DIFF
--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -830,6 +830,9 @@ class Export(QDialog):
             if "crf" in self.txtVideoBitRate.text():
                 w.SetOption(openshot.VIDEO_STREAM, "crf", str(int(video_settings.get("video_bitrate"))) )
 
+            # Muxing options for mp4/mov
+            w.SetOption(openshot.VIDEO_STREAM, "muxing_preset", "mp4_faststart")
+
             # Open the writer
             w.Open()
 


### PR DESCRIPTION
Set new default multiplexing to "faststart" of FFmpeg (for MP4/MOV files only). Change only because YouTube suggests to upload "streamable" file formats. While MP4 is default in OpenShot's export - it is wise to set one of the most compatible streamable formats for MP4 export as default.

**Edit 2:** the PR meaning was changed, so info below is a bit outdated now.

Add new control to make user to choose at _Export Video>Advanced tab>Multiplexing Settings_ other multiplexing preset or disable it (that was previous default).

**Edit:** Should look like this or similar, -
![OpenShot muxing export controls](https://user-images.githubusercontent.com/19683044/61116233-b29d0880-a49c-11e9-8f60-f11b0eca7ffa.png)
