### PR TITLE
Make Preferences window taller & wider

### DIFF
--- a/src/windows/ui/preferences.ui
+++ b/src/windows/ui/preferences.ui
@@ -12,8 +12,8 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>700</width>
-    <height>350</height>
+    <width>800</width>
+    <height>450</height>
    </size>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
#### Increase width by `100px` to `800px` (for "Playback Audio Device")

Turns out Linux isn't the only system with long audio device names:

![image](https://user-images.githubusercontent.com/538020/62187288-dda9a800-b336-11e9-8ae3-744a618af661.png)

#### Increase height by `100px` to `450px` (for Performance tab)

All the new options don't quite fit in the window anymore.