### PR TITLE
Fixing cx_Freeze issues with renamed EXE (openshot-qt.exe)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,7 +115,7 @@ windows-builder-x86:
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0)
     - git log "$PREV_GIT_LABEL..HEAD" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x86/share/$CI_PROJECT_NAME.log"
     - python3 freeze.py build
-    - editbin /LARGEADDRESSAWARE "$CI_PROJECT_DIR\build\exe.mingw-3.6\openshot-qt.exe"
+    - editbin /LARGEADDRESSAWARE "$CI_PROJECT_DIR\build\exe.mingw-3.7\openshot-qt.exe"
     - python3 installer/build-server.py "$SLACK_TOKEN" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "True" "$CI_COMMIT_REF_NAME"
   when: always
   except:

--- a/freeze.py
+++ b/freeze.py
@@ -115,6 +115,7 @@ src_files = []
 external_so_files = []
 build_options = {}
 build_exe_options = {}
+exe_name = info.NAME
 
 # Copy QT translations to local folder (to be packaged)
 qt_local_path = os.path.join(PATH, "openshot_qt", "language")
@@ -142,6 +143,7 @@ for project in ["libopenshot-audio", "libopenshot", "openshot-qt"]:
 if sys.platform == "win32":
     base = "Win32GUI"
     build_exe_options["include_msvcr"] = True
+    exe_name += ".exe"
 
     # Append Windows ICON file
     iconFile += ".ico"
@@ -282,8 +284,7 @@ setup(name=info.PRODUCT_NAME,
                               icon=os.path.join(PATH, "xdg", iconFile),
                               shortcutName="%s" % info.PRODUCT_NAME,
                               shortcutDir="ProgramMenuFolder",
-                              targetName = info.NAME,
-                              copyright = info.COPYRIGHT)])
+                              targetName=exe_name)])
 
 
 # Remove temporary folder (if SRC folder present)

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -459,7 +459,7 @@ try:
             only_64_bit = ""
 
         # Add version metadata to frozen app launcher
-        launcher_exe = os.path.join(exe_dir, "launch.exe")
+        launcher_exe = os.path.join(exe_dir, "openshot-qt.exe")
         verpatch_success = True
         verpatch_command = '"verpatch.exe" "{}" /va /high "{}" /pv "{}" /s product "{}" /s company "{}" /s copyright "{}" /s desc "{}"'.format(launcher_exe, info.VERSION, info.VERSION, info.PRODUCT_NAME, info.COMPANY_NAME, info.COPYRIGHT, info.PRODUCT_NAME)
         verpatch_output = ""

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -344,7 +344,7 @@ try:
         shutil.copytree(os.path.join(PATH, "build", exe_dir), os.path.join(app_dir_path, "usr", "bin"))
 
         # Copy desktop integration wrapper (prompts users to install shortcut)
-        launcher_path = os.path.join(app_dir_path, "usr", "bin", "openshot-qt")
+        launcher_path = os.path.join(app_dir_path, "usr", "bin", "openshot-qt-launch")
         os.rename(os.path.join(app_dir_path, "usr", "bin", "launch-linux.sh"), launcher_path)
         desktop_wrapper = os.path.join(app_dir_path, "usr", "bin", "openshot-qt.wrapper")
         shutil.copyfile("/home/ubuntu/apps/AppImageKit/desktopintegration", desktop_wrapper)


### PR DESCRIPTION
Fixing regression from https://github.com/OpenShot/openshot-qt/pull/2796/, where an ".exe" needs to be appended in Windows, and the `copyright` attribute is invalid.