### PR TITLE
Destroy webview when exiting

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -136,6 +136,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.preview_parent.background.exit()
         self.preview_parent.background.wait(5000)
 
+        # Shut down the webview
+        self.timeline.close()
+
         # Close Timeline
         self.timeline_sync.timeline.Close()
         self.timeline_sync.timeline = None

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -2967,8 +2967,11 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         self.last_position_frames = None
         self.document_is_ready = False
 
+        # Delete the webview when closed
+        self.setAttribute(Qt.WA_DeleteOnClose)
+
         # Disable image caching on timeline
-        self.settings().setObjectCacheCapacities(0, 0, 0);
+        self.settings().setObjectCacheCapacities(0, 0, 0)
 
         # Get settings
         self.settings_obj = settings.get_settings()


### PR DESCRIPTION
Since commit aa165c44ec3a40ee1abef9cd7ea17934d81ca706 I've been having issues with OpenShot not exiting cleanly, due to timers in the WebView process that continue trying to access Timeline data after the object's been destroyed. (See comments at aa165c44ec3a40ee1abef9cd7ea17934d81ca706.)

This change sets the TimelineWebView attribute `WA_DeleteOnClose`, which will cause the widget to be destroyed on close. It also calls `timeline.close()` _before_ destroying libopenshot's Timeline object, to stop the WebView timers attempting further data access.