### PR TITLE
Migration to new Windows builder (with updated dependencies)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,7 +83,7 @@ windows-builder-x64:
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - Copy-Item "$CI_PROJECT_DIR/build/install-x64/python/*" -Destination "$CI_PROJECT_DIR"
     - $env:Path = "$CI_PROJECT_DIR\build\install-x64\lib;$CI_PROJECT_DIR\build\install-x64\lib\python3.7\site-packages\;C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\home\jonathan\depot_tools;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
-    - $env:PYTHONPATH = "C:\msys64\usr\lib;C:\msys64\usr\lib\site-packages\;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;";
+    - $env:PYTHONPATH = "$CI_PROJECT_DIR\build\install-x64\lib\python3.7\site-packages\;C:\msys64\usr\lib;C:\msys64\usr\lib\site-packages\;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;";
     - New-Item -path "build/install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
     - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,6 +115,7 @@ windows-builder-x86:
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
     - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x86/share/$CI_PROJECT_NAME.log"
     - python3 freeze.py build
+    - editbin /LARGEADDRESSAWARE "$CI_PROJECT_DIR\build\exe.mingw-3.7\launch.exe"
     - python3 installer/build-server.py "$SLACK_TOKEN" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "True" "$CI_COMMIT_REF_NAME"
   when: always
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -109,7 +109,8 @@ windows-builder-x86:
     - if (-not (Test-Path "artifacts.zip")) { Invoke-WebRequest -Uri "http://gitlab.openshot.org/OpenShot/libopenshot/-/jobs/artifacts/develop/download?job=windows-builder-x86" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" }
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - Copy-Item "$CI_PROJECT_DIR/build/install-x86/python/*" -Destination "$CI_PROJECT_DIR"
-    - $env:Path = "$CI_PROJECT_DIR\build\install-x86\lib;C:\msys32\mingw32\bin;C:\msys32\mingw32\lib;C:\msys32\usr\lib\cmake\UnitTest++;C:\msys32\home\jonathan\depot_tools;C:\msys32\usr;C:\msys32\usr\lib;" + $env:Path;
+    - $env:Path = "$CI_PROJECT_DIR\build\install-x86\lib;$CI_PROJECT_DIR\build\install-x86\lib\python3.7\site-packages\;C:\msys32\mingw32\bin;C:\msys32\mingw32\lib;C:\msys32\mingw32\lib\python3.7\;C:\msys32\mingw32\lib\python3.7\site-packages\;C:\msys32\mingw32\lib\python3.7\site-packages\PyQt5;C:\msys32\usr\lib\cmake\UnitTest++;C:\msys32\home\jonathan\depot_tools;C:\msys32\usr;C:\msys32\usr\lib;" + $env:Path;
+    - $env:PYTHONPATH = "$CI_PROJECT_DIR\build\install-x86\lib\python3.7\site-packages\;C:\msys32\usr\lib;C:\msys32\usr\lib\site-packages\;C:\msys32\mingw32\lib\python3.7\;C:\msys32\mingw32\lib\python3.7\site-packages\;C:\msys32\mingw32\lib\python3.7\site-packages\PyQt5;";
     - New-Item -path "build/install-x86/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
     - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x86/share/$CI_PROJECT_NAME.log"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,6 +83,7 @@ windows-builder-x64:
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - Copy-Item "$CI_PROJECT_DIR/build/install-x64/python/*" -Destination "$CI_PROJECT_DIR"
     - $env:Path = "$CI_PROJECT_DIR\build\install-x64\lib;C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\home\jonathan\depot_tools;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
+    - $env:PYTHONPATH = "C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;";
     - New-Item -path "build/install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
     - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,7 @@ windows-builder-x64:
     - if (-not (Test-Path "artifacts.zip")) { Invoke-WebRequest -Uri "http://gitlab.openshot.org/OpenShot/libopenshot/-/jobs/artifacts/develop/download?job=windows-builder-x64" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" }
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - Copy-Item "$CI_PROJECT_DIR/build/install-x64/python/*" -Destination "$CI_PROJECT_DIR"
-    - $env:Path = "$CI_PROJECT_DIR\build\install-x64\lib;C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\home\jonathan\depot_tools;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
+    - $env:Path = "$CI_PROJECT_DIR\build\install-x64\lib;C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\home\jonathan\depot_tools;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
     - New-Item -path "build/install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
     - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,7 +115,6 @@ windows-builder-x86:
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
     - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x86/share/$CI_PROJECT_NAME.log"
     - python3 freeze.py build
-    - #editbin /LARGEADDRESSAWARE "$CI_PROJECT_DIR\build\exe.mingw-3.7\launch.exe"
     - python3 installer/build-server.py "$SLACK_TOKEN" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "True" "$CI_COMMIT_REF_NAME"
   when: always
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,7 @@ windows-builder-x64:
     - if (-not (Test-Path "artifacts.zip")) { Invoke-WebRequest -Uri "http://gitlab.openshot.org/OpenShot/libopenshot/-/jobs/artifacts/develop/download?job=windows-builder-x64" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" }
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - Copy-Item "$CI_PROJECT_DIR/build/install-x64/python/*" -Destination "$CI_PROJECT_DIR"
-    - $env:Path = "$CI_PROJECT_DIR\build\install-x64\lib;C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\home\jonathan\depot_tools;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
+    - $env:Path = "$CI_PROJECT_DIR\build\install-x64\lib;$CI_PROJECT_DIR\build\install-x64\lib\python3.7\site-packages\;C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\home\jonathan\depot_tools;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
     - $env:PYTHONPATH = "C:\msys64\usr\lib;C:\msys64\usr\lib\site-packages\;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;";
     - New-Item -path "build/install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,7 @@ windows-builder-x64:
     - if (-not (Test-Path "artifacts.zip")) { Invoke-WebRequest -Uri "http://gitlab.openshot.org/OpenShot/libopenshot/-/jobs/artifacts/develop/download?job=windows-builder-x64" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" }
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - Copy-Item "$CI_PROJECT_DIR/build/install-x64/python/*" -Destination "$CI_PROJECT_DIR"
-    - $env:Path = "$CI_PROJECT_DIR\build\install-x64\lib;$CI_PROJECT_DIR\build\install-x64\lib\python3.7\site-packages\;C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\home\jonathan\depot_tools;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
+    - $env:Path = "$CI_PROJECT_DIR\build\install-x64\lib;$CI_PROJECT_DIR\build\install-x64\lib\python3.7\site-packages\;C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
     - $env:PYTHONPATH = "$CI_PROJECT_DIR\build\install-x64\lib\python3.7\site-packages\;C:\msys64\usr\lib;C:\msys64\usr\lib\site-packages\;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;";
     - New-Item -path "build/install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
@@ -109,7 +109,7 @@ windows-builder-x86:
     - if (-not (Test-Path "artifacts.zip")) { Invoke-WebRequest -Uri "http://gitlab.openshot.org/OpenShot/libopenshot/-/jobs/artifacts/develop/download?job=windows-builder-x86" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" }
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - Copy-Item "$CI_PROJECT_DIR/build/install-x86/python/*" -Destination "$CI_PROJECT_DIR"
-    - $env:Path = "$CI_PROJECT_DIR\build\install-x86\lib;$CI_PROJECT_DIR\build\install-x86\lib\python3.7\site-packages\;C:\msys32\mingw32\bin;C:\msys32\mingw32\lib;C:\msys32\mingw32\lib\python3.7\;C:\msys32\mingw32\lib\python3.7\site-packages\;C:\msys32\mingw32\lib\python3.7\site-packages\PyQt5;C:\msys32\usr\lib\cmake\UnitTest++;C:\msys32\home\jonathan\depot_tools;C:\msys32\usr;C:\msys32\usr\lib;" + $env:Path;
+    - $env:Path = "$CI_PROJECT_DIR\build\install-x86\lib;$CI_PROJECT_DIR\build\install-x86\lib\python3.7\site-packages\;C:\msys32\mingw32\bin;C:\msys32\mingw32\lib;C:\msys32\mingw32\lib\python3.7\;C:\msys32\mingw32\lib\python3.7\site-packages\;C:\msys32\mingw32\lib\python3.7\site-packages\PyQt5;C:\msys32\usr\lib\cmake\UnitTest++;C:\msys32\usr;C:\msys32\usr\lib;" + $env:Path;
     - $env:PYTHONPATH = "$CI_PROJECT_DIR\build\install-x86\lib\python3.7\site-packages\;C:\msys32\usr\lib;C:\msys32\usr\lib\site-packages\;C:\msys32\mingw32\lib\python3.7\;C:\msys32\mingw32\lib\python3.7\site-packages\;C:\msys32\mingw32\lib\python3.7\site-packages\PyQt5;";
     - New-Item -path "build/install-x86/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,7 +115,7 @@ windows-builder-x86:
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
     - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x86/share/$CI_PROJECT_NAME.log"
     - python3 freeze.py build
-    - editbin /LARGEADDRESSAWARE "$CI_PROJECT_DIR\build\exe.mingw-3.7\launch.exe"
+    - #editbin /LARGEADDRESSAWARE "$CI_PROJECT_DIR\build\exe.mingw-3.7\launch.exe"
     - python3 installer/build-server.py "$SLACK_TOKEN" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "True" "$CI_COMMIT_REF_NAME"
   when: always
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,7 @@ windows-builder-x64:
     - if (-not (Test-Path "artifacts.zip")) { Invoke-WebRequest -Uri "http://gitlab.openshot.org/OpenShot/libopenshot/-/jobs/artifacts/develop/download?job=windows-builder-x64" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" }
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - Copy-Item "$CI_PROJECT_DIR/build/install-x64/python/*" -Destination "$CI_PROJECT_DIR"
-    - $env:Path = "$CI_PROJECT_DIR\build\install-x64\lib;C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\home\jonathan\depot_tools;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
+    - $env:Path = "$CI_PROJECT_DIR\build\install-x64\lib;C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\home\jonathan\depot_tools;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
     - New-Item -path "build/install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
     - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,7 +115,7 @@ windows-builder-x86:
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
     - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x86/share/$CI_PROJECT_NAME.log"
     - python3 freeze.py build
-    - editbin /LARGEADDRESSAWARE "$CI_PROJECT_DIR\build\exe.mingw-3.6\launch.exe"
+    - editbin /LARGEADDRESSAWARE "$CI_PROJECT_DIR\build\exe.mingw-3.7\launch.exe"
     - python3 installer/build-server.py "$SLACK_TOKEN" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "True" "$CI_COMMIT_REF_NAME"
   when: always
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,7 +83,7 @@ windows-builder-x64:
     - Expand-Archive -Path artifacts.zip -DestinationPath .
     - Copy-Item "$CI_PROJECT_DIR/build/install-x64/python/*" -Destination "$CI_PROJECT_DIR"
     - $env:Path = "$CI_PROJECT_DIR\build\install-x64\lib;C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\home\jonathan\depot_tools;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
-    - $env:PYTHONPATH = "C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;";
+    - $env:PYTHONPATH = "C:\msys64\usr\lib;C:\msys64\usr\lib\site-packages\;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;";
     - New-Item -path "build/install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
     - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"

--- a/freeze.py
+++ b/freeze.py
@@ -58,7 +58,6 @@ import fnmatch
 from shutil import copytree, rmtree, copy
 from cx_Freeze import setup, Executable
 from PyQt5.QtCore import QLibraryInfo
-from PyQt5 import *
 import shutil
 
 
@@ -74,7 +73,7 @@ except ImportError:
     json_library = "simplejson"
 
 # Packages to include
-python_packages = ["os", "sys", "openshot", "time", "uuid", "shutil", "threading", "subprocess",
+python_packages = ["os", "sys", "PyQt5", "openshot", "time", "uuid", "shutil", "threading", "subprocess",
                                  "re", "math", "xml", "logging", "urllib", "requests", "zmq", "webbrowser", json_library]
 
 # Determine absolute PATH of OpenShot folder
@@ -282,7 +281,6 @@ for filename in find_files("openshot_qt", ["*"]):
 
 # Dependencies are automatically detected, but it might need fine tuning.
 build_exe_options["packages"] = python_packages
-build_exe_options["includes"] = ["PyQt5.QtCore","PyQt5.QtGui", "PyQt5.QtWidgets"]
 build_exe_options["include_files"] = src_files + external_so_files
 
 # Set options

--- a/freeze.py
+++ b/freeze.py
@@ -74,7 +74,7 @@ except ImportError:
     json_library = "simplejson"
 
 # Packages to include
-python_packages = ["os", "sys", "PyQt5", "openshot", "time", "uuid", "shutil", "threading", "subprocess",
+python_packages = ["os", "sys", "openshot", "time", "uuid", "shutil", "threading", "subprocess",
                                  "re", "math", "xml", "logging", "urllib", "requests", "zmq", "webbrowser", json_library]
 
 # Determine absolute PATH of OpenShot folder
@@ -277,6 +277,7 @@ for filename in find_files("openshot_qt", ["*"]):
 
 # Dependencies are automatically detected, but it might need fine tuning.
 build_exe_options["packages"] = python_packages
+build_exe_options["includes"] = ["PyQt5.QtCore","PyQt5.QtGui", "PyQt5.QtWidgets"]
 build_exe_options["include_files"] = src_files + external_so_files
 
 # Set options

--- a/freeze.py
+++ b/freeze.py
@@ -155,9 +155,12 @@ if sys.platform == "win32":
     src_files.append((os.path.join(PATH, "installer", "launch-win.bat"), "launch-win.bat"))
 
     # Add libresvg (if found)
-    resvg_path = "C:\\msys64\\usr\\local\\lib\\resvg.dll"
+    resvg_path = "C:\\msys64\\usr\\lib\\resvg.dll"
+    if not os.path.exists(resvg_path):
+        resvg_path = "C:\\msys32\\usr\\lib\\resvg.dll"
     if os.path.exists(resvg_path):
-        external_so_files.append((resvg_path, resvg_path.replace("C:\\msys64\\usr\\local\\lib\\", "")))
+        external_so_files.append((resvg_path, resvg_path.replace("C:\\msys64\\usr\\lib\\", "")))
+
 
     # Add additional package
     python_packages.append('idna')

--- a/freeze.py
+++ b/freeze.py
@@ -79,11 +79,6 @@ python_packages = ["os", "sys", "PyQt5", "openshot", "time", "uuid", "shutil", "
 # Determine absolute PATH of OpenShot folder
 PATH = os.path.dirname(os.path.realpath(__file__))  # Primary openshot folder
 
-print("Start of FREEZE")
-print("PATH: %s" % PATH)
-print("sys.path: %s" % str(sys.path))
-print("dir(): %s" % str(dir()))
-
 # Make a copy of the src tree (temporary for naming reasons only)
 if os.path.exists(os.path.join(PATH, "src")):
     print("Copying modules to openshot_qt directory: %s" % os.path.join(PATH, "openshot_qt"))

--- a/freeze.py
+++ b/freeze.py
@@ -80,6 +80,11 @@ python_packages = ["os", "sys", "openshot", "time", "uuid", "shutil", "threading
 # Determine absolute PATH of OpenShot folder
 PATH = os.path.dirname(os.path.realpath(__file__))  # Primary openshot folder
 
+print("Start of FREEZE")
+print("PATH: %s" % PATH)
+print("sys.path: %s" % str(sys.path))
+print("dir(): %s" % str(dir()))
+
 # Make a copy of the src tree (temporary for naming reasons only)
 if os.path.exists(os.path.join(PATH, "src")):
     print("Copying modules to openshot_qt directory: %s" % os.path.join(PATH, "openshot_qt"))

--- a/freeze.py
+++ b/freeze.py
@@ -73,7 +73,7 @@ except ImportError:
     json_library = "simplejson"
 
 # Packages to include
-python_packages = ["os", "sys", "PyQt5", "openshot", "time", "uuid", "shutil", "threading", "subprocess",
+python_packages = ["os", "sys", "PyQt5.QtCore", "PyQt5.QtGui", "PyQt5.QtWidgets", "PyQt5.Qt", "openshot", "time", "uuid", "shutil", "threading", "subprocess",
                                  "re", "math", "xml", "logging", "urllib", "requests", "zmq", "webbrowser", json_library]
 
 # Determine absolute PATH of OpenShot folder

--- a/freeze.py
+++ b/freeze.py
@@ -134,6 +134,10 @@ for project in ["libopenshot-audio", "libopenshot", "openshot-qt"]:
     git_log_path = os.path.join(PATH, "build", "install-x64", "share", "%s.log" % project)
     if os.path.exists(git_log_path):
         src_files.append((git_log_path, "settings/%s.log" % project))
+    else:
+        git_log_path = os.path.join(PATH, "build", "install-x86", "share", "%s.log" % project)
+        if os.path.exists(git_log_path):
+            src_files.append((git_log_path, "settings/%s.log" % project))
 
 if sys.platform == "win32":
     base = "Win32GUI"

--- a/freeze.py
+++ b/freeze.py
@@ -58,6 +58,7 @@ import fnmatch
 from shutil import copytree, rmtree, copy
 from cx_Freeze import setup, Executable
 from PyQt5.QtCore import QLibraryInfo
+from PyQt5 import *
 import shutil
 
 
@@ -73,7 +74,7 @@ except ImportError:
     json_library = "simplejson"
 
 # Packages to include
-python_packages = ["os", "sys", "PyQt5.QtCore", "PyQt5.QtGui", "PyQt5.QtWidgets", "PyQt5.Qt", "openshot", "time", "uuid", "shutil", "threading", "subprocess",
+python_packages = ["os", "sys", "PyQt5", "openshot", "time", "uuid", "shutil", "threading", "subprocess",
                                  "re", "math", "xml", "logging", "urllib", "requests", "zmq", "webbrowser", json_library]
 
 # Determine absolute PATH of OpenShot folder

--- a/freeze.py
+++ b/freeze.py
@@ -57,24 +57,16 @@ import sys
 import fnmatch
 from shutil import copytree, rmtree, copy
 from cx_Freeze import setup, Executable
+import cx_Freeze
 from PyQt5.QtCore import QLibraryInfo
 import shutil
 
 
-# Determine which JSON library is installed
-json_library = None
-try:
-    import json
-
-    json_library = "json"
-except ImportError:
-    import simplejson as json
-
-    json_library = "simplejson"
+print (str(cx_Freeze))
 
 # Packages to include
 python_packages = ["os", "sys", "PyQt5", "openshot", "time", "uuid", "shutil", "threading", "subprocess",
-                                 "re", "math", "xml", "logging", "urllib", "requests", "zmq", "webbrowser", json_library]
+                                 "re", "math", "xml", "logging", "urllib", "requests", "zmq", "webbrowser", "json"]
 
 # Determine absolute PATH of OpenShot folder
 PATH = os.path.dirname(os.path.realpath(__file__))  # Primary openshot folder

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -152,7 +152,7 @@ def get_release(repo, tag_name):
     @param repo:        github3 repository object
     @returns:           github3 release object or None
     """
-    for release in repo.releases():
+    for release in repo.iter_releases():
         if release.tag_name == tag_name:
             return release
 

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -428,10 +428,12 @@ try:
         # Replace these folders (cx_Freeze messes this up, so this fixes it)
         paths_to_replace = ['imageformats', 'platforms']
         for replace_name in paths_to_replace:
+            print(os.path.join('C:\\msys32\\mingw32\\share\\qt5\\plugins', replace_name))
+            print(os.path.join(exe_dir, replace_name))
             if windows_32bit:
-                shutil.copy2(os.path.join('C:/msys32/mingw32/share/qt5/plugins', replace_name), exe_dir)
+                shutil.copytree(os.path.join('C:\\msys32\\mingw32\\share\\qt5\\plugins', replace_name), os.path.join(exe_dir, replace_name))
             else:
-                shutil.copy2(os.path.join('C:/msys64/mingw64/share/qt5/plugins', replace_name), exe_dir)
+                shutil.copytree(os.path.join('C:\\msys64\\mingw64\\share\\qt5\\plugins', replace_name), os.path.join(exe_dir, replace_name))
 
         # Delete debug Qt libraries (since they are not needed, and cx_Freeze grabs them)
         for sub_folder in ['', 'platforms', 'imageformats', 'mediaservice']:

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -404,20 +404,11 @@ try:
         # Move python folder structure, since Cx_Freeze doesn't put it in the correct place
         exe_dir = os.path.join(PATH, 'build', 'exe.mingw-3.7')
         python_dir = os.path.join(exe_dir, 'lib', 'python3.7')
-        if not os.path.exists(python_dir):
-            os.mkdir(python_dir)
 
-            # Copy all non-zip files from /lib/ into /python3.X/
-            for lib_file in os.listdir(os.path.join(exe_dir, 'lib')):
-                if not ".zip" in lib_file and not lib_file == "python3.7":
-                    lib_src_path = os.path.join(os.path.join(exe_dir, 'lib'), lib_file)
-                    lib_dst_path = os.path.join(os.path.join(python_dir), lib_file)
-                    shutil.move(lib_src_path, lib_dst_path)
-
-            # Remove a redundant openshot_qt module folder (duplicates lots of files)
-            duplicate_openshot_qt_path = os.path.join(python_dir, 'openshot_qt')
-            if os.path.exists(duplicate_openshot_qt_path):
-                shutil.rmtree(duplicate_openshot_qt_path, True)
+        # Remove a redundant openshot_qt module folder (duplicates lots of files)
+        duplicate_openshot_qt_path = os.path.join(python_dir, 'openshot_qt')
+        if os.path.exists(duplicate_openshot_qt_path):
+            shutil.rmtree(duplicate_openshot_qt_path, True)
 
         # Delete debug Qt libraries (since they are not needed, and cx_Freeze grabs them)
         for sub_folder in ['', 'platforms', 'imageformats', 'mediaservice']:

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -429,9 +429,9 @@ try:
         paths_to_replace = ['imageformats', 'platforms']
         for replace_name in paths_to_replace:
             if windows_32bit:
-                shutil.copytree(os.path.join('C:/msys32/mingw32/share/qt5/plugins/', replace_name), exe_dir)
+                shutil.copytree(os.path.join('C:/msys32/mingw32/share/qt5/plugins/', replace_name), os.path.join(exe_dir, replace_name))
             else:
-                shutil.copytree(os.path.join('C:/msys64/mingw64/share/qt5/plugins/', replace_name), exe_dir)
+                shutil.copytree(os.path.join('C:/msys64/mingw64/share/qt5/plugins/', replace_name), os.path.join(exe_dir, replace_name))
 
         # Delete debug Qt libraries (since they are not needed, and cx_Freeze grabs them)
         for sub_folder in ['', 'platforms', 'imageformats', 'mediaservice']:

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -449,20 +449,20 @@ try:
 
         # Add version metadata to frozen app launcher
         launcher_exe = os.path.join(exe_dir, "launch.exe")
-        verpatch_success = True
-        verpatch_command = '"verpatch.exe" "{}" /va /high "{}" /pv "{}" /s product "{}" /s company "{}" /s copyright "{}" /s desc "{}"'.format(launcher_exe, info.VERSION, info.VERSION, info.PRODUCT_NAME, info.COMPANY_NAME, info.COPYRIGHT, info.PRODUCT_NAME)
-        verpatch_output = ""
-        # version-stamp executable
-        for line in run_command(verpatch_command):
-            output(line)
-            if line:
-                verpatch_success = False
-                verpatch_output = line
-                
-        # Was the verpatch command successful
-        if not verpatch_success:
-            # Verpatch failed (not fatal)
-            error("Verpatch Error: Had output when none was expected (%s)" % verpatch_output)
+        # verpatch_success = True
+        # verpatch_command = '"verpatch.exe" "{}" /va /high "{}" /pv "{}" /s product "{}" /s company "{}" /s copyright "{}" /s desc "{}"'.format(launcher_exe, info.VERSION, info.VERSION, info.PRODUCT_NAME, info.COMPANY_NAME, info.COPYRIGHT, info.PRODUCT_NAME)
+        # verpatch_output = ""
+        # # version-stamp executable
+        # for line in run_command(verpatch_command):
+        #     output(line)
+        #     if line:
+        #         verpatch_success = False
+        #         verpatch_output = line
+        #
+        # # Was the verpatch command successful
+        # if not verpatch_success:
+        #     # Verpatch failed (not fatal)
+        #     error("Verpatch Error: Had output when none was expected (%s)" % verpatch_output)
 
         # Copy uninstall files into build folder
         for file in os.listdir(os.path.join("c:/", "InnoSetup")):

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -152,7 +152,7 @@ def get_release(repo, tag_name):
     @param repo:        github3 repository object
     @returns:           github3 release object or None
     """
-    for release in repo.iter_releases():
+    for release in repo.releases():
         if release.tag_name == tag_name:
             return release
 

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -429,9 +429,9 @@ try:
         paths_to_replace = ['imageformats', 'platforms']
         for replace_name in paths_to_replace:
             if windows_32bit:
-                shutil.copytree(os.path.join('C:/msys32/mingw32/share/qt5/plugins/', replace_name), os.path.join(exe_dir, replace_name))
+                shutil.copytree(os.path.join('C:/msys32/mingw32/share/qt5/plugins', replace_name), os.path.join(exe_dir, replace_name))
             else:
-                shutil.copytree(os.path.join('C:/msys64/mingw64/share/qt5/plugins/', replace_name), os.path.join(exe_dir, replace_name))
+                shutil.copytree(os.path.join('C:/msys64/mingw64/share/qt5/plugins', replace_name), os.path.join(exe_dir, replace_name))
 
         # Delete debug Qt libraries (since they are not needed, and cx_Freeze grabs them)
         for sub_folder in ['', 'platforms', 'imageformats', 'mediaservice']:

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -410,6 +410,26 @@ try:
         if os.path.exists(duplicate_openshot_qt_path):
             shutil.rmtree(duplicate_openshot_qt_path, True)
 
+        # Remove the following paths. cx_Freeze is including many unneeded files. This prunes them out.
+        paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport', 'libicudt64.dll', 'lib/libicudt64.dll',
+                           'lib/avcodec-58.dll', '/lib/PyQt5/Qt5WebKit.dll', '/lib/PyQt5/libicudt64.dll']
+        for delete_path in paths_to_delete:
+            full_delete_path = os.path.join(exe_path, delete_path)
+            if os.path.exists(full_delete_path):
+                if os.path.isdir(full_delete_path):
+                    # Delete Folder
+                    for delete_file_path in os.listdir(full_delete_path):
+                        os.unlink(os.path.join(full_delete_path, delete_file_path))
+                    os.rmdir(full_delete_path)
+                else:
+                    # Delete File
+                    os.unlink(full_delete_path)
+
+        # Replace these folders (cx_Freeze messes this up, so this fixes it)
+        paths_to_replace = ['imageformats', 'platforms']
+        for replace_name in paths_to_replace:
+            shutil.copytree(os.path.join('C:/msys64/mingw64/share/qt5/plugins/', replace_name), exe_path)
+
         # Delete debug Qt libraries (since they are not needed, and cx_Freeze grabs them)
         for sub_folder in ['', 'platforms', 'imageformats', 'mediaservice']:
             parent_path = exe_dir

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -456,7 +456,7 @@ try:
 
         # Create Installer (OpenShot-%s-x86_64.exe)
         inno_success = True
-        inno_command = '"C:\Program Files (x86)\Inno Setup 5\iscc.exe" /Q /DVERSION=%s /DONLY_64_BIT=%s "%s"' % (version, only_64_bit, os.path.join(PATH, 'installer', 'windows-installer.iss'))
+        inno_command = '"C:\Program Files (x86)\Inno Setup 6\iscc.exe" /Q /DVERSION=%s /DONLY_64_BIT=%s "%s"' % (version, only_64_bit, os.path.join(PATH, 'installer', 'windows-installer.iss'))
         inno_output = ""
         # Compile Inno installer
         for line in run_command(inno_command):

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -420,7 +420,7 @@ try:
                 shutil.rmtree(duplicate_openshot_qt_path, True)
 
         # Delete debug Qt libraries (since they are not needed, and cx_Freeze grabs them)
-        for sub_folder in ['', 'platforms', 'imageformats']:
+        for sub_folder in ['', 'platforms', 'imageformats', 'mediaservice']:
             parent_path = exe_dir
             if sub_folder:
                 parent_path = os.path.join(parent_path, sub_folder)
@@ -436,7 +436,7 @@ try:
         # Add version metadata to frozen app launcher
         launcher_exe = os.path.join(exe_dir, "launch.exe")
         verpatch_success = True
-        verpatch_command = '"C:\Program Files (x86)\Verpatch\\verpatch.exe" "{}" /va /high "{}" /pv "{}" /s product "{}" /s company "{}" /s copyright "{}" /s desc "{}"'.format(launcher_exe, info.VERSION, info.VERSION, info.PRODUCT_NAME, info.COMPANY_NAME, info.COPYRIGHT, info.PRODUCT_NAME)
+        verpatch_command = '"verpatch.exe" "{}" /va /high "{}" /pv "{}" /s product "{}" /s company "{}" /s copyright "{}" /s desc "{}"'.format(launcher_exe, info.VERSION, info.VERSION, info.PRODUCT_NAME, info.COMPANY_NAME, info.COPYRIGHT, info.PRODUCT_NAME)
         verpatch_output = ""
         # version-stamp executable
         for line in run_command(verpatch_command):
@@ -456,7 +456,7 @@ try:
 
         # Create Installer (OpenShot-%s-x86_64.exe)
         inno_success = True
-        inno_command = '"C:\Program Files (x86)\Inno Setup 6\iscc.exe" /Q /DVERSION=%s /DONLY_64_BIT=%s "%s"' % (version, only_64_bit, os.path.join(PATH, 'installer', 'windows-installer.iss'))
+        inno_command = '"iscc.exe" /Q /DVERSION=%s /DONLY_64_BIT=%s "%s"' % (version, only_64_bit, os.path.join(PATH, 'installer', 'windows-installer.iss'))
         inno_output = ""
         # Compile Inno installer
         for line in run_command(inno_command):
@@ -479,7 +479,7 @@ try:
 
         # Sign the installer
         key_sign_success = True
-        key_sign_command = '"C:\\Program Files (x86)\\kSign\\kSignCMD.exe" /f "%s" /p "%s" /d "OpenShot Video Editor" /du "http://www.openshot.org" "%s"' % (windows_key, windows_key_password, app_build_path)
+        key_sign_command = '"kSignCMD.exe" /f "%s" /p "%s" /d "OpenShot Video Editor" /du "http://www.openshot.org" "%s"' % (windows_key, windows_key_password, app_build_path)
         key_sign_output = ""
         # Sign MSI
         for line in run_command(key_sign_command):

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -479,7 +479,7 @@ try:
 
         # Sign the installer
         key_sign_success = True
-        key_sign_command = '"kSignCMD.exe" /f "%s" /p "%s" /d "OpenShot Video Editor" /du "http://www.openshot.org" "%s"' % (windows_key, windows_key_password, app_build_path)
+        key_sign_command = '"kSignCMD.exe" /f "%s%s" /p "%s" /d "OpenShot Video Editor" /du "http://www.openshot.org" "%s"' % (windows_key, only_64_bit, windows_key_password, app_build_path)
         key_sign_output = ""
         # Sign MSI
         for line in run_command(key_sign_command):

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -411,8 +411,7 @@ try:
             shutil.rmtree(duplicate_openshot_qt_path, True)
 
         # Remove the following paths. cx_Freeze is including many unneeded files. This prunes them out.
-        paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport', 'lib/openshot_qt',
-                           'libicudt64.dll', 'resvg.dll']
+        paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport', 'lib/openshot_qt', 'resvg.dll']
         for delete_path in paths_to_delete:
             full_delete_path = os.path.join(exe_dir, delete_path)
             output("Delete path: %s" % full_delete_path)

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -411,8 +411,8 @@ try:
             shutil.rmtree(duplicate_openshot_qt_path, True)
 
         # Remove the following paths. cx_Freeze is including many unneeded files. This prunes them out.
-        paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport', 'libicudt64.dll', 'lib/libicudt64.dll',
-                           'lib/PyQt5/Qt5WebKit.dll', 'lib/PyQt5/libicudt64.dll', 'lib/openshot_qt']
+        paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport',
+                           'lib/PyQt5/Qt5WebKit.dll', 'lib/openshot_qt']
         for delete_path in paths_to_delete:
             full_delete_path = os.path.join(exe_dir, delete_path)
             if os.path.exists(full_delete_path):

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -411,7 +411,8 @@ try:
             shutil.rmtree(duplicate_openshot_qt_path, True)
 
         # Remove the following paths. cx_Freeze is including many unneeded files. This prunes them out.
-        paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport', 'lib/openshot_qt']
+        paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport', 'lib/openshot_qt'
+                           'libicudt64.dll', 'resvg.dll']
         for delete_path in paths_to_delete:
             full_delete_path = os.path.join(exe_dir, delete_path)
             if os.path.exists(full_delete_path):

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -428,7 +428,10 @@ try:
         # Replace these folders (cx_Freeze messes this up, so this fixes it)
         paths_to_replace = ['imageformats', 'platforms']
         for replace_name in paths_to_replace:
-            shutil.copytree(os.path.join('C:/msys64/mingw64/share/qt5/plugins/', replace_name), exe_path)
+            if windows_32bit:
+                shutil.copytree(os.path.join('C:/msys32/mingw32/share/qt5/plugins/', replace_name), exe_path)
+            else:
+                shutil.copytree(os.path.join('C:/msys64/mingw64/share/qt5/plugins/', replace_name), exe_path)
 
         # Delete debug Qt libraries (since they are not needed, and cx_Freeze grabs them)
         for sub_folder in ['', 'platforms', 'imageformats', 'mediaservice']:

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -449,20 +449,20 @@ try:
 
         # Add version metadata to frozen app launcher
         launcher_exe = os.path.join(exe_dir, "launch.exe")
-        # verpatch_success = True
-        # verpatch_command = '"verpatch.exe" "{}" /va /high "{}" /pv "{}" /s product "{}" /s company "{}" /s copyright "{}" /s desc "{}"'.format(launcher_exe, info.VERSION, info.VERSION, info.PRODUCT_NAME, info.COMPANY_NAME, info.COPYRIGHT, info.PRODUCT_NAME)
-        # verpatch_output = ""
-        # # version-stamp executable
-        # for line in run_command(verpatch_command):
-        #     output(line)
-        #     if line:
-        #         verpatch_success = False
-        #         verpatch_output = line
-        #
-        # # Was the verpatch command successful
-        # if not verpatch_success:
-        #     # Verpatch failed (not fatal)
-        #     error("Verpatch Error: Had output when none was expected (%s)" % verpatch_output)
+        verpatch_success = True
+        verpatch_command = '"verpatch.exe" "{}" /va /high "{}" /pv "{}" /s product "{}" /s company "{}" /s copyright "{}" /s desc "{}"'.format(launcher_exe, info.VERSION, info.VERSION, info.PRODUCT_NAME, info.COMPANY_NAME, info.COPYRIGHT, info.PRODUCT_NAME)
+        verpatch_output = ""
+        # version-stamp executable
+        for line in run_command(verpatch_command):
+            output(line)
+            if line:
+                verpatch_success = False
+                verpatch_output = line
+
+        # Was the verpatch command successful
+        if not verpatch_success:
+            # Verpatch failed (not fatal)
+            error("Verpatch Error: Had output when none was expected (%s)" % verpatch_output)
 
         # Copy uninstall files into build folder
         for file in os.listdir(os.path.join("c:/", "InnoSetup")):

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -429,9 +429,9 @@ try:
         paths_to_replace = ['imageformats', 'platforms']
         for replace_name in paths_to_replace:
             if windows_32bit:
-                shutil.copytree(os.path.join('C:/msys32/mingw32/share/qt5/plugins', replace_name), os.path.join(exe_dir, replace_name))
+                shutil.copy2(os.path.join('C:/msys32/mingw32/share/qt5/plugins', replace_name), exe_dir)
             else:
-                shutil.copytree(os.path.join('C:/msys64/mingw64/share/qt5/plugins', replace_name), os.path.join(exe_dir, replace_name))
+                shutil.copy2(os.path.join('C:/msys64/mingw64/share/qt5/plugins', replace_name), exe_dir)
 
         # Delete debug Qt libraries (since they are not needed, and cx_Freeze grabs them)
         for sub_folder in ['', 'platforms', 'imageformats', 'mediaservice']:

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -412,7 +412,7 @@ try:
 
         # Remove the following paths. cx_Freeze is including many unneeded files. This prunes them out.
         paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport', 'libicudt64.dll', 'lib/libicudt64.dll',
-                           '/lib/PyQt5/Qt5WebKit.dll', '/lib/PyQt5/libicudt64.dll', '/lib/openshot-qt']
+                           'lib/PyQt5/Qt5WebKit.dll', 'lib/PyQt5/libicudt64.dll', 'lib/openshot-qt']
         for delete_path in paths_to_delete:
             full_delete_path = os.path.join(exe_dir, delete_path)
             if os.path.exists(full_delete_path):

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -412,24 +412,15 @@ try:
 
         # Remove the following paths. cx_Freeze is including many unneeded files. This prunes them out.
         paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport', 'libicudt64.dll', 'lib/libicudt64.dll',
-                           'lib/avcodec-58.dll', '/lib/PyQt5/Qt5WebKit.dll', '/lib/PyQt5/libicudt64.dll']
+                           '/lib/PyQt5/Qt5WebKit.dll', '/lib/PyQt5/libicudt64.dll', '/lib/openshot-qt']
         for delete_path in paths_to_delete:
             full_delete_path = os.path.join(exe_dir, delete_path)
             if os.path.exists(full_delete_path):
-                if os.path.isdir(full_delete_path):
-                    # Delete Folder
-                    for delete_file_path in os.listdir(full_delete_path):
-                        os.unlink(os.path.join(full_delete_path, delete_file_path))
-                    os.rmdir(full_delete_path)
-                else:
-                    # Delete File
-                    os.unlink(full_delete_path)
+                shutil.rmtree(full_delete_path)
 
         # Replace these folders (cx_Freeze messes this up, so this fixes it)
         paths_to_replace = ['imageformats', 'platforms']
         for replace_name in paths_to_replace:
-            print(os.path.join('C:\\msys32\\mingw32\\share\\qt5\\plugins', replace_name))
-            print(os.path.join(exe_dir, replace_name))
             if windows_32bit:
                 shutil.copytree(os.path.join('C:\\msys32\\mingw32\\share\\qt5\\plugins', replace_name), os.path.join(exe_dir, replace_name))
             else:

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -416,7 +416,12 @@ try:
         for delete_path in paths_to_delete:
             full_delete_path = os.path.join(exe_dir, delete_path)
             if os.path.exists(full_delete_path):
-                shutil.rmtree(full_delete_path)
+                if os.path.isdir(full_delete_path):
+                    # Delete Folder
+                    shutil.rmtree(full_delete_path)
+                else:
+                    # Delete File
+                    os.unlink(full_delete_path)
 
         # Replace these folders (cx_Freeze messes this up, so this fixes it)
         paths_to_replace = ['imageformats', 'platforms']

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -411,7 +411,7 @@ try:
             shutil.rmtree(duplicate_openshot_qt_path, True)
 
         # Remove the following paths. cx_Freeze is including many unneeded files. This prunes them out.
-        paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport', 'lib/openshot_qt'
+        paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport', 'lib/openshot_qt',
                            'libicudt64.dll', 'resvg.dll']
         for delete_path in paths_to_delete:
             full_delete_path = os.path.join(exe_dir, delete_path)

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -415,6 +415,7 @@ try:
                            'libicudt64.dll', 'resvg.dll']
         for delete_path in paths_to_delete:
             full_delete_path = os.path.join(exe_dir, delete_path)
