### PR TITLE
classes.assets: Remove unused settings import

### DIFF
--- a/src/classes/assets.py
+++ b/src/classes/assets.py
@@ -26,7 +26,7 @@
  """
 
 import os
-from classes import info, settings
+from classes import info
 from classes.logger import log
 
 


### PR DESCRIPTION
Recent AppImages are failing on startup, at least for me, with the following intimidating-looking traceback:
```
Module: None

Traceback (most recent call last):
  File "/tmp/.mount_tcpJot/usr/bin/classes/app.py", line 72, in __init__
    from classes import settings, project_data, updates, language, ui_util, logger_libopenshot
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 2284, in _handle_fromlist
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 321, in _call_with_frames_removed
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 2237, in _find_and_load
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 2226, in _find_and_load_unlocked
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 1200, in _load_unlocked
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 1129, in _exec
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 1471, in exec_module
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 321, in _call_with_frames_removed
  File "/tmp/.mount_tcpJot/usr/bin/classes/settings.py", line 38, in <module>
    from classes.json_data import JsonDataStore
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 2237, in _find_and_load
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 2226, in _find_and_load_unlocked
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 1200, in _load_unlocked
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 1129, in _exec
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 1471, in exec_module
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 321, in _call_with_frames_removed
  File "/tmp/.mount_tcpJot/usr/bin/classes/json_data.py", line 36, in <module>
    from classes.assets import get_assets_path
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 2237, in _find_and_load
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 2226, in _find_and_load_unlocked
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 1200, in _load_unlocked
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 1129, in _exec
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 1471, in exec_module
  File "/usr/lib/python3.4/importlib/_bootstrap.py", line 321, in _call_with_frames_removed
  File "/tmp/.mount_tcpJot/usr/bin/classes/assets.py", line 29, in <module>
    from classes import info, settings
ImportError: cannot import name 'settings'
```

...If I'm interpreting that _correctly_, I believe the problem is caused by a circular import chain: `classes.app` imports `classes.settings`, which imports `classes.json_data`, which imports `classes.assets`, which tries to _again_ import `classes.settings` and 'round and 'round we go.

But, `classes.assets` doesn't actually _use_ `settings` at all, so this PR simply removes it.

I've created it on a branch in the project repo, so that I can get a test AppImage build and verify that it indeed solves the problem.