### PR TITLE
Revert "Set default multiplexing preset for exported media"

### DIFF
--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -830,9 +830,6 @@ class Export(QDialog):
             if "crf" in self.txtVideoBitRate.text():
                 w.SetOption(openshot.VIDEO_STREAM, "crf", str(int(video_settings.get("video_bitrate"))) )
 
-            # Muxing options for mp4/mov
-            w.SetOption(openshot.VIDEO_STREAM, "muxing_preset", "mp4_faststart")
-
             # Open the writer
             w.Open()
 


### PR DESCRIPTION
@jonoomph @SuslikV 

This is causing bad exports with any MP4 profile, unfortunately. At the end of export, these messages are output on the console:

```
[mp4 @ 0x562a3ba3a540] Starting second pass: moving the moov atom to the beginning of the file
[mp4 @ 0x562a3ba3a540] Unable to re-open /var/tm output file for the second pass (faststart)
```

Then, attempting to play that file in `ffplay` results in:

```
[mov,mp4,m4a,3gp,3g2,mj2 @ 0x7ff700000b80] moov atom not found
/var/tmp/OpenShotTest.mp4: Invalid data found when processing input 
```

(You can see there the full path name to the file, which is truncated in the output during encode. I'm not sure if that's part of the issue or not.)

Removing the `SetOption()` for `muxing_preset` restores correct output.

This reverts commit bee098f481a5cfb3541134c80068d9919917ac03.