### PR TITLE
Show waiting cursor when launching Preferences

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -754,6 +754,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         ui_util.setup_icon(self, self.actionPlay, "actionPlay", "media-playback-start")
         self.actionPlay.setChecked(False)
 
+        # Set cursor to waiting
+        get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
+
         # Show dialog
         from windows.preferences import Preferences
         win = Preferences()
@@ -767,6 +770,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Save settings
         s = settings.get_settings()
         s.save()
+
+        # Restore normal cursor
+        get_app().restoreOverrideCursor()
 
     def actionFilesShowAll_trigger(self, event):
         self.filesTreeView.refresh_view()

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -90,6 +90,9 @@ class Preferences(QDialog):
         # Populate preferences
         self.Populate()
 
+        # Restore normal cursor
+        get_app().restoreOverrideCursor()
+
     def txtSearch_changed(self):
         """textChanged event handler for search box"""
         log.info("Search for %s" % self.txtSearch.text())


### PR DESCRIPTION
Show waiting cursor when launching Preferences, and normal cursor once preferences has loaded fully. This is needed due to Preferences running a bunch of hardware acceleration checks now, and thus is much slower to load.