### PR TITLE
Add Python and JavaScript rules to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,4 @@
+root = true
 [*]
 insert_final_newline = true
+end_of_line = 'lf'

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,13 @@ root = true
 [*]
 insert_final_newline = true
 end_of_line = 'lf'
+[*.py]
+charset = 'utf8'
+trim_trailing_whitespace = true
+indent_style = 'space'
+indent_size = 4
+[*.js]
+charset = 'utf8'
+trim_trailing_whitespace = true
+indent_style = 'space'
+indent_size = 2


### PR DESCRIPTION
This builds on #3029, and adds some basic Python and JavaScript style rules:

#### Python
* UTF-8 encoding
* Four-space indents
* No trailing whitespace

#### JavaScript
* UTF-8 encoding
* Two-space indents
* No trailing whitespace

These settings seem to be roughly in line with the existing codebase. (The indentation on the JavaScript code is actually a complete mess, it switches seemingly at random between four-, two-, and _one_-space indents mixed with tab indents.)