### PR TITLE
Raise max video dimensions to 40000x40000

### DIFF
--- a/src/windows/ui/export.ui
+++ b/src/windows/ui/export.ui
@@ -526,7 +526,7 @@
                 <number>2</number>
                </property>
                <property name="maximum">
-                <number>9999</number>
+                <number>40000</number>
                </property>
               </widget>
              </item>
@@ -559,7 +559,7 @@
                 <number>2</number>
                </property>
                <property name="maximum">
-                <number>9999</number>
+                <number>40000</number>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
Believe it or not, 9999 pixels to a side isn't enough for some users' projects, and the only thing preventing them from working in larger dimensions was the max value the export dialog would accept.

(Also, 9999 is a terrible value to stop at because most codecs require dimensions in multiples of 2, 4, 8... 40,000 is still just as arbitrary, but at least it's a multiple of 2, 4, _and_ 8.)

Addresses #2889