### PR TITLE
Remove default-project progress key

### DIFF
--- a/src/settings/_default.project
+++ b/src/settings/_default.project
@@ -66,7 +66,6 @@
     }
   ],
   "markers": [  ],
-  "progress": [  ],
   "history": {
     "undo": [],
     "redo": []

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -204,25 +204,6 @@ App.controller('TimelineCtrl',function($scope) {
 	           //        icon : 'purple.png'
 	           //      },
               // ],
-	  	progress : {}
-	  			// {
-				//    max_bytes : "0",
-				//    ranges : [
-				// 	  {
-				// 		 end : "30",
-				// 		 start : "0"
-				// 	  },
-				// 	  {
-				// 		 end : "40",
-				// 		 start : "50"
-				// 	  },
-				// 	  {
-				// 		 end : "100",
-				// 		 start : "150"
-				// 	  }
-				//    ],
-				//    version : "2"
-				// }
     };
   
   // Additional variables used to control the rendering of HTML


### PR DESCRIPTION
Project files contain an unused, empty list key `"progress"`, and the only reason it's there is because it's in the default file template. This PR removes it.
