### PR TITLE
Properties: Enable clear button on filter input  field

### DIFF
--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -376,6 +376,9 @@
        <property name="placeholderText">
         <string>Filter</string>
        </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
     </layout>
@@ -1347,7 +1350,7 @@
     <string>File Properties</string>
    </property>
   </action>
-  <action name="actionPropertyClear">
+  <action name="actionPropertyFilterClear">
    <property name="icon">
     <iconset theme="edit-clear" resource="../../images/openshot.qrc">
      <normaloff>:/icons/Humanity/actions/16/edit-clear.svg</normaloff>:/icons/Humanity/actions/16/edit-clear.svg</iconset>


### PR DESCRIPTION
I noticed that the filter text input area for the Properties dock didn't have a clear button, like the other ones do. 

So I went into Qt Creator, enabled the default one for the QLineEdit widget, and to my surprise it JFW™ without my having to do anything else or write a single line of code.

![PropertiesFilterClear_optim](https://user-images.githubusercontent.com/538020/62226835-d14e3b00-b388-11e9-8355-aad317cbffa7.gif)

In fact, I think it works _better_ than our existing clear buttons (which are outside the input field and always visible, taking up space). Now I wish they all worked like this.

But, for now, at least Properties' filter has a clear button.