### PR TITLE
Remove ModuleNotFoundError exception check

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -74,7 +74,7 @@ class OpenShotApp(QApplication):
 
             # Re-route stdout and stderr to logger
             reroute_output()
-        except (ImportError, ModuleNotFoundError) as ex:
+        except ImportError as ex:
             tb = traceback.format_exc()
             QMessageBox.warning(None, "Import Error",
                                 "Module: %(name)s\n\n%(tb)s" % {"name": ex.name, "tb": tb})


### PR DESCRIPTION
Turns out `ModuleNotFoundError` was only added in Python 3.6, and since our AppImages are built with 3.4 this causes problems.

But `ModuleNotFoundError` is a subclass of `ImportError` anyway, so just checking for `ImportError` covers all cases.