### PR TITLE
Fix readonly text fields visibility for light system themes

### DIFF
--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -105,7 +105,10 @@ class PropertyDelegate(QItemDelegate):
             else:
                 painter.setBrush(QBrush(QColor("#3e3e3e")))
 
-        if not readonly:
+        if readonly:
+            # Set text color for read only fields
+            painter.setPen(QPen(get_app().window.palette().color(QPalette.Disabled, QPalette.Text)))
+        else:
             path = QPainterPath()
             path.addRoundedRect(QRectF(option.rect), 15, 15)
             painter.fillPath(path, QColor("#3e3e3e"))
@@ -135,8 +138,9 @@ class PropertyDelegate(QItemDelegate):
                 # Draw interpolation icon on top
                 painter.drawPixmap(option.rect.x() + option.rect.width() - 30.0, option.rect.y() + 4, self.curve_pixmaps[interpolation])
 
-        # set text color
-        painter.setPen(QPen(Qt.white))
+            # Set text color
+            painter.setPen(QPen(Qt.white))
+
         value = index.data(Qt.DisplayRole)
         if value:
             painter.drawText(option.rect, Qt.AlignCenter, value)


### PR DESCRIPTION
Fixes an issue when read only fields of properties are hard to read on bright backgrounds.

**Before** (the _Duration_ field):

![OpenShot properties view system01](https://user-images.githubusercontent.com/19683044/74607424-86580300-50e1-11ea-94e5-a58199276170.png)

**After** (the _Duration_ field):

![OpenShot properties view system02](https://user-images.githubusercontent.com/19683044/74607429-8c4de400-50e1-11ea-8c0b-2f8a53726801.png)

The Dark theme changes is not significant, bright text replaced with the "disabled" style, see below:

<details>
  <summary>Click to expand</summary>

**Before** (the _Duration_ field):

![OpenShot properties view dark01](https://user-images.githubusercontent.com/19683044/74607458-b99a9200-50e1-11ea-8e63-e4fe9a9b5bbc.png)

**After** (the _Duration_ field):

![OpenShot properties view dark02](https://user-images.githubusercontent.com/19683044/74607466-c4edbd80-50e1-11ea-892b-54bebde8ebd4.png)

</details>

Actually, I was thinking that these fields is just empty... (I'm using system theme for OpenShot).