### PR TITLE
Thumbnail server: Some fixes

### DIFF
--- a/src/classes/thumbnail.py
+++ b/src/classes/thumbnail.py
@@ -33,6 +33,7 @@ import time
 from threading import Thread
 from classes import info
 from classes.query import File
+from classes.logger import log
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingMixIn
 
@@ -54,7 +55,7 @@ def GenerateThumbnail(file_path, thumb_path, thumbnail_frame, width, height, mas
     try:
         if reader.info.metadata.count("rotate"):
             rotate = float(reader.info.metadata.find("rotate").value()[1])
-    except:
+    except Exception:
         pass
 
     # Create thumbnail folder (if needed)
@@ -98,6 +99,14 @@ class httpThumbnailServerThread(Thread):
 
 class httpThumbnailHandler(BaseHTTPRequestHandler):
     """ This class handles HTTP requests to the HTTP thumbnail server above."""
+
+    def log_message(self, msg_format, *args):
+        """ Log message from HTTPServer """
+        log.info(msg_format % args)
+
+    def log_error(self, msg_format, *args):
+        """ Log error from HTTPServer """
+        log.error(msg_format % args)
 
     def do_GET(self):
         # Pause processing of request (since we don't currently use thread pooling, this allows

--- a/src/classes/thumbnail.py
+++ b/src/classes/thumbnail.py
@@ -151,12 +151,16 @@ class httpThumbnailHandler(BaseHTTPRequestHandler):
 
         # Locate thumbnail
         thumb_path = os.path.join(info.THUMBNAIL_PATH, file_id, "%s.png" % file_frame)
-        if not os.path.exists(thumb_path) and file_frame == 1:
-            # Try ID with no frame # (for backwards compatibility)
-            thumb_path = os.path.join(info.THUMBNAIL_PATH, "%s.png" % file_id)
-        if not os.path.exists(thumb_path) and file_frame != 1:
-            # Try with ID and frame # in filename (for backwards compatibility)
-            thumb_path = os.path.join(info.THUMBNAIL_PATH, "%s-%s.png" % (file_id, file_frame))
+        if not os.path.exists(thumb_path):
+            if file_frame == 1:
+                # Try ID with no frame # (for backwards compatibility)
+                alt_path = os.path.join(info.THUMBNAIL_PATH, "%s.png" % file_id)
+            else:
+                # Try with ID and frame # in filename (for backwards compatibility)
+                alt_path = os.path.join(info.THUMBNAIL_PATH, "%s-%s.png" % (file_id, file_frame))
+
+            if os.path.exists(alt_path):
+                thumb_path = alt_path
 
         if not os.path.exists(thumb_path):
             # Generate thumbnail (since we can't find it)

--- a/src/classes/thumbnail.py
+++ b/src/classes/thumbnail.py
@@ -58,7 +58,7 @@ def GenerateThumbnail(file_path, thumb_path, thumbnail_frame, width, height, mas
         pass
 
     # Create thumbnail folder (if needed)
-    parent_path, file_name = os.path.split(thumb_path)
+    parent_path = os.path.dirname(thumb_path)
     if not os.path.exists(parent_path):
         os.mkdir(parent_path)
 

--- a/src/classes/thumbnail.py
+++ b/src/classes/thumbnail.py
@@ -112,7 +112,7 @@ class httpThumbnailHandler(BaseHTTPRequestHandler):
             # Path is expected to have 3 matched components (third is optional though)
             #   /thumbnails/FILE-ID/FRAME-NUMBER/   or
             #   /thumbnails/FILE-ID/FRAME-NUMBER/path/
-            self.send_response(200)
+            self.send_response_only(200)
         else:
             self.send_error(404)
             return

--- a/src/classes/thumbnail.py
+++ b/src/classes/thumbnail.py
@@ -36,7 +36,7 @@ from classes.query import File
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingMixIn
 
-REGEX_THUMBNAIL_URL = re.compile(r"/thumbnails/(.+?)/(\d+)(/path/)?")
+REGEX_THUMBNAIL_URL = re.compile(r"/thumbnails/(?P<file_id>.+?)/(?P<file_frame>\d+)(?P<only_path>/path/)?")
 
 
 def GenerateThumbnail(file_path, thumb_path, thumbnail_frame, width, height, mask, overlay):
@@ -107,8 +107,8 @@ class httpThumbnailHandler(BaseHTTPRequestHandler):
 
         """ Process each GET request and return a value (image or file path)"""
         # Parse URL
-        url_output = REGEX_THUMBNAIL_URL.findall(self.path)
-        if url_output and len(url_output[0]) == 3:
+        url_output = REGEX_THUMBNAIL_URL.match(self.path)
+        if url_output and len(url_output.groups()) == 3:
             # Path is expected to have 3 matched components (third is optional though)
             #   /thumbnails/FILE-ID/FRAME-NUMBER/   or
             #   /thumbnails/FILE-ID/FRAME-NUMBER/path/
@@ -118,9 +118,9 @@ class httpThumbnailHandler(BaseHTTPRequestHandler):
             return
 
         # Get URL parts
-        file_id = url_output[0][0]
-        file_frame = int(url_output[0][1])
-        only_path = url_output[0][2]
+        file_id = url_output.group('file_id')
+        file_frame = int(url_output.group('file_frame'))
+        only_path = url_output.group('only_path')
 
         # Catch undefined calls
         if file_id == "undefined":


### PR DESCRIPTION
* Use `send_response_only()` to avoid logging (at ERROR level) successful thumbnail loads
* Name regular expression groups, access matches by name
* Use `match()` instead of `findall()`, to avoid unnecessary nesting of result
* Look up File object from supplied ID earlier, return 404 on lookup failures
  (This covers both the previous "undefined" condition, and IDs that aren't recognized)
* Fix output path for thumbnail generation (don't override with legacy/compatibility path)
* Add overrides for logging functions:
  -  log to Python `logging` instance
  - don't log server address (always `127.0.0.1`), timestamp