### PR TITLE
Add confirmation dialog when canceling export

### DIFF
--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -979,6 +979,21 @@ class Export(QDialog):
             super(Export, self).accept()
 
     def reject(self):
+        # Handle cancel
+        if self.exporting and not self.close_button.isVisible():
+            _ = get_app()._tr
+            ret = QMessageBox(self)
+            ret.setIcon(QMessageBox.Question)
+            ret.setWindowTitle(_("Video Export"))
+            ret.setText(_("Are you sure you want to abort the video export?"))
+            ret.addButton(_("Yes"), QMessageBox.AcceptRole)
+            button_No = QPushButton(_("No"))
+            ret.addButton(button_No, QMessageBox.RejectRole)
+            ret.setDefaultButton(button_No)
+            ret.exec_()
+            if ret.clickedButton() == button_No:
+                return
+
         # Re-set OMP thread enabled flag
         if self.s.get("omp_threads_enabled"):
             openshot.Settings.Instance().WAIT_FOR_VIDEO_PROCESSING_TASK = False

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -36,6 +36,7 @@ from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 from PyQt5.QtGui import QIcon
 
+from classes import info
 from classes import ui_util
 from classes.app import get_app
 from classes.metrics import *
@@ -979,19 +980,15 @@ class Export(QDialog):
             super(Export, self).accept()
 
     def reject(self):
-        # Handle cancel
         if self.exporting and not self.close_button.isVisible():
+            # Show confirmation dialog
             _ = get_app()._tr
-            ret = QMessageBox(self)
-            ret.setIcon(QMessageBox.Question)
-            ret.setWindowTitle(_("Video Export"))
-            ret.setText(_("Are you sure you want to abort the video export?"))
-            ret.addButton(_("Yes"), QMessageBox.AcceptRole)
-            button_No = QPushButton(_("No"))
-            ret.addButton(button_No, QMessageBox.RejectRole)
-            ret.setDefaultButton(button_No)
-            ret.exec_()
-            if ret.clickedButton() == button_No:
+            result = QMessageBox.question(self,
+                _("Export Video"),
+                _("Are you sure you want to cancel the export?"),
+                QMessageBox.No | QMessageBox.Yes)
+            if result == QMessageBox.No:
+                # Resume export
                 return
 
         # Re-set OMP thread enabled flag


### PR DESCRIPTION
Just fully localized temporary solution that targets this small request: https://github.com/OpenShot/openshot-qt/issues/3190#issuecomment-576935708

Export paused until decision taken.

Is it works for all systems? I can only test it in Windows.