### PR TITLE
Preferences: Start "Browse" at location of current setting

### DIFF
--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -399,7 +399,19 @@ class Preferences(QDialog):
     def selectExecutable(self, widget, param):
         _ = get_app()._tr
 
-        fileName, fileType = QFileDialog.getOpenFileName(self, _("Select executable file"), QDir.rootPath(), _("All Files (*)"))
+        # Fallback default to user home
+        startpath = QDir.rootPath()
+
+        # Start at directory of old setting, if it exists, or walk up the
+        # path until we encounter a directory that does exist and start there
+        if "setting" in param and param["setting"]:
+            prev_val = self.s.get(param["setting"])
+            while prev_val and not os.path.exists(prev_val):
+                prev_val = os.path.dirname(prev_val)
+            if prev_val and os.path.exists(prev_val):
+                startpath = prev_val
+
+        fileName, fileType = QFileDialog.getOpenFileName(self, _("Select executable file"), startpath, _("All Files (*)"))
         if fileName:
             self.s.set(param["setting"], fileName)
             widget.setText(fileName)


### PR DESCRIPTION
When the user clicks the "Browse" button next to a browse-type preference item, instead of always starting at `QDir.rootPath()`, take the old value for that setting and open at its parent directory. 

If the parent directory doesn't exist, walk up the path and start at the first extant directory encountered. (Or the root of the filesystem, our old starting point, if every path element fails.)