### PR TITLE
darkPalette: More complete disabled color group

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -179,19 +179,32 @@ class OpenShotApp(QApplication):
             self.setStyle(QStyleFactory.create("Fusion"))
 
             darkPalette = self.palette()
+
             darkPalette.setColor(QPalette.Window, QColor(53, 53, 53))
             darkPalette.setColor(QPalette.WindowText, Qt.white)
             darkPalette.setColor(QPalette.Base, QColor(25, 25, 25))
             darkPalette.setColor(QPalette.AlternateBase, QColor(53, 53, 53))
-            darkPalette.setColor(QPalette.ToolTipBase, Qt.white)
-            darkPalette.setColor(QPalette.ToolTipText, Qt.white)
+            darkPalette.setColor(QPalette.Light, QColor(68, 68, 68))
             darkPalette.setColor(QPalette.Text, Qt.white)
             darkPalette.setColor(QPalette.Button, QColor(53, 53, 53))
             darkPalette.setColor(QPalette.ButtonText, Qt.white)
-            darkPalette.setColor(QPalette.BrightText, Qt.red)
-            darkPalette.setColor(QPalette.Highlight, QColor(42, 130, 218))
+            darkPalette.setColor(QPalette.Highlight, QColor(42, 130, 218, 192))
             darkPalette.setColor(QPalette.HighlightedText, Qt.black)
-            darkPalette.setColor(QPalette.Disabled, QPalette.Text, QColor(104, 104, 104))
+            #
+            # Disabled palette
+            #
+            darkPalette.setColor(QPalette.Disabled, QPalette.WindowText, QColor(255, 255, 255, 128))
+            darkPalette.setColor(QPalette.Disabled, QPalette.Base, QColor(68, 68, 68))
+            darkPalette.setColor(QPalette.Disabled, QPalette.Text, QColor(255, 255, 255, 128))
+            darkPalette.setColor(QPalette.Disabled, QPalette.Button, QColor(53, 53, 53, 128))
+            darkPalette.setColor(QPalette.Disabled, QPalette.ButtonText, QColor(255, 255, 255, 128))
+            darkPalette.setColor(QPalette.Disabled, QPalette.Highlight, QColor(151, 151, 151, 192))
+            darkPalette.setColor(QPalette.Disabled, QPalette.HighlightedText, Qt.black)
+
+            # Tooltips
+            darkPalette.setColor(QPalette.ToolTipBase, QColor(42, 130, 218))
+            darkPalette.setColor(QPalette.ToolTipText, Qt.white)
+
             self.setPalette(darkPalette)
             self.setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 0px solid white; }")
 

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -657,7 +657,9 @@ class Export(QDialog):
 
     def disableControls(self):
         """Disable all controls"""
+        self.lblFileName.setEnabled(False)
         self.txtFileName.setEnabled(False)
+        self.lblFolderPath.setEnabled(False)
         self.txtExportFolder.setEnabled(False)
         self.tabWidget.setEnabled(False)
         self.export_button.setEnabled(False)
@@ -665,7 +667,9 @@ class Export(QDialog):
 
     def enableControls(self):
         """Enable all controls"""
+        self.lblFileName.setEnabled(True)
         self.txtFileName.setEnabled(True)
+        self.lblFolderPath.setEnabled(True)
         self.txtExportFolder.setEnabled(True)
         self.tabWidget.setEnabled(True)
         self.export_button.setEnabled(True)


### PR DESCRIPTION
This PR updates the color definitions for the app's `darkPalette` color scheme, primarily to define a more complete `QPalette.Disabled` color group — this allows us to usefully disable more interface elements. (The user will be presented with better visual indications of their disabled status.) (#2907)

Other changes:
  * Set `QPalette.Light` in active palette, to eliminate white line on left edge of floating docks in Linux. (#1591)
  * Define `QPalette.Highlight` semi-transparently.
  * Remove `QPalette.BrightText` from active palette.
  * Set `QPalette.ToolTipBase` to same color as CSS background, rather than `Qt.white`.
  * Disable/enable the text labels for the path fields in the Export dialog, along with the rest of the window's interface.

Fixes #1591
Fixes #2907

Taking the Export dialog's progress display as an example, while the export is running the user will see:

![Screenshot from 2019-08-03 21-23-37](https://user-images.githubusercontent.com/538020/62418367-2910ce80-b635-11e9-9054-9d8156383395.png)

or

![Screenshot from 2019-08-03 21-23-49](https://user-images.githubusercontent.com/538020/62418369-2e6e1900-b635-11e9-8bd3-0fb8bcb6abc5.png)

...The disabled elements become muted and quite obviously non-interactive, but still remain very readable.
