### PR TITLE
Blender Python scripts: Code formatting

### DIFF
--- a/src/blender/scripts/blinds.py
+++ b/src/blender/scripts/blinds.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -22,63 +22,64 @@
 # with this library pre-installed.
 import bpy
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
+
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
+
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
+
+    # no new font was added
+    return None
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
 # -P = run a Python script within the context of the project file
 
+
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())
@@ -93,12 +94,12 @@ text_object.space_character = params["width"]
 # Get font object
 font = None
 if params["fontname"] != "Bfont":
-	# Add font so it's available to Blender
-	font = load_font(params["fontname"])
+    # Add font so it's available to Blender
+    font = load_font(params["fontname"])
 else:
-	# Get default font
-	font = bpy.data.fonts["Bfont"]
-	
+    # Get default font
+    font = bpy.data.fonts["Bfont"]
+
 text_object.font = font
 
 text_object = bpy.data.curves["Subtitle"]
@@ -134,15 +135,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/blur.py
+++ b/src/blender/scripts/blur.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -22,65 +22,66 @@
 # with this library pre-installed.
 import bpy
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
+
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
+
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
+
+    # no new font was added
+    return None
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
 # -P = run a Python script within the context of the project file
 
+
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-			'blur_amount_x': 75,
-			'blur_amount_y': 75,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+    'blur_amount_x': 75,
+    'blur_amount_y': 75,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())
@@ -95,11 +96,11 @@ text_object.space_character = params["width"]
 # Get font object
 font = None
 if params["fontname"] != "Bfont":
-	# Add font so it's available to Blender
-	font = load_font(params["fontname"])
+    # Add font so it's available to Blender
+    font = load_font(params["fontname"])
 else:
-	# Get default font
-	font = bpy.data.fonts["Bfont"]
+    # Get default font
+    font = bpy.data.fonts["Bfont"]
 
 text_object.font = font
 
@@ -131,15 +132,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/colors.py
+++ b/src/blender/scripts/colors.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -22,63 +22,64 @@
 # with this library pre-installed.
 import bpy
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
+
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
+
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
+
+    # no new font was added
+    return None
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
 # -P = run a Python script within the context of the project file
 
+
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # TITLE 1 - Modify Text / Curve settings
 text_object1 = bpy.data.curves["Title1"]
@@ -91,11 +92,11 @@ text_object1.space_character = params["width"]
 # Get font object
 font = None
 if params["fontname"] != "Bfont":
-	# Add font so it's available to Blender
-	font = load_font(params["fontname"])
+    # Add font so it's available to Blender
+    font = load_font(params["fontname"])
 else:
-	# Get default font
-	font = bpy.data.fonts["Bfont"]
+    # Get default font
+    font = bpy.data.fonts["Bfont"]
 text_object1.font = font
 
 # TITLE 2 - Modify Text / Curve settings
@@ -143,10 +144,10 @@ material_object4.specular_intensity = params["specular_intensity_bg"]
 
 # Shadeless Background
 # TODO: Unsupported in Blender 2.8 (not sure of workaround yet)
-#if params["shadeless"] == "Yes":
-#	material_object4.use_shadeless = True
-#else:
-#	material_object4.use_shadeless = False
+# if params["shadeless"] == "Yes":
+# material_object4.use_shadeless = True
+# else:
+# material_object4.use_shadeless = False
 
 # BACKGROUND COLORS (KEYFRAMES) ----------------------
 # TILE 1
@@ -254,15 +255,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/dissolve.py
+++ b/src/blender/scripts/dissolve.py
@@ -1,32 +1,31 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
-# run from the context of Blender.  Blender contains it's own version of Python
+# run from the context of Blender.  Blender contains its own version of Python
 # with this library pre-installed.
-from math import pi
-
 import bpy
 from bpy.props import *
 
+from math import pi
 
-# Load a font
+
 def load_font(font_path):
     """ Load a new TTF font into Blender, and return the font object """
     # get the original list of fonts (before we add a new one)
@@ -45,11 +44,11 @@ def load_font(font_path):
 
 
 # the stuff
-#  
+#
 #  name: createDissolveText
 #  @param
 #  @return
-#  
+#
 def createDissolveText(title, extrude, bevel_depth, spacemode, textsize, width, font):
     """ Create aned animate the exploding texte """
 
@@ -249,7 +248,7 @@ params = {
     'diffuse_color': [0.57, 0.57, 0.57, 1.0]
 }
 
-#INJECT_PARAMS_HERE
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file

--- a/src/blender/scripts/earth.py
+++ b/src/blender/scripts/earth.py
@@ -1,148 +1,151 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
+import math
 import bpy
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
+
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
+
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
+
+    # no new font was added
+    return None
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
 # -P = run a Python script within the context of the project file
 
+
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
-import math
 
-#depart = {"title":"Paris", 
-#		  "lat_deg": 48, "lat_min": 51, "lat_sec": 24, "lat_dir": "N",
-#		  "lon_deg": 2, "lon_min": 21, "lon_sec": 7, "lon_dir": "E",
-#		}
+# depart = {"title":"Paris",
+#    "lat_deg": 48, "lat_min": 51, "lat_sec": 24, "lat_dir": "N",
+#    "lon_deg": 2, "lon_min": 21, "lon_sec": 7, "lon_dir": "E",
+# }
 #
