### PR TITLE
Add SVG to image-sequence extensions

### DIFF
--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -205,7 +205,7 @@ class FilesTreeView(QTreeView):
 
         # Get just the file name
         (dirName, fileName) = os.path.split(file_path)
-        extensions = ["png", "jpg", "jpeg", "gif", "tif"]
+        extensions = ["png", "jpg", "jpeg", "gif", "tif", "svg"]
         match = re.findall(r"(.*[^\d])?(0*)(\d+)\.(%s)" % "|".join(extensions), fileName, re.I)
 
         if not match:


### PR DESCRIPTION
We occasionally get requests to support SVG as an image sequence filetype, and AFAICT there's no  reason we can't. Simply adding `svg` to the list of recognized filename extensions in the image sequence code made it Just Work™, at least in my testing.

This change allows importing of image sequences that comprise groups of sequentially-numbered SVG files, in addition to the other supported image formats.

(Note that I'm not currently able to test this with ReSVG, and the caveat should be noted that QtSVG-rendered SVG image sequences will likely not produce accurate results.)

Fixes #675 and possibly others