### PR TITLE
Blender: Fix injection of params

### DIFF
--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -530,7 +530,7 @@ class BlenderListView(QListView):
             script_body = f.read()
 
         # modify script variable
-        script_body = script_body.replace("#INJECT_PARAMS_HERE", user_params)
+        script_body = script_body.replace("# INJECT_PARAMS_HERE", user_params)
 
         # Write update script
         with open(path, "w", encoding="UTF-8", errors="strict") as f:
@@ -719,7 +719,7 @@ class Worker(QObject):
             # Shell the blender command to create the image sequence
             command_get_version = [self.blender_exec_path, '-v']
             command_render = [self.blender_exec_path, '-b', self.blend_file_path, '-P', self.target_script]
-            
+
             # debug info
             # NOTE: If the length of the command_render list changes, update to match!
             log.info("Blender command: {} {} '{}' {} '{}'".format(*command_render))


### PR DESCRIPTION
I reformatted the Blender scripts a few days ago, and accidentally broke the process which injects our parameters into the scripts.

(This also revealed an issue with the scripts, namely that the _default_ parameters have gotten completely out of sync. The scripts were originally written so that they could be run **without** injected parameters, for testing, but now they just crash due to missing parameters in their default set. That's worth fixing, but it'll have to be done some other time.)

Fixes #3099 