### PR TITLE
Effects/Transitions: Remove redundant column

### DIFF
--- a/src/windows/models/effects_model.py
+++ b/src/windows/models/effects_model.py
@@ -50,7 +50,7 @@ class EffectsStandardItemModel(QStandardItemModel):
         files = []
         for item in indexes:
             selected_row = self.itemFromIndex(item).row()
-            files.append(self.item(selected_row, 4).text())
+            files.append(self.item(selected_row, 3).text())
         data.setText(json.dumps(files))
         data.setHtml("effect")
 
@@ -73,7 +73,7 @@ class EffectsModel():
             self.model.clear()
 
         # Add Headers
-        self.model.setHorizontalHeaderLabels([_("Thumb"), _("Name"), _("Description")])
+        self.model.setHorizontalHeaderLabels([_("Name"), _("Description"), _("Type")])
 
         # Get the folder path of effects
         effects_dir = os.path.join(info.PATH, "effects")
@@ -142,21 +142,13 @@ class EffectsModel():
 
             row = []
 
-            # Append thumbnail
-            col = QStandardItem()
-
             icon_pixmap = QPixmap(thumb_path)
             scaled_pixmap = icon_pixmap.scaled(QSize(98, 64), Qt.IgnoreAspectRatio, Qt.SmoothTransformation)
-            col.setIcon(QIcon(scaled_pixmap))
-            col.setText(self.app._tr(title))
-            col.setToolTip(self.app._tr(title))
-            col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
-            row.append(col)
 
-            # Append Name
-            col = QStandardItem("Name")
+            # Append Name & thumbnail
+            col = QStandardItem(QIcon(scaled_pixmap), self.app._tr(title))
             col.setData(self.app._tr(title), Qt.DisplayRole)
-            col.setText(self.app._tr(title))
+            col.setToolTip(self.app._tr(title))
             col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
             row.append(col)
 
@@ -166,22 +158,20 @@ class EffectsModel():
             col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
             row.append(col)
 
-            # Append Category
-            col = QStandardItem("Category")
+            # Append Category (Type)
+            col = QStandardItem(category)
             col.setData(category, Qt.DisplayRole)
-            col.setText(category)
             col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
             row.append(col)
 
             # Append Path
-            col = QStandardItem("Effect")
+            col = QStandardItem(effect_name)
             col.setData(effect_name, Qt.DisplayRole)
-            col.setText(effect_name)
             col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
             row.append(col)
 
             # Append ROW to MODEL (if does not already exist in model)
-            if not effect_name in self.model_names:
+            if effect_name not in self.model_names:
                 self.model.appendRow(row)
                 self.model_names[effect_name] = effect_name
 
@@ -190,5 +180,5 @@ class EffectsModel():
         # Create standard model
         self.app = get_app()
         self.model = EffectsStandardItemModel()
-        self.model.setColumnCount(5)
+        self.model.setColumnCount(4)
         self.model_names = {}

--- a/src/windows/models/transition_model.py
+++ b/src/windows/models/transition_model.py
@@ -38,6 +38,7 @@ from classes.app import get_app
 
 import json
 
+
 class TransitionStandardItemModel(QStandardItemModel):
     def __init__(self, parent=None):
         QStandardItemModel.__init__(self)
@@ -50,7 +51,7 @@ class TransitionStandardItemModel(QStandardItemModel):
         files = []
         for item in indexes:
             selected_row = self.itemFromIndex(item).row()
-            files.append(self.item(selected_row, 3).text())
+            files.append(self.item(selected_row, 2).text())
         data.setText(json.dumps(files))
         data.setHtml("transition")
 
@@ -73,7 +74,7 @@ class TransitionsModel():
             self.model.clear()
 
         # Add Headers
-        self.model.setHorizontalHeaderLabels([_("Thumb"), _("Name")])
+        self.model.setHorizontalHeaderLabels([_("Name")])
 
         # get a list of files in the OpenShot /transitions directory
         transitions_dir = os.path.join(info.PATH, "transitions")
@@ -125,7 +126,7 @@ class TransitionsModel():
                         continue
 
                 # Check for thumbnail path (in build-in cache)
-                thumb_path = os.path.join(info.IMAGES_PATH, "cache",  "{}.png".format(fileBaseName))
+                thumb_path = os.path.join(info.IMAGES_PATH, "cache", "{}.png".format(fileBaseName))
 
                 # Check built-in cache (if not found)
                 if not os.path.exists(thumb_path):
@@ -159,37 +160,26 @@ class TransitionsModel():
 
                 row = []
 
-                # Append thumbnail
-                col = QStandardItem()
-                col.setIcon(QIcon(thumb_path))
-                col.setText(trans_name)
+                # Append thumbnail & name
+                col = QStandardItem(QIcon(thumb_path), trans_name)
                 col.setToolTip(trans_name)
                 col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
                 row.append(col)
 