-#arrive = {"title":"New York", 
-#		  "lat_deg": 40, "lat_min": 42, "lat_sec": 51, "lat_dir": "N",
-#		  "lon_deg": 74, "lon_min": 0, "lon_sec": 23, "lon_dir": "O",
-#		}
+# arrive = {"title":"New York",
+#    "lat_deg": 40, "lat_min": 42, "lat_sec": 51, "lat_dir": "N",
+#    "lon_deg": 74, "lon_min": 0, "lon_sec": 23, "lon_dir": "O",
+# }
 
 depart = {
-		  "lat_deg": params["depart_lat_deg"], "lat_min": params["depart_lat_min"], "lat_sec": params["depart_lat_sec"], "lat_dir": params["depart_lat_dir"],
-		  "lon_deg": params["depart_lon_deg"], "lon_min": params["depart_lon_min"], "lon_sec": params["depart_lon_sec"], "lon_dir": params["depart_lon_dir"],
-		}
+    "lat_deg": params["depart_lat_deg"], "lat_min": params["depart_lat_min"], "lat_sec": params["depart_lat_sec"], "lat_dir": params["depart_lat_dir"],
+    "lon_deg": params["depart_lon_deg"], "lon_min": params["depart_lon_min"], "lon_sec": params["depart_lon_sec"], "lon_dir": params["depart_lon_dir"],
+}
 
 arrive = {
-		  "lat_deg": params["arrive_lat_deg"], "lat_min": params["arrive_lat_min"], "lat_sec": params["arrive_lat_sec"], "lat_dir": params["arrive_lat_dir"],
-		  "lon_deg": params["arrive_lon_deg"], "lon_min": params["arrive_lon_min"], "lon_sec": params["arrive_lon_sec"], "lon_dir": params["arrive_lon_dir"],
-		}
+    "lat_deg": params["arrive_lat_deg"], "lat_min": params["arrive_lat_min"], "lat_sec": params["arrive_lat_sec"], "lat_dir": params["arrive_lat_dir"],
+    "lon_deg": params["arrive_lon_deg"], "lon_min": params["arrive_lon_min"], "lon_sec": params["arrive_lon_sec"], "lon_dir": params["arrive_lon_dir"],
+}
 
 point_a = {}
 point_b = {}
 point_c = {}
 point_d = {}
 
+
 def get_latitude(direction, degrees, minutes, seconds):
-	
-	latitude = 0.0
-	if direction == "N":
-		# North of the equator
-		latitude = -(degrees + minutes / 60.0 + seconds / 3600.0)
-	else:
-		# South of the equator
-		latitude = degrees + minutes / 60.0 + seconds / 3600.0
-		
-	return latitude
+
+    latitude = 0.0
+    if direction == "N":
+        # North of the equator
+        latitude = -(degrees + minutes / 60.0 + seconds / 3600.0)
+    else:
+        # South of the equator
+        latitude = degrees + minutes / 60.0 + seconds / 3600.0
+
+    return latitude
 
 
 def get_longitude(direction, degrees, minutes, seconds):
 
-	longitude = 0.0
-	if direction == "E":
-		# North of the equator
-		longitude = degrees + minutes / 60.0 + seconds / 3600.0
-	else:
-		# South of the equator
-		longitude = - (degrees + minutes / 60.0 + seconds / 3600.0)
-		
-	return longitude
+    longitude = 0.0
+    if direction == "E":
+        # North of the equator
+        longitude = degrees + minutes / 60.0 + seconds / 3600.0
+    else:
+        # South of the equator
+        longitude = - (degrees + minutes / 60.0 + seconds / 3600.0)
+
+    return longitude
+
 
 def check_longitude(depart_longitude, arrive_longitude):
-	
-	if -180 < (arrive_longitude - depart_longitude) and (arrive_longitude - depart_longitude) < 180:
-		return depart_longitude
-	else:
-		if depart_longitude < 0:
-			return depart_longitude + 360
-		else:
-			return depart_longitude - 360
-		
-		
+
+    if -180 < (arrive_longitude - depart_longitude) and (arrive_longitude - depart_longitude) < 180:
+        return depart_longitude
+    else:
+        if depart_longitude < 0:
+            return depart_longitude + 360
+        else:
+            return depart_longitude - 360
+
+
 # Calculate latitude / longitude for depart and arrive points
 sphere_radius = 10.0
 point_a["lat"] = get_latitude(depart["lat_dir"], depart["lat_deg"], depart["lat_min"], depart["lat_sec"])
@@ -160,7 +163,8 @@ point_a["z"] = sphere_radius * math.sin(math.radians(point_a["lat"]))
 point_b["z"] = sphere_radius * math.sin(math.radians(point_b["lat"]))
 
 # Get angle between A & B points
-ab_angle_radians = math.acos((point_a["x"] * point_b["x"] + point_a["y"] * point_b["y"] + point_a["z"] * point_b["z"]) / (sphere_radius * sphere_radius))
+ab_angle_radians = math.acos((point_a["x"] * point_b["x"] + point_a["y"] * point_b["y"]
+                              + point_a["z"] * point_b["z"]) / (sphere_radius * sphere_radius))
 ab_angle_degrees = ab_angle_radians * 180 / math.pi
 
 # calculate points C & D
@@ -209,16 +213,16 @@ bpy.data.actions["EmptyCamAction"].fcurves[2].keyframe_points[1].handle_right.y 
 
 # set world texture (i.e. the globe texture)
 if params["map_texture"]:
-	bpy.data.textures["Texture.002"].image.filepath = params["map_texture"]
+    bpy.data.textures["Texture.002"].image.filepath = params["map_texture"]
 
 # Get font object
 font = None
 if params["fontname"] != "Bfont":
-	# Add font so it's available to Blender
-	font = load_font(params["fontname"])
+    # Add font so it's available to Blender
+    font = load_font(params["fontname"])
 else:
-	# Get default font
-	font = bpy.data.fonts["Bfont"]
+    # Get default font
+    font = bpy.data.fonts["Bfont"]
 
 # Modify Text for Departure
 text_object = bpy.data.curves["Text"]
@@ -274,14 +278,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])

--- a/src/blender/scripts/explode.py
+++ b/src/blender/scripts/explode.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -23,120 +23,121 @@
 import bpy
 from math import pi
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
-# the stuff
-def createExplodeTxt(title,particle_number,extrude,bevel_depth,spacemode,textsize,width,font,ground):
-	""" Create aned animate the exploding texte """
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
 
-	newText = title
-	#create text
-	bpy.ops.object.text_add(radius=1.0, enter_editmode=False, align='WORLD', location=(0.0, 0.0, 0.0), rotation=(0.0, 0.0, 0.0))
-	newtext = bpy.context.view_layer.objects.active
-	
-	#modifying the text
-	newtext.data.size = textsize
-	newtext.data.space_character = width
-	newtext.data.font = font
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
 
-	#centering text
-	newtext.data.align_x=spacemode
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
 
-	#extrude text
-	newtext.data.extrude=extrude
+    # no new font was added
+    return None
 
-	#bevel text
-	newtext.data.bevel_depth = bevel_depth
-	newtext.data.bevel_resolution = 10
 
