### PR TITLE
Fix favicon for timeline/index.html

### DIFF
--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -5,7 +5,7 @@
 		<META name="author" content="OpenShot Studios, LLC">
   		<META name="copyright" content="Copyright (c) 2008-2018 OpenShot Studios, LLC">
   		<META name="license" content="GPLv3">
-		<link rel="icon" type="image/png" href="../../xdg/openshot.png" />
+		<link rel="icon" type="image/png" href="../images/openshot.png" />
 		<title>OpenShot Timeline</title>
 		
 		<!-- JQuery & Angular -->


### PR DESCRIPTION
It's a stupid thing, but the HTML for the web timeline contains a favicon header tag that points to a nonexistent file.
