### PR TITLE
WIP: Rework Preview File optimizations

### DIFF
--- a/src/windows/cutting.py
+++ b/src/windows/cutting.py
@@ -59,11 +59,11 @@ class Cutting(QDialog):
     SpeedSignal = pyqtSignal(float)
     StopSignal = pyqtSignal()
 
-    def __init__(self, file=None, preview=False):
+    def __init__(self, parent=None, file=None, preview=False):
         _ = get_app()._tr
 
         # Create dialog class
-        QDialog.__init__(self)
+        QDialog.__init__(self, parent)
 
         # Load UI from designer
         ui_util.load_ui(self, self.ui_path)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -900,7 +900,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # show dialog
         from windows.cutting import Cutting
-        win = Cutting(f, preview=True)
+        win = Cutting(parent=self, file=f, preview=True)
         win.show()
 
     def previewFrame(self, position_frames):
@@ -1545,7 +1545,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # show dialog
         from windows.cutting import Cutting
-        win = Cutting(f)
+        win = Cutting(parent=self, file=f)
         # Run the dialog event loop - blocking interaction on this window during that time
         result = win.exec_()
         if result == QDialog.Accepted:

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -902,6 +902,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         from windows.cutting import Cutting
         win = Cutting(parent=self, file=f, preview=True)
         win.show()
+        win.openReader()
 
     def previewFrame(self, position_frames):
         """Preview a specific frame"""
@@ -1546,12 +1547,8 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # show dialog
         from windows.cutting import Cutting
         win = Cutting(parent=self, file=f)
-        # Run the dialog event loop - blocking interaction on this window during that time
-        result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('Cutting Finished')
-        else:
-            log.info('Cutting Cancelled')
+        win.show()
+        win.openReader()
 
     def actionRemove_from_Project_trigger(self, event):
         log.info("actionRemove_from_Project_trigger")


### PR DESCRIPTION
**To do**

- [ ] separate regular _Video Preview_ and _Preview File_ optimizations. Currently (and in this PR too), when _Preview_ (file) window scaled up/down the regular _Video Preview_ content inherits same optimizations (scale). Thus if _Preview_ (file) window resized to almost minimum - any file in _Video Preview_ will be shown at bad quality too.
- [ ] see if aspect ratio/canvas size of the preview file can be separated from the current profile., to render video correctly and without black borders on the sides.

**What is done**
The logic to initialize the Timeline object now uses correct geometry data that itself updates only after the _show()_ method in Qt.

**Side effects**
* _Preview_ (file) window now closes together with the main window (parent->child widget relationship; no new entry in taskbar; when application minimized - all opened previews minimizes too)
* _Split Clip_ (project files menu) is modeless window now (can be changed back to the modal by simple `win.setModal(True)` before `win.show()` if needed).

**Behavior**
Currently it (PR) looks like total regression: quality of _Preview_ (file) drops, aspect ratio and scaling are wrong.