-	#rotating text
-	#angles are in radians
-	#bpy.ops.transform.rotate(value=(pi/2,), axis=(1.0, 0.0, 0.0), constraint_axis=(False, False, False), constraint_orientation='GLOBAL', mirror=False, proportional='DISABLED', proportional_edit_falloff='SMOOTH', proportional_size=1, snap=False, snap_target='CLOSEST', snap_point=(0, 0, 0), snap_align=False, snap_normal=(0, 0, 0), release_confirm=False)
-	#second solution
-	newtext.rotation_euler[0]=pi/2 #xaxis
-	newtext.rotation_euler[1]=0.0  #yaxis
-	newtext.rotation_euler[2]=0.0  #zaxis
+def createExplodeTxt(title, particle_number, extrude, bevel_depth, spacemode, textsize, width, font, ground):
+    """ Create aned animate the exploding texte """
 
-	#changing text
-	bpy.ops.object.editmode_toggle()
-	for x in range(20):
-		bpy.ops.font.delete()
-	bpy.ops.font.text_insert(text=newText, accent=False)
-	bpy.ops.object.editmode_toggle()
-	
-	#convert to mesh to apply effect
-	bpy.ops.object.convert(target='MESH', keep_original=False)
+    newText = title
+    # create text
+    bpy.ops.object.text_add(radius=1.0, enter_editmode=False, align='WORLD', location=(0.0, 0.0, 0.0), rotation=(0.0, 0.0, 0.0))
+    newtext = bpy.context.view_layer.objects.active
 
-	#solidify 
-	bpy.ops.object.modifier_add(type='SOLIDIFY')
+    # modifying the text
+    newtext.data.size = textsize
+    newtext.data.space_character = width
+    newtext.data.font = font
 
-	#apply quick explode
-	bpy.ops.object.quick_explode(style='EXPLODE', amount=100, frame_duration=50, frame_start=1, frame_end=51, velocity=1, fade=True)
+    # centering text
+    newtext.data.align_x = spacemode
 
-	#modifying Particle System
-	#emitfrom
-	newtext.particle_systems[0].settings.emit_from = 'VERT'
-	#particle number
-	newtext.particle_systems[0].settings.count=particle_number
-	#particle lifetime
-	newtext.particle_systems[0].settings.lifetime=200 # 200 +48 > 150 ;-)z
-	# start/end explosion
-	newtext.particle_systems[0].settings.frame_end = 48
-	newtext.particle_systems[0].settings.frame_start = 48
-	#explosion power
-	newtext.particle_systems[0].settings.normal_factor=5.5
-	#integration method
-	# aa'MIDPOINT' #'RK4'
-	newtext.particle_systems[0].settings.integrator='RK4'
-	#size of particles
-	newtext.particle_systems[0].settings.particle_size = 0.1
-	#particles time step
-	newtext.particle_systems[0].settings.timestep = 0.02
-	#mass of particles
-	newtext.particle_systems[0].settings.mass = 2.0
-	newtext.particle_systems[0].settings.use_multiply_size_mass = True
-	
-	#affect an existing material
-	newtext.material_slots[0].material = bpy.data.materials['TextMaterial']
-	
-	#solidify parameter
-	newtext.modifiers['Solidify'].edge_crease_inner=0.01
-	newtext.modifiers['Solidify'].thickness = 0.02
-	#ground management
-	newtext.particle_systems[0].point_cache.frame_step = 1
-	if ground=='1':
-		bpy.ops.object.select_all(action='DESELECT')
-		#selecting Text
-		bpy.context.view_layer.objects.active = bpy.data.objects['Ground']
-		if bpy.data.objects['Ground'].modifiers.keys()[0] != 'Collision':
-			bpy.ops.object.modifier_add(type="COLLISION")
-		bpy.data.objects['Ground'].hide_render = False
-		
-	else:
-		bpy.ops.object.select_all(action='DESELECT')
-		#selecting Text
-		bpy.context.view_layer.objects.active  = bpy.data.objects['Ground']
-		bpy.ops.object.modifier_remove(modifier="Collision")
-		bpy.data.objects['Ground'].hide_render = True
-	    
-	bpy.ops.ptcache.free_bake_all()   # erase baked dynamics
-	bpy.ops.ptcache.bake_all() # bake dynamics : take time but needed before rendering animation
-	
-	
+    # extrude text
+    newtext.data.extrude = extrude
+
+    # bevel text
+    newtext.data.bevel_depth = bevel_depth
+    newtext.data.bevel_resolution = 10
+
+    # rotating text
+    # angles are in radians
+    #bpy.ops.transform.rotate(value=(pi/2,), axis=(1.0, 0.0, 0.0), constraint_axis=(False, False, False), constraint_orientation='GLOBAL', mirror=False, proportional='DISABLED', proportional_edit_falloff='SMOOTH', proportional_size=1, snap=False, snap_target='CLOSEST', snap_point=(0, 0, 0), snap_align=False, snap_normal=(0, 0, 0), release_confirm=False)
+    # second solution
+    newtext.rotation_euler[0] = pi / 2  # xaxis
+    newtext.rotation_euler[1] = 0.0  # yaxis
+    newtext.rotation_euler[2] = 0.0  # zaxis
+
+    # changing text
+    bpy.ops.object.editmode_toggle()
+    for x in range(20):
+        bpy.ops.font.delete()
+    bpy.ops.font.text_insert(text=newText, accent=False)
+    bpy.ops.object.editmode_toggle()
+
+    # convert to mesh to apply effect
+    bpy.ops.object.convert(target='MESH', keep_original=False)
+
+    # solidify
+    bpy.ops.object.modifier_add(type='SOLIDIFY')
+
+    # apply quick explode
+    bpy.ops.object.quick_explode(style='EXPLODE', amount=100, frame_duration=50, frame_start=1, frame_end=51, velocity=1, fade=True)
+
+    # modifying Particle System
+    # emitfrom
+    newtext.particle_systems[0].settings.emit_from = 'VERT'
+    # particle number
+    newtext.particle_systems[0].settings.count = particle_number
+    # particle lifetime
+    newtext.particle_systems[0].settings.lifetime = 200  # 200 +48 > 150 ;-)z
+    # start/end explosion
+    newtext.particle_systems[0].settings.frame_end = 48
+    newtext.particle_systems[0].settings.frame_start = 48
+    # explosion power
+    newtext.particle_systems[0].settings.normal_factor = 5.5
+    # integration method
+    # aa'MIDPOINT' #'RK4'
+    newtext.particle_systems[0].settings.integrator = 'RK4'
+    # size of particles
+    newtext.particle_systems[0].settings.particle_size = 0.1
+    # particles time step
+    newtext.particle_systems[0].settings.timestep = 0.02
+    # mass of particles
+    newtext.particle_systems[0].settings.mass = 2.0
+    newtext.particle_systems[0].settings.use_multiply_size_mass = True
+
+    # affect an existing material
+    newtext.material_slots[0].material = bpy.data.materials['TextMaterial']
+
+    # solidify parameter
+    newtext.modifiers['Solidify'].edge_crease_inner = 0.01
+    newtext.modifiers['Solidify'].thickness = 0.02
+    # ground management
+    newtext.particle_systems[0].point_cache.frame_step = 1
+    if ground == '1':
+        bpy.ops.object.select_all(action='DESELECT')
+        # selecting Text
+        bpy.context.view_layer.objects.active = bpy.data.objects['Ground']
+        if bpy.data.objects['Ground'].modifiers.keys()[0] != 'Collision':
+            bpy.ops.object.modifier_add(type="COLLISION")
+        bpy.data.objects['Ground'].hide_render = False
+
+    else:
+        bpy.ops.object.select_all(action='DESELECT')
+        # selecting Text
+        bpy.context.view_layer.objects.active = bpy.data.objects['Ground']
+        bpy.ops.object.modifier_remove(modifier="Collision")
+        bpy.data.objects['Ground'].hide_render = True
+
+    bpy.ops.ptcache.free_bake_all()   # erase baked dynamics
+    bpy.ops.ptcache.bake_all()  # bake dynamics : take time but needed before rendering animation
+
+
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
@@ -145,40 +146,40 @@ def createExplodeTxt(title,particle_number,extrude,bevel_depth,spacemode,textsiz
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'particle_number' : 100,
-			'ground_on_off' : 1,
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'particle_number': 100,
+    'ground_on_off': 1,
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())
@@ -195,16 +196,17 @@ params = {
 # Get font object
 font = None
 if params["fontname"] != "Bfont":
-	# Add font so it's available to Blender
-	font = load_font(params["fontname"])
+    # Add font so it's available to Blender
+    font = load_font(params["fontname"])
 else:
-	# Get default font
-	font = bpy.data.fonts["Bfont"]
+    # Get default font
+    font = bpy.data.fonts["Bfont"]
 
 # set the font
 #text_object.font = font
 
-createExplodeTxt(params["title"],params["particle_number"],params["extrude"],params["bevel_depth"],params["spacemode"],params["text_size"],params["width"], font, params["ground_on_off"])
+createExplodeTxt(params["title"], params["particle_number"], params["extrude"], params["bevel_depth"],
+                 params["spacemode"], params["text_size"], params["width"], font, params["ground_on_off"])
 
 # Change the material settings (color, alpha, etc...)
 material_object = bpy.data.materials["TextMaterial"]
@@ -229,14 +231,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])