-                # Append Filename
-                col = QStandardItem("Name")
-                col.setData(trans_name, Qt.DisplayRole)
-                col.setText(trans_name)
-                col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
-                row.append(col)
-
-                # Append Media Type
-                col = QStandardItem("Type")
+                # Categorize
+                col = QStandardItem(type)
                 col.setData(type, Qt.DisplayRole)
-                col.setText(type)
                 col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
                 row.append(col)
 
                 # Append Path
-                col = QStandardItem("Path")
+                col = QStandardItem(path)
                 col.setData(path, Qt.DisplayRole)
-                col.setText(path)
                 col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
                 row.append(col)
 
                 # Append ROW to MODEL (if does not already exist in model)
-                if not path in self.model_paths:
+                if path not in self.model_paths:
                     self.model.appendRow(row)
                     self.model_paths[path] = path
 
@@ -198,5 +188,5 @@ class TransitionsModel():
         # Create standard model
         self.app = get_app()
         self.model = TransitionStandardItemModel()
-        self.model.setColumnCount(4)
+        self.model.setColumnCount(3)
         self.model_paths = {}

--- a/src/windows/views/effects_treeview.py
+++ b/src/windows/views/effects_treeview.py
@@ -1,26 +1,26 @@
-""" 
+"""
  @file
  @brief This file contains the effects file treeview, used by the main window
  @author Jonathan Thomas <jonathan@openshot.org>
- 
+
  @section LICENSE
- 
+
  Copyright (c) 2008-2018 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
@@ -34,9 +34,14 @@ from windows.models.effects_model import EffectsModel
 
 import json
 
+
 class EffectsTreeView(QTreeView):
     """ A TreeView QWidget used on the main window """
     drag_item_size = 48
+
+    def resizeEvent(self, event):
+        name_width = max(150, min(event.size().width() * 0.4, 280))
+        self.header().resizeSection(0, name_width)
 
     def contextMenuEvent(self, event):
         # Set context menu mode
@@ -57,7 +62,6 @@ class EffectsTreeView(QTreeView):
         # Start drag operation
         drag = QDrag(self)
         drag.setMimeData(self.effects_model.model.mimeData(self.selectionModel().selectedIndexes()))
-        # drag.setPixmap(QIcon.fromTheme('document-new').pixmap(QSize(self.drag_item_size,self.drag_item_size)))
         drag.setPixmap(icon.pixmap(QSize(self.drag_item_size, self.drag_item_size)))
         drag.setHotSpot(QPoint(self.drag_item_size / 2, self.drag_item_size / 2))
         drag.exec_()
@@ -67,8 +71,8 @@ class EffectsTreeView(QTreeView):
 
     def refresh_view(self):
         self.effects_model.update_model()
+        self.hideColumn(2)
         self.hideColumn(3)
-        self.hideColumn(4)
 
     def __init__(self, *args):
         # Invoke parent init

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -410,8 +410,8 @@ class PropertiesTableView(QTableView):
                     modelIndex = self.transition_model.model.index(transIndex, 0)
                     transItem = self.transition_model.model.itemFromIndex(modelIndex)
                     transIcon = self.transition_model.model.item(transItem.row(), 0).icon()
-                    transName = self.transition_model.model.item(transItem.row(), 1).text()
-                    transPath = self.transition_model.model.item(transItem.row(), 3).text()
+                    transName = self.transition_model.model.item(transItem.row(), 0).text()
+                    transPath = self.transition_model.model.item(transItem.row(), 2).text()
 
                     # Append transition choice
                     trans_choices.append({"name": transName, "value": transPath, "selected": False, "icon": transIcon})

--- a/src/windows/views/transitions_treeview.py
+++ b/src/windows/views/transitions_treeview.py
@@ -1,26 +1,26 @@
-""" 
+"""
  @file
  @brief This file contains the transitions file treeview, used by the main window
  @author Jonathan Thomas <jonathan@openshot.org>
- 
+
  @section LICENSE
- 
+
  Copyright (c) 2008-2018 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
@@ -67,8 +67,8 @@ class TransitionsTreeView(QTreeView):
 
     def refresh_view(self):
         self.transition_model.update_model()
+        self.hideColumn(1)
         self.hideColumn(2)
-        self.hideColumn(3)
 
     def __init__(self, *args):
         # Invoke parent init


### PR DESCRIPTION
- The thumbnail column already contains the "Name" string (as the icon caption), so rather than having a separate column, rename the "Thumb" column to "Name" and only display that.
- The Effects `TreeView` requires special handling, since the width of the column has to be set explicitly to balance with the "Details" column. A `resizeEvent()` implementation sets it to 40% of the widget width, constrained within the range <code>[150:<strike>260</strike>280]</code>.