### PR TITLE
Small correction in Doxyfile.in

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -687,7 +687,7 @@ RECURSIVE              = YES
 # run.
 
 EXCLUDE                = "_darcs" \
-						 "/src/blender/scripts/"
+                         "src/blender/scripts/"
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded


### PR DESCRIPTION
It doesn't make sense to exclude a directory starting with a '/' when it is not in the INPUT, the intended directory is the one without the starting '/'.