### PR TITLE
Fix render progress display in Animated Titles editor

### DIFF
--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -314,10 +314,6 @@ class BlenderListView(QListView):
         # Enable the Render button again
         self.win.close()
 
-    def close_window(self):
-        # Close window
-        self.close()
-
     @pyqtSlot(int)
     def update_progress_bar(self, current_frame):
 

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -25,7 +25,6 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-import codecs
 import os
 import uuid
 import shutil
@@ -541,7 +540,7 @@ class BlenderListView(QListView):
         script_body = script_body.replace("#INJECT_PARAMS_HERE", user_params)
 
         # Write update script
-        with codecs.open(path, "w", encoding="UTF-8") as f:
+        with open(path, "w", encoding="UTF-8", errors="strict") as f:
             f.write(script_body)
 
     @pyqtSlot(str)


### PR DESCRIPTION
Blender 2.80 doesn't output "Part" messages anymore, so the frame regexp was always failing, and the progress bar never updated.

This switches to detecting the final "Sce:" message for the scene, and using it to update the progress bar.

It also cleans up an unused method, and eliminates unnecessary slot methods like
```py
def onRenderFinish(self):
    self.render_finished()
```
in favor of decorating `render_finished` as a slot and connecting the signal directly.