### PR TITLE
Add socket, socketserver, http modules to freeze.py list

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -160,6 +160,8 @@ for project in ["libopenshot-audio", "libopenshot", "openshot-qt"]:
             src_files.append((git_log_path, "settings/%s.log" % project))
 
 if sys.platform == "win32":
+    extra_exe = {"base": None, "name": exe_name + "-cli.exe"}
+
     base = "Win32GUI"
     build_exe_options["include_msvcr"] = True
     exe_name += ".exe"
@@ -271,9 +273,9 @@ elif sys.platform == "linux":
                     "libpangoft2-1.0.so.0",
                     "libharfbuzz.so.0",
                     "libthai.so.0",
-                    ]
+                ]
                 and not libpath_file.startswith("libxcb-")
-               ) \
+                ) \
                or libpath_file in ["libgcrypt.so.11", "libQt5DBus.so.5", "libpng12.so.0", "libbz2.so.1.0", "libqxcb.so"]:
 
                 # Ignore missing files
@@ -322,18 +324,27 @@ build_exe_options["include_files"] = src_files + external_so_files
 # Set options
 build_options["build_exe"] = build_exe_options
 
+exes = [Executable("openshot_qt/launch.py",
+                   base=base,
+                   icon=os.path.join(PATH, "xdg", iconFile),
+                   shortcutName="%s" % info.PRODUCT_NAME,
+                   shortcutDir="ProgramMenuFolder",
+                   targetName=exe_name)]
+
+if extra_exe:
+    exes.append(Executable("openshot_qt/launch.py",
+                base=extra_exe.base,
+                icon=os.path.join(PATH, "xdg", iconFile),
+                targetName=extra_exe.name))
+
+
 # Create distutils setup object
 setup(name=info.PRODUCT_NAME,
       version=info.VERSION,
       description=info.DESCRIPTION,
       author=info.COMPANY_NAME,
       options=build_options,
-      executables=[Executable("openshot_qt/launch.py",
-                              base=base,
-                              icon=os.path.join(PATH, "xdg", iconFile),
-                              shortcutName="%s" % info.PRODUCT_NAME,
-                              shortcutDir="ProgramMenuFolder",
-                              targetName=exe_name)])
+      executables=exes)
 
 
 # Remove temporary folder (if SRC folder present)

--- a/freeze.py
+++ b/freeze.py
@@ -1,26 +1,26 @@
-""" 
+"""
  @file
  @brief cx_Freeze script to build OpenShot package with dependencies (for Mac and Windows)
  @author Jonathan Thomas <jonathan@openshot.org>
- 
+
  @section LICENSE
- 
+
  Copyright (c) 2008-2016 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
@@ -65,8 +65,27 @@ import shutil
 print (str(cx_Freeze))
 
 # Packages to include
-python_packages = ["os", "sys", "PyQt5", "openshot", "time", "uuid", "shutil", "threading", "subprocess",
-                                 "re", "math", "xml", "logging", "urllib", "requests", "zmq", "webbrowser", "json"]
+python_packages = ["os",
+                   "sys",
+                   "PyQt5",
+                   "openshot",
+                   "time",
+                   "uuid",
+                   "shutil",
+                   "threading",
+                   "subprocess",
+                   "re",
+                   "math",
+                   "xml",
+                   "logging",
+                   "urllib",
+                   "requests",
+                   "zmq",
+                   "webbrowser",
+                   "json",
+                   "http",
+                   "socket",
+                   "socketserver"]
 
 # Determine absolute PATH of OpenShot folder
 PATH = os.path.dirname(os.path.realpath(__file__))  # Primary openshot folder
@@ -256,7 +275,7 @@ elif sys.platform == "linux":
                 and not libpath_file.startswith("libxcb-")
                ) \
                or libpath_file in ["libgcrypt.so.11", "libQt5DBus.so.5", "libpng12.so.0", "libbz2.so.1.0", "libqxcb.so"]:
-              
+
                 # Ignore missing files
                 if os.path.exists(libpath):
                     filepath, filename = os.path.split(libpath)

--- a/freeze.py
+++ b/freeze.py
@@ -331,12 +331,13 @@ exes = [Executable("openshot_qt/launch.py",
                    shortcutDir="ProgramMenuFolder",
                    targetName=exe_name)]
 
-if extra_exe:
+try:
     exes.append(Executable("openshot_qt/launch.py",
-                base=extra_exe.base,
+                base=extra_exe['base'],
                 icon=os.path.join(PATH, "xdg", iconFile),
-                targetName=extra_exe.name))
-
+                targetName=extra_exe['name']))
+except NameError:
+    pass
 
 # Create distutils setup object
 setup(name=info.PRODUCT_NAME,


### PR DESCRIPTION
The latest Daily Builds don't seem to be able to import media on Windows 7, due to issues with the thumbnail server. I notice that the http and socketserver modules don't seem to be included in the distribution, attempting to add them explicitly.
