### PR TITLE
Don't copy permissions when dup'ing template files (animated titles, still titles)

### DIFF
--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -177,7 +177,7 @@ class TitleEditor(QDialog):
         self.filename = os.path.join(info.TITLE_PATH, "temp.svg")
 
         # Copy template to temp file
-        shutil.copy(template_path, self.filename)
+        shutil.copyfile(template_path, self.filename)
 
         # return temp path
         return self.filename

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -572,7 +572,9 @@ class BlenderListView(QListView):
 
         # Copy the .py script associated with this template to the temp folder.  This will allow
         # OpenShot to inject the user-entered params into the Python script.
-        shutil.copy(source_script, target_script)
+        # XXX: Note that copyfile() is used instead of copy(), as the original
+        #      file may be readonly, and we don't want to duplicate those permissions
+        shutil.copyfile(source_script, target_script)
 
         # Open new temp .py file, and inject the user parameters
         self.inject_params(target_script, frame)


### PR DESCRIPTION
A user reported that the `.py` scripts in the blender output directory and the `.svg` title files from the title editor are being created read-only on their system, due to the original templates being installed read-only. This change switches from `shutil.copy()` to `shutil.copyfile()`, which will duplicate the templates _without_ copying their original permissions.

Fixes #2972 