### PR TITLE
Retire Windows envvar-deletion code (again)

### DIFF
--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -121,10 +121,6 @@ Type: dirifempty; Name: "{app}\*"
 Type: files; Name: "{group}\OpenShot Video Editor"; BeforeInstall: DeleteInvalidFiles
 
 [Registry]
-; Remove previously installed registry keys (no longer needed)
-Root: HKLM; Subkey: "System\CurrentControlSet\Control\Session Manager\Environment"; ValueName:"QT_PLUGIN_PATH"; ValueType: none; Flags: deletevalue;
-Root: HKLM; Subkey: "System\CurrentControlSet\Control\Session Manager\Environment"; ValueName:"MAGICK_CONFIGURE_PATH"; ValueType: none; Flags: deletevalue;
-
 ; Associate .osp files with the installed application. Uninstaller will clean them up, when run.
 
 ; Filename extension .osp


### PR DESCRIPTION
(I actually did this once before, over the summer, but it subsequently got lost during conflict resolution on another branch.)

It's been three years since OpenShot stopped inserting those envvars.
If anyone still has them set today, it's likely they were created by
some other software and we shouldn't be removing them.