### PR TITLE
Stop messing with users' filename formatting

### DIFF
--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -157,7 +157,7 @@ class Export(QDialog):
             # Get just the filename
             parent_path, filename = os.path.split(get_app().project.current_filepath)
             filename, ext = os.path.splitext(filename)
-            self.txtFileName.setText(filename.replace("_", " ").replace("-", " ").capitalize())
+            self.txtFileName.setText(filename)
 
         # Default image type
         self.txtImageFormat.setText("-%05d.png")

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2020,7 +2020,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             # Get just the filename
             parent_path, filename = os.path.split(get_app().project.current_filepath)
             filename, ext = os.path.splitext(filename)
-            filename = filename.replace("_", " ").replace("-", " ").capitalize()
             self.setWindowTitle("%s %s [%s] - %s" % (save_indicator, filename, profile, "OpenShot Video Editor"))
 
     # Update undo and redo buttons enabled/disabled to available changes

--- a/src/windows/models/titles_model.py
+++ b/src/windows/models/titles_model.py
@@ -39,6 +39,7 @@ from classes.app import get_app
 
 import json
 
+
 class TitleStandardItemModel(QStandardItemModel):
     def __init__(self, parent=None):
         QStandardItemModel.__init__(self)
@@ -104,7 +105,7 @@ class TitlesModel():
             if name_parts[-1].isdigit():
                 suffix_number = name_parts[-1]
 
-            # get name of transition
+            # get name of title template
             title_name = fileBaseName.replace("_", " ").capitalize()
 
             # replace suffix number with placeholder (if any)
@@ -115,7 +116,7 @@ class TitlesModel():
                 title_name = self.app._tr(title_name)
 
             # Check for thumbnail path (in build-in cache)
-            thumb_path = os.path.join(info.IMAGES_PATH, "cache",  "{}.png".format(fileBaseName))
+            thumb_path = os.path.join(info.IMAGES_PATH, "cache", "{}.png".format(fileBaseName))
 
             # Check built-in cache (if not found)
             if not os.path.exists(thumb_path):
@@ -172,7 +173,7 @@ class TitlesModel():
             row.append(col)
 
             # Append ROW to MODEL (if does not already exist in model)
-            if not path in self.model_paths:
+            if path not in self.model_paths:
                 self.model.appendRow(row)
                 self.model_paths[path] = path
 


### PR DESCRIPTION
In a couple of places:
* The code to set the main window title
* The Export dialog generating its initial base export filename

we were processing the user's assigned project file name, replacing `_` and `-` characters with spaces and altering the capitalization. That's simply rude, and there's no reason to mess with the user's file naming.

If they want spaces in the name, they'll insert them. If they want their project file to be named `MY_OPENSHOT_PROJECT.osp`, then we should default to `MY_OPENSHOT_PROJECT.mp4` as the export filename.