### PR TITLE
Remove ellipses from "New Project" menu/binding

### DIFF
--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -583,7 +583,7 @@
   },
   {
     "category": "Keyboard",
-    "title": "New Project...",
+    "title": "New Project",
     "restart": true,
     "setting": "actionNew",
     "value": "Ctrl+N",

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -504,7 +504,7 @@
      <normaloff>:/icons/Humanity/actions/16/document-new.svg</normaloff>:/icons/Humanity/actions/16/document-new.svg</iconset>
    </property>
    <property name="text">
-    <string>New Project...</string>
+    <string>New Project</string>
    </property>
    <property name="toolTip">
     <string>New Project</string>


### PR DESCRIPTION
As pointed out by @udippel in #2806, our "New Project..." action does not even remotely fit the criteria for [menu items that should be followed by ellipses](https://stackoverflow.com/questions/637683/when-to-use-ellipsis-after-menu-items) as provided by all major systems' Human Interface Guidelines. This change removes the ellipses from both the File menu item, and the keyboard binding label in the settings file (as displayed in the Preferences' Keyboard tab).

Fixes #2806