+            output("Delete path: %s" % full_delete_path)
             if os.path.exists(full_delete_path):
                 if os.path.isdir(full_delete_path):
                     # Delete Folder
@@ -422,6 +423,8 @@ try:
                 else:
                     # Delete File
                     os.unlink(full_delete_path)
+            else:
+                output("Invalid delete path: %s" % full_delete_path)
 
         # Replace these folders (cx_Freeze messes this up, so this fixes it)
         paths_to_replace = ['imageformats', 'platforms']

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -411,8 +411,7 @@ try:
             shutil.rmtree(duplicate_openshot_qt_path, True)
 
         # Remove the following paths. cx_Freeze is including many unneeded files. This prunes them out.
-        paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport',
-                           'lib/PyQt5/Qt5WebKit.dll', 'lib/openshot_qt']
+        paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport', 'lib/openshot_qt']
         for delete_path in paths_to_delete:
             full_delete_path = os.path.join(exe_dir, delete_path)
             if os.path.exists(full_delete_path):

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -414,7 +414,7 @@ try:
         paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport', 'libicudt64.dll', 'lib/libicudt64.dll',
                            'lib/avcodec-58.dll', '/lib/PyQt5/Qt5WebKit.dll', '/lib/PyQt5/libicudt64.dll']
         for delete_path in paths_to_delete:
