### PR TITLE
Title Editor: Reuse previous selection in Font selector

### DIFF
--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -346,11 +346,11 @@ class TitleEditor(QDialog):
             self.update_font_color_button()
             self.font_color_code = col
 
-        # Something changed, so update temp SVG
-        self.writeToFile(self.xmldoc)
+            # Something changed, so update temp SVG
+            self.writeToFile(self.xmldoc)
 
-        # Display SVG again
-        self.display_svg()
+            # Display SVG again
+            self.display_svg()
 
     def btnBackgroundColor_clicked(self):
         app = get_app()
@@ -366,11 +366,11 @@ class TitleEditor(QDialog):
             self.update_background_color_button()
             self.bg_color_code = col
 
-        # Something changed, so update temp SVG
-        self.writeToFile(self.xmldoc)
+            # Something changed, so update temp SVG
+            self.writeToFile(self.xmldoc)
 
-        # Display SVG again
-        self.display_svg()
+            # Display SVG again
+            self.display_svg()
 
     def btnFont_clicked(self):
         app = get_app()
@@ -387,11 +387,11 @@ class TitleEditor(QDialog):
             self.font_weight = fontinfo.weight()
             self.set_font_style()
 
-        # Something changed, so update temp SVG
-        self.writeToFile(self.xmldoc)
+            # Something changed, so update temp SVG
+            self.writeToFile(self.xmldoc)
 
-        # Display SVG again
-        self.display_svg()
+            # Display SVG again
+            self.display_svg()
 
     def find_in_list(self, l, value):
         '''when passed a partial value, function will return the list index'''

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -50,6 +50,7 @@ from windows.views.titles_listview import TitlesListView
 
 import json
 
+
 class TitleEditor(QDialog):
     """ Title Editor Dialog """
 
@@ -430,11 +431,11 @@ class TitleEditor(QDialog):
                 pass
 
             # Default the font color to white if non-existing
-            if color == None:
+            if color is None:
                 color = "#FFFFFF"
 
             # Default the opacity to fully visible if non-existing
-            if opacity == None:
+            if opacity is None:
                 opacity = 1.0
 
             color = QtGui.QColor(color)
@@ -443,9 +444,9 @@ class TitleEditor(QDialog):
             colrgb = color.getRgbF()
             lum = (0.299 * colrgb[0] + 0.587 * colrgb[1] + 0.114 * colrgb[2])
             if (lum < 0.5):
-              text_color = QtGui.QColor(Qt.white)
+                text_color = QtGui.QColor(Qt.white)
             else:
-              text_color = QtGui.QColor(Qt.black)
+                text_color = QtGui.QColor(Qt.black)
 
             # Convert the opacity into the alpha value
             alpha = int(opacity * 65535.0)
@@ -488,11 +489,11 @@ class TitleEditor(QDialog):
                 pass
 
             # Default the background color to black if non-existing
-            if color == None:
+            if color is None:
                 color = "#000000"
 
             # Default opacity to fully visible if non-existing
-            if opacity == None:
+            if opacity is None:
                 opacity = 1.0
 
             color = QtGui.QColor(color)
@@ -501,9 +502,9 @@ class TitleEditor(QDialog):
             colrgb = color.getRgbF()
             lum = (0.299 * colrgb[0] + 0.587 * colrgb[1] + 0.114 * colrgb[2])
             if (lum < 0.5):
-              text_color = QtGui.QColor(Qt.white)
+                text_color = QtGui.QColor(Qt.white)
             else:
-              text_color = QtGui.QColor(Qt.black)
+                text_color = QtGui.QColor(Qt.black)
 
             # Convert the opacity into the alpha value
             alpha = int(opacity * 65535.0)
@@ -571,13 +572,13 @@ class TitleEditor(QDialog):
             s = self.rect_node[0].attributes["style"].value
             ar = s.split(";")
             fill = self.find_in_list(ar, "fill:")
-            if fill == None:
+            if fill is None:
                 ar.append("fill:" + color)
             else:
                 ar[fill] = "fill:" + color
 
             opacity = self.find_in_list(ar, "opacity:")
-            if opacity == None:
+            if opacity is None:
                 ar.append("opacity:" + str(alpha))
             else:
                 ar[opacity] = "opacity:" + str(alpha)
@@ -598,13 +599,13 @@ class TitleEditor(QDialog):
             # split the text node so we can access each part
             ar = s.split(";")
             fill = self.find_in_list(ar, "fill:")
-            if fill == None:
+            if fill is None:
                 ar.append("fill:" + color)
             else:
                 ar[fill] = "fill:" + color
 
             opacity = self.find_in_list(ar, "opacity:")
-            if opacity == None:
+            if opacity is None:
                 ar.append("opacity:" + str(alpha))
             else:
                 ar[opacity] = "opacity:" + str(alpha)
@@ -621,7 +622,7 @@ class TitleEditor(QDialog):
                 # split the text node so we can access each part
                 ar = s.split(";")
                 fill = self.find_in_list(ar, "fill:")
-                if fill == None:
+                if fill is None:
                     ar.append("fill:" + color)
                 else:
                     ar[fill] = "fill:" + color

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -102,6 +102,8 @@ class TitleEditor(QDialog):
         self.font_family = "Bitstream Vera Sans"
         self.tspan_node = None
 
+        self.qfont = QFont(self.font_family)
+
         # Add titles list view
         self.titlesTreeView = TitlesListView(self)
         self.verticalLayout.addWidget(self.titlesTreeView)
@@ -194,6 +196,12 @@ class TitleEditor(QDialog):
         # get the text elements
         self.tspan_node = self.xmldoc.getElementsByTagName('tspan')
         self.text_fields = len(self.tspan_node)
+
+        # Reset default font
+        self.font_family = "Bitstream Vera Sans"
+        if self.qfont:
+            del self.qfont
+        self.qfont = QFont(self.font_family)
 
         # Loop through child widgets (and remove them)
         for child in self.settingsContainer.children():
@@ -377,11 +385,15 @@ class TitleEditor(QDialog):
         app = get_app()
         _ = app._tr
 
+        # Default to previously-selected font
+        oldfont = self.qfont
+
         # Get font from user
-        font, ok = QFontDialog.getFont(QFont(), caption=_("Change Font"))
+        font, ok = QFontDialog.getFont(oldfont, caption=("Change Font"))
 
         # Update SVG font
-        if ok:
+        if ok and font is not oldfont:
+            self.qfont = font
             fontinfo = QtGui.QFontInfo(font)
             self.font_family = fontinfo.family()
             self.font_style = fontinfo.styleName()


### PR DESCRIPTION
Open the font selection dialog with the previous selection as the default, instead of always resetting to the application font (Ubuntu).

When the window is created or a new file is loaded, we construct a default `QFont()` from the "Bitstream Vera Sans" typeface to use as the initial selection. 

Just as with the color picker, because we are not actually parsing the information from the data file, **this initial selection may be incorrect**... especially if the title file is a user-customized copy of a template. (However, it has a much better chance of being correct on the first try than defaulting to Ubuntu, which none of our templates use as their default font.)

In addition:
* Some code-style fixes suggested by the linter
* If the user cancels a font/color dialog or accepts it without changing the selected item, don't force a save of the file data or a refresh of the preview image as there's nothing to update.

Fixes #2945 