### PR TITLE
PlayheadMoved: Eliminate unused args

### DIFF
--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief The AngularJS controller used by the OpenShot Timeline 
+ * @brief The AngularJS controller used by the OpenShot Timeline
  * @author Jonathan Thomas <jonathan@openshot.org>
  * @author Cody Parker <cody@yourcodepro.com>
  *
@@ -27,7 +27,7 @@
  */
 
 
-// Initialize the main controller module 
+// Initialize the main controller module
 App.controller('TimelineCtrl',function($scope) {
 
 	// DEMO DATA (used when debugging outside of Qt using Chrome)
@@ -241,12 +241,12 @@ App.controller('TimelineCtrl',function($scope) {
   $scope.min_width = 1024;
   $scope.track_label = "Track %s";
   $scope.enable_sorting = true;
-  
+
   // Method to set if Qt is detected (which clears demo data)
   $scope.Qt = false;
-  $scope.EnableQt = function() { 
+  $scope.EnableQt = function() {
 	  	$scope.Qt = true;
-	  	timeline.qt_log("$scope.Qt = true;"); 
+	  	timeline.qt_log("$scope.Qt = true;");
   };
 
   // Move the playhead to a specific time
@@ -281,10 +281,10 @@ App.controller('TimelineCtrl',function($scope) {
 	  // Determine frame
 	  var frames_per_second = $scope.project.fps.num / $scope.project.fps.den;
 	  var frame = Math.round(position_seconds * frames_per_second) + 1;
-	  
-	  // Update GUI with position (to the preview can be updated)
+
+	  // Update GUI with position (so the preview can be updated)
 	  if ($scope.Qt) {
-		  timeline.PlayheadMoved(position_seconds, frame, secondsToTime(position_seconds, $scope.project.fps.num, $scope.project.fps.den));
+		  timeline.PlayheadMoved(frame);
 	  }
   };
 
@@ -297,7 +297,7 @@ App.controller('TimelineCtrl',function($scope) {
 	  var frames_per_second = $scope.project.fps.num / $scope.project.fps.den;
 	  var frame = Math.round(position_seconds_rounded * frames_per_second) + 1;
 
-	  // Update GUI with position (to the preview can be updated)
+	  // Update GUI with position (so the preview can be updated)
 	  if ($scope.Qt) {
 		  timeline.PreviewClipFrame(clip_id, frame);
 	  }
@@ -571,8 +571,8 @@ App.controller('TimelineCtrl',function($scope) {
 		ctx.fillStyle = '#4B92AD';
 		ctx.fill();
 	}
- };	
-	
+ };
+
  // Clear all selections
  $scope.ClearAllSelections = function() {
 	// Clear the selections on the main window
@@ -1432,13 +1432,13 @@ $scope.SetTrackLabel = function (label) {
 	 // return true
 	 return true;
  };
-  
-// ############# END QT FUNCTIONS #################### //   
+
+// ############# END QT FUNCTIONS #################### //
 
 
 
 // ############ DEBUG STUFFS ################## //
- 
+
  $scope.ToggleDebug = function() {
 	 if ($scope.debug == true) {
 		 $scope.debug = false;

--- a/src/timeline/js/functions.js
+++ b/src/timeline/js/functions.js
@@ -314,4 +314,3 @@ function moveBoundingBox(scope, previous_x, previous_y, x_offset, y_offset, left
 
     return { 'position': snapping_result, 'x_offset' : x_offset, 'y_offset' : y_offset };
 }
-

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -882,7 +882,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         win = Cutting(f, preview=True)
         win.show()
 
-    def previewFrame(self, position_seconds, position_frames, time_code):
+    def previewFrame(self, position_frames):
         """Preview a specific frame"""
         # Notify preview thread
         self.previewFrameSignal.emit(position_frames)

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -2523,8 +2523,8 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         # Seek to frame
         self.window.SeekSignal.emit(frame_number)
 
-    @pyqtSlot(float, int, str)
-    def PlayheadMoved(self, position_seconds, position_frames, time_code):
+    @pyqtSlot(int)
+    def PlayheadMoved(self, position_frames):
 
         # Load the timeline into the Player (ignored if this has already happened)
         self.window.LoadFileSignal.emit('')
@@ -2534,7 +2534,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
             self.last_position_frames = position_frames
 
             # Notify main window of current frame
-            self.window.previewFrame(position_seconds, position_frames, time_code)
+            self.window.previewFrame(position_frames)
 
     @pyqtSlot(int)
     def movePlayhead(self, position_frames):


### PR DESCRIPTION
As came to light during the discussion of PR #2512, the JS code was passing three args to `PlayheadMoved()`, two of them never used. This PR eliminates them from `PlayheadMoved()` itself and its slot declaration, and also eliminates those same args from being forwarded along in a subsequent call to `window.previewFrame()`.

(My editor also did a bit of automated whitespace-cleanup, sorry.)