-            full_delete_path = os.path.join(exe_path, delete_path)
+            full_delete_path = os.path.join(exe_dir, delete_path)
             if os.path.exists(full_delete_path):
                 if os.path.isdir(full_delete_path):
                     # Delete Folder

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -412,7 +412,7 @@ try:
 
         # Remove the following paths. cx_Freeze is including many unneeded files. This prunes them out.
         paths_to_delete = ['mediaservice', 'imageformats', 'platforms', 'printsupport', 'libicudt64.dll', 'lib/libicudt64.dll',
-                           'lib/PyQt5/Qt5WebKit.dll', 'lib/PyQt5/libicudt64.dll', 'lib/openshot-qt']
+                           'lib/PyQt5/Qt5WebKit.dll', 'lib/PyQt5/libicudt64.dll', 'lib/openshot_qt']
         for delete_path in paths_to_delete:
             full_delete_path = os.path.join(exe_dir, delete_path)
             if os.path.exists(full_delete_path):

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -436,7 +436,7 @@ try:
                 shutil.copytree(os.path.join('C:\\msys64\\mingw64\\share\\qt5\\plugins', replace_name), os.path.join(exe_dir, replace_name))
 
         # Delete debug Qt libraries (since they are not needed, and cx_Freeze grabs them)
-        for sub_folder in ['', 'platforms', 'imageformats', 'mediaservice']:
+        for sub_folder in ['', 'platforms', 'imageformats']:
             parent_path = exe_dir
             if sub_folder:
                 parent_path = os.path.join(parent_path, sub_folder)

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -429,9 +429,9 @@ try:
         paths_to_replace = ['imageformats', 'platforms']
         for replace_name in paths_to_replace:
             if windows_32bit:
