### PR TITLE
Fix a regression in Windows Installer (file associations)

### DIFF
--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -71,7 +71,7 @@ Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
-Name: "fileassoc"; Description: "{cm:AssocFileExtension,{#MyAppName},.osp"; GroupDescription: "{cm:AdditionalIcons}"; Flags: checked
+Name: "fileassoc"; Description: "{cm:AssocFileExtension,{#MyAppName},.osp"; GroupDescription: "{cm:AdditionalIcons}";
 Name: "firewall"; Description: "Add an exception to the Windows Firewall"; GroupDescription: "{cm:AdditionalIcons}";
 
 [InstallDelete]


### PR DESCRIPTION
Fix a small regression (syntax error) introduced in https://github.com/OpenShot/openshot-qt/pull/2872. There is no "checked" flag... although there probably should be in my opinion.