### PR TITLE
Recents list: Never add relative paths

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -851,12 +851,15 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
     def add_to_recent_files(self, file_path):
         """ Add this project to the recent files list """
-        if "backup.osp" in file_path:
+        if not file_path or "backup.osp" in file_path:
             # Ignore backup recovery project
             return
 
         s = settings.get_settings()
         recent_projects = s.get("recent_projects")
+
+        # Make sure file_path is absolute
+        file_path = os.path.abspath(file_path)
 
         # Remove existing project
         if file_path in recent_projects:


### PR DESCRIPTION
Because relative paths on the Recent Files list break whenever you
run OpenShot from a different directory, the submitted path should
always be converted to absolute when inserting into `recent_projects`.

Also, add a defensive check for null/empty `file_path`, before we
start passing it to os library functions.

Fixes #2826 