### PR TITLE
Preferences: Raise max samplerate to 192kHz.

### DIFF
--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -152,7 +152,7 @@
     "restart": true
   },
   {
-    "max": 128000,
+    "max": 192000,
     "title": "Default Audio Sample Rate",
     "category": "Preview",
     "min": 22050,


### PR DESCRIPTION
I thought I'd fixed this forever ago (I know I _noticed_ it forever ago), but I guess not since it's still there. Oops.

The range-max for the field was set **lower** than the largest selectable value.