--- a/src/blender/scripts/fly_by_1.py
+++ b/src/blender/scripts/fly_by_1.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -22,63 +22,64 @@
 # with this library pre-installed.
 import bpy
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
+
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
+
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
+
+    # no new font was added
+    return None
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
 # -P = run a Python script within the context of the project file
 
+
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())
@@ -93,11 +94,11 @@ text_object.space_character = params["width"]
 # Get font object
 font = None
 if params["fontname"] != "Bfont":
-	# Add font so it's available to Blender
-	font = load_font(params["fontname"])
+    # Add font so it's available to Blender
+    font = load_font(params["fontname"])
 else:
-	# Get default font
-	font = bpy.data.fonts["Bfont"]
+    # Get default font
+    font = bpy.data.fonts["Bfont"]
 
 # set the font
 text_object.font = font
@@ -124,15 +125,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/fly_by_two_titles.py
+++ b/src/blender/scripts/fly_by_two_titles.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -22,63 +22,64 @@
 # with this library pre-installed.
 import bpy
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
+
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
+
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
+
+    # no new font was added
+    return None
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
 # -P = run a Python script within the context of the project file
 
+
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())
@@ -93,11 +94,11 @@ text_object.space_character = params["width"]
 # Get font object
 font = None
 if params["fontname"] != "Bfont":
-	# Add font so it's available to Blender
-	font = load_font(params["fontname"])
+    # Add font so it's available to Blender
+    font = load_font(params["fontname"])
 else:
-	# Get default font
-	font = bpy.data.fonts["Bfont"]
+    # Get default font
+    font = bpy.data.fonts["Bfont"]
 
 text_object.font = font
 
@@ -133,15 +134,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/glare.py
+++ b/src/blender/scripts/glare.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -22,63 +22,64 @@
 # with this library pre-installed.
 import bpy
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
+
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
+
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
+
+    # no new font was added
+    return None
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
 # -P = run a Python script within the context of the project file
 
+
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())
@@ -93,11 +94,11 @@ text_object.space_character = params["width"]
 # Get font object
 font = None
 if params["fontname"] != "Bfont":
-	# Add font so it's available to Blender
-	font = load_font(params["fontname"])
+    # Add font so it's available to Blender
+    font = load_font(params["fontname"])
 else:
-	# Get default font
-	font = bpy.data.fonts["Bfont"]
+    # Get default font
+    font = bpy.data.fonts["Bfont"]
 
 text_object.font = font
 
@@ -115,11 +116,11 @@ bpy.context.scene.render.filepath = params["output_path"]
 bpy.context.scene.render.fps = params["fps"]
 bpy.context.scene.render.image_settings.file_format = params["file_format"]
 if params["use_alpha"] == "No":
-	bpy.context.scene.render.image_settings.color_mode = "RGB"
-	bpy.context.scene.render.alpha_mode = "SKY"
+    bpy.context.scene.render.image_settings.color_mode = "RGB"
+    bpy.context.scene.render.alpha_mode = "SKY"
 else:
