### PR TITLE
Always make attempts to set option only for existing stream

### DIFF
--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -835,12 +835,15 @@ class Export(QDialog):
             # These extra options should be set in an extra method
             # No feedback is given to the user
             # TODO: Tell user if option is not available
-            # Set the quality in case crf was selected
-            if "crf" in self.txtVideoBitRate.text():
-                w.SetOption(openshot.VIDEO_STREAM, "crf", str(int(video_settings.get("video_bitrate"))) )
-
-            # Muxing options for mp4/mov
-            w.SetOption(openshot.VIDEO_STREAM, "muxing_preset", "mp4_faststart")
+            if export_type in [_("Audio Only")]:
+                # Muxing options for mp4/mov
+                w.SetOption(openshot.AUDIO_STREAM, "muxing_preset", "mp4_faststart")
+            else:
+                # Muxing options for mp4/mov
+                w.SetOption(openshot.VIDEO_STREAM, "muxing_preset", "mp4_faststart")
+                # Set the quality in case crf was selected
+                if "crf" in self.txtVideoBitRate.text():
+                    w.SetOption(openshot.VIDEO_STREAM, "crf", str(int(video_settings.get("video_bitrate"))) )
 
             # Open the writer
             w.Open()


### PR DESCRIPTION
When clip exported to the Audio Only file the error:

>The stream was not found. Be sure to call PrepareStreams() first.

may appear because the export video has no video stream where program attempts to apply the _SetOption()_. The regression was introduced in https://github.com/OpenShot/openshot-qt/pull/2860 and some masked version ("crf" text field) in https://github.com/OpenShot/openshot-qt/pull/2543

This change allows Audio Only export again.