### PR TITLE
CONTRIBUTING: Correct filename of openshot logfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,10 @@
   2. Then enable 'Debug Mode (Verbose)' in the Preferences
   3. Quit OpenShot and delete both log files:
       * **Windows**: OpenShot stores its logs in your user profile directory (`%USERPROFILE%`, e.g. `C:\Users\username\`)
-        * **`%USERPROFILE%/.openshot_qt/openshot_qt.log`**
+        * **`%USERPROFILE%/.openshot_qt/openshot-qt.log`**
         * **`%USERPROFILE%/.openshot_qt/libopenshot.log`**
       * **Linux/MacOS**: OpenShot stores its logs in your home directory (`$HOME`, e.g. `/home/username/`)
-        * **`$HOME/.openshot_qt/openshot_qt.log`**
+        * **`$HOME/.openshot_qt/openshot-qt.log`**
         * **`$HOME/.openshot_qt/libopenshot.log`**
   4. Re-launch OpenShot and trigger the crash as quickly as possible (to keep the log files small)
   5. Attach **both** log files


### PR DESCRIPTION
@SuslikV mentioned way back in https://github.com/OpenShot/openshot-qt/issues/2114#issuecomment-487891990 that the filename was wrong (`openshot_qt.log` instead of `openshot-qt.log`), but nobody ever corrected it.