### PR TITLE
Make onLogTheEnd() a Python atexit function

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -31,6 +31,7 @@ import os
 import sys
 import platform
 import traceback
+import atexit
 from uuid import uuid4
 from PyQt5.QtWidgets import QApplication, QStyleFactory, QMessageBox
 from PyQt5.QtGui import QPalette, QColor, QFontDatabase, QFont
@@ -102,9 +103,6 @@ class OpenShotApp(QApplication):
         except Exception:
             pass
 			
-        # Connect QCoreApplication::aboutToQuit() signal to log end of the session
-        self.aboutToQuit.connect(self.onLogTheEnd)
-
         # Setup application
         self.setApplicationName('openshot')
         self.setApplicationVersion(info.SETUP['version'])
@@ -257,19 +255,17 @@ class OpenShotApp(QApplication):
         # return exit result
         return res
 
-    # Log the session's end
-    @pyqtSlot()
-    def onLogTheEnd(self):
-        """ Log when the primary Qt event loop ends """
+# Log the session's end
+@atexit.register
+def onLogTheEnd():
+    """ Log when the primary Qt event loop ends """
 
-        try:
-            from classes.logger import log
-            import time
-            log.info('OpenShot\'s session ended'.center(48))
-            log.info(time.asctime().center(48))
-            log.info("================================================")
-        except Exception:
-            pass
+    try:
+        from classes.logger import log
+        import time
+        log.info('OpenShot\'s session ended'.center(48))
+        log.info(time.asctime().center(48))
+        log.info("================================================")
+    except Exception:
+        pass
 
-        # return 0 on success
-        return 0


### PR DESCRIPTION
In #2936 @SuslikV added some much-needed bookending to our session logging, which is great to have.

The exit logging made use of a Qt signal `aboutToQuit`, which _seemed_ great at the time — the final log messages would be output when the program was, well, about to quit. Unfortunately, I subsequently discovered that In PyQt, things are a bit more complicated.

When running OpenShot in the interactive Python console (not a typical use case, but a helpful debugging technique I often do make use of), it seems that the `aboutToQuit` signal fires _every_ time the Qt event loop is suspended, including anytime it yields to the console! Literally every keypress in the interactive session would be followed by another repetition of the final end-of-session log messages, which made the console unusable.

Fortunately, Python to the rescue. This PR takes `onLogTheEnd()` and converts it from a Qt slot, into a Python function registered as an [`atexit`](https://docs.python.org/3.4/library/atexit.html) exit handler (via the `@atexit.register` decorator). This means that _Python_ (not Qt) will handle running it at termination of the program. That way, it will only be called _once_ per session, no matter how many times the Qt event loop yields. It'll also be called if Python aborts with a traceback, unlike the Qt slot. (@SuslikV: It even gets called after the unit tests complete.)