### PR TITLE
Timeline: Refresh position on JSON load

### DIFF
--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -1479,7 +1479,10 @@ $scope.SetTrackLabel = function (label) {
 		scrollTop: 0,
 		scrollLeft: 0
 	 }, 'slow');
-	 
+
+     // Update playhead position and time readout
+     $scope.MovePlayhead($scope.project.playhead_position)
+
 	 // return true
 	 return true;
  };


### PR DESCRIPTION
This corrects a bug I discovered when working on #3033, where loading a new project file into an existing session doesn't refresh the time index display next to the ruler.