### PR TITLE
 Add support for a user default project file

### DIFF
--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -1,26 +1,26 @@
-""" 
+"""
  @file
  @brief This file contains the current version number of OpenShot, along with other global settings.
  @author Jonathan Thomas <jonathan@openshot.org>
- 
+
  @section LICENSE
- 
+
  Copyright (c) 2008-2018 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
@@ -57,6 +57,7 @@ EXPORT_PRESETS_PATH = os.path.join(PATH, "presets")
 EXPORT_TESTS = os.path.join(USER_PATH, "tests")
 USER_PROFILES_PATH = os.path.join(USER_PATH, "profiles")
 USER_PRESETS_PATH = os.path.join(USER_PATH, "presets")
+USER_DEFAULT_PROJECT = os.path.join(USER_PATH, "default.project")
 
 # Create PATHS if they do not exist (this is where temp files are stored... such as cached thumbnails)
 for folder in [USER_PATH, THUMBNAIL_PATH, CACHE_PATH, BLENDER_PATH, ASSETS_PATH, TITLE_PATH, PROFILES_PATH, IMAGES_PATH,

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -49,6 +49,10 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         self.data_type = "project data"  # Used in error messages
         self.default_project_filepath = os.path.join(info.PATH, 'settings', '_default.project')
 
+        # Always set, in case the user creates the file mid-session
+        if info.USER_DEFAULT_PROJECT:
+            self.user_project_filepath = info.USER_DEFAULT_PROJECT
+
         # Set default filepath to user's home folder
         self.current_filepath = None
 
@@ -252,7 +256,24 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
     def new(self):
         """ Try to load default project settings file, will raise error on failure """
         import openshot
-        self._data = self.read_from_file(self.default_project_filepath)
+
+        # Try to load user default project
+        if os.path.exists(self.user_project_filepath):
+            try:
+                self._data = self.read_from_file(self.user_project_filepath)
+            except (FileNotFoundError, PermissionError) as ex:
+                log.warning("Unable to load defaults from {}: {}".format(
+                    new_project_file, ex))
+            except Exception:
+                raise
+            else:
+                log.info("Loaded user project defaults from {}".format(
+                    self.user_project_filepath))
+
+        # Fall back to OpenShot defaults, if user defaults didn't load
+        if not self._data:
+            self._data = self.read_from_file(self.default_project_filepath)
+
         self.current_filepath = None
         self.has_unsaved_changes = False
 


### PR DESCRIPTION
This allows the user to create a file at `info.USER_DEFAULT_PROJECT` (set to `info.USER_PATH/default.project`) which contains their personal default project settings. If this file is found and can be successfully loaded, its contents will be used as the "New Project" initialization data. Otherwise, `info.PATH/settings/_default.project` will be loaded as usual.

Addresses concerns raised by @SuslikV in #2856 

Honestly, I'm not sure about this one... it's got the potential to cause difficulties. It's meant to be a "power user" feature, not a supported normal config, and there's a lot to be said for just telling people, "If you use this, you're on your own for problems it causes you." But, still, it's not a _great_ idea. 

(As far as problems, I'm thinking of things like new fields being added to the system default project file. Those won't automatically be carried over to users' personal defaults, they'll have to manually update them.) 

However, it's also true that the current one-size-fits-all default project may _not_ fit all users equally, and this is at least a solution to that, which doesn't mean that the defaults for _everyone_ have to try and fit the needs of users with more demanding requirements.