### PR TITLE
Fix the updating of the interpolation type of previous keyframe point

### DIFF
--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -324,13 +324,12 @@ class PropertiesModel(updates.UpdateInterface):
                                 # Only update interpolation type (and the LEFT side of the curve)
                                 found_point = True
                                 clip_updated = True
-                                point["interpolation"] = interpolation
                                 if interpolation == 0:
                                     point["handle_right"] = point.get("handle_right") or {"Y": 0.0, "X": 0.0}
                                     point["handle_right"]["X"] = interpolation_details[0]
                                     point["handle_right"]["Y"] = interpolation_details[1]
 
-                                log.info("updating interpolation mode point: co.X = %s to %s" % (point["co"]["X"], interpolation))
+                                log.info("updating interpolation preset of the point: co.X = %s" % (point["co"]["X"]))
                                 log.info("use interpolation preset: %s" % str(interpolation_details))
 
                             elif interpolation > -1 and point["co"]["X"] == closest_point_x:
@@ -454,13 +453,12 @@ class PropertiesModel(updates.UpdateInterface):
                             # Only update interpolation type (and the LEFT side of the curve)
                             found_point = True
                             clip_updated = True
-                            point["interpolation"] = interpolation
                             if interpolation == 0:
                                 point["handle_right"] = point.get("handle_right") or {"Y": 0.0, "X": 0.0}
                                 point["handle_right"]["X"] = interpolation_details[0]
                                 point["handle_right"]["Y"] = interpolation_details[1]
 
-                            log.info("updating interpolation mode point: co.X = %s to %s" % (point["co"]["X"], interpolation))
+                            log.info("updating interpolation preset of the point: co.X = %s" % (point["co"]["X"]))
                             log.info("use interpolation preset: %s" % str(interpolation_details))
 
                         elif interpolation > -1 and point["co"]["X"] == closest_point_x:


### PR DESCRIPTION
Fixes: https://github.com/OpenShot/openshot-qt/issues/2552

This fixes issue when current and previous segment both modifies its
interpolation type, when only current was modified.

If you try to modify the segment of the _Constant_ type keyframed animation that lies between the two  same _Constant_ type of animation keys (red vertical line) with the Bezier _Ease In (Expo)_ preset :
![OpenShot step to bezier 01](https://user-images.githubusercontent.com/19683044/72849557-9ed62880-3caf-11ea-913d-32c027419066.png)
you will end with 2 Bezier interpolations:
**Before the fix:**
![OpenShot step to bezier 03](https://user-images.githubusercontent.com/19683044/72849948-a21de400-3cb0-11ea-8947-ab014928690e.png)

(left, where the was Const is now Bezier, straight line but Bezier interpolation, no Properties Table shown on the screen but it is Bezier, sure. The backward, 3 _Linear_ segments to _Constant_ in the middle will produce 2 _Constant_ + 1 _Linear_, instead of 1 _Linear_ + 1 _Constant_ + 1 _Linear_).

**After the fix:**
And how it should be
![OpenShot step to bezier 02](https://user-images.githubusercontent.com/19683044/72849883-7ac71700-3cb0-11ea-9662-31fa626bb20c.png)


**Edit:** the change will be useful for Curve Editor too (https://github.com/OpenShot/openshot-qt/pull/3084).