### PR TITLE
Add tooltips for Bit Rate control of the video

### DIFF
--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -265,6 +265,11 @@ class Export(QDialog):
         # Determine the length of the timeline (in frames)
         self.updateFrameRate()
 
+        # Tooltips
+        bitrateTT = _("Type <b>N crf</b><br> where N = 0..63, to use Constant Rate Factor control for quality setting instead of the bitrate")
+        self.lblVideoBitrate.setToolTip(bitrateTT)
+        self.txtVideoBitRate.setToolTip(bitrateTT)
+
     def delayed_fps_callback(self):
         """Callback for fps/profile changed event timer (to delay the timeline mapping so we don't spam libopenshot)"""
         # Stop timer


### PR DESCRIPTION
Aimed at issues similar to the: https://github.com/OpenShot/openshot-qt/issues/2962
From UI it is unknown to the end user (since feature was implemented) that other control is available.

Option for the _Advanced_ tab of the video export settings now has tooltip to aware user that he can try to use CRF like setting:

![openshot export tooltip bitrate](https://user-images.githubusercontent.com/19683044/64130201-706fb380-cdc9-11e9-9d92-bbd1e2c5a23e.png)

