### PR TITLE
freeze.py: Win CLI launcher, filepath fixes

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -76,7 +76,7 @@ python_packages = ["os",
                    "openshot",
                    "time",
                    "uuid",
-                   "shutil", 
+                   "shutil",
                    "threading",
                    "subprocess",
                    "re",
@@ -86,7 +86,7 @@ python_packages = ["os",
                    "urllib",
                    "requests",
                    "zmq",
-                   "webbrowser", 
+                   "webbrowser",
                    "json"
                    ]
 
@@ -301,7 +301,9 @@ elif sys.platform == "linux":
                       ]:
         if os.path.exists(added_lib):
             external_so_files.append((added_lib, os.path.basename(added_lib)))
-                      
+        else:
+            log.warning("{}: not found, skipping".format(added_lib))
+
 elif sys.platform == "darwin":
     # Copy Mac specific files that cx_Freeze misses
     # JPEG library

--- a/freeze.py
+++ b/freeze.py
@@ -64,6 +64,11 @@ import shutil
 
 print (str(cx_Freeze))
 
+# Set '${ARCHLIB}' envvar to override system library path
+ARCHLIB = os.getenv('ARCHLIB', "/usr/lib/x86_64-linux-gnu/")
+if not ARCHLIB.endswith('/'):
+    ARCHLIB += '/'
+
 # Packages to include
 python_packages = ["os",
                    "sys",
@@ -221,7 +226,7 @@ elif sys.platform == "linux":
 
     lib_list = [os.path.join(libopenshot_path, "libopenshot.so"),
                 "/usr/local/lib/libresvg.so",
-                "/usr/lib/x86_64-linux-gnu/qt5/plugins/platforms/libqxcb.so"
+                ARCHLIB + "qt5/plugins/platforms/libqxcb.so"
                 ] + pyqt5_mod_files
 
     import subprocess
@@ -285,14 +290,18 @@ elif sys.platform == "linux":
 
     # Manually add missing files (that were missed in the above step). These files are required
     # for certain distros (like Fedora, openSUSE, Debian, etc...)
-    external_so_files.append(("/lib/x86_64-linux-gnu/libssl.so.1.0.0", "libssl.so.1.0.0"))
-    external_so_files.append(("/lib/x86_64-linux-gnu/libcrypto.so.1.0.0", "libcrypto.so.1.0.0"))
-    # Glib related files (required for some distros)
-    external_so_files.append(("/usr/lib/x86_64-linux-gnu/libglib-2.0.so", "libglib-2.0.so"))
-    external_so_files.append(("/usr/lib/x86_64-linux-gnu/libgio-2.0.so", "libgio-2.0.so"))
-    external_so_files.append(("/usr/lib/x86_64-linux-gnu/libgmodule-2.0.so", "libgmodule-2.0.so"))
-    external_so_files.append(("/usr/lib/x86_64-linux-gnu/libgthread-2.0.so", "libgthread-2.0.so"))
+    # Also add Glib related files (required for some distros)
 
+    for added_lib in [ARCHLIB + "libssl.so.1.0.0",
+                      ARCHLIB + "libcrypto.so.1.0.0",
+                      ARCHLIB + "libglib-2.0.so",
+                      ARCHLIB + "libgio-2.0.so",
+                      ARCHLIB + "libgmodule-2.0.so",
+                      ARCHLIB + "libthread-2.0.so"
+                      ]:
+        if os.path.exists(added_lib):
+            external_so_files.append((added_lib, os.path.basename(added_lib)))
+                      
 elif sys.platform == "darwin":
     # Copy Mac specific files that cx_Freeze misses
     # JPEG library

--- a/freeze.py
+++ b/freeze.py
@@ -65,8 +65,25 @@ import shutil
 print (str(cx_Freeze))
 
 # Packages to include
-python_packages = ["os", "sys", "PyQt5", "openshot", "time", "uuid", "shutil", "threading", "subprocess",
-                                 "re", "math", "xml", "logging", "urllib", "requests", "zmq", "webbrowser", "json"]
+python_packages = ["os",
+                   "sys",
+                   "PyQt5",
+                   "openshot",
+                   "time",
+                   "uuid",
+                   "shutil", 
+                   "threading",
+                   "subprocess",
+                   "re",
+                   "math",
+                   "xml",
+                   "logging",
+                   "urllib",
+                   "requests",
+                   "zmq",
+                   "webbrowser", 
+                   "json"
+                   ]
 
 # Determine absolute PATH of OpenShot folder
 PATH = os.path.dirname(os.path.realpath(__file__))  # Primary openshot folder
@@ -161,9 +178,9 @@ if sys.platform == "win32":
     # Manually add zmq dependency (windows does not freeze it correctly)
     import zmq
     python_packages.remove('zmq')
-    zmq_path = os.path.dirname(inspect.getfile(zmq))
+    zmq_path = os.path.normpath(os.path.dirname(inspect.getfile(zmq)))
     for filename in find_files(zmq_path, ["*"]):
-        src_files.append((filename, os.path.join("lib", "zmq", filename.replace(zmq_path + "\\", ""))))
+        src_files.append((filename, os.path.join("lib", "zmq", os.path.relpath(filename, start=zmq_path))))
 
 elif sys.platform == "linux":
     # Find libopenshot.so path (GitLab copies artifacts into local build/install folder)
@@ -177,12 +194,12 @@ elif sys.platform == "linux":
     # Find all related SO files
     for filename in find_files(libopenshot_path, ["*openshot*.so*"]):
         if '_' in filename or filename.count(".") == 2:
-            external_so_files.append((filename, filename.replace("/usr/local/lib/", "").replace(libopenshot_path + "/", "")))
+            external_so_files.append((filename, os.path.relpath(filename, start=libopenshot_path)))
 
     # Add libresvg (if found)
     resvg_path = "/usr/local/lib/libresvg.so"
     if os.path.exists(resvg_path):
-        external_so_files.append((resvg_path, resvg_path.replace("/usr/local/lib/", "")))
+        external_so_files.append((resvg_path, os.path.basename(resvg_path)))
 
     # Append Linux ICON file
     iconFile += ".svg"
@@ -197,10 +214,10 @@ elif sys.platform == "linux":
     # Get a list of all openshot.so dependencies (scan these libraries for their dependencies)
     pyqt5_mod_files = []
     from importlib import import_module
-    for submod in ['QtWebKit', 'QtSvg', 'QtWebKitWidgets', 'QtWidgets', 'QtCore', 'QtGui', 'QtDBus']:
+    for submod in ['Qt', 'QtWebKit', 'QtSvg', 'QtWebKitWidgets', 'QtWidgets', 'QtCore', 'QtGui', 'QtDBus']:
         mod_name  = "PyQt5.{}".format(submod)
-        import_module(mod_name)
-        pyqt5_mod_files.append(sys.modules.get(mod_name).__spec__.origin)
+        mod = import_module(mod_name)
+        pyqt5_mod_files.append(inspect.getfile(mod))
 
     lib_list = [os.path.join(libopenshot_path, "libopenshot.so"),
                 "/usr/local/lib/libresvg.so",


### PR DESCRIPTION
#### Windows debugging CLI

So, I discovered experimentally that the only thing required to run OpenShot in a console session on Windows is to configure the build that way.

By adding a second `Executable` to the cx_Freeze configuration which _unsets_ the `base = Win32GUI` option that selects the graphical launcher, running `python3 freeze.py build` places two `.exe` files in the destination directory. With our current Inno Setup configuration, the extra executable will automatically be packaged and installed. So you end up with:
* `openshot-qt.exe`, still the graphical launcher, the target of the `OpenShot Video Editor` Start menu entry / optional Desktop icon / `.osp` file associations
* `openshot-qt-cli.exe`, which is an effectively-"hidden" alternate launcher. (In the sense that it's present in the application dir for all to see, but nothing calls attention to it so you have to either know about it or discover it on your own).

If `openshot-qt-cli.exe` is launched graphically (by double-clicking) or by typing its name into the search field of the Start menu, it will open a terminal window before launching, which automatically closes when it exits. But it can also be run from a Windows COMMAND.COM terminal, or even an MSYS shell, so that the output is preserved after exit. (It can even be run from an MSYS shell, however it becomes confused and uses the MSYS homedir instead of the Windows one as the path to `.openshot_qt`, meaning no settings and etc.)

While running, the experience is exactly the same as running from a Linux terminal: All of the standard console output is displayed in the Windows terminal. In addition, **the FFmpeg STDERR output is _also_ displayed**.

![image](https://user-images.githubusercontent.com/538020/69899022-ba1b5c00-132e-11ea-8d4a-f37bbbb21f8d.png)

When errors occur... well, now that we've fixed most of our Windows launcher reporting issues (like the QMessageBoxes that displayed in place of useful error info), the experience is roughly the same as the graphical launcher. Yes, you'll see tracebacks on the console, but they'll also be displayed in popup dialogs with the graphical launcher.

Still, for debugging and testing purposes this can be an invaluable tool. I think we should just silently include it in our WIndows installers (which merging this PR will accomplish), so it's available both for our own use, and for any users who have difficult-to-diagnose problems running OpenShot on Windows.

#### Other changes

 I also made a couple of changes to the freeze script that should make it easier to run from locations _other_ than the GitLab builders, without affecting the normal build-server runs.

* I fixed my CPython-extension-file lookup code to use `inspect.getfile()`, instead of manually pulling the filename out of Python class metadata.
* I added a variable ARCHLIB to represent the architecture-specific library path on the build system. It defaults to `/usr/lib/x86_64-linux-gnu/`, the correct value for the Linux builders, _but_ it can be overridden by setting an `ARCHLIB` environment variable. All of the paths that were formerly hardcoded as `/usr/lib/x86_64-linux-gnu/somefile.so` and etc. are replaced with `ARCHLIB + "somefile.so" which allows them to be overridden with a different library path.
* I made the bundling of a number of hardcoded library files conditional on the _existence_ of the file, so that if the machine doesn't have a `libssl.so.1.0.0` file or whatever it'll freeze the program without that file, instead of throwing an exception and aborting the build.
* I reformatted a long list of Python modules to be one-per-line, making them easier to sort through and examine individually.

This PR was created in a branch of the project repo, so the Gitlab builders have already produced an installer package that includes the CLI launcher. I can make that available online if anyone would like to try it out, just let me know.