### PR TITLE
Update timeline zoom directly, on project load

### DIFF
--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -200,6 +200,11 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
             initial_scale = get_app().project.get("scale") or 15
             get_app().window.sliderZoom.setValue(secondsToZoom(initial_scale))
 
+            # The setValue() above doesn't trigger update_zoom when a project file is
+            # loaded on the command line (too early?), so also call the JS directly
+            cmd = JS_SCOPE_SELECTOR + ".setScale(" + str(initial_scale) + ", 0);"
+            self.eval_js(cmd)
+
     # Javascript callable function to update the project data when a clip changes
     @pyqtSlot(str, bool, bool, bool)
     def update_clip_data(self, clip_json, only_basic_props=True, ignore_reader=False, ignore_refresh=False):
@@ -2613,7 +2618,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
         # Get access to timeline scope and set scale to new computed value
         cmd = JS_SCOPE_SELECTOR + ".setScale(" + str(newScale) + "," + str(cursor_x) + ");"
-        self.page().mainFrame().evaluateJavaScript(cmd)
+        self.eval_js(cmd)
 
         # Start timer to redraw audio
         self.redraw_audio_timer.start()


### PR DESCRIPTION
For reasons that are not _entirely_ clear to me, when a project file is loaded on the command line (or by double-clicking it in the OS file manager), the saved zoom level isn't applied to the timeline. The `update_zoom` slot _should_ be triggered in response to the `setValue()` call on `slider_zoom`, it's just... not. Perhaps we're jumping the gun on it being connected or something?

Regardless, in my testing just calling the JS `setScale()` function directly, immediately after setting the slider value, causes zoom to be set properly even when a project file is loaded at launch.