### PR TITLE
Add barebones .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,4 @@
+root = true
 [*]
 insert_final_newline = true
+end_of_line = 'lf'


### PR DESCRIPTION
This adds an `.editorconfig` file to the root of the project, which currently contains only three settings, applied to all files of any type:

```ini
root = true
[*]
insert_final_newline = true
end_of_line = 'lf'
```

The 'root' marker tells editors not to continue scanning the parents of the current directory for additional `.editorconfig` files. (By default editors first check the current directory, then walk up each parent member of its path.) The other two are self-explanatory.

Additional configs (like spaces-vs-tabs, indent width, etc., for various file types) can be added as we agree on what they should be.