### PR TITLE
Remove the rest of the external filter-field clear buttons

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2152,9 +2152,8 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.filesFilter = QLineEdit()
         self.filesFilter.setObjectName("filesFilter")
         self.filesFilter.setPlaceholderText(_("Filter"))
+        self.filesFilter.setClearButtonEnabled(True)
         self.filesToolbar.addWidget(self.filesFilter)
-        self.actionFilesClear.setEnabled(False)
-        self.filesToolbar.addAction(self.actionFilesClear)
         self.tabFiles.layout().addWidget(self.filesToolbar)
 
         # Add transitions toolbar
@@ -2169,9 +2168,8 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.transitionsFilter = QLineEdit()
         self.transitionsFilter.setObjectName("transitionsFilter")
         self.transitionsFilter.setPlaceholderText(_("Filter"))
+        self.transitionsFilter.setClearButtonEnabled(True)
         self.transitionsToolbar.addWidget(self.transitionsFilter)
-        self.actionTransitionsClear.setEnabled(False)
-        self.transitionsToolbar.addAction(self.actionTransitionsClear)
         self.tabTransitions.layout().addWidget(self.transitionsToolbar)
 
         # Add effects toolbar
@@ -2179,9 +2177,8 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.effectsFilter = QLineEdit()
         self.effectsFilter.setObjectName("effectsFilter")
         self.effectsFilter.setPlaceholderText(_("Filter"))
+        self.effectsFilter.setClearButtonEnabled(True)
         self.effectsToolbar.addWidget(self.effectsFilter)
-        self.actionEffectsClear.setEnabled(False)
-        self.effectsToolbar.addAction(self.actionEffectsClear)
         self.tabEffects.layout().addWidget(self.effectsToolbar)
 
         # Add Video Preview toolbar

--- a/src/windows/views/effects_listview.py
+++ b/src/windows/views/effects_listview.py
@@ -61,14 +61,7 @@ class EffectsListView(QListView):
         drag.setHotSpot(QPoint(self.drag_item_size / 2, self.drag_item_size / 2))
         drag.exec_()
 
-    def clear_filter(self):
-        get_app().window.effectsFilter.setText("")
-
     def filter_changed(self):
-        if self.win.effectsFilter.text() == "":
-            self.win.actionEffectsClear.setEnabled(False)
-        else:
-            self.win.actionEffectsClear.setEnabled(True)
         self.refresh_view()
 
     def refresh_view(self):
@@ -106,4 +99,3 @@ class EffectsListView(QListView):
         # setup filter events
         app = get_app()
         app.window.effectsFilter.textChanged.connect(self.filter_changed)
-        app.window.actionEffectsClear.triggered.connect(self.clear_filter)

--- a/src/windows/views/effects_treeview.py
+++ b/src/windows/views/effects_treeview.py
@@ -62,14 +62,7 @@ class EffectsTreeView(QTreeView):
         drag.setHotSpot(QPoint(self.drag_item_size / 2, self.drag_item_size / 2))
         drag.exec_()
 
-    def clear_filter(self):
-        get_app().window.effectsFilter.setText("")
-
     def filter_changed(self):
-        if self.win.effectsFilter.text() == "":
-            self.win.actionEffectsClear.setEnabled(False)
-        else:
-            self.win.actionEffectsClear.setEnabled(True)
         self.refresh_view()
 
     def refresh_view(self):
@@ -108,4 +101,3 @@ class EffectsTreeView(QTreeView):
         # setup filter events
         app = get_app()
         app.window.effectsFilter.textChanged.connect(self.filter_changed)
-        app.window.actionEffectsClear.triggered.connect(self.clear_filter)

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -274,17 +274,8 @@ class FilesListView(QListView):
                     if self.add_file(filepath):
                         event.accept()
 
-    def clear_filter(self):
-        if self:
-            self.win.filesFilter.setText("")
-
     def filter_changed(self):
-        if self:
-            if self.win.filesFilter.text() == "":
-                self.win.actionFilesClear.setEnabled(False)
-            else:
-                self.win.actionFilesClear.setEnabled(True)
-            self.refresh_view()
+        self.refresh_view()
 
     def refresh_view(self):
         self.files_model.update_model()
@@ -336,4 +327,3 @@ class FilesListView(QListView):
         # setup filter events
         app = get_app()
         app.window.filesFilter.textChanged.connect(self.filter_changed)
-        app.window.actionFilesClear.triggered.connect(self.clear_filter)

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -273,17 +273,8 @@ class FilesTreeView(QTreeView):
                     if self.add_file(filepath):
                         event.accept()
 
-    def clear_filter(self):
-        if self:
-            self.win.filesFilter.setText("")
-
     def filter_changed(self):
-        if self:
-            if self.win.filesFilter.text() == "":
-                self.win.actionFilesClear.setEnabled(False)
-            else:
-                self.win.actionFilesClear.setEnabled(True)
-            self.refresh_view()
+        self.refresh_view()
 
     def refresh_view(self):
         self.files_model.update_model()
@@ -389,5 +380,4 @@ class FilesTreeView(QTreeView):
         # setup filter events
         app = get_app()
         app.window.filesFilter.textChanged.connect(self.filter_changed)
-        app.window.actionFilesClear.triggered.connect(self.clear_filter)
         self.files_model.model.itemChanged.connect(self.value_updated)

--- a/src/windows/views/transitions_listview.py
+++ b/src/windows/views/transitions_listview.py
@@ -65,14 +65,7 @@ class TransitionsListView(QListView):
         drag.setHotSpot(QPoint(self.drag_item_size / 2, self.drag_item_size / 2))
         drag.exec_()
 
-    def clear_filter(self):
-        get_app().window.transitionsFilter.setText("")
-
     def filter_changed(self):
-        if self.win.transitionsFilter.text() == "":
-            self.win.actionTransitionsClear.setEnabled(False)
-        else:
-            self.win.actionTransitionsClear.setEnabled(True)
         self.refresh_view()
 
     def refresh_view(self):
@@ -110,4 +103,3 @@ class TransitionsListView(QListView):
         # setup filter events
         app = get_app()
         app.window.transitionsFilter.textChanged.connect(self.filter_changed)
-        app.window.actionTransitionsClear.triggered.connect(self.clear_filter)

--- a/src/windows/views/transitions_treeview.py
+++ b/src/windows/views/transitions_treeview.py
@@ -62,14 +62,7 @@ class TransitionsTreeView(QTreeView):
         drag.setHotSpot(QPoint(self.drag_item_size / 2, self.drag_item_size / 2))
         drag.exec_()
 
-    def clear_filter(self):
-        get_app().window.transitionsFilter.setText("")
-
     def filter_changed(self):
-        if self.win.transitionsFilter.text() == "":
-            self.win.actionTransitionsClear.setEnabled(False)
-        else:
-            self.win.actionTransitionsClear.setEnabled(True)
         self.refresh_view()
 
     def refresh_view(self):
@@ -108,4 +101,3 @@ class TransitionsTreeView(QTreeView):
         # setup filter events
         app = get_app()
         app.window.transitionsFilter.textChanged.connect(self.filter_changed)
-        app.window.actionTransitionsClear.triggered.connect(self.clear_filter)


### PR DESCRIPTION
We can just use the Qt magic built-in ones, with less code.