-	bpy.context.scene.render.image_settings.color_mode = params["color_mode"]
-	bpy.context.scene.render.film_transparent = params["alpha_mode"]
+    bpy.context.scene.render.image_settings.color_mode = params["color_mode"]
+    bpy.context.scene.render.film_transparent = params["alpha_mode"]
 #bpy.data.worlds[0].color = params["horizon_color"]
 bpy.context.scene.render.resolution_x = params["resolution_x"]
 bpy.context.scene.render.resolution_y = params["resolution_y"]
@@ -128,15 +129,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/glass_slider.py
+++ b/src/blender/scripts/glass_slider.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -22,63 +22,64 @@
 # with this library pre-installed.
 import bpy
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
+
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
+
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
+
+    # no new font was added
+    return None
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
 # -P = run a Python script within the context of the project file
 
+
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'LEFT',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'LEFT',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # TITLE 1 - Modify Text / Curve settings
 text_object1 = bpy.data.curves["Title1"]
@@ -91,11 +92,11 @@ text_object1.space_character = params["width"]
 # Get font object
 font = None
 if params["fontname"] != "Bfont":
-	# Add font so it's available to Blender
-	font = load_font(params["fontname"])
+    # Add font so it's available to Blender
+    font = load_font(params["fontname"])
 else:
-	# Get default font
-	font = bpy.data.fonts["Bfont"]
+    # Get default font
+    font = bpy.data.fonts["Bfont"]
 text_object1.font = font
 
 
@@ -104,15 +105,15 @@ material_object1 = bpy.data.materials["Title.Material"]
 material_object1.diffuse_color = params["diffuse_color"]
 material_object1.specular_color = params["specular_color"]
 material_object1.specular_intensity = params["specular_intensity"]
-bpy.data.materials["Title.Material"].node_tree.nodes[1].inputs[0].default_value =  params["diffuse_color"]
+bpy.data.materials["Title.Material"].node_tree.nodes[1].inputs[0].default_value = params["diffuse_color"]
 
 # GLASS - Change the material settings (color, alpha, etc...)
 material_object2 = bpy.data.materials["Background.Material"]
 material_object2.diffuse_color = params["diffuse_color_bg"]
 material_object2.specular_color = params["specular_color_bg"]
 material_object2.specular_intensity = params["specular_intensity_bg"]
-bpy.data.materials["Background.Material"].node_tree.nodes[1].inputs[0].default_value  = params["diffuse_color_bg"]
-bpy.data.materials["Background.Material"].node_tree.nodes[1].inputs[18].default_value  = params["alpha_bg"]
+bpy.data.materials["Background.Material"].node_tree.nodes[1].inputs[0].default_value = params["diffuse_color_bg"]
+bpy.data.materials["Background.Material"].node_tree.nodes[1].inputs[18].default_value = params["alpha_bg"]
 
 # ADJUST STARTING POSITION (Keyframes)
 bpy.data.actions["TextAction"].fcurves[0].keyframe_points[0].co = (40.0, params["start_x"])
@@ -155,15 +156,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/lens_flare.py
+++ b/src/blender/scripts/lens_flare.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -30,38 +30,38 @@ import bpy
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify the Location of the Wand
 sphere_object = bpy.data.objects["Sphere"]
@@ -126,15 +126,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/magic_wand.py
+++ b/src/blender/scripts/magic_wand.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -30,38 +30,38 @@ import bpy
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify the Location of the Wand
 wand_object = bpy.data.objects["Wand"]
@@ -129,15 +129,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/neon_curves.py
+++ b/src/blender/scripts/neon_curves.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -22,68 +22,69 @@
 # with this library pre-installed.
 import bpy
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
+
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
+
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
+
+    # no new font was added
+    return None
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
 # -P = run a Python script within the context of the project file
 
+
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'line1_diffuse_color' : [0.8,0.8,0.8,1.0],
-			'line2_diffuse_color' : [0.8,0.8,0.8,1.0],
-			'line3_diffuse_color' : [0.8,0.8,0.8,1.0],
-			'line4_diffuse_color' : [0.8,0.8,0.8,1.0],
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'line1_diffuse_color': [0.8, 0.8, 0.8, 1.0],
+    'line2_diffuse_color': [0.8, 0.8, 0.8, 1.0],
+    'line3_diffuse_color': [0.8, 0.8, 0.8, 1.0],
+    'line4_diffuse_color': [0.8, 0.8, 0.8, 1.0],
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())
@@ -98,11 +99,11 @@ text_object.space_character = params["width"]
 # Get font object
 font = None
 if params["fontname"] != "Bfont":
-	# Add font so it's available to Blender
-	font = load_font(params["fontname"])
+    # Add font so it's available to Blender
+    font = load_font(params["fontname"])
 else:
-	# Get default font
-	font = bpy.data.fonts["Bfont"]
+    # Get default font
+    font = bpy.data.fonts["Bfont"]
 
 text_object.font = font
 
@@ -143,15 +144,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/picture_frames_4.py
+++ b/src/blender/scripts/picture_frames_4.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -30,118 +30,119 @@ import bpy
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
+
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
 
 def get_scale_values(height, width):
-	""" Calculate the correct scale parameters to display an image with the 
-	correct height / width ratio in Blender. """
-	
-	height_ratio = 1.0
-	width_ratio = float(width) / float(height)
-	
-	return (height_ratio, width_ratio)
-	
+    """ Calculate the correct scale parameters to display an image with the
+    correct height / width ratio in Blender. """
 
-#INJECT_PARAMS_HERE
+    height_ratio = 1.0
+    width_ratio = float(width) / float(height)
+
+    return (height_ratio, width_ratio)
+
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Split the picture information
 picture1 = params["project_files1"].split("|")
 if len(picture1) > 1:
-	picture1_scale = get_scale_values(picture1[1], picture1[2])
+    picture1_scale = get_scale_values(picture1[1], picture1[2])
 
 picture2 = params["project_files2"].split("|")
 if len(picture2) > 1:
-	picture2_scale = get_scale_values(picture2[1], picture2[2])
+    picture2_scale = get_scale_values(picture2[1], picture2[2])
 
 picture3 = params["project_files3"].split("|")
 if len(picture3) > 1:
-	picture3_scale = get_scale_values(picture3[1], picture3[2])
+    picture3_scale = get_scale_values(picture3[1], picture3[2])
 
 picture4 = params["project_files4"].split("|")
 if len(picture4) > 1:
