### PR TITLE
Fix import error popup, other exceptions

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -171,7 +171,6 @@ class OpenShotApp(QApplication):
                 QApplication.setFont(font)
             except Exception as ex:
                 log.error("Error setting Ubuntu-R.ttf QFont: %s" % str(ex))
-                raise
 
         # Set Experimental Dark Theme
         if self.settings.get("theme") == "Humanity: Dark":
@@ -230,7 +229,6 @@ class OpenShotApp(QApplication):
             self.settings.save()
         except Exception as ex:
             log.error("Couldn't save user settings on exit.\n{}".format(ex))
-            raise
 
         # return exit result
         return res

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -30,6 +30,7 @@
 import os
 import sys
 import platform
+import traceback
 from uuid import uuid4
 from PyQt5.QtWidgets import QApplication, QStyleFactory, QMessageBox
 from PyQt5.QtGui import QPalette, QColor, QFontDatabase, QFont
@@ -65,10 +66,15 @@ class OpenShotApp(QApplication):
 
             # Re-route stdout and stderr to logger
             reroute_output()
-        except Exception as ex:
+        except (ImportError, ModuleNotFoundError) as ex:
+            tb = traceback.format_exc()
             QMessageBox.warning(None, "Import Error",
-                                "%(error)s. Please delete <b>%(path)s</b> and launch OpenShot again." % {"error": str(ex), "path": info.USER_PATH})
+                                "Module: %(name)s\n\n%(tb)s" % {"name": ex.name, "tb": tb})
             # Stop launching and exit
+            raise
+            sys.exit()
+        except Exception:
+            raise
             sys.exit()
 
         # Log some basic system info
@@ -143,6 +149,7 @@ class OpenShotApp(QApplication):
             QMessageBox.warning(None, _("Permission Error"),
                                       _("%(error)s. Please delete <b>%(path)s</b> and launch OpenShot again." % {"error": str(ex), "path": info.USER_PATH}))
             # Stop launching and exit
+            raise
             sys.exit()
 
         # Start libopenshot logging thread
@@ -164,6 +171,7 @@ class OpenShotApp(QApplication):
                 QApplication.setFont(font)
             except Exception as ex:
                 log.error("Error setting Ubuntu-R.ttf QFont: %s" % str(ex))
+                raise
 
         # Set Experimental Dark Theme
         if self.settings.get("theme") == "Humanity: Dark":
@@ -222,6 +230,7 @@ class OpenShotApp(QApplication):
             self.settings.save()
         except Exception as ex:
             log.error("Couldn't save user settings on exit.\n{}".format(ex))
+            raise
 
         # return exit result
         return res


### PR DESCRIPTION
It was pointed out to me that there was a _second_ message popup box in `classes.app` (like the one fixed in #2862, which had even worse sins:
* It was also eating _all_ exceptions, even ones that might have nothing to do with import errors.
* It was displaying the same advice about deleting the user's profile directory, even though there is no situation I can think of where that would be effective at fixing an import error. (Unlike with the other popup, where deleting the directory most likely would solve a permissions error.)
* Also like the other popup, because it was catching the exception and doing nothing useful with it, it was robbing us of important troubleshooting information.

So, while I kept the popup, I removed the bad advice about deleting the user profile, and instead display a full traceback (using the standard `traceback` module) in the popup dialog. I also `raise` the exception, so that the same traceback will be printed to stderr. Any other exception blocks in `classes.app` that end in `sys.exit()` received the same `raise` statements, so that tracebacks are always captured.

Now, if there's an import error (like this one I engineered for myself, by deleting `reroute_output` from `logger.py`), the popup will look something like this:

![image](https://user-images.githubusercontent.com/538020/61180145-edf42000-a5df-11e9-9fe2-ee6706699016.png)

And the same traceback will appear on the console, for debugging purposes.

If we want to make the popup more friendly (though that's hard when it can't be localized to the user's language), I can see including some advice about reinstalling OpenShot as a possible solution to the problem. But deleting their configuration is simply not going to solve an ImportError.

Addresses #2748 