### PR TITLE
Undo/Redo history: don't track import/export path changes, don't clear redo for untracked changes

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -939,7 +939,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                 if path and is_modified and not is_skipped:
                     # Found file, update path
                     file["path"] = path
-                    get_app().updates.update(["import_path"], os.path.dirname(path))
+                    get_app().updates.update_untracked(["import_path"], os.path.dirname(path))
                     log.info("Auto-updated missing file: %s" % path)
                 elif is_skipped:
                     # Remove missing file

--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -306,8 +306,8 @@ class UpdateManager:
         """ Insert a new UpdateAction into the UpdateManager (this action will then be distributed to all listeners) """
 
         self.last_action = UpdateAction('insert', key, values)
-        self.redoHistory.clear()
         if not self.ignore_history:
+            self.redoHistory.clear()
             self.actionHistory.append(self.last_action)
         self.dispatch_action(self.last_action)
 
@@ -315,10 +315,10 @@ class UpdateManager:
         """ Update the UpdateManager with an UpdateAction (this action will then be distributed to all listeners) """
 
         self.last_action = UpdateAction('update', key, values, partial_update)
-        if self.last_action.key and self.last_action.key[0] != "history":
-            # Clear redo history for any update except a "history" update
-            self.redoHistory.clear()
         if not self.ignore_history:
+            if self.last_action.key and self.last_action.key[0] != "history":
+                # Clear redo history for any update except a "history" update
+                self.redoHistory.clear()
             self.actionHistory.append(self.last_action)
         self.dispatch_action(self.last_action)
 
@@ -333,8 +333,8 @@ class UpdateManager:
         """ Delete an item from the UpdateManager with an UpdateAction (this action will then be distributed to all listeners) """
 
         self.last_action = UpdateAction('delete', key)
-        self.redoHistory.clear()
         if not self.ignore_history:
+            self.redoHistory.clear()
             self.actionHistory.append(self.last_action)
         self.dispatch_action(self.last_action)
 

--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -322,6 +322,13 @@ class UpdateManager:
             self.actionHistory.append(self.last_action)
         self.dispatch_action(self.last_action)
 
+    def update_untracked(self, key, values, partial_update=False):
+        """ Update the UpdateManager with an UpdateAction, without creating a new entry in the history table (this action will then be distributed to all listeners) """
+        previous_ignore = self.ignore_history
+        self.ignore_history = True
+        self.update(key, values, partial_update)
+        self.ignore_history = previous_ignore
+
     def delete(self, key):
         """ Delete an item from the UpdateManager with an UpdateAction (this action will then be distributed to all listeners) """
 

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -615,7 +615,7 @@ class Export(QDialog):
         if os.path.exists(file_path):
             self.txtExportFolder.setText(file_path)
             # update export folder path in project file
-            app.updates.update(["export_path"], file_path)
+            app.updates.update_untracked(["export_path"], file_path)
 
     def convert_to_bytes(self, BitRateString):
         bit_rate_bytes = 0

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1019,7 +1019,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         if not framePath.endswith(".png"):
             framePath = "%s.png" % framePath
 
-        app.updates.update(["export_path"], os.path.dirname(framePath))
+        app.updates.update_untracked(["export_path"], os.path.dirname(framePath))
         log.info("Saving frame to %s" % framePath)
 
         # Pause playback (to prevent crash since we are fixing to change the timeline's max size)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -694,7 +694,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         for file_path in files:
             self.filesTreeView.add_file(file_path)
             self.filesTreeView.refresh_view()
-            app.updates.update(["import_path"], os.path.dirname(file_path))
+            app.updates.update_untracked(["import_path"], os.path.dirname(file_path))
             log.info("Imported media file {}".format(file_path))
 
     def actionAdd_to_Timeline_trigger(self, event):
@@ -929,7 +929,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         """Update playhead position"""
         # Notify preview thread
         self.timeline.movePlayhead(position_frames)
-    
+
     def SetPlayheadFollow(self, enable_follow):
         """ Enable / Disable follow mode """
         self.timeline.SetPlayheadFollow(enable_follow)
@@ -1325,7 +1325,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             # Update the preview and reselct current frame in properties
             get_app().window.refreshFrameSignal.emit()
             get_app().window.propertyTableView.select_frame(frame_to_seek)
-            
+
     def actionCenterOnPlayhead_trigger(self, event):
         """ Center the timeline on the current playhead position """
         self.timeline.centerOnPlayhead()


### PR DESCRIPTION
This PR makes some small changes to the undo/redo tracking:
1. Add a convenience method `update_untracked`, which takes the same args as `update()` and is equivalent to:
    ```python
    app.updates.ignore_history = True
    app.updates.update(...)
    app.updates.ignore_history = False
    ```
    Except that it preserves and restores the previous value of `ignore_history`, so it's safe to use even when `ignore_history` is already `True` without losing that state.
3. Only clear the `redoHistory` if `ignore_history` is `False`, since there's no reason to clear it if no new `actionHistory` (undo) items are being created. This means that e.g. changes to the timeline zoom will no longer erase the redo history.

In addition, all updates to `import_path` and `export_path` are changed to use `update_untracked()`, so they won't appear on the undo list.

Fixes #3111