### PR TITLE
Added the ability to automatically scroll the timeline to points of i…

### DIFF
--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -29,7 +29,7 @@ import os
 
 from PyQt5.QtCore import QDir
 
-VERSION = "2.4.4-shift-select"
+VERSION = "2.4.4-dev2"
 MINIMUM_LIBOPENSHOT_VERSION = "0.2.3"
 DATE = "20190315000000"
 NAME = "openshot-qt"

--- a/src/classes/query.py
+++ b/src/classes/query.py
@@ -139,6 +139,26 @@ class QueryObject:
         else:
             return None
 
+    def getAll(OBJECT_TYPE):
+        """ Return all objects of the type """
+
+        # Get a list of all objects of this type
+        parent = project.get(OBJECT_TYPE.object_key)
+        matching_objects = []
+
+        # Loop through all children objects
+        if parent:
+            for child in parent:
+                object = OBJECT_TYPE()
+                object.id = child["id"]
+                object.key = [OBJECT_TYPE.object_name, {"id": object.id}]
+                object.data = copy.deepcopy(child) # copy of object
+                object.type = "update"
+                matching_objects.append(object)
+
+        # Return matching objects
+        return matching_objects
+        
 
 class Clip(QueryObject):
     """ This class allows Clips to be queried, updated, and deleted from the project data. """
@@ -160,6 +180,10 @@ class Clip(QueryObject):
     def get(**kwargs):
         """ Take any arguments given as filters, and find the first matching object """
         return QueryObject.get(Clip, **kwargs)
+        
+    def getAll():
+        """ Return all objects of the type """
+        return QueryObject.getAll(Clip)
 
     def title(self):
         """ Get the translated display title of this item """
@@ -187,6 +211,10 @@ class Transition(QueryObject):
     def get(**kwargs):
         """ Take any arguments given as filters, and find the first matching object """
         return QueryObject.get(Transition, **kwargs)
+        
+    def getAll():
+        """ Return all objects of the type """
+        return QueryObject.getAll(Transition)
 
     def title(self):
         """ Get the translated display title of this item """
@@ -231,6 +259,10 @@ class File(QueryObject):
     def get(**kwargs):
         """ Take any arguments given as filters, and find the first matching object """
         return QueryObject.get(File, **kwargs)
+        
+    def getAll():
+        """ Return all objects of the type """
+        return QueryObject.getAll(File)
 
     def absolute_path(self):
         """ Get absolute file path of file """
@@ -281,6 +313,10 @@ class Marker(QueryObject):
     def get(**kwargs):
         """ Take any arguments given as filters, and find the first matching object """
         return QueryObject.get(Marker, **kwargs)
+        
+    def getAll():
+        """ Return all objects of the type """
+        return QueryObject.getAll(Marker)
 
 
 class Track(QueryObject):
@@ -303,6 +339,10 @@ class Track(QueryObject):
     def get(**kwargs):
         """ Take any arguments given as filters, and find the first matching object """
         return QueryObject.get(Track, **kwargs)
+        
+    def getAll():
+        """ Return all objects of the type """
+        return QueryObject.getAll(Track)
 
 
 class Effect(QueryObject):
@@ -348,6 +388,29 @@ class Effect(QueryObject):
                             object.type = "update"
                             object.parent = clip
                             matching_objects.append(object)
