### PR TITLE
Fix resvg and Qt5Core.dll freeze / build-server issues

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -150,14 +150,6 @@ if sys.platform == "win32":
     # Append some additional files for Windows (this is a debug launcher)
     src_files.append((os.path.join(PATH, "installer", "launch-win.bat"), "launch-win.bat"))
 
-    # Add libresvg (if found)
-    resvg_path = "C:\\msys64\\usr\\lib\\resvg.dll"
-    if not os.path.exists(resvg_path):
-        resvg_path = "C:\\msys32\\usr\\lib\\resvg.dll"
-    if os.path.exists(resvg_path):
-        external_so_files.append((resvg_path, resvg_path.replace("C:\\msys64\\usr\\lib\\", "")))
-
-
     # Add additional package
     python_packages.append('idna')
 

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -433,6 +433,13 @@ try:
             else:
                 shutil.copytree(os.path.join('C:\\msys64\\mingw64\\share\\qt5\\plugins', replace_name), os.path.join(exe_dir, replace_name))
 
+        # Copy Qt5Core.dll to root of frozen directory
+        qt5_core_path = os.path.join(exe_dir, "lib", "Qt5Core.dll")
+        new_qt5_core_path = os.path.join(exe_dir, "Qt5Core.dll")
+        if os.path.exists(qt5_core_path) and not os.path.exists(new_qt5_core_path):
+            output("Copying %s to %s" % (qt5_core_path, new_qt5_core_path))
+            shutil.copy(qt5_core_path, new_qt5_core_path)
+
         # Delete debug Qt libraries (since they are not needed, and cx_Freeze grabs them)
         for sub_folder in ['', 'platforms', 'imageformats']:
             parent_path = exe_dir


### PR DESCRIPTION
Removing resvg.dll from the cx_Freeze logic, which then removed a needed Qt5Core.dll. So, adding that back in. Ideally this would happen in freeze.py (technically anything related to building a working frozen folder), but for now, this was simpler.