### PR TITLE
Fix SVG image sequences

### DIFF
--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -206,7 +206,7 @@ class FilesListView(QListView):
 
         # Get just the file name
         (dirName, fileName) = os.path.split(file_path)
-        extensions = ["png", "jpg", "jpeg", "gif", "tif"]
+        extensions = ["png", "jpg", "jpeg", "gif", "tif", "svg"]
         match = re.findall(r"(.*[^\d])?(0*)(\d+)\.(%s)" % "|".join(extensions), fileName, re.I)
 
         if not match:


### PR DESCRIPTION
Almost six MONTHS ago in #2893, I added SVG image sequence support.

...to `src/windows/views/files_treeview.py`.

I somehow _**missed**_ adding the same support to `src/windows/views/files_listview.py`, which means that currently the user's ability to import SVG files as image sequences is dependent on which format they've selected for their Project Files listing.

Because that's terrible and I am stupid, this PR is a very belated fix to that problem.