-	picture4_scale = get_scale_values(picture4[1], picture4[2])
+    picture4_scale = get_scale_values(picture4[1], picture4[2])
 
 # Modify picture paths
 if len(picture1) > 1:
-	bpy.data.objects["Plane.001"].scale.y = -picture1_scale[0]
-	bpy.data.objects["Plane.001"].scale.x = -picture1_scale[1]
-	
-	if picture1[3] == "image":
-		bpy.data.materials["Material.001"].node_tree.nodes[2].image.source = 'FILE'
-		bpy.data.materials["Material.001"].node_tree.nodes[2].image.filepath = picture1[0]
-	else:
-		bpy.data.materials["Material.001"].node_tree.nodes[2].image.source = 'MOVIE'
-		bpy.data.materials["Material.001"].node_tree.nodes[2].image.filepath = picture1[0]
-		bpy.data.materials["Material.001"].node_tree.nodes[2].image_user.use_cyclic = True
-		bpy.data.materials["Material.001"].node_tree.nodes[2].image_user.frame_duration = 230.0
+    bpy.data.objects["Plane.001"].scale.y = -picture1_scale[0]
+    bpy.data.objects["Plane.001"].scale.x = -picture1_scale[1]
+
+    if picture1[3] == "image":
+        bpy.data.materials["Material.001"].node_tree.nodes[2].image.source = 'FILE'
+        bpy.data.materials["Material.001"].node_tree.nodes[2].image.filepath = picture1[0]
+    else:
+        bpy.data.materials["Material.001"].node_tree.nodes[2].image.source = 'MOVIE'
+        bpy.data.materials["Material.001"].node_tree.nodes[2].image.filepath = picture1[0]
+        bpy.data.materials["Material.001"].node_tree.nodes[2].image_user.use_cyclic = True
+        bpy.data.materials["Material.001"].node_tree.nodes[2].image_user.frame_duration = 230.0
 
 if len(picture2) > 1:
-	bpy.data.objects["Plane.002"].scale.y = -picture2_scale[0]
-	bpy.data.objects["Plane.002"].scale.x = -picture2_scale[1]
+    bpy.data.objects["Plane.002"].scale.y = -picture2_scale[0]
+    bpy.data.objects["Plane.002"].scale.x = -picture2_scale[1]
 
-	if picture2[3] == "image":
-		bpy.data.materials["Material.002"].node_tree.nodes[2].image.source = 'FILE'
-		bpy.data.materials["Material.002"].node_tree.nodes[2].image.filepath = picture2[0]
-	else:
-		bpy.data.materials["Material.002"].node_tree.nodes[2].image.source = 'MOVIE'
-		bpy.data.materials["Material.002"].node_tree.nodes[2].image.filepath = picture2[0]
-		bpy.data.materials["Material.002"].node_tree.nodes[2].image_user.use_cyclic = True
-		bpy.data.materials["Material.002"].node_tree.nodes[2].image_user.frame_duration = 230.0
+    if picture2[3] == "image":
+        bpy.data.materials["Material.002"].node_tree.nodes[2].image.source = 'FILE'
+        bpy.data.materials["Material.002"].node_tree.nodes[2].image.filepath = picture2[0]
+    else:
+        bpy.data.materials["Material.002"].node_tree.nodes[2].image.source = 'MOVIE'
+        bpy.data.materials["Material.002"].node_tree.nodes[2].image.filepath = picture2[0]
+        bpy.data.materials["Material.002"].node_tree.nodes[2].image_user.use_cyclic = True
+        bpy.data.materials["Material.002"].node_tree.nodes[2].image_user.frame_duration = 230.0
 
 if len(picture3) > 1:
-	bpy.data.objects["Plane.003"].scale.y = -picture3_scale[0]
-	bpy.data.objects["Plane.003"].scale.x = -picture3_scale[1]
+    bpy.data.objects["Plane.003"].scale.y = -picture3_scale[0]
+    bpy.data.objects["Plane.003"].scale.x = -picture3_scale[1]
 
-	if picture3[3] == "image":
-		bpy.data.materials["Material.003"].node_tree.nodes[2].image.source = 'FILE'
-		bpy.data.materials["Material.003"].node_tree.nodes[2].image.filepath = picture3[0]
-	else:
-		bpy.data.materials["Material.003"].node_tree.nodes[2].image.source = 'MOVIE'
-		bpy.data.materials["Material.003"].node_tree.nodes[2].image.filepath = picture3[0]
-		bpy.data.materials["Material.003"].node_tree.nodes[2].image_user.use_cyclic = True
-		bpy.data.materials["Material.003"].node_tree.nodes[2].image_user.frame_duration = 230.0
+    if picture3[3] == "image":
+        bpy.data.materials["Material.003"].node_tree.nodes[2].image.source = 'FILE'
+        bpy.data.materials["Material.003"].node_tree.nodes[2].image.filepath = picture3[0]
+    else:
+        bpy.data.materials["Material.003"].node_tree.nodes[2].image.source = 'MOVIE'
+        bpy.data.materials["Material.003"].node_tree.nodes[2].image.filepath = picture3[0]
+        bpy.data.materials["Material.003"].node_tree.nodes[2].image_user.use_cyclic = True
+        bpy.data.materials["Material.003"].node_tree.nodes[2].image_user.frame_duration = 230.0
 
 if len(picture4) > 1:
-	bpy.data.objects["Plane.004"].scale.y = -picture4_scale[0]
-	bpy.data.objects["Plane.004"].scale.x = -picture4_scale[1]
+    bpy.data.objects["Plane.004"].scale.y = -picture4_scale[0]
+    bpy.data.objects["Plane.004"].scale.x = -picture4_scale[1]
 
