### PR TITLE
JavaScript: Fixes to comparisons, iteration

### DIFF
--- a/src/timeline/app.js
+++ b/src/timeline/app.js
@@ -65,7 +65,7 @@ var App = angular.module('openshot-timeline', ['ui.bootstrap','ngAnimate']);
 	
 	// Bind to keydown event (to detect SHIFT)
 	$( "body" ).keydown(function(event) {
-	  if (event.which==16)
+	  if (event.which === 16)
     	$('body').scope().shift_pressed = true;
 	});
 	$( "body" ).keyup(function(event) {
@@ -73,4 +73,3 @@ var App = angular.module('openshot-timeline', ['ui.bootstrap','ngAnimate']);
 	  	$('body').scope().shift_pressed = false;
 	});
 });
-

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -397,7 +397,7 @@ App.controller('TimelineCtrl',function($scope) {
 
 	  // Determine actual x coordinate (over timeline)
       var center_x = Math.max(cursor_x - track_labels_width, 0);
-      if (cursor_x == 0) {
+      if (cursor_x === 0) {
 		center_x = 0;
       }
 
@@ -977,7 +977,7 @@ $scope.SetTrackLabel = function (label) {
 
 		// Compare position of track to Y param (for unlocked tracks)
 		if (!layer.lock) {
-			if ((top < layer.y && top > bounding_box.track_position) || bounding_box.track_position==0) {
+			if ((top < layer.y && top > bounding_box.track_position) || bounding_box.track_position === 0) {
 				// return first matching layer
 				bounding_box.track_position = layer.y;
 			}
@@ -1205,7 +1205,7 @@ $scope.SetTrackLabel = function (label) {
 	}
 	
 	// no nearby found?
-	if (smallest_diff == 900.0) {
+	if (smallest_diff === 900.0) {
 		smallest_diff = 0.0;
 	}
 	
@@ -1440,7 +1440,7 @@ $scope.SetTrackLabel = function (label) {
 // ############ DEBUG STUFFS ################## //
 
  $scope.ToggleDebug = function() {
-	 if ($scope.debug == true) {
+	 if ($scope.debug === true) {
 		 $scope.debug = false;
 	 }
 	 else {

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -320,20 +320,18 @@ App.controller('TimelineCtrl',function($scope) {
 	    }
 	    // Determine if this property is a Keyframe
 	 	if (typeof object[child] == "object" && "Points" in object[child]) {
-			for (var point = 0; point < object[child].Points.length; point++) {
-				var co = object[child].Points[point].co;
-				if (co.X >= clip_start_x && co.X <= clip_end_x)
+			for (const point of object[child].Points) {
+				if (point.co.X >= clip_start_x && point.co.X <= clip_end_x)
 					// Only add keyframe coordinates that are within the bounds of the clip
-					keyframes[co.X] = co.Y;
+					keyframes[point.co.X] = point.co.Y;
 			}
 		}
 	    // Determine if this property is a Color Keyframe
 	 	if (typeof object[child] == "object" && "red" in object[child]) {
-			for (var point = 0; point < object[child]["red"].Points.length; point++) {
-				var co = object[child]["red"].Points[point].co;
-				if (co.X >= clip_start_x && co.X <= clip_end_x)
+			for (const point of object[child]["red"].Points) {
+				if (point.co.X >= clip_start_x && point.co.X <= clip_end_x)
 					// Only add keyframe coordinates that are within the bounds of the clip
-					keyframes[co.X] = co.Y;
+					keyframes[point.co.X] = point.co.Y;
 			}
 		}
 	}
@@ -348,20 +346,18 @@ App.controller('TimelineCtrl',function($scope) {
 				}
 				// Determine if this property is a Keyframe
 				if (typeof object["effects"][effect][child] == "object" && "Points" in object["effects"][effect][child]) {
-					for (var point = 0; point < object["effects"][effect][child].Points.length; point++) {
-						var co = object["effects"][effect][child].Points[point].co;
-						if (co.X >= clip_start_x && co.X <= clip_end_x)
+					for (const point of object["effects"][effect][child].Points) {
+						if (point.co.X >= clip_start_x && point.co.X <= clip_end_x)
 							// Only add keyframe coordinates that are within the bounds of the clip
-							keyframes[co.X] = co.Y;
+							keyframes[point.co.X] = point.co.Y;
 					}
 				}
 				// Determine if this property is a Color Keyframe
 				if (typeof object["effects"][effect][child] == "object" && "red" in object["effects"][effect][child]) {
-					for (var point = 0; point < object["effects"][effect][child]["red"].Points.length; point++) {
-						var co = object["effects"][effect][child]["red"].Points[point].co;
-						if (co.X >= clip_start_x && co.X <= clip_end_x)
+					for (const point of object["effects"][effect][child]["red"].Points) {
+						if (point.co.X >= clip_start_x && point.co.X <= clip_end_x)
 							// Only add keyframe coordinates that are within the bounds of the clip
-							keyframes[co.X] = co.Y;
+							keyframes[point.co.X] = point.co.Y;
 					}
 				}
 			}
@@ -425,12 +421,12 @@ App.controller('TimelineCtrl',function($scope) {
  // Set the audio data for a clip
  $scope.setAudioData = function(clip_id, audio_data) {
  	// Find matching clip
-	for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-		if ($scope.project.clips[clip_index].id == clip_id) {
+	for (const clip of $scope.project.clips) {
+		if (clip.id == clip_id) {
 			// Set audio data
 			$scope.$apply(function(){
-				$scope.project.clips[clip_index].audio_data = audio_data;
-				$scope.project.clips[clip_index].show_audio = true;
+				clip.audio_data = audio_data;
+				clip.show_audio = true;
 			});
 			timeline.qt_log("Audio data successful set on clip JSON");
 			break;
@@ -444,12 +440,12 @@ App.controller('TimelineCtrl',function($scope) {
  // Hide the audio waveform for a clip
  $scope.hideAudioData = function(clip_id, audio_data) {
  	// Find matching clip
-	for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-		if ($scope.project.clips[clip_index].id == clip_id) {
+	for (const clip of $scope.project.clips) {
+		if (clip.id == clip_id) {
 			// Set audio data
 			$scope.$apply(function(){
-				$scope.project.clips[clip_index].show_audio = false;
-				$scope.project.clips[clip_index].audio_data = [];
+				clip.show_audio = false;
+				clip.audio_data = [];
 			});
 			break;
 		}
@@ -459,10 +455,10 @@ App.controller('TimelineCtrl',function($scope) {
  // Redraw all audio waveforms on the timeline (if any)
  $scope.reDrawAllAudioData = function() {
  	// Find matching clip
-	for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-		if ("audio_data" in $scope.project.clips[clip_index] && $scope.project.clips[clip_index].audio_data.length > 0) {
+	for (const clip of $scope.project.clips) {
+		if ("audio_data" in clip && clip.audio_data.length > 0) {
 			// Redraw audio data (since it has audio data)
-			drawAudio($scope, $scope.project.clips[clip_index].id);
+			drawAudio($scope, clip.id);
 		}
 	}
  };
@@ -470,8 +466,8 @@ App.controller('TimelineCtrl',function($scope) {
  // Does clip have audio_data?
  $scope.hasAudioData = function(clip_id) {
  	// Find matching clip
-	for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-		if ($scope.project.clips[clip_index].id == clip_id && "audio_data" in $scope.project.clips[clip_index] && $scope.project.clips[clip_index].audio_data.length > 0) {
+	for (const clip of $scope.project.clips) {
+		if (clip.id == clip_id && "audio_data" in clip && clip.audio_data.length > 0) {
 			return true;
 			break;
 		}
@@ -581,11 +577,11 @@ App.controller('TimelineCtrl',function($scope) {
 
 	// Update scope
 	$scope.$apply(function() {
-		for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-			$scope.project.clips[clip_index].selected = false;
+		for (const clip of $scope.project.clips) {
+			clip.selected = false;
 		}
-		for (var effect_index = 0; effect_index < $scope.project.effects.length; effect_index++) {
-			$scope.project.effects[effect_index].selected = false;
+		for (const effect of $scope.project.effects) {
+			effect.selected = false;
 		}
 	});
  };
@@ -594,14 +590,14 @@ App.controller('TimelineCtrl',function($scope) {
  $scope.SelectAll = function() {
 	 $scope.$apply(function() {
 		 // Select all clips
-		 for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-			 $scope.project.clips[clip_index].selected = true;
-			 timeline.addSelection($scope.project.clips[clip_index].id, "clip", false);
+		 for (const clip of $scope.project.clips) {
+			 clip.selected = true;
+			 timeline.addSelection(clip.id, "clip", false);
 		 }
 		 // Select all transitions
-		 for (var effect_index = 0; effect_index < $scope.project.effects.length; effect_index++) {
-			 $scope.project.effects[effect_index].selected = true;
-			 timeline.addSelection($scope.project.effects[effect_index].id, "transition", false);
+		 for (const effect of $scope.project.effects) {
+			 effect.selected = true;
+			 timeline.addSelection(effect.id, "transition", false);
 		 }
 	 });
  };
@@ -632,17 +628,17 @@ App.controller('TimelineCtrl',function($scope) {
 	}
  	
  	// Unselect all clips
-	for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-		if ($scope.project.clips[clip_index].id == id) {
-			$scope.project.clips[clip_index].selected = true;
+	for (const clip of $scope.project.clips) {
+		if (clip.id == id) {
+			clip.selected = true;
 			if ($scope.Qt) {
 				timeline.addSelection(id, "clip", clear_selections);
 			}
 		}
 		else if (clear_selections && !is_ctrl) {
-			$scope.project.clips[clip_index].selected = false;
+			clip.selected = false;
 			if ($scope.Qt) {
-	 			timeline.removeSelection($scope.project.clips[clip_index].id, "clip");
+	 			timeline.removeSelection(clip.id, "clip");
 			}
 		}
 	}
@@ -675,16 +671,16 @@ App.controller('TimelineCtrl',function($scope) {
 	}
 
  	// Unselect all transitions
-	for (var tran_index = 0; tran_index < $scope.project.effects.length; tran_index++) {
-		if ($scope.project.effects[tran_index].id == id) {
-			$scope.project.effects[tran_index].selected = true;
+	for (const tran of $scope.project.effects) {
+		if (tran.id == id) {
+			tran.selected = true;
 		 	if ($scope.Qt)
 				timeline.addSelection(id, "transition", clear_selections);
 		}
 		else if (clear_selections && !is_ctrl) {
-			$scope.project.effects[tran_index].selected = false;
+			tran.selected = false;
 		 	if ($scope.Qt)
-			 	timeline.removeSelection($scope.project.effects[tran_index].id, "transition");
+			 	timeline.removeSelection(tran.id, "transition");
 		}
 	}
  };
@@ -710,8 +706,7 @@ App.controller('TimelineCtrl',function($scope) {
  $scope.ResizeTimeline = function() {
  	// Unselect all clips
 	var furthest_right_edge = 0;
-	for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-		var clip = $scope.project.clips[clip_index];
+	for (const clip of $scope.project.clips) {
 		var right_edge = clip.position + (clip.end - clip.start);
 		if (right_edge > furthest_right_edge)
 			furthest_right_edge = right_edge;
@@ -901,20 +896,20 @@ $scope.SetTrackLabel = function (label) {
  	// Select new clip object (and unselect others)
 	// This needs to be done inline due to async issues with the
 	// above calls to SelectClip/SelectTransition
-	for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-		if ($scope.project.clips[clip_index].id == item_id) {
-			$scope.project.clips[clip_index].selected = true;
+	for (const clip of $scope.project.clips) {
+		if (clip.id == item_id) {
+			clip.selected = true;
 		} else {
-			$scope.project.clips[clip_index].selected = false;
+			clip.selected = false;
 		}
 	}
 
 	// Select new transition object (and unselect others)
-	for (var tran_index = 0; tran_index < $scope.project.effects.length; tran_index++) {
-		if ($scope.project.effects[tran_index].id == item_id) {
-			$scope.project.effects[tran_index].selected = true;
+	for (const tran of $scope.project.effects) {
+		if (tran.id == item_id) {
+			tran.selected = true;
 		} else {
-			$scope.project.effects[tran_index].selected = false;
+			tran.selected = false;
 		}
 	}
 
@@ -972,9 +967,7 @@ $scope.SetTrackLabel = function (label) {
 	}
 	// Loop through each layer (looking for the closest track based on Y coordinate)
 	bounding_box.track_position = 0;
-	for (var layer_index = $scope.project.layers.length - 1; layer_index >= 0 ; layer_index--) {
-		var layer = $scope.project.layers[layer_index];
-
+	for (const layer of $scope.project.layers) {
 		// Compare position of track to Y param (for unlocked tracks)
 		if (!layer.lock) {
 			if ((top < layer.y && top > bounding_box.track_position) || bounding_box.track_position === 0) {
@@ -1004,9 +997,7 @@ $scope.SetTrackLabel = function (label) {
 
 	 $scope.$apply(function() {
 		 // Loop through each layer
-		for (var layer_index = 0; layer_index < $scope.project.layers.length; layer_index++) {
-			var layer = $scope.project.layers[layer_index];
-			
+		for (const layer of $scope.project.layers) {
 			// Find element on screen (bound to this layer)
 			var layer_elem = $("#track_" + layer.number);
 			if (layer_elem) {
@@ -1075,9 +1066,7 @@ $scope.SetTrackLabel = function (label) {
  	var original_right = original_clip.position + (original_clip.end - original_clip.start);
 	
 	// Search through all other clips on this track, and look for overlapping ones
-	for (var index = 0; index < $scope.project.clips.length; index++) {
-		var clip = $scope.project.clips[index];
-
+	for (const clip of $scope.project.clips) {
 		// skip clips that are not on the same layer
 		if (original_clip.layer != clip.layer) {
 			continue;
@@ -1105,9 +1094,7 @@ $scope.SetTrackLabel = function (label) {
 	}
 	// Search through all existing transitions, and don't overlap an existing one
 	if (transition_size != null) {
-		for (var tran_index = 0; tran_index < $scope.project.effects.length; tran_index++) {
-			var tran = $scope.project.effects[tran_index];
-
+		for (const tran of $scope.project.effects) {
 			// skip transitions that are not on the same layer
 			if (tran.layer != transition_size.layer) {
 				continue;
@@ -1140,12 +1127,9 @@ $scope.SetTrackLabel = function (label) {
 	var diffs = [];
 
 	// Loop through each pixel position (supports multiple positions: i.e. left and right side of bounding box)
-	for (var pos_index = 0; pos_index < pixel_positions.length; pos_index++) {
-		var position = pixel_positions[pos_index];
-
+	for (const position of pixel_positions) {
 		// Add clip positions to array
-		for (var index = 0; index < $scope.project.clips.length; index++) {
-			var clip = $scope.project.clips[index];
+		for (const clip of $scope.project.clips) {
 			var clip_left_position = clip.position * $scope.pixelsPerSecond;
 			var clip_right_position = (clip.position + (clip.end - clip.start)) * $scope.pixelsPerSecond;
 
@@ -1159,8 +1143,7 @@ $scope.SetTrackLabel = function (label) {
 		}
 		
 		// Add transition positions to array
-		for (var index = 0; index < $scope.project.effects.length; index++) {
-			var transition = $scope.project.effects[index];
+		for (const transition of $scope.project.effects) {
 			var tran_left_position = transition.position * $scope.pixelsPerSecond;
 			var tran_right_position = (transition.position + (transition.end - transition.start)) * $scope.pixelsPerSecond;
 
@@ -1169,14 +1152,13 @@ $scope.SetTrackLabel = function (label) {
 			if (ignore_ids.hasOwnProperty(transition.id)) {
 				continue;
 			}
-			
+
 			diffs.push({'diff' : position - tran_left_position, 'position' : tran_left_position}, // left side of transition
 			           {'diff' : position - tran_right_position, 'position' : tran_right_position}); // right side of transition
 		}
 
 		// Add marker positions to array
-		for (var index = 0; index < $scope.project.markers.length; index++) {
-			var marker = $scope.project.markers[index];
+		for (const marker of $scope.project.markers) {
 			var marker_position = marker.position * $scope.pixelsPerSecond;
 
 			diffs.push({'diff' : position - marker_position, 'position' : marker_position}, // left side of marker
@@ -1187,19 +1169,19 @@ $scope.SetTrackLabel = function (label) {
 		var playhead_pixel_position = $scope.project.playhead_position * $scope.pixelsPerSecond;
 		var playhead_diff = position - playhead_pixel_position;
 		diffs.push({'diff' : playhead_diff, 'position' : playhead_pixel_position });
-		
+
 		// Loop through diffs (and find the smallest one)
-		for (var diff_index = 0; diff_index < diffs.length; diff_index++) {
-			var diff = diffs[diff_index].diff;
-			var position = diffs[diff_index].position;
+		for (const each_diff of diffs) {
+			var diff = each_diff.diff;
+			var diff_position = each_diff.position;
 			var abs_diff = Math.abs(diff);
-			
+
 			// Check if this clip is nearby
 			if (abs_diff < smallest_abs_diff && abs_diff <= threshold) {
 				// This one is smaller
 				smallest_diff = diff;
 				smallest_abs_diff = abs_diff;
-				snapping_position = position;
+				snapping_position = diff_position;
 			}
 		}
 	}
@@ -1294,9 +1276,7 @@ $scope.SetTrackLabel = function (label) {
  $scope.ApplyJsonDiff = function(jsonDiff) {
 
 	 // Loop through each UpdateAction
-	for (var action_index = 0; action_index < jsonDiff.length; action_index++) {
-		var action = jsonDiff[action_index];
-	 	
+	for (const action of jsonDiff) {
 		 // Iterate through the key levels (looking for a matching element in the $scope.project)
 		 var previous_object = null;
 		 var current_object = $scope.project;

--- a/src/timeline/js/directives/playhead.js
+++ b/src/timeline/js/directives/playhead.js
@@ -43,7 +43,7 @@ App.directive('tlPlayhead', function(){
 
 			// Move playhead to new position (if it's not currently being animated)
 			element.on('mousemove', function(e){
-				if (e.which == 1 && !scope.playhead_animating) { // left button
+				if (e.which === 1 && !scope.playhead_animating) { // left button
 					var playhead_seconds = (e.pageX - $("#ruler").offset().left) / scope.pixelsPerSecond;
 					scope.MovePlayhead(playhead_seconds);
 					scope.PreviewFrame(playhead_seconds);
@@ -53,5 +53,3 @@ App.directive('tlPlayhead', function(){
 		}
 	};
 });
-
-

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -56,7 +56,7 @@ App.directive('tlScrollableTracks', function () {
 
 			// Initialize panning when middle mouse is clicked
 			element.on('mousedown', function(e) {
-				if (e.which == 2) { // middle button
+				if (e.which === 2) { // middle button
 					e.preventDefault();
 					is_scrolling = true;
 					starting_scrollbar = { x: element.scrollLeft(), y: element.scrollTop() };
@@ -93,7 +93,7 @@ App.directive('tlBody', function () {
 		link: function (scope, element, attrs){
 
 			element.on('mouseup', function(e){
-				if (e.which == 2) // middle button
+				if (e.which === 2) // middle button
 					is_scrolling = false;
 			});
 
@@ -170,10 +170,10 @@ App.directive('tlRuler', function ($timeout) {
 							ctx.beginPath();
 
 							//if it's even, make the line longer
-							if (x%2 == 0){
+							if (x%2 === 0){
 								line_top = 18;
 								//if it's not the first line, set the time text
-								if (x != 0){
+								if (x !== 0){
 									//get time for this tick
 									time = (scale * x) /2;
 									time_text = secondsToTime(time, scope.project.fps.num, scope.project.fps.den);
@@ -219,7 +219,7 @@ App.directive('tlRulertime', function () {
 
 			// Move playhead to new position (if it's not currently being animated)
 			element.on('mousemove', function(e){
-				if (e.which == 1 && !scope.playhead_animating) { // left button
+				if (e.which === 1 && !scope.playhead_animating) { // left button
 					var playhead_seconds = 0.0;
 					// Update playhead
 					scope.MovePlayhead(playhead_seconds);
@@ -231,8 +231,3 @@ App.directive('tlRulertime', function () {
 		}
 	};
 });
-
-
-
-
-

--- a/src/timeline/js/directives/track.js
+++ b/src/timeline/js/directives/track.js
@@ -76,15 +76,15 @@ App.directive('tlTrack', function($timeout) {
 		       			// Remove all selections
 						if ($(".ui-selected").length > 1)
 						{
-							for (var clip_index = 0; clip_index < scope.project.clips.length; clip_index++) {
-								scope.project.clips[clip_index].selected = false;
+							for (const clip of scope.project.clips) {
+								clip.selected = false;
 								if (scope.Qt)
-									timeline.removeSelection(scope.project.clips[clip_index].id.replace("clip_", ""), "clip");
+									timeline.removeSelection(clip.id.replace("clip_", ""), "clip");
 							}
-							for (var tran_index = 0; tran_index < scope.project.effects.length; tran_index++) {
-								scope.project.effects[tran_index].selected = false;
+							for (const tran of scope.project.effects) {
+								tran.selected = false;
 								if (scope.Qt)
-									timeline.removeSelection(scope.project.effects[tran_index].id.replace("transition_", ""), "transition");
+									timeline.removeSelection(tran.id.replace("transition_", ""), "transition");
 							}
 						}
 						
@@ -160,11 +160,9 @@ App.directive('tlTrack', function($timeout) {
 					// Add missing transitions (if any)
 					if (dropped_clips.length === 1)
 						// Hack to only add missing transitions if a single clip is being dropped
-						for (var clip_index = 0; clip_index < dropped_clips.length; clip_index++) {
-							var item_data = dropped_clips[clip_index];
-
+						for (const clip of dropped_clips) {
 							// Check again for missing transitions
-							missing_transition_details = scope.GetMissingTransitions(item_data);
+							missing_transition_details = scope.GetMissingTransitions(clip);
 							if (scope.Qt && missing_transition_details != null)
 								timeline.add_missing_transition(JSON.stringify(missing_transition_details));
 						}

--- a/src/timeline/js/directives/track.js
+++ b/src/timeline/js/directives/track.js
@@ -125,7 +125,7 @@ App.directive('tlTrack', function($timeout) {
 		            			item_data = findElement(scope.project.effects, "id", item_num);
 
 							// set time diff (if not already determined)
-							if (position_diff == 0.0)
+							if (position_diff === 0.0)
 								// once calculated, we want to apply the exact same time diff to each clip/trans
 		            			position_diff = (item_left / scope.pixelsPerSecond) - item_data.position;
 
@@ -158,7 +158,7 @@ App.directive('tlTrack', function($timeout) {
 		            });
 
 					// Add missing transitions (if any)
-					if (dropped_clips.length == 1)
+					if (dropped_clips.length === 1)
 						// Hack to only add missing transitions if a single clip is being dropped
 						for (var clip_index = 0; clip_index < dropped_clips.length; clip_index++) {
 							var item_data = dropped_clips[clip_index];

--- a/src/timeline/js/functions.js
+++ b/src/timeline/js/functions.js
@@ -168,7 +168,7 @@ function findTrackAtLocation(scope, top){
 
 		// Compare position of track to Y param (of unlocked tracks)
         if (!layer.lock)
-            if ((top < layer.y && top > track_position) || track_position==0) {
+            if ((top < layer.y && top > track_position) || track_position === 0) {
                 // return first matching layer
                 track_position = layer.y;
                 track_number = layer.number;

--- a/src/timeline/js/functions.js
+++ b/src/timeline/js/functions.js
@@ -29,12 +29,10 @@
 
 // Find a JSON element / object with a particular value in the json data
 function findElement(arr, propName, propValue) {
-
   // Loop through array looking for a matching element
-  for (var i=0; i < arr.length; i++)
-    if (arr[i][propName] == propValue)
-      return arr[i];
-
+  for (const elem of arr)
+    if (elem[propName] == propValue)
+      return elem;
 }
 
 // Get the height of the track container (minus bottom margin of last track)
@@ -232,14 +230,14 @@ function setBoundingBox(scope, item){
 
     // Get list of current selected ids (so we can ignore their snapping x coordinates)
     bounding_box.selected_ids = {};
-    for (var clip_index = 0; clip_index < scope.project.clips.length; clip_index++) {
-        if (scope.project.clips[clip_index].selected) {
-            bounding_box.selected_ids[scope.project.clips[clip_index].id] = true;
+    for (const clip of scope.project.clips) {
+        if (clip.selected) {
+            bounding_box.selected_ids[clip.id] = true;
         }
     }
-    for (var effect_index = 0; effect_index < scope.project.effects.length; effect_index++) {
-        if (scope.project.effects[effect_index].selected) {
-            bounding_box.selected_ids[scope.project.effects[effect_index].id] = true;
+    for (const effect of scope.project.effects) {
+        if (effect.selected) {
+            bounding_box.selected_ids[effect.id] = true;
         }
     }
 }


### PR DESCRIPTION
As Codacy was kind enough to point out, we should:

### Use === and !== with bool, numbers
We should really be using `===` and `!==`, instead of `==` and `!=` (respectively) when comparing values to Number or Boolean, to ensure that we're not accidentally type-converting values unexpectedly.

### Iterate over arrays with `for...of` loops
`variable[key]` syntax [is evil](https://web.archive.org/web/20150430062816/https://blog.liftsecurity.io/2015/01/15/the-dangers-of-square-bracket-notation), which makes loops of the form `for (var index = 0; index < array.length; index++) { }` inherently problematic, because they're _going_ to access `array[index]` inside the loop.

Fortunately, there's a better way: [`for...of`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/statements/for...of). Not only is is better/safer, but it often makes the code _so_ much cleaner. So, I've replaced all of the indexed `for()` loops that looped over arrays from `[0 ... length]` with `for (const element of array) { }` loops. (Which is another advantage to `for...of` loops: The iterator variable can be `const`, if the array contents don't need to be modified.)

So `for...of` both cuts down on temporary variables and helps keep everything block-scoped. (`var` has [scoping issues](https://dev.to/johnwolfe820/should-you-never-truly-use-var-bdi). In fact, by changing to `const` iterator variables I already caught one function where a variable was being redeclared inside a large-ish loop. In that particular case it didn't matter, but the fact that `var` allows that to happen silently is a problem.)

As I said, I replaced all of the `for (index = 0; index < array.length; index++)` loops. I left a few indexed `for ()` loops alone, though, like the ones that iterated backwards over the list elements from `length - 1` to `0`. Basically, if it couldn't be trivially converted to `for...of`, I let it be.
