### PR TITLE
Image sequence import improvements

### DIFF
--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -194,8 +194,10 @@ class FilesListView(QListView):
             file.save()
             return True
 
-        except:
-            # Handle exception
+        except Exception as ex:
+            # Log exception
+            log.warning("Failed to import file: {}".format(str(ex)))
+            # Show message to user
             msg = QMessageBox()
             msg.setText(_("{} is not a valid video, audio, or image file.".format(filename)))
             msg.exec_()

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -192,6 +192,9 @@ class FilesListView(QListView):
 
             # Save file
             file.save()
+            # Reset list of ignored paths
+            self.ignore_image_sequence_paths = []
+
             return True
 
         except Exception as ex:
@@ -239,7 +242,7 @@ class FilesListView(QListView):
                 is_sequence = False
 
             if is_sequence and dirName not in self.ignore_image_sequence_paths:
-                log.info('Prompt user to import image sequence')
+                log.info('Prompt user to import image sequence from {}'.format(dirName))
                 # Ignore this path (temporarily)
                 self.ignore_image_sequence_paths.append(dirName)
 
@@ -250,6 +253,7 @@ class FilesListView(QListView):
                 ret = QMessageBox.question(self, _("Import Image Sequence"), _("Would you like to import %s as an image sequence?") % fileName, QMessageBox.No | QMessageBox.Yes)
                 if ret == QMessageBox.Yes:
                     # Yes, import image sequence
+                    log.info('Importing {} as image sequence {}'.format(file_path, base_name + '*.' + extension))
                     parameters = {"file_path":file_path, "folder_path":dirName, "base_name":base_name, "fixlen":fixlen, "digits":digits, "extension":extension}
                     return parameters
                 else:

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -191,6 +191,9 @@ class FilesTreeView(QTreeView):
 
             # Save file
             file.save()
+            # Reset list of ignored paths
+            self.ignore_image_sequence_paths = []
+
             return True
 
         except Exception as ex:
@@ -238,7 +241,7 @@ class FilesTreeView(QTreeView):
                 is_sequence = False
 
             if is_sequence and dirName not in self.ignore_image_sequence_paths:
-                log.info('Prompt user to import image sequence')
+                log.info('Prompt user to import image sequence from {}'.format(dirName))
                 # Ignore this path (temporarily)
                 self.ignore_image_sequence_paths.append(dirName)
 
@@ -249,6 +252,7 @@ class FilesTreeView(QTreeView):
                 ret = QMessageBox.question(self, _("Import Image Sequence"), _("Would you like to import %s as an image sequence?") % fileName, QMessageBox.No | QMessageBox.Yes)
                 if ret == QMessageBox.Yes:
                     # Yes, import image sequence
+                    log.info('Importing {} as image sequence {}'.format(file_path, base_name + '*.' + extension))
                     parameters = {"file_path":file_path, "folder_path":dirName, "base_name":base_name, "fixlen":fixlen, "digits":digits, "extension":extension}
                     return parameters
                 else:

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -193,8 +193,10 @@ class FilesTreeView(QTreeView):
             file.save()
             return True
 
-        except:
-            # Handle exception
+        except Exception as ex:
+            # Log exception
+            log.warning("Failed to import file: {}".format(str(ex)))
+            # Show message to user
             msg = QMessageBox()
             msg.setText(_("{} is not a valid video, audio, or image file.".format(filename)))
             msg.exec_()


### PR DESCRIPTION
Several fixes to the process of importing image sequences:

- Also log (at warning level) the exception that caused an import failure QMessageBox
- Add paths, filenames to logging of image sequence discovery
- Reset `ignored_image_sequence_paths` after a successful import