-	if picture3[4] == "image":
-		bpy.data.materials["Material.004"].node_tree.nodes[2].image.source = 'FILE'
-		bpy.data.materials["Material.004"].node_tree.nodes[2].image.filepath = picture4[0]
-	else:
-		bpy.data.materials["Material.004"].node_tree.nodes[2].image.source = 'MOVIE'
-		bpy.data.materials["Material.004"].node_tree.nodes[2].image.filepath = picture4[0]
-		bpy.data.materials["Material.004"].node_tree.nodes[2].image_user.use_cyclic = True
-		bpy.data.materials["Material.004"].node_tree.nodes[2].image_user.frame_duration = 230.0
+    if picture3[4] == "image":
+        bpy.data.materials["Material.004"].node_tree.nodes[2].image.source = 'FILE'
+        bpy.data.materials["Material.004"].node_tree.nodes[2].image.filepath = picture4[0]
+    else:
+        bpy.data.materials["Material.004"].node_tree.nodes[2].image.source = 'MOVIE'
+        bpy.data.materials["Material.004"].node_tree.nodes[2].image.filepath = picture4[0]
+        bpy.data.materials["Material.004"].node_tree.nodes[2].image_user.use_cyclic = True
+        bpy.data.materials["Material.004"].node_tree.nodes[2].image_user.frame_duration = 230.0
 
 # Set the render options.  It is important that these are set
 # to the same values as the current OpenShot project.  These
@@ -159,15 +160,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/rotate_360.py
+++ b/src/blender/scripts/rotate_360.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -22,63 +22,64 @@
 # with this library pre-installed.
 import bpy
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
+
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
+
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
+
+    # no new font was added
+    return None
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
 # -P = run a Python script within the context of the project file
 
+
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())
@@ -93,12 +94,12 @@ text_object.space_character = params["width"]
 # Get font object
 font = None
 if params["fontname"] != "Bfont":
-	# Add font so it's available to Blender
-	font = load_font(params["fontname"])
+    # Add font so it's available to Blender
+    font = load_font(params["fontname"])
 else:
-	# Get default font
-	font = bpy.data.fonts["Bfont"]
-	
+    # Get default font
+    font = bpy.data.fonts["Bfont"]
+
 text_object.font = font
 
 # Change the material settings (color, alpha, etc...)
@@ -124,15 +125,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/slide_left_to_right.py
+++ b/src/blender/scripts/slide_left_to_right.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -22,63 +22,64 @@
 # with this library pre-installed.
 import bpy
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
+
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
+
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
+
+    # no new font was added
+    return None
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
 # -P = run a Python script within the context of the project file
 
+
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())
@@ -93,11 +94,11 @@ text_object.space_character = params["width"]
 # Get font object
 font = None
 if params["fontname"] != "Bfont":
-	# Add font so it's available to Blender
-	font = load_font(params["fontname"])
+    # Add font so it's available to Blender
+    font = load_font(params["fontname"])
 else:
-	# Get default font
-	font = bpy.data.fonts["Bfont"]
+    # Get default font
+    font = bpy.data.fonts["Bfont"]
 
 text_object.font = font
 
@@ -124,15 +125,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/snow.py
+++ b/src/blender/scripts/snow.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -30,38 +30,38 @@ import bpy
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify the Location of the Wand
 wand_object = bpy.data.objects["Wand"]
@@ -96,15 +96,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/spacemovie_intro.py
+++ b/src/blender/scripts/spacemovie_intro.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -22,69 +22,70 @@
 # with this library pre-installed.
 import bpy
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
+
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
+
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
+
+    # no new font was added
+    return None
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
 # -P = run a Python script within the context of the project file
 
+
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'Alongtimeago' : 'Some cycles ago, in The Grid\nfar, far inside....',
-			'Episode' : 'Episode I.V',
-			'EpisodeTitle' : 'A NEW OPENSHOT',
-			'TitleSpaceMovie' : 'Space\nMovie',
-			'MainText' : 'It is a period of software war. Free software developers have won some battles with free, and open-source applications. They leave the source code available for everybody in the Galaxy, allowing people to access software knowledge and truth.\n\nBut the EULA Galactic Empire is not dead and prepares its revenge with an ultimate weapon: the blue screen of DEATH. This armored system can anihilate an entire device by a simple segfault.\n\nBut the rebel hackers have a secret weapon too: an atomic penguin which protects them from almost all digital injuries...',
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'Alongtimeago': 'Some cycles ago, in The Grid\nfar, far inside....',
+    'Episode': 'Episode I.V',
+    'EpisodeTitle': 'A NEW OPENSHOT',
+    'TitleSpaceMovie': 'Space\nMovie',
+    'MainText': 'It is a period of software war. Free software developers have won some battles with free, and open-source applications. They leave the source code available for everybody in the Galaxy, allowing people to access software knowledge and truth.\n\nBut the EULA Galactic Empire is not dead and prepares its revenge with an ultimate weapon: the blue screen of DEATH. This armored system can anihilate an entire device by a simple segfault.\n\nBut the rebel hackers have a secret weapon too: an atomic penguin which protects them from almost all digital injuries...',
 
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.0, 0.0, 0.0],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 1,
-			'end_frame' : 2232,
-			'animation' : True,
-		}
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.0, 0.0, 0.0],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 1,
+    'end_frame': 2232,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())
@@ -110,15 +111,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/wireframe_text.py
+++ b/src/blender/scripts/wireframe_text.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -22,64 +22,65 @@
 # with this library pre-installed.
 import bpy
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
+
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
+
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
+
+    # no new font was added
+    return None
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
 # -P = run a Python script within the context of the project file
 
+
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.7, 0.7, 0.7],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-			'thickness' : 0.015,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.7, 0.7, 0.7],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+    'thickness': 0.015,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())
@@ -94,11 +95,11 @@ text_object.space_character = params["width"]
 # Get font object
 font = None
 if params["fontname"] != "Bfont":
-	# Add font so it's available to Blender
-	font = load_font(params["fontname"])
+    # Add font so it's available to Blender
+    font = load_font(params["fontname"])
 else:
-	# Get default font
-	font = bpy.data.fonts["Bfont"]
+    # Get default font
+    font = bpy.data.fonts["Bfont"]
 
 # set the font
 text_object.font = font
@@ -134,15 +135,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-

--- a/src/blender/scripts/zoom_clapboard.py
+++ b/src/blender/scripts/zoom_clapboard.py
@@ -1,20 +1,20 @@
-#	OpenShot Video Editor is a program that creates, modifies, and edits video files.
+# OpenShot Video Editor is a program that creates, modifies, and edits video files.
 #   Copyright (C) 2009  Jonathan Thomas
 #
-#	This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
+# This file is part of OpenShot Video Editor (http://launchpad.net/openshot/).
 #
