### PR TITLE
Removing usage of `-webkit-fill-available` in keyframe CSS

### DIFF
--- a/src/timeline/media/css/main.css
+++ b/src/timeline/media/css/main.css
@@ -119,18 +119,11 @@ img {
     margin-left: -7px;
 }
 .point_icon {
-    width: -webkit-fill-available;
-    height: -webkit-fill-available;
+    width: 1px;
+    height: 6px;
     margin: 0 4px;
     background: -webkit-gradient(linear, left top, left bottom, color-stop(40%,rgba(0,255,0,1)), color-stop(100%,rgba(0,255,0,0)));
 }
-
-/*
-.point_region:hover {
-    height: 20px;
-    width: 14px;
-}
-*/
 
 /* Transitions */
 .transition_top { background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,0.75)), color-stop(100%,rgba(255,255,255,0))); border-radius: 8px; overflow: hidden;}


### PR DESCRIPTION
Support older versions of webkit, since nothing renders for keyframes using the `-webkit-fill-available` value. Not really sure what this does, but all I know is that it doesn't work for me. :wink:. Fixing the size to very narrow (1 px) and the same green gradient as before. Feels pretty good to me.