### PR TITLE
Change separator for the frame number display

### DIFF
--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -39,7 +39,7 @@
 		
 		<!-- RULER NAME (left of screen) -->
 		<div tl-rulertime id="ruler_label">
-			<div id="ruler_time">{{playheadTime.hour}}:{{playheadTime.min}}:{{playheadTime.sec}}:{{playheadTime.frame}}</div>
+			<div id="ruler_time">{{playheadTime.hour}}:{{playheadTime.min}}:{{playheadTime.sec}} [{{playheadTime.frame}}]</div>
 		</div>
 		<!-- RULER (right of screen) -->
 		<div id="scrolling_ruler">

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -93,7 +93,7 @@ App.controller("TimelineCtrl", function ($scope) {
     // Use JQuery to move playhead (for performance reasons) - scope.apply is too expensive here
     $(".playhead-top").css("left", (($scope.project.playhead_position * $scope.pixelsPerSecond) + $scope.playheadOffset) + "px");
     $(".playhead-line").css("left", (($scope.project.playhead_position * $scope.pixelsPerSecond) + $scope.playheadOffset) + "px");
-    $("#ruler_time").text($scope.playheadTime.hour + ":" + $scope.playheadTime.min + ":" + $scope.playheadTime.sec + ":" + $scope.playheadTime.frame);
+    $("#ruler_time").text($scope.playheadTime.hour + ":" + $scope.playheadTime.min + ":" + $scope.playheadTime.sec + " [" + $scope.playheadTime.frame + "]");
   };
 
   // Move the playhead to a specific frame

--- a/src/windows/add_to_timeline.py
+++ b/src/windows/add_to_timeline.py
@@ -404,7 +404,7 @@ class AddToTimeline(QDialog):
 
         # Update label
         total_parts = time_parts.secondsToTime(total, fps["num"], fps["den"])
-        timestamp = "%s:%s:%s:%s" % (total_parts["hour"], total_parts["min"], total_parts["sec"], total_parts["frame"])
+        timestamp = "%s:%s:%s [%s]" % (total_parts["hour"], total_parts["min"], total_parts["sec"], total_parts["frame"])
         self.lblTotalLengthValue.setText(timestamp)
 
     def reject(self):

--- a/src/windows/cutting.py
+++ b/src/windows/cutting.py
@@ -191,7 +191,7 @@ class Cutting(QDialog):
 
         # Convert seconds to time stamp
         time_text = time_parts.secondsToTime(seconds, self.fps_num, self.fps_den)
-        timestamp = "%s:%s:%s:%s" % (time_text["hour"], time_text["min"], time_text["sec"], time_text["frame"])
+        timestamp = "%s:%s:%s [%s]" % (time_text["hour"], time_text["min"], time_text["sec"], time_text["frame"])
 
         # Update label
         self.lblVideoTime.setText(timestamp)


### PR DESCRIPTION
**Edit:**
`:` to `[ ]`  (for frames only)

before
![Timecode old](https://user-images.githubusercontent.com/19683044/72084203-bf939b00-330b-11ea-80b9-f8485bfc286d.png)

after
![Timecode new 02](https://user-images.githubusercontent.com/19683044/73930571-65243500-48df-11ea-95d9-8001c81772ca.png)


While OpenShot uses own 1-31 markup for frames notation (instead of standard 0-29) for the 30fps videos, it is OK to make it more noticeable for the end users.

Mentioned in: https://github.com/OpenShot/openshot-qt/issues/3164#issuecomment-571758511
