### PR TITLE
Update data from the default project too

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -288,6 +288,8 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                     self._data["width"] = profile.info.width
                     self._data["height"] = profile.info.height
                     self._data["fps"] = {"num" : profile.info.fps.num, "den" : profile.info.fps.den}
+                    self._data["display_ratio"] = {"num": profile.info.display_ratio.num, "den": profile.info.display_ratio.den}
+                    self._data["pixel_ratio"] = {"num": profile.info.pixel_ratio.num, "den": profile.info.pixel_ratio.den}
                     break
 
         # Get the default audio settings for the timeline (and preview playback)


### PR DESCRIPTION
**Edit:**
Inspired by: https://github.com/OpenShot/openshot-qt/issues/2969
It doesn't fixes it completely but applies profile as it was intended during startup of the application.

With the https://github.com/OpenShot/openshot-qt/commit/eae7170494118af6dca5b30d972d80f3f54e1c6b was introduced new `changed(self, action)` method for `VideoWidget` that applies default values of some parameters if data not exist.
This PR ensures that required data will be filled on project load during application startup.

Issues connected to the incorrect aspect ratios of the videos loaded in _Preview File_ (cutting.py) isn't affected by this PR.