### PR TITLE
Import missing variable

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -226,6 +226,7 @@ class OpenShotApp(QApplication):
         res = self.exec_()
 
         try:
+            from classes.logger import log
             self.settings.save()
         except Exception as ex:
             log.error("Couldn't save user settings on exit.\n{}".format(ex))


### PR DESCRIPTION
Fixes: https://github.com/OpenShot/openshot-qt/issues/2939

**Edit:**
Log entries in case of error now will look like this:
```
preview_thread:INFO exiting thread
   json_data:ERROR Couldn't save user settings file:
C:\Users\***\.openshot_qt\openshot.settings
[Errno 13] Permission denied: 'C:\\Users\\***\\.openshot_qt\\openshot.settings'
         app:ERROR Couldn't save user settings on exit.
Couldn't save user settings file:
C:\Users\***\.openshot_qt\openshot.settings
[Errno 13] Permission denied: 'C:\\Users\\***\\.openshot_qt\\openshot.settings'
```