### PR TITLE
Animated Titles: Use QPlainTextEdit for multi-line

### DIFF
--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -128,8 +128,8 @@ class BlenderListView(QListView):
                 self.params[param["name"]] = _(param["default"])
 
                 # create spinner
-                widget = QTextEdit()
-                widget.setText(_(param["default"]).replace("\\n", "\n"))
+                widget = QPlainTextEdit()
+                widget.setPlainText(_(param["default"]).replace("\\n", "\n"))
                 widget.textChanged.connect(functools.partial(self.text_value_changed, widget, param))
 
             elif param["type"] == "dropdown":
@@ -200,11 +200,11 @@ class BlenderListView(QListView):
 
     def text_value_changed(self, widget, param, value=None):
         try:
-            # Attempt to load value from QTextEdit (i.e. multi-line)
+            # Attempt to load value from QPlainTextEdit (i.e. multi-line)
             if not value:
                 value = widget.toPlainText()
-        except:
-            pass
+        except Exception:
+            return
         self.params[param["name"]] = value.replace("\n", "\\n")
         # XXX: This will log every individual KEYPRESS in the text field.
         # log.info('Animation param %s set to %s' % (param["name"], value))

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -47,15 +47,6 @@ from windows.models.blender_model import BlenderModel
 
 import json
 
-class QBlenderEvent(QEvent):
-    """ A custom Blender QEvent, which can safely be sent from the Blender thread to the Qt thread (to communicate) """
-
-    def __init__(self, id, data=None, *args):
-        # Invoke parent init
-        QEvent.__init__(self, id)
-        self.data = data
-        self.id = id
-
 
 class BlenderListView(QListView):
     """ A TreeView QWidget used on the animated title window """


### PR DESCRIPTION
Qt offers [QPlainTextEdit](https://doc.qt.io/qt-5/qplaintextedit.html) which is supposed to be slightly faster in some situations than QTextEdit, and since we're _always_ explicitly accessing the content as plain text, it just makes sense.

(Also, another "while I was in there": The `QBlenderEvent` class was entirely unused, so I yanked it.)