### PR TITLE
Preferences: Avoid code duplication for browse type

### DIFF
--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -221,19 +221,16 @@ class Preferences(QDialog):
                     widget.setToolTip(param["title"])
                     widget.valueChanged.connect(functools.partial(self.spinner_value_changed, param))
 
-                elif param["type"] == "text":
+                elif param["type"] == "text" or param["type"] == "browse":
                     # create QLineEdit
                     widget = QLineEdit()
                     widget.setText(_(param["value"]))
                     widget.textChanged.connect(functools.partial(self.text_value_changed, widget, param))
 
-                elif param["type"] == "browse":
-                    # create QLineEdit
-                    widget = QLineEdit()
-                    widget.setText(_(param["value"]))
-                    widget.textChanged.connect(functools.partial(self.text_value_changed, widget, param))
-                    extraWidget = QPushButton(_("Browse..."))
-                    extraWidget.clicked.connect(functools.partial(self.selectExecutable, widget, param))
+                    if param["type"] == "browse":
+                        # Add filesystem browser button
+                        extraWidget = QPushButton(_("Browse..."))
+                        extraWidget.clicked.connect(functools.partial(self.selectExecutable, widget, param))
 
                 elif param["type"] == "bool":
                     # create spinner


### PR DESCRIPTION
A _really_ minor thing, but I happened to be in `preferences.py` and noticed we could avoid some code duplication for the "browse"-type prefs.