### PR TITLE
files_treeview: Fix image import

### DIFF
--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -209,7 +209,7 @@ class FilesTreeView(QTreeView):
         """Inspect a file path and determine if this is an image sequence"""
 
         # Get just the file name
-        fileName = os.path.basename(file_path)
+        (dirName, fileName) = os.path.split(file_path)
         extensions = ["png", "jpg", "jpeg", "gif", "tif", "svg"]
         match = re.findall(r"(.*[^\d])?(0*)(\d+)\.(%s)" % "|".join(extensions), fileName, re.I)
 


### PR DESCRIPTION
This fixes an inadvertent breakage introduced in #3021, where I removed a variable from `files_treeview.py` that _was_ actually needed. **#MyBad** 🤭

(I left it in `files_listview.py`, though, so the two modes actually exhibit different behavior right now. Which helps demonstrate the problem with all of the copy-paste code present in both files, all of which _should_ be part of `files_model.py` **instead**. But I digress...)

Fixes #3137 