### PR TITLE
Export: Don't double file extensions

### DIFF
--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -711,10 +711,15 @@ class Export(QDialog):
         # Determine final exported file path (and replace blank paths with default ones)
         default_filename = "Untitled Project"
         default_folder = os.path.join(info.HOME_PATH)
-        if export_type != _("Image Sequence"):
-            file_name_with_ext = "%s.%s" % (self.txtFileName.text().strip() or default_filename, self.txtVideoFormat.text().strip())
-        else:
+        if export_type == _("Image Sequence"):
             file_name_with_ext = "%s%s" % (self.txtFileName.text().strip() or default_filename, self.txtImageFormat.text().strip())
+        else:
+            file_ext = self.txtVideoFormat.text().strip()
+            file_name_with_ext = self.txtFileName.text().strip() or default_filename
+            # Append extension, if not already present
+            if not file_name_with_ext.endswith(file_ext):
+                file_name_with_ext = '{}.{}'.format(file_name_with_ext, file_ext)
+
         export_file_path = os.path.join(self.txtExportFolder.text().strip() or default_folder, file_name_with_ext)
         log.info("Export path: %s" % export_file_path)
 


### PR DESCRIPTION
If the user includes the format string (extension) at the end of their filename, don't add it again.

Fixes #2510 
