### PR TITLE
Log the start and end of the session

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -37,6 +37,7 @@ from PyQt5.QtGui import QPalette, QColor, QFontDatabase, QFont
 from PyQt5.QtCore import Qt
 from PyQt5.QtCore import QT_VERSION_STR
 from PyQt5.QtCore import PYQT_VERSION_STR
+from PyQt5.QtCore import pyqtSlot
 
 try:
     # Enable High-DPI resolutions
@@ -61,6 +62,13 @@ class OpenShotApp(QApplication):
             # Import modules
             from classes import info
             from classes.logger import log, reroute_output
+
+            # Log the session's start
+            import time
+            log.info("------------------------------------------------")
+            log.info(time.asctime().center(48))
+            log.info('Starting new session'.center(48))
+
             from classes import settings, project_data, updates, language, ui_util, logger_libopenshot
             import openshot
 
@@ -80,7 +88,7 @@ class OpenShotApp(QApplication):
         # Log some basic system info
         try:
             log.info("------------------------------------------------")
-            log.info("   OpenShot (version %s)" % info.SETUP['version'])
+            log.info(("OpenShot (version %s)" % info.SETUP['version']).center(48))
             log.info("------------------------------------------------")
 
             v = openshot.GetVersion()
@@ -94,6 +102,9 @@ class OpenShotApp(QApplication):
             log.info("pyqt5 version: %s" % PYQT_VERSION_STR)
         except:
             pass
+			
+        # Connect QCoreApplication::aboutToQuit() signal to log end of the session
+        self.aboutToQuit.connect(self.onLogTheEnd)
 
         # Setup application
         self.setApplicationName('openshot')
@@ -233,3 +244,20 @@ class OpenShotApp(QApplication):
 
         # return exit result
         return res
+
+    # Log the session's end
+    @pyqtSlot()
+    def onLogTheEnd(self):
+        """ Log when the primary Qt event loop ends """
+
+        try:
+            from classes.logger import log
+            import time
+            log.info('OpenShot\'s session ended'.center(48))
+            log.info(time.asctime().center(48))
+            log.info("================================================")
+        except Exception:
+            pass
+
+        # return 0 on success
+        return 0

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -100,7 +100,7 @@ class OpenShotApp(QApplication):
             log.info("python version: %s" % platform.python_version())
             log.info("qt5 version: %s" % QT_VERSION_STR)
             log.info("pyqt5 version: %s" % PYQT_VERSION_STR)
-        except:
+        except Exception:
             pass
 			
         # Connect QCoreApplication::aboutToQuit() signal to log end of the session

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -101,9 +101,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
     # Save window settings on close
     def closeEvent(self, event):
 
-        # Close any tutorial dialogs
-        self.tutorial_manager.exit_manager()
-
         # Prompt user to save (if needed)
         if get_app().project.needs_save() and not self.mode == "unittest":
             log.info('Prompt user to save project')
@@ -120,6 +117,12 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 # User canceled prompt - don't quit
                 event.ignore()
                 return
+
+        # Log the exit routine
+        log.info('---------------- Shutting down -----------------')
+
+        # Close any tutorial dialogs
+        self.tutorial_manager.exit_manager()
 
         # Save settings
         self.save_settings()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -101,6 +101,10 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
     # Save window settings on close
     def closeEvent(self, event):
 
+        # Some window managers handels dragging of the modal messages incorrectly if other windows are open
+        # Hide tutorial window first
+        self.tutorial_manager.hide_dialog()
+
         # Prompt user to save (if needed)
         if get_app().project.needs_save() and not self.mode == "unittest":
             log.info('Prompt user to save project')
@@ -114,6 +118,8 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 self.actionSave_trigger(event)
                 event.accept()
             elif ret == QMessageBox.Cancel:
+                # Show tutorial again, if any
+                self.tutorial_manager.re_show_dialog()
                 # User canceled prompt - don't quit
                 event.ignore()
                 return

--- a/src/windows/views/tutorial.py
+++ b/src/windows/views/tutorial.py
@@ -287,6 +287,11 @@ class TutorialManager(object):
             self.dock.raise_()
             self.dock.show()
 
+    def hide_dialog(self):
+        """ Hide an active dialog """
+        if self.current_dialog:
+            self.dock.hide()
+
     def re_position_dialog(self):
         """ Reposition a tutorial dialog next to another widget """
         if self.current_dialog:


### PR DESCRIPTION
Make the exit event more noticeable in the log. Threads may leave entries below the last line. But the overall look of the log-file is much better now (as for me).

Example of the new log-file end with the Preview thread still running in background (debug mode enabled):
```
...
logger_libopenshot:INFO VideoPlaybackThread::run (before render) (frame->number=359.0000, need_render=1.0000)
logger_libopenshot:INFO PlayerPrivate::run (determine sleep) (video_frame_diff=-10.0000, video_position=359.0000, audio_position=369.0000, speed=1.0000, render_time=0.0000, sleep_time=33.0000)
     cutting:INFO btnPlay_clicked
     cutting:INFO pause (icon to play)
preview_thread:INFO onModeChanged
 main_window:INFO ================ Shutting down =================
 main_window:INFO Prompt user to save project
preview_thread:INFO onModeChanged
preview_thread:INFO exiting thread
logger_libopenshot:INFO Timeline::Close ()
 main_window:INFO ================================================

     cutting:INFO closeEvent
preview_thread:INFO exiting thread
```

Just minor improvement for beauty of the log-file.