### PR TITLE
Fix another regression in Windows Installer

### DIFF
--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -71,7 +71,7 @@ Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
-Name: "fileassoc"; Description: "{cm:AssocFileExtension,{#MyAppName},.osp"; GroupDescription: "{cm:AdditionalIcons}";
+Name: "fileassoc"; Description: "{cm:AssocFileExtension},{#MyAppName},.osp"; GroupDescription: "{cm:AdditionalIcons}";
 Name: "firewall"; Description: "Add an exception to the Windows Firewall"; GroupDescription: "{cm:AdditionalIcons}";
 
 [InstallDelete]

--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -71,7 +71,7 @@ Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
-Name: "fileassoc"; Description: "{cm:AssocFileExtension},{#MyAppName},.osp"; GroupDescription: "{cm:AdditionalIcons}";
+Name: "fileassoc"; Description: "{cm:AssocFileExtension,{#MyAppName},.osp}"; GroupDescription: "{cm:AdditionalIcons}";
 Name: "firewall"; Description: "Add an exception to the Windows Firewall"; GroupDescription: "{cm:AdditionalIcons}";
 
 [InstallDelete]


### PR DESCRIPTION
One more syntax error in the description (from https://github.com/OpenShot/openshot-qt/pull/2872). Also, I haven't tested this one yet, but is `cm:AssocFileExtension` this defined somewhere?