### PR TITLE
Update appdata.xml file with 2.4.4 release

### DIFF
--- a/xdg/openshot-qt.appdata.xml
+++ b/xdg/openshot-qt.appdata.xml
@@ -69,6 +69,7 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
+    <release version="2.4.4" date="2019-03-20"/>
     <release version="2.4.3" date="2018-09-22"/>
     <release version="2.4.2" date="2018-06-30"/>
     <release version="2.4.1" date="2017-11-12"/>


### PR DESCRIPTION
Cart waaaay after the horse, but updating the appdata.xml file for
the 2.4.4 release was missed at the time, and it was actually never
done after. So, adding in the 2.4.4 release tag, very belatedly.
Hopefully we'll get it next time (_before_ the release).