### PR TITLE
Correct profile references

### DIFF
--- a/src/presets/instagram.xml
+++ b/src/presets/instagram.xml
@@ -22,7 +22,7 @@
 	<projectprofile>HD 720p 30 fps</projectprofile>
 	<projectprofile>HD 1080p 25 fps</projectprofile>
 	<projectprofile>HD 1080p 30 fps</projectprofile>
-	<projectprofile>HD Vertical 720p 30fps</projectprofile>
-	<projectprofile>HD Vertical 1080p 30fps</projectprofile>
+	<projectprofile>HD Vertical 720p 30 fps</projectprofile>
+	<projectprofile>HD Vertical 1080p 30 fps</projectprofile>
 	
 </export-option>

--- a/src/presets/twitter.xml
+++ b/src/presets/twitter.xml
@@ -21,8 +21,8 @@
 	<projectprofile>HD 720p 30 fps</projectprofile>
 	<projectprofile>HD 1080p 25 fps</projectprofile>
 	<projectprofile>HD 1080p 30 fps</projectprofile>
-	<projectprofile>HD Vertical 720p 30fps</projectprofile> 
-        <projectprofile>HD Vertical 1080p 30fps</projectprofile>
+	<projectprofile>HD Vertical 720p 30 fps</projectprofile> 
+        <projectprofile>HD Vertical 1080p 30 fps</projectprofile>
 
 
 


### PR DESCRIPTION
The Instagram and Twitter preset references to the Vertical profiles were missing a space, which causes the name not to show up in the export dialog. (And also means the profile can't actually be selected for export, more importantly.)