-                shutil.copytree(os.path.join('C:/msys32/mingw32/share/qt5/plugins/', replace_name), exe_path)
+                shutil.copytree(os.path.join('C:/msys32/mingw32/share/qt5/plugins/', replace_name), exe_dir)
             else:
-                shutil.copytree(os.path.join('C:/msys64/mingw64/share/qt5/plugins/', replace_name), exe_path)
+                shutil.copytree(os.path.join('C:/msys64/mingw64/share/qt5/plugins/', replace_name), exe_dir)
 
         # Delete debug Qt libraries (since they are not needed, and cx_Freeze grabs them)
         for sub_folder in ['', 'platforms', 'imageformats', 'mediaservice']:

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -402,14 +402,14 @@ try:
     if platform.system() == "Windows":
 
         # Move python folder structure, since Cx_Freeze doesn't put it in the correct place
-        exe_dir = os.path.join(PATH, 'build', 'exe.mingw-3.6')
-        python_dir = os.path.join(exe_dir, 'lib', 'python3.6')
+        exe_dir = os.path.join(PATH, 'build', 'exe.mingw-3.7')
+        python_dir = os.path.join(exe_dir, 'lib', 'python3.7')
         if not os.path.exists(python_dir):
             os.mkdir(python_dir)
 
             # Copy all non-zip files from /lib/ into /python3.X/
             for lib_file in os.listdir(os.path.join(exe_dir, 'lib')):
-                if not ".zip" in lib_file and not lib_file == "python3.6":
+                if not ".zip" in lib_file and not lib_file == "python3.7":
                     lib_src_path = os.path.join(os.path.join(exe_dir, 'lib'), lib_file)
                     lib_dst_path = os.path.join(os.path.join(python_dir), lib_file)
                     shutil.move(lib_src_path, lib_dst_path)


### PR DESCRIPTION
This includes updated versions of MSYS2, FFmpeg, Resvg, cx_Freeze, Qt5, PyQt5, and much more. This also required some changes to `freeze.py` and `build-server.py`, since so many things were updated. I've also updated the Wiki build instructions for Windows: https://github.com/OpenShot/libopenshot/wiki/Windows-Build-Instructions.

On a side note, now both 32-bit and 64-bit Windows installers include libresvg.

This took a bunch of trial and error, so I will be collapsing the terribly named commits into 1 on merge. :smile: 