+
+        # Return matching objects
+        return matching_objects
+        
+    def getAll():
+        """ Return all objects of the type """
+        # Get a list of clips
+        clips = project.get("clips")
+        matching_objects = []
+
+        # Loop through all clips
+        if clips:
+            for clip in clips:
+                # Loop through all effects
+                if "effects" in clip:
+                    for child in clip["effects"]:
+                        object = Effect()
+                        object.id = child["id"]
+                        object.key = ["clips", {"id": clip["id"]}, "effects", {"id": object.id}]
+                        object.data = child
+                        object.type = "update"
+                        object.parent = clip
+                        matching_objects.append(object)
 
         # Return matching objects
         return matching_objects

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -542,6 +542,14 @@
   },
   {
     "category": "Keyboard",
+    "title": "Center on Playhead",
+    "restart": true,
+    "setting": "actionCenterOnPlayhead",
+    "value": "Ctrl+Up",
+    "type": "text"
+  },
+  {
+    "category": "Keyboard",
     "title": "Add to Timeline",
     "restart": true,
     "setting": "actionAdd_to_Timeline",

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -204,7 +204,7 @@ App.controller('TimelineCtrl',function($scope) {
 	           //        icon : 'purple.png'
 	           //      },
               // ],
-	  	progress : {},
+	  	progress : {}
 	  			// {
 				//    max_bytes : "0",
 				//    ranges : [
@@ -223,7 +223,6 @@ App.controller('TimelineCtrl',function($scope) {
 				//    ],
 				//    version : "2"
 				// }
-        prev_selected_clip_id : ""
     };
   
   // Additional variables used to control the rendering of HTML
@@ -592,9 +591,6 @@ App.controller('TimelineCtrl',function($scope) {
 	// Clear the selections on the main window
 	$scope.SelectTransition("", true);
 	$scope.SelectEffect("", true);
-    
-    // Clear the previously selected clip ID
-    $scope.project.prev_selected_clip_id = "";
 
 	// Update scope
 	$scope.$apply(function() {
@@ -609,9 +605,6 @@ App.controller('TimelineCtrl',function($scope) {
  
  // Select all clips and transitions
  $scope.SelectAll = function() {
-    // It doesn't make sense to have a "previously selected clip" if everything is selected
-    $scope.project.prev_selected_clip_id = "";
-
 	 $scope.$apply(function() {
 		 // Select all clips
 		 for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
@@ -624,39 +617,6 @@ App.controller('TimelineCtrl',function($scope) {
 			 timeline.addSelection($scope.project.effects[effect_index].id, "transition", false);
 		 }
 	 });
- };
- 
- // Select all items between two times
- $scope.SelectTimeRange = function(select_start_time, select_end_time) {
- 	//$scope.$apply(function() {
-        // Iterate over all clips
-        for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-            // Retrieve the start and end times of this clip
-            var clip_start_time = $scope.project.clips[clip_index].start;
-            var clip_end_time = $scope.project.clips[clip_index].end;
-
-            // If the clip falls within the selection time range
-            if (clip_start_time >= select_start_time && clip_end_time <= select_end_time) {
-                // Select the clip
-                $scope.project.clips[clip_index].selected = true;
-                timeline.addSelection($scope.project.clips[clip_index].id, "clip", false);
-            } 
-        }
-
-        // Iterate over all transitions
-        for (var transition_index = 0; transition_index < $scope.project.effects.length; transition_index++) {
-            // Retrieve the start and end times of this transition
-            var transition_start_time = $scope.project.effects[transition_index].start;
-            var transition_end_time = $scope.project.effects[transition_index].end;
-
-            // If the transition falls withing the selection time range
-            if (transition_start_time >= select_start_time && transition_end_time <= selection_end_time) {
-                // Select the transition
-                $scope.project.effects[transition_index].selected = true;
-                timeline.addSelection($scope.project.effects[transition_index].id, "effect", false);
-            }
-        } 
-    //});
  };
 	
  // Select clip in scope
@@ -699,45 +659,6 @@ App.controller('TimelineCtrl',function($scope) {
 			}
 		}
 	}
-    
-    // If shift was pressed, then all clips and transitions between the currently
-    // selected and the previously selected clip need to be selected as well
-    if (event && event.shiftKey && $scope.project.prev_selected_clip_id != "") {
-        // Retrieve the start and end times of the currently-selected clip
-        var curr_clip_start_time = 0;
-        var curr_clip_end_time = 0;
-        for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-            if ($scope.project.clips[clip_index].id == id) {
-                curr_clip_start_time = $scope.project.clips[clip_index].start;
-                curr_clip_end_time = $scope.project.clips[clip_index].end;
-                break;
-            }
-        }
-
-        // Retrieve the start and end times of the previously-selected clip
-        var prev_clip_start_time = 0;
-        var prev_clip_end_time = 0;
-        for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-            if ($scope.project.clips[clip_index].id == $scope.project.prev_selected_clip_id) {
-                timeline.qt_log("found previous clip");
-                prev_clip_start_time = $scope.project.clips[clip_index].start;
-                prev_clip_end_time = $scope.project.clips[clip_index].end;
-                break;
-            }
-        }
-        
-        // Determine the time range to select between
-        var select_start_time = Math.min(curr_clip_start_time, prev_clip_start_time);
-        var select_end_time = Math.max(curr_clip_end_time, prev_clip_end_time);
-        
-        // Select all clips in the selection range
-        $scope.SelectTimeRange(select_start_time, select_end_time);
-    }
-    
-    // Update the previously-selected clip ID
- 	//$scope.$apply(function() {
-        $scope.project.prev_selected_clip_id = id;
- 	//});
  };
  
   // Select transition in scope

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -415,7 +415,7 @@ App.controller('TimelineCtrl',function($scope) {
  };
  
  // Center the timeline on a given time position
- $scope.centerOnTime = function(scaleVal, centerTime) {
+ $scope.centerOnTime = function(centerTime) {
     // Get the width of the timeline
     var scrollingTracksWidth = $("#scrolling_tracks").width();
     

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -413,6 +413,19 @@ App.controller('TimelineCtrl',function($scope) {
 	 var new_cursor_x = Math.round((cursor_time * $scope.pixelsPerSecond) - center_x);
 	 $("#scrolling_tracks").scrollLeft(new_cursor_x);
  };
+ 
+ // Center the timeline on a given time position
+ $scope.centerOnTime = function(scaleVal, centerTime) {
+    // Get the width of the timeline
+    var scrollingTracksWidth = $("#scrolling_tracks").width();
+    
+    // Calculate the position to scroll the timeline to to center on the requested time
+    var pixelToCenterOn = centerTime * $scope.pixelsPerSecond;
+    var scrollPosition = Math.max(pixelToCenterOn - (scrollingTracksWidth / 2.0), 0);
+    
+    // Scroll the timeline
+    $("#scrolling_tracks").scrollLeft(Math.round(scrollPosition + 0.5));
+ };
 
  // Update thumbnail for clip
  $scope.updateThumbnail = function(clip_id) {

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1212,7 +1212,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # Look for existing Marker
         marker = Marker()
-        marker.data = {"position": position, "icon": "blue.png"}
+        marker.data = {"position": position, "icon": "blue.png", "name": ""}
         marker.save()
 
     def actionPreviousMarker_trigger(self, event):
@@ -1778,6 +1778,28 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         for marker_id in self.selected_markers:
             marker = Marker.filter(id=marker_id)
             for m in marker:
+                # Remove track
+                m.delete()
+
+    def actionRemoveAllMarkers_trigger(self, event):
+        log.info('actionRemoveAllMarkers_trigger')
+
+        marker = Marker.getAll()
+        for m in marker:
+            # Remove track
+            m.delete()
+
+    def actionRemoveAllOtherMarkers_trigger(self, event):
+        log.info('actionRemoveAllOtherMarkers_trigger')
+
+        marker = Marker.getAll()
+        for m in marker:
+            match = False
+            for marker_id in self.selected_markers:
+                if (m.id == marker_id):
+                    match = True
+                    break
+            if (match == False):
                 # Remove track
                 m.delete()
 

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -352,6 +352,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # Seek to frame 0
         self.SeekSignal.emit(1)
+        
+        # Scroll the timeline to the start
+        self.timeline.centerOnTime(0.0)
 
     def actionAnimatedTitle_trigger(self, event):
         # show dialog
@@ -951,6 +954,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # Seek to the 1st frame
         self.SeekSignal.emit(1)
+        
+        # Scroll the timeline to the start as well
+        self.timeline.centerOnTime(0.0)
 
     def actionJumpEnd_trigger(self, event):
         log.info("actionJumpEnd_trigger")
@@ -968,8 +974,11 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Convert to int and round
         timeline_length_int = round(timeline_length * fps) + 1
 
-        # Seek to the 1st frame
+        # Seek to the last frame
         self.SeekSignal.emit(timeline_length_int)
+        
+        # Scroll the timeline to the end as well
+        self.timeline.centerOnTime(timeline_length)
 
     def actionSaveFrame_trigger(self, event):
         log.info("actionSaveFrame_trigger")
@@ -1254,9 +1263,12 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             frame_to_seek = round(closest_position * fps_float) + 1
             self.SeekSignal.emit(frame_to_seek)
 
-            # Update the preview and reselct current frame in properties
+            # Update the preview and reselect current frame in properties
             get_app().window.refreshFrameSignal.emit()
             get_app().window.propertyTableView.select_frame(frame_to_seek)
+            
+            # Center the timeline on the marker
+            self.timeline.centerOnTime(closest_position)
 
     def actionNextMarker_trigger(self, event):
         log.info("actionNextMarker_trigger")
@@ -1307,10 +1319,29 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             frame_to_seek = round(closest_position * fps_float) + 1
             self.SeekSignal.emit(frame_to_seek)
 
-            # Update the preview and reselct current frame in properties
+            # Update the preview and reselect current frame in properties
             get_app().window.refreshFrameSignal.emit()
             get_app().window.propertyTableView.select_frame(frame_to_seek)
 
+            # Center the timeline on the marker
+            self.timeline.centerOnTime(closest_position)
+            
+    def actionCenterOnPlayhead_trigger(self, event):
+        log.info('actionCenterOnPlayhead_trigger')
+        
+        # Get player object
+        player = self.preview_thread.player
+        
+        # Calculate frames per second
+        fps = get_app().project.get("fps")
+        fps_float = float(fps["num"]) / float(fps["den"])
+        
+        # Calculate the playhead position in seconds
+        playheadPosition = player.Position() / fps_float
+        
+        # Center the timeline on the playhead position
+        self.timeline.centerOnTime(playheadPosition)
+            
     def getShortcutByName(self, setting_name):
         """ Get a key sequence back from the setting name """
         s = settings.get_settings()
@@ -1431,6 +1462,8 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             self.actionPreviousMarker.trigger()
         elif key.matches(self.getShortcutByName("actionNextMarker")) == QKeySequence.ExactMatch:
             self.actionNextMarker.trigger()
+        elif key.matches(self.getShortcutByName("actionCenterOnPlayhead")) == QKeySequence.ExactMatch:
+            self.actionCenterOnPlayhead.trigger()
         elif key.matches(self.getShortcutByName("actionTimelineZoomIn")) == QKeySequence.ExactMatch:
             self.actionTimelineZoomIn.trigger()
         elif key.matches(self.getShortcutByName("actionTimelineZoomOut")) == QKeySequence.ExactMatch:
@@ -2246,6 +2279,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.timelineToolbar.addSeparator()
         self.timelineToolbar.addAction(self.actionAddMarker)
         self.timelineToolbar.addAction(self.actionPreviousMarker)
+        self.timelineToolbar.addAction(self.actionCenterOnPlayhead)
         self.timelineToolbar.addAction(self.actionNextMarker)
         self.timelineToolbar.addSeparator()
 

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -875,7 +875,7 @@
   </action>
   <action name="actionPreviousMarker">
    <property name="icon">
-    <iconset theme="go-first" resource="../../images/openshot.qrc">
+    <iconset resource="../../images/openshot.qrc">
      <normaloff>:/icons/Humanity/actions/16/go-first.svg</normaloff>:/icons/Humanity/actions/16/go-first.svg</iconset>
    </property>
    <property name="text">
@@ -887,7 +887,7 @@
   </action>
   <action name="actionNextMarker">
    <property name="icon">
-    <iconset theme="go-last" resource="../../images/openshot.qrc">
+    <iconset resource="../../images/openshot.qrc">
      <normaloff>:/icons/Humanity/actions/16/go-last.svg</normaloff>:/icons/Humanity/actions/16/go-last.svg</iconset>
    </property>
    <property name="text">
@@ -895,6 +895,18 @@
    </property>
    <property name="toolTip">
     <string>Next Marker</string>
+   </property>
+  </action>
+  <action name="actionCenterOnPlayhead">
+   <property name="icon">
+    <iconset resource="../../images/openshot.qrc">
+     <normaloff>:/icons/Humanity/actions/16/object-flip-horizontal.svg</normaloff>:/icons/Humanity/actions/16/object-flip-horizontal.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Center on Playhead</string>
+   </property>
+   <property name="toolTip">
+    <string>Center the timeline on the Playhead</string>
    </property>
   </action>
   <action name="actionFilesShowAll">

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -1397,6 +1397,30 @@
     <string>Remove Marker</string>
    </property>
   </action>
+  <action name="actionRemoveAllMarkers">
+   <property name="icon">
+    <iconset theme="list-remove" resource="../../images/openshot.qrc">
+     <normaloff>:/icons/Humanity/actions/16/list-remove.svg</normaloff>:/icons/Humanity/actions/16/list-remove.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Remove All Markers</string>
+   </property>
+   <property name="toolTip">
+    <string>Remove All Markers</string>
+   </property>
+  </action>
+  <action name="actionRemoveAllOtherMarkers">
+   <property name="icon">
+    <iconset theme="list-remove" resource="../../images/openshot.qrc">
+     <normaloff>:/icons/Humanity/actions/16/list-remove.svg</normaloff>:/icons/Humanity/actions/16/list-remove.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Remove All Other Markers</string>
+   </property>
+   <property name="toolTip">
+    <string>Remove All Other Markers</string>
+   </property>
+  </action>
   <action name="actionAddTrackAbove">
    <property name="icon">
     <iconset theme="list-add" resource="../../images/openshot.qrc">

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -2499,6 +2499,8 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
         menu = QMenu(self)
         menu.addAction(self.window.actionRemoveMarker)
+        menu.addAction(self.window.actionRemoveAllMarkers)
+        menu.addAction(self.window.actionRemoveAllOtherMarkers)
         return menu.popup(QCursor.pos())
 
     @pyqtSlot(str, int)

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -2548,11 +2548,8 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         
     @pyqtSlot(float)
     def centerOnTime(self, time):
-        # Retrieve the current timeline scale
-        scale = get_app().project.get("scale")
-        
         # Execute JavaScript to center the timeline
-        cmd = '%s.centerOnTime(%s, %s);' % (JS_SCOPE_SELECTOR, str(scale), str(time))
+        cmd = '%s.centerOnTime(%s);' % (JS_SCOPE_SELECTOR, str(time))
         self.page().mainFrame().evaluateJavaScript(cmd)
         
     @pyqtSlot(int)

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -398,7 +398,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         # Save transition
         existing_item.save()
 
-        # Update the preview and reselct current frame in properties
+        # Update the preview and reselect current frame in properties
         if not ignore_refresh:
             get_app().window.refreshFrameSignal.emit()
             get_app().window.propertyTableView.select_frame(self.window.preview_thread.player.Position())
@@ -2543,7 +2543,16 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         # Get access to timeline scope and set scale to zoom slider value (passed in)
         code = JS_SCOPE_SELECTOR + ".MovePlayheadToFrame(" + str(position_frames) + ");"
         self.eval_js(code)
-
+        
+    @pyqtSlot(float)
+    def centerOnTime(self, time):
+        # Retrieve the current timeline scale
+        scale = get_app().project.get("scale")
+        
+        # Execute JavaScript to center the timeline
+        cmd = '%s.centerOnTime(%s, %s);' % (JS_SCOPE_SELECTOR, str(scale), str(time))
+        self.page().mainFrame().evaluateJavaScript(cmd)
+        
     @pyqtSlot(int)
     def SetSnappingMode(self, enable_snapping):
         """ Enable / Disable snapping mode """
@@ -2893,7 +2902,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         # Accept event
         event.accept()
 
-        # Update the preview and reselct current frame in properties
+        # Update the preview and reselect current frame in properties
         get_app().window.refreshFrameSignal.emit()
         get_app().window.propertyTableView.select_frame(self.window.preview_thread.player.Position())
 


### PR DESCRIPTION
…nterest.  Specifically, the user can center the timeline on the current playhead position using a toolbar button or a keyboard shortcut.  Additionally, when the playhead is moved to a marker or the start or end of the timeline, the timeline is scrolled to match.  This eliminates the need to search for the playhead in long projects.

Added the function "centerOnTime" to controllers.js to allow the timeline to be centered on an arbitrary time.
Added the function "centerOnTime" to timeline_webview.py to call the "centerOnTime" function in controllers.js.
Added the action "actionCenterOnPlayhead" to main-window.ui and added it to the toolbox between "actionPreviousMarker" and "actionNextMarker".
Added the function "actionCenterOnPlayhead" to main_window.py to center the timeline on the current playhead position.
Modified main_window.py to automatically scroll the timeline when the playhead is moved to a marker or the start or end of the timeline.