### PR TITLE
JSON: Lower indent level on formatted data

### DIFF
--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -144,7 +144,7 @@ class JsonDataStore:
     def write_to_file(self, file_path, data, path_mode="ignore", previous_path=None):
         """ Save JSON settings to a file """
         try:
-            contents = json.dumps(data, indent=4)
+            contents = json.dumps(data, indent=1)
             if path_mode == "relative":
                 # Convert any paths to relative
                 contents = self.convert_paths_to_relative(file_path, previous_path, contents)

--- a/src/windows/file_properties.py
+++ b/src/windows/file_properties.py
@@ -132,7 +132,7 @@ class FileProperties(QDialog):
         self.txtAudioBitRate.setValue(int(self.file.data["audio_bit_rate"]))
 
         # Populate output field
-        self.txtOutput.setText(json.dumps(file.data, sort_keys=True, indent=4, separators=(',', ': ')))
+        self.txtOutput.setText(json.dumps(file.data, sort_keys=True, indent=2))
 
         # Add channel layouts
         channel_layout_index = 0


### PR DESCRIPTION
- classes.json_data: Write output files with `indent=1`
- windows/file_properties: Format "Output" listing with `indent=2` (due to the proportional font)
    - (I also removed a `separators` arg from the file properties call, as it was set to the default values anyway.)

I'm all for pretty-printing, but JSON is a verbose enough format that all of the extra indentation just makes things unnecessarily wide, especially since our data is pretty heavily nested.

Before (excerpt:)
```json
{
    "id": "27F47U42V0",
    "fps": {
        "num": 30,
        "den": 1
    },
    "display_ratio": {
        "num": 16,
        "den": 9
    },
    "pixel_ratio": {
        "num": 1,
        "den": 1
    },
    "width": 1280,
    "height": 720,
    "sample_rate": 48000,
    "channels": 2,
    "channel_layout": 3,
    "settings": {},
    "clips": [
        {
            "alpha": {
                "Points": [
                    {
                        "co": {
                            "X": 1.0,
                            "Y": 1.0
                        },
                        "interpolation": 2
                    }
                ]
            },
            "anchor": 0,
            "channel_filter": {
                "Points": [
                    {
                        "co": {
                            "X": 1.0,
                            "Y": -1.0
                        },
                        "interpolation": 2
                    }
                ]
            },
```

After (same excerpt):
```json
{
 "id": "27F47U42V0",
 "fps": {
  "num": 30,
  "den": 1
 },
 "display_ratio": {
  "num": 16,
  "den": 9
 },
 "pixel_ratio": {
  "num": 1,
  "den": 1
 },
 "width": 1280,
 "height": 720,
 "sample_rate": 48000,
 "channels": 2,
 "channel_layout": 3,
 "settings": {},
 "clips": [
  {
   "alpha": {
    "Points": [
     {
      "co": {
       "X": 1.0,
       "Y": 1.0
      },
      "interpolation": 2
     }
    ]
   },
   "anchor": 0,
   "channel_filter": {
    "Points": [
     {
      "co": {
       "X": 1.0,
       "Y": -1.0
      },
      "interpolation": 2
     }
    ]
   },
```