### PR TITLE
Create Vertical profiles

### DIFF
--- a/src/profiles/vertical_1080p_30
+++ b/src/profiles/vertical_1080p_30
@@ -1,0 +1,11 @@
+description=HD Vertical 1080p 30 fps
+frame_rate_num=30
+frame_rate_den=1
+width=1080
+height=1920
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709

--- a/src/profiles/vertical_720p_30
+++ b/src/profiles/vertical_720p_30
@@ -1,0 +1,11 @@
+description=HD Vertical 720p 30 fps
+frame_rate_num=30
+frame_rate_den=1
+width=720
+height=1280
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709


### PR DESCRIPTION
The Instagram export preset lists two Vertical profiles among its profile options:

https://github.com/OpenShot/openshot-qt/blob/ff78c8943155b903171219352c727428c0871ac5/src/presets/instagram.xml#L21-L26

Problem is, neither profile exists. This PR creates them, in the brute-force manner of specifying an actual `720×1280` or `1080×1920` resolution and `9:16` aspect ratio. While it might be _better_ to export as standard `720p` or `1080p` video with rotation metadata (the same way this is typically handled by cellphones when recording vertical video), libopenshot lacks support for doing that currently. So, this should be considered a stopgap.
