### PR TITLE
keyPressEvent: Remove key sequence debugging output

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1338,18 +1338,15 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         """ Process key press events and match with known shortcuts"""
         # Detect the current KeySequence pressed (including modifier keys)
         key_value = event.key()
-        print(key_value)
         modifiers = int(event.modifiers())
-        if (key_value > 0 and key_value != Qt.Key_Shift and key_value != Qt.Key_Alt and
-                    key_value != Qt.Key_Control and key_value != Qt.Key_Meta):
-            # A valid keysequence was detected
-            key = QKeySequence(modifiers + key_value)
-        else:
-            # No valid keysequence detected
+
+        # Abort handling if the key sequence is invalid
+        if (key_value <= 0 or key_value in
+           [Qt.Key_Shift, Qt.Key_Alt, Qt.Key_Control, Qt.Key_Meta]):
             return
 
-        # Debug
-        log.info("keyPressEvent: %s" % (key.toString()))
+        # A valid keysequence was detected
+        key = QKeySequence(modifiers + key_value)
 
         # Get the video player object
         player = self.preview_thread.player


### PR DESCRIPTION
`keyPressEvent` contained both a bare `print(key_value)` statement, and a separate log message for the subsequently-decoded keypress. This was no only redundant and annoying, it causes occasional tracebacks in users' logs. This example, from the logs included with #3056, is typical:

```
      logger:INFO 16777299
      logger:ERROR --- Logging error ---
      logger:ERROR Traceback (most recent call last):
      logger:ERROR   File "/usr/lib/python3.7/logging/__init__.py", line 1028, in emit
      logger:ERROR     stream.write(msg + self.terminator)
      logger:ERROR UnicodeEncodeError: 'utf-8' codec can't encode character '\udc53' in position 34: surrogates not allowed
      logger:ERROR Call stack:
      logger:ERROR   File "/usr/bin/openshot-qt", line 11, in <module>
      logger:ERROR     load_entry_point('openshot-qt==2.4.4', 'gui_scripts', 'openshot-qt')()
      logger:ERROR   File "/usr/lib/python3.7/site-packages/openshot_qt/launch.py", line 106, in main
      logger:ERROR     sys.exit(app.run())
      logger:ERROR   File "/usr/lib/python3.7/site-packages/openshot_qt/classes/app.py", line 186, in run
      logger:ERROR     res = self.exec_()
      logger:ERROR   File "/usr/lib/python3.7/site-packages/openshot_qt/windows/main_window.py", line 1292, in keyPressEvent
      logger:ERROR     log.info("keyPressEvent: %s" % (key.toString()))
      logger:ERROR Message: 'keyPressEvent: ៀ\udc53'
      logger:ERROR Arguments: ()
```

This PR removes both output lines. The results of keypresses can be logged by the actions they trigger, if necessary.

A conditional in `keyPressEvent()` is also inverted and simplified for readability.