### PR TITLE
Use openshot.OPENSHOT_VERSION_FULL for version checking

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -91,9 +91,8 @@ class OpenShotApp(QApplication):
             log.info(("OpenShot (version %s)" % info.SETUP['version']).center(48))
             log.info("------------------------------------------------")
 
-            v = openshot.GetVersion()
             log.info("openshot-qt version: %s" % info.VERSION)
-            log.info("libopenshot version: %s" % v.ToString())
+            log.info("libopenshot version: %s" % openshot.OPENSHOT_VERSION_FULL)
             log.info("platform: %s" % platform.platform())
             log.info("processor: %s" % platform.processor())
             log.info("machine: %s" % platform.machine())
@@ -123,7 +122,7 @@ class OpenShotApp(QApplication):
 
         # Detect minimum libopenshot version
         _ = self._tr
-        libopenshot_version = openshot.GetVersion().ToString()
+        libopenshot_version = openshot.OPENSHOT_VERSION_FULL
         if mode != "unittest" and libopenshot_version < info.MINIMUM_LIBOPENSHOT_VERSION:
             QMessageBox.warning(None, _("Wrong Version of libopenshot Detected"),
                                       _("<b>Version %(minimum_version)s is required</b>, but %(current_version)s was detected. Please update libopenshot or download our latest installer.") %

--- a/src/classes/metrics.py
+++ b/src/classes/metrics.py
@@ -41,10 +41,6 @@ import openshot
 from PyQt5.QtCore import QT_VERSION_STR
 from PyQt5.QtCore import PYQT_VERSION_STR
 
-
-# Get libopenshot version
-libopenshot_version = openshot.GetVersion()
-
 # Get settings
 s = settings.get_settings()
 
@@ -74,21 +70,22 @@ except Exception as Ex:
 user_agent = "Mozilla/5.0 (%s) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.120 Safari/537.36" % os_version
 
 params = {
-    "cid" : s.get("unique_install_id"),     # Unique install ID
-    "v" : 1,                                # Google Measurement API version
-    "tid" : "UA-4381101-5",                 # Google Analytic Tracking ID
-    "an" : info.PRODUCT_NAME,               # App Name
-    "aip" : 1,                              # Anonymize IP
-    "aid" : "org.openshot.%s" % info.NAME,  # App ID
-    "av" : info.VERSION,                    # App Version
-    "ul" : language.get_current_locale().replace('_','-').lower(),   # Current Locale
-    "ua" : user_agent,                      # Custom User Agent (for OS, Processor, and OS version)
-    "cd1" : libopenshot_version.ToString(), # Dimension 1: libopenshot version
-    "cd2" : platform.python_version(),      # Dimension 2: python version (i.e. 3.4.3)
-    "cd3" : QT_VERSION_STR,                 # Dimension 3: qt5 version (i.e. 5.2.1)
-    "cd4" : PYQT_VERSION_STR,               # Dimension 4: pyqt5 version (i.e. 5.2.1)
-    "cd5" : linux_distro
+    "cid": s.get("unique_install_id"),      # Unique install ID
+    "v": 1,                                 # Google Measurement API version
+    "tid": "UA-4381101-5",                  # Google Analytic Tracking ID
+    "an": info.PRODUCT_NAME,                # App Name
+    "aip": 1,                               # Anonymize IP
+    "aid": "org.openshot.%s" % info.NAME,   # App ID
+    "av": info.VERSION,                     # App Version
+    "ul": language.get_current_locale().replace('_', '-').lower(),   # Current Locale
+    "ua": user_agent,                       # Custom User Agent (for OS, Processor, and OS version)
+    "cd1": openshot.OPENSHOT_VERSION_FULL,  # Dimension 1: libopenshot version
+    "cd2": platform.python_version(),       # Dimension 2: python version (i.e. 3.4.3)
+    "cd3": QT_VERSION_STR,                  # Dimension 3: qt5 version (i.e. 5.2.1)
+    "cd4": PYQT_VERSION_STR,                # Dimension 4: pyqt5 version (i.e. 5.2.1)
+    "cd5": linux_distro
 }
+
 
 def track_metric_screen(screen_name):
     """Track a GUI screen being shown"""
@@ -99,6 +96,7 @@ def track_metric_screen(screen_name):
 
     t = threading.Thread(target=send_metric, args=[metric_params])
     t.start()
+
 
 def track_metric_event(event_action, event_label, event_category="General", event_value=0):
     """Track a GUI screen being shown"""
@@ -113,6 +111,7 @@ def track_metric_event(event_action, event_label, event_category="General", even
     t = threading.Thread(target=send_metric, args=[metric_params])
     t.start()
 
+
 def track_metric_error(error_name, is_fatal=False):
     """Track an error has occurred"""
     metric_params = deepcopy(params)
@@ -125,10 +124,12 @@ def track_metric_error(error_name, is_fatal=False):
     t = threading.Thread(target=send_metric, args=[metric_params])
     t.start()
 
+
 def track_exception_stacktrace(stacktrace, source):
     """Track an exception/stacktrace has occurred"""
     t = threading.Thread(target=send_exception, args=[stacktrace, source])
     t.start()
+
 
 def track_metric_session(is_start=True):
     """Track a GUI screen being shown"""
@@ -143,6 +144,7 @@ def track_metric_session(is_start=True):
 
     t = threading.Thread(target=send_metric, args=[metric_params])
     t.start()
+
 
 def send_metric(params):
     """Send anonymous metric over HTTP for tracking"""
@@ -160,16 +162,17 @@ def send_metric(params):
         except Exception as Ex:
             log.error("Failed to Track metric: %s" % (Ex))
 
+
 def send_exception(stacktrace, source):
     """Send exception stacktrace over HTTP for tracking"""
     # Check if the user wants to send metrics and errors
     if s.get("send_metrics"):
 
-        data = urllib.parse.urlencode({ "stacktrace": stacktrace,
-                                        "platform": platform.system(),
-                                        "version": info.VERSION,
-                                        "source": source,
-                                        "unique_install_id": s.get("unique_install_id" )})
+        data = urllib.parse.urlencode({"stacktrace": stacktrace,
+                                       "platform": platform.system(),
+                                       "version": info.VERSION,
+                                       "source": source,
+                                       "unique_install_id": s.get("unique_install_id")})
         url = "http://www.openshot.org/exception/json/"
 
         # Send exception HTTP data

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -448,10 +448,9 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         _ = get_app()._tr
 
         # Append version info
-        v = openshot.GetVersion()
         project_data = {}
-        project_data["version"] = {"openshot-qt" : info.VERSION,
-                                   "libopenshot" : v.ToString()}
+        project_data["version"] = {"openshot-qt": info.VERSION,
+                                   "libopenshot": openshot.OPENSHOT_VERSION_FULL}
 
         # Get FPS from project
         from classes.app import get_app
@@ -697,8 +696,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         openshot_version = self._data["version"]["openshot-qt"]
         libopenshot_version = self._data["version"]["libopenshot"]
 
-        log.info(openshot_version)
-        log.info(libopenshot_version)
+        log.info("Project data: openshot {}, libopenshot {}".format(openshot_version, libopenshot_version))
 
         if openshot_version == "0.0.0":
             # If version = 0.0.0, this is the beta of OpenShot
@@ -762,9 +760,8 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             self.move_temp_paths_to_project_folder(file_path)
 
         # Append version info
-        v = openshot.GetVersion()
-        self._data["version"] = { "openshot-qt" : info.VERSION,
-                                  "libopenshot" : v.ToString() }
+        self._data["version"] = {"openshot-qt": info.VERSION,
+                                 "libopenshot": openshot.OPENSHOT_VERSION_FULL}
 
         # Try to save project settings file, will raise error on failure
         self.write_to_file(file_path, self._data, path_mode="relative", previous_path=self.current_filepath)


### PR DESCRIPTION
Now that libopenshot defines `OPENSHOT_VERSION_FULL` (which includes the `-dev#` extension, for development builds), use that instead of `GetVersion().ToString()` to record and compare libopenshot versions in application logic, logs, and project data.