### PR TITLE
Fix main menu actions state (UI)

### DIFF
--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -191,6 +191,7 @@ class UpdateManager:
         """ Reset the UpdateManager, and clear all UpdateActions and History. This does not clear listeners and watchers. """
         self.actionHistory.clear()
         self.redoHistory.clear()
+        self.update_watchers()
 
     def add_listener(self, listener, index=-1):
         """ Add a new listener (which will invoke the changed(action) method each time an UpdateAction is available). """

--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -344,3 +344,4 @@ class UpdateManager:
         if self.last_action:
             self.last_action.set_old_values(previous_value)
             self.actionHistory.append(self.last_action)
+            self.update_watchers()


### PR DESCRIPTION
After the main menu _Edit>Clear History_ clicked the main menu _Edit>Undo_ action stays enabled.

This change is attempt to fix the UI inconsistency to the available features.

**Edit:** designed to work with the Curve Editor: https://github.com/OpenShot/openshot-qt/pull/3084