### PR TITLE
Profile dialog: Remove skip_first, fix loading

### DIFF
--- a/src/windows/profile.py
+++ b/src/windows/profile.py
@@ -27,7 +27,6 @@
 
 import os
 import sys
-import functools
 
 from PyQt5.QtCore import *
 from PyQt5.QtGui import QIcon, QStandardItemModel, QStandardItem
@@ -52,27 +51,22 @@ class Profile(QDialog):
         # Create dialog class
         QDialog.__init__(self)
 
-        # Load UI from designer
+        # Load UI from designer & init
         ui_util.load_ui(self, self.ui_path)
-
-        # Init UI
         ui_util.init_ui(self)
 
         # get translations
         app = get_app()
         _ = app._tr
 
-        # Get settings
-        self.s = settings.get_settings()
-
         # Pause playback (to prevent crash since we are fixing to change the timeline's max size)
-        get_app().window.actionPlay_trigger(None, force="pause")
+        app.window.actionPlay_trigger(None, force="pause")
 
         # Track metrics
         track_metric_screen("profile-screen")
 
-        # Ignore first dropdown selected index callback (TODO: Find better way to avoid this)
-        self.skip_first = True
+        # Keep track of starting selection
+        self.initial_index = 0
 
         # Loop through profiles
         self.profile_names = []
@@ -93,7 +87,6 @@ class Profile(QDialog):
 
         # Loop through sorted profiles
         box_index = 0
-        selected_index = 0
         for profile_name in self.profile_names:
 
             # Add to dropdown
@@ -101,27 +94,21 @@ class Profile(QDialog):
 
             # Set default (if it matches the project)
             if app.project.get(['profile']) in profile_name:
-                selected_index = box_index
+                self.initial_index = box_index
 
             # increment item counter
             box_index += 1
 
-
-        # Connect signal
-        self.cboProfile.currentIndexChanged.connect(functools.partial(self.dropdown_index_changed, self.cboProfile))
+        # Connect signals
+        self.cboProfile.currentIndexChanged.connect(self.dropdown_index_changed)
+        self.cboProfile.activated.connect(self.dropdown_activated)
 
         # Set current item (from project)
-        self.cboProfile.setCurrentIndex(selected_index)
+        self.cboProfile.setCurrentIndex(self.initial_index)
 
-    def dropdown_index_changed(self, widget, index):
-        # Ignore first callback
-        if self.skip_first:
-            self.skip_first = False
-            return
-
+    def dropdown_index_changed(self, index):
         # Get profile path
         value = self.cboProfile.itemData(index)
-        log.info(value)
 
         # Load profile
         profile = openshot.Profile(value)
@@ -130,6 +117,17 @@ class Profile(QDialog):
         self.lblSize.setText("%sx%s" % (profile.info.width, profile.info.height))
         self.lblFPS.setText("%0.2f" % (profile.info.fps.num / profile.info.fps.den))
         self.lblOther.setText("DAR: %s/%s, SAR: %s/%s, Interlaced: %s" % (profile.info.display_ratio.num, profile.info.display_ratio.den, profile.info.pixel_ratio.num, profile.info.pixel_ratio.den, profile.info.interlaced_frame))
+
+    def dropdown_activated(self, index):
+        # Ignore if the selection wasn't changed
+        if index == self.initial_index:
+            return
+
+        # Get profile path
+        value = self.cboProfile.itemData(index)
+
+        # Load profile
+        profile = openshot.Profile(value)
 
         # Get current FPS (prior to changing)
         current_fps = get_app().project.get("fps")
@@ -141,7 +139,7 @@ class Profile(QDialog):
         get_app().updates.update(["profile"], profile.info.description)
         get_app().updates.update(["width"], profile.info.width)
         get_app().updates.update(["height"], profile.info.height)
-        get_app().updates.update(["fps"], {"num" : profile.info.fps.num, "den" : profile.info.fps.den})
+        get_app().updates.update(["fps"], {"num": profile.info.fps.num, "den": profile.info.fps.den})
         get_app().updates.update(["display_ratio"], {"num": profile.info.display_ratio.num, "den": profile.info.display_ratio.den})
         get_app().updates.update(["pixel_ratio"], {"num": profile.info.pixel_ratio.num, "den": profile.info.pixel_ratio.den})
 
@@ -152,8 +150,9 @@ class Profile(QDialog):
         # Force ApplyMapperToClips to apply these changes
         get_app().window.timeline_sync.timeline.ApplyMapperToClips()
 
-        # Update Window Title
+        # Update Window Title and stored index
         get_app().window.SetWindowTitle(profile.info.description)
+        self.initial_index = index
 
         # Refresh frame (since size of preview might have changed)
         QTimer.singleShot(500, get_app().window.refreshFrameSignal.emit)


### PR DESCRIPTION
Since eae7170494118af6dca5b30d972d80f3f54e1c6b the profile dialog hasn't displayed the selected profile information on initial load, as `skip_first` was preventing the initial refresh.

This PR breaks out the update logic into two separate slots, connected to different signals:
- `dropdown_index_changed` takes the `currentIndexChanged()` signal and just refreshes the dialog display, including on initial load
- `dropdown_activated` will receive the `activated()` signal, which is sent only on user interaction (not when the code updates the combo-box), and will perform the actual project data update if the selection has actually changed

Also:
- Removed the unused local Settings handle
- Removed the unused `widget` argument to the slot(s)
- Removed the bare debug-printf logging of the profile-file's full path every time `dropdown_index_changed` is called