### PR TITLE
Make Unicode path for projects work again

### DIFF
--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -127,13 +127,13 @@ class JsonDataStore:
     def read_from_file(self, file_path, path_mode="ignore"):
         """ Load JSON settings from a file """
         try:
-            with open(file_path, 'r') as f:
+            with open(file_path, 'r', encoding='utf-8') as f:
                 contents = f.read()
                 if contents:
                     if path_mode == "absolute":
                         # Convert any paths to absolute
                         contents = self.convert_paths_to_absolute(file_path, contents)
-                    return json.loads(contents, strict=False)
+                    return json.loads(contents)
         except Exception as ex:
             msg = ("Couldn't load {} file: {}".format(self.data_type, ex))
             log.error(msg)
@@ -145,11 +145,11 @@ class JsonDataStore:
     def write_to_file(self, file_path, data, path_mode="ignore", previous_path=None):
         """ Save JSON settings to a file """
         try:
-            contents = json.dumps(data, indent=1)
+            contents = json.dumps(data, ensure_ascii=False, indent=1)
             if path_mode == "relative":
                 # Convert any paths to relative
                 contents = self.convert_paths_to_relative(file_path, previous_path, contents)
-            with open(file_path, 'w') as f:
+            with open(file_path, 'w', encoding='utf-8') as f:
                 f.write(contents)
         except Exception as ex:
             msg = ("Couldn't save {} file:\n{}\n{}".format(self.data_type, file_path, ex))
@@ -164,18 +164,18 @@ class JsonDataStore:
         # Find absolute path of file (if needed)
         if "@transitions" in path:
             new_path = path.replace("@transitions", os.path.join(info.PATH, "transitions"))
-            new_path = json.dumps(new_path)  # Escape backslashes
+            new_path = json.dumps(new_path, ensure_ascii=False)
             return '"%s": %s' % (key, new_path)
 
         elif "@assets" in path:
             new_path = path.replace("@assets", path_context["new_project_assets"])
-            new_path = json.dumps(new_path)  # Escape backslashes
+            new_path = json.dumps(new_path, ensure_ascii=False)
             return '"%s": %s' % (key, new_path)
 
         else:
             # Convert path to the correct relative path
             new_path = os.path.abspath(os.path.join(path_context.get("new_project_folder", ""), path))
-            new_path = json.dumps(new_path)  # Escape backslashes
+            new_path = json.dumps(new_path, ensure_ascii=False)
             return '"%s": %s' % (key, new_path)
 
     def convert_paths_to_absolute(self, file_path, data):
@@ -205,7 +205,7 @@ class JsonDataStore:
         if info.THUMBNAIL_PATH in folder_path:
             # Convert path to relative thumbnail path
             new_path = os.path.join("thumbnail", file_path).replace("\\", "/")
-            new_path = json.dumps(new_path)  # Escape backslashes
+            new_path = json.dumps(new_path, ensure_ascii=False)
             return '"%s": %s' % (key, new_path)
 
         # Determine if @transitions path is found
@@ -215,7 +215,7 @@ class JsonDataStore:
 
             # Convert path to @transitions/ path
             new_path = os.path.join("@transitions", category_path, file_path).replace("\\", "/")
-            new_path = json.dumps(new_path)  # Escape backslashes
+            new_path = json.dumps(new_path, ensure_ascii=False)
             return '"%s": %s' % (key, new_path)
 
         # Determine if @assets path is found
@@ -225,7 +225,7 @@ class JsonDataStore:
 
             # Convert path to @transitions/ path
             new_path = os.path.join(folder_path, file_path).replace("\\", "/")
-            new_path = json.dumps(new_path)  # Escape backslashes
+            new_path = json.dumps(new_path, ensure_ascii=False)
             return '"%s": %s' % (key, new_path)
 
         # Find absolute path of file (if needed)
@@ -239,7 +239,7 @@ class JsonDataStore:
             # Calculate new relateive path
             new_rel_path_folder = os.path.relpath(orig_abs_folder, path_context.get("new_project_folder", ""))
             new_rel_path = os.path.join(new_rel_path_folder, file_path).replace("\\", "/")
-            new_rel_path = json.dumps(new_rel_path)  # Escape backslashes
+            new_rel_path = json.dumps(new_rel_path, ensure_ascii=False)
             return '"%s": %s' % (key, new_rel_path)
 
     def convert_paths_to_relative(self, file_path, previous_path, data):

--- a/src/classes/thumbnail.py
+++ b/src/classes/thumbnail.py
@@ -153,7 +153,7 @@ class httpThumbnailHandler(BaseHTTPRequestHandler):
         if not only_path:
             self.send_header('Content-type', 'image/png')
         else:
-            self.send_header('Content-type', 'text/html')
+            self.send_header('Content-type', 'text/html; charset=utf-8')
         self.end_headers()
 
         # Locate thumbnail


### PR DESCRIPTION
Fixes: https://github.com/OpenShot/openshot-qt/issues/3227

`export` and `updates` also uses `json.dumps()`, but it is slightly different thing. It needs more time to investigate if changes are required. In my tests it doesn't affect this issue itself.

Let's see if this fix is woks for you too.