### PR TITLE
WIP: Make OpenShot less verbose

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -125,6 +125,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 event.ignore()
                 return
 
+        # On exit always write INFO messages to the log
+        log.setLevel(logging.INFO)
+
         # Log the exit routine
         log.info('---------------- Shutting down -----------------')
 

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -32,6 +32,7 @@ import sys
 import platform
 import shutil
 import webbrowser
+import logging
 from operator import itemgetter
 from uuid import uuid4
 from copy import deepcopy
@@ -2102,6 +2103,11 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             self.actionFreeze_View.setVisible(False)
             self.actionUn_Freeze_View.setVisible(True)
             self.docks_frozen = True
+
+        # If not in degug mode Log only errors
+        if not s.get('debug-mode'):
+            log.info("Changing log level to the 'ERROR'")
+            log.setLevel(logging.ERROR)
 
         # Load Recent Projects
         self.load_recent_menu()

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -29,6 +29,7 @@
 import os
 import operator
 import functools
+import logging
 
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
@@ -424,6 +425,13 @@ class Preferences(QDialog):
 
             # Enable / Disable logger
             openshot.ZmqLogger.Instance().Enable(debug_enabled)
+
+            # Change log level
+            if debug_enabled:
+                log.setLevel(logging.INFO)
+            else:
+                log.info("Changing log level to the 'ERROR'")
+                log.setLevel(logging.ERROR)
 
         elif param["setting"] == "enable-auto-save":
             # Toggle autosave


### PR DESCRIPTION
Attempt to implement the: https://github.com/OpenShot/openshot-qt/issues/2752

I believe that end-user will able set _Debug_ checkbox in the application's _Preferences_ to get old-style verbose log back...