### PR TITLE
Permission popup: Don't eat other exceptions

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -1,28 +1,28 @@
-""" 
+"""
  @file
  @brief This file creates the QApplication, and displays the main window
  @author Noah Figg <eggmunkee@hotmail.com>
  @author Jonathan Thomas <jonathan@openshot.org>
  @author olivier Girard <eolinwen@gmail.com>
- 
+
  @section LICENSE
- 
+
  Copyright (c) 2008-2018 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
@@ -138,8 +138,7 @@ class OpenShotApp(QApplication):
             # Delete test paths
             os.unlink(TEST_PATH_FILE)
             os.rmdir(TEST_PATH_DIR)
-        except Exception as ex:
-            # Permission error (most likely)
+        except PermissionError as ex:
             log.error('Failed to create PERMISSION/test.osp file (likely permissions error): %s' % TEST_PATH_FILE)
             QMessageBox.warning(None, _("Permission Error"),
                                       _("%(error)s. Please delete <b>%(path)s</b> and launch OpenShot again." % {"error": str(ex), "path": info.USER_PATH}))


### PR DESCRIPTION
The new "Permission Error" popup message is causing major troubleshooting problems, because it eats **ALL** exceptions, and is triggering for lots of problems that have _nothing_ to do with permission errors. This is presenting users with incorrect information (deleting their OpenShot configuration is going to do nothing to solve their problem), and robbing us of access to the useful error information that would be presented if not for the popup.

(See #2748, #2841, probably others. I even had the box come up once during development, due to a bug in my code that had _absolutely nothing_ to do with permissions.)

This change limits the exceptions that can trigger a Permission Error popup box to **only** the actual `PermissionError` exception, which is the only one that should be thrown in the case of an actual permission error.