### PR TITLE
Revert "thumbnail: Fix path for thumb output"

### DIFF
--- a/src/classes/thumbnail.py
+++ b/src/classes/thumbnail.py
@@ -151,16 +151,12 @@ class httpThumbnailHandler(BaseHTTPRequestHandler):
 
         # Locate thumbnail
         thumb_path = os.path.join(info.THUMBNAIL_PATH, file_id, "%s.png" % file_frame)
-        if not os.path.exists(thumb_path):
-            if file_frame == 1:
-                # Try ID with no frame # (for backwards compatibility)
-                alt_path = os.path.join(info.THUMBNAIL_PATH, "%s.png" % file_id)
-            else:
-                # Try with ID and frame # in filename (for backwards compatibility)
-                alt_path = os.path.join(info.THUMBNAIL_PATH, "%s-%s.png" % (file_id, file_frame))
-
-            if os.path.exists(alt_path):
-                thumb_path = alt_path
+        if not os.path.exists(thumb_path) and file_frame == 1:
+            # Try ID with no frame # (for backwards compatibility)
+            thumb_path = os.path.join(info.THUMBNAIL_PATH, "%s.png" % file_id)
+        if not os.path.exists(thumb_path) and file_frame != 1:
+            # Try with ID and frame # in filename (for backwards compatibility)
+            thumb_path = os.path.join(info.THUMBNAIL_PATH, "%s-%s.png" % (file_id, file_frame))
 
         if not os.path.exists(thumb_path):
             # Generate thumbnail (since we can't find it)


### PR DESCRIPTION
This reverts commit 5a1419d52be760e50da65e27ea1b4a71ac72ec10.

Turns out that, even if the multi-directory organization was the
INTENT, it can't be used. The asset-consolidation logic in
`project_data:move_temp_paths_to_project_folder expects` only
files, not directories, in the thumbnail dir.

(Note that this revert means that the program logic goes back to being incorrect, as the thumbnail path will never _actually_ be `os.path.join(info.THUMBNAIL_PATH, file_id, "%s.png" % file_frame)` — but that's OK, because we don't actually want it to be. Still, it would be better to fix that part of the code.)