### PR TITLE
Don't use deprecated "AllDockWidgetFeatures", don't make Timeline closable

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1885,14 +1885,14 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 dock.show()
 
     def freezeDocks(self):
-        """ Freeze all dockable widgets on the main screen (no float, moving, or closing) """
+        """ Freeze all dockable widgets on the main screen (prevent them being closed, floated, or moved) """
         for dock in self.getDocks():
             dock.setFeatures(QDockWidget.NoDockWidgetFeatures)
 
     def unFreezeDocks(self):
-        """ Un-freeze all dockable widgets on the main screen (allow them to be moved, closed, and floated) """
+        """ Un-freeze all dockable widgets on the main screen (allow them to be closed, floated, and moved) """
         for dock in self.getDocks():
-            dock.setFeatures(QDockWidget.AllDockWidgetFeatures)
+            dock.setFeatures(QDockWidget.DockWidgetClosable | QDockWidget.DockWidgetFloatable | QDockWidget.DockWidgetMovable)
 
     def hideDocks(self):
         """ Hide all dockable widgets on the main screen """

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1890,9 +1890,12 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             dock.setFeatures(QDockWidget.NoDockWidgetFeatures)
 
     def unFreezeDocks(self):
-        """ Un-freeze all dockable widgets on the main screen (allow them to be closed, floated, and moved) """
+        """ Un-freeze all dockable widgets on the main screen (allow them to be closed, floated, or moved, as appropriate) """
         for dock in self.getDocks():
-            dock.setFeatures(QDockWidget.DockWidgetClosable | QDockWidget.DockWidgetFloatable | QDockWidget.DockWidgetMovable)
+            if dock is self.dockTimeline:
+                dock.setFeatures(QDockWidget.DockWidgetFloatable | QDockWidget.DockWidgetMovable)
+            else:
+                dock.setFeatures(QDockWidget.DockWidgetClosable | QDockWidget.DockWidgetFloatable | QDockWidget.DockWidgetMovable)
 
     def hideDocks(self):
         """ Hide all dockable widgets on the main screen """


### PR DESCRIPTION
As @SuslikV pointed out, `QDockWidget::AllDockWidgetFeatures` is [deprecated in Qt](https://doc.qt.io/qt-5/qdockwidget.html). Their recommendation is to use the individual features it expands to (Closable, Floatable, Movable), a recommendation this PR implements.

It also corrects a bug where the Timeline widget would become closable on unfreeze.