-#	OpenShot Video Editor is free software: you can redistribute it and/or modify
-#	it under the terms of the GNU General Public License as published by
-#	the Free Software Foundation, either version 3 of the License, or
-#	(at your option) any later version.
+# OpenShot Video Editor is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#	OpenShot Video Editor is distributed in the hope that it will be useful,
-#	but WITHOUT ANY WARRANTY; without even the implied warranty of
-#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#	GNU General Public License for more details.
+# OpenShot Video Editor is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#	You should have received a copy of the GNU General Public License
-#	along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License
+# along with OpenShot Video Editor.  If not, see <http://www.gnu.org/licenses/>.
 
 
 # Import Blender's python API.  This only works when the script is being
@@ -22,63 +22,64 @@
 # with this library pre-installed.
 import bpy
 
-# Load a font
+
 def load_font(font_path):
-	""" Load a new TTF font into Blender, and return the font object """
-	# get the original list of fonts (before we add a new one)
-	original_fonts = bpy.data.fonts.keys()
-	
-	# load new font
-	bpy.ops.font.open(filepath=font_path)
-	
-	# get the new list of fonts (after we added a new one)
-	for font_name in bpy.data.fonts.keys():
-		if font_name not in original_fonts:
-			return bpy.data.fonts[font_name]
-		
-	# no new font was added
-	return None
+    """ Load a new TTF font into Blender, and return the font object """
+    # get the original list of fonts (before we add a new one)
+    original_fonts = bpy.data.fonts.keys()
+
+    # load new font
+    bpy.ops.font.open(filepath=font_path)
+
+    # get the new list of fonts (after we added a new one)
+    for font_name in bpy.data.fonts.keys():
+        if font_name not in original_fonts:
+            return bpy.data.fonts[font_name]
+
+    # no new font was added
+    return None
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
 # -b = background mode
 # -P = run a Python script within the context of the project file
 
+
 # Init all of the variables needed by this script.  Because Blender executes
 # this script, OpenShot will inject a dictionary of the required parameters
 # before this script is executed.
-params = {		
-			'title' : 'Oh Yeah! OpenShot!',
-			'extrude' : 0.1,
-			'bevel_depth' : 0.02,
-			'spacemode' : 'CENTER',
-			'text_size' : 1.5,
-			'width' : 1.0,
-			'fontname' : 'Bfont',
-			
-			'color' : [0.8,0.8,0.8],
-			'alpha' : 1.0,
-			
-			'output_path' : '/tmp/',
-			'fps' : 24,
-			'quality' : 90,
-			'file_format' : 'PNG',
-			'color_mode' : 'RGBA',
-			'horizon_color' : [0.57, 0.57, 0.57],
-			'resolution_x' : 1920,
-			'resolution_y' : 1080,
-			'resolution_percentage' : 100,
-			'start_frame' : 20,
-			'end_frame' : 25,
-			'animation' : True,
-		}
+params = {
+    'title': 'Oh Yeah! OpenShot!',
+    'extrude': 0.1,
+    'bevel_depth': 0.02,
+    'spacemode': 'CENTER',
+    'text_size': 1.5,
+    'width': 1.0,
+    'fontname': 'Bfont',
 
-#INJECT_PARAMS_HERE
+    'color': [0.8, 0.8, 0.8],
+    'alpha': 1.0,
+
+    'output_path': '/tmp/',
+    'fps': 24,
+    'quality': 90,
+    'file_format': 'PNG',
+    'color_mode': 'RGBA',
+    'horizon_color': [0.57, 0.57, 0.57],
+    'resolution_x': 1920,
+    'resolution_y': 1080,
+    'resolution_percentage': 100,
+    'start_frame': 20,
+    'end_frame': 25,
+    'animation': True,
+}
+
+# INJECT_PARAMS_HERE
 
 # The remainder of this script will modify the current Blender .blend project
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
-#----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())
@@ -93,12 +94,12 @@ text_object.space_character = params["width"]
 # Get font object
 font = None
 if params["fontname"] != "Bfont":
-	# Add font so it's available to Blender
-	font = load_font(params["fontname"])
+    # Add font so it's available to Blender
+    font = load_font(params["fontname"])
 else:
-	# Get default font
-	font = bpy.data.fonts["Bfont"]
-	
+    # Get default font
+    font = bpy.data.fonts["Bfont"]
+
 text_object.font = font
 
 # Change the material settings (color, alpha, etc...)
@@ -115,9 +116,9 @@ bpy.context.scene.render.filepath = params["output_path"]
 bpy.context.scene.render.fps = params["fps"]
 bpy.context.scene.render.image_settings.file_format = params["file_format"]
 if params["use_alpha"] == "No":
-	bpy.context.scene.render.image_settings.color_mode = "RGB"
+    bpy.context.scene.render.image_settings.color_mode = "RGB"
 else:
-	bpy.context.scene.render.image_settings.color_mode = params["color_mode"]
+    bpy.context.scene.render.image_settings.color_mode = params["color_mode"]
 bpy.context.scene.render.film_transparent = params["alpha_mode"]
 bpy.context.scene.render.resolution_x = params["resolution_x"]
 bpy.context.scene.render.resolution_y = params["resolution_y"]
@@ -126,15 +127,14 @@ bpy.context.scene.frame_start = params["start_frame"]
 bpy.context.scene.frame_end = params["end_frame"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-animation_speed = int(params["animation_speed"])	# time remapping multiplier
-new_length = int(params["end_frame"]) * animation_speed	# new length (in frames)
+animation_speed = int(params["animation_speed"])  # time remapping multiplier
+new_length = int(params["end_frame"]) * animation_speed  # new length (in frames)
 bpy.context.scene.frame_end = new_length
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = animation_speed
 if params["start_frame"] == params["end_frame"]:
-	bpy.context.scene.frame_start = params["end_frame"]
-	bpy.context.scene.frame_end = params["end_frame"]
+    bpy.context.scene.frame_start = params["end_frame"]
+    bpy.context.scene.frame_end = params["end_frame"]
 
 # Render the current animation to the params["output_path"] folder
 bpy.ops.render.render(animation=params["animation"])
-


### PR DESCRIPTION
I noticed that the Python files in `src/blender/scripts` were indented with _tabs_ instead of spaces, and had other weird formatting issues, so I went through each of them and used Atom's Beautify tool (which mostly runs `autopep8` on the file) to fix the formatting, then did a quick visual scan to make sure it didn't do anything too weird.