### PR TITLE
Fixing logic when trying to parse changelogs in official releases

### DIFF
--- a/src/windows/about.py
+++ b/src/windows/about.py
@@ -289,6 +289,7 @@ class Changelog(QDialog):
                                                    'date': line[9:20].strip(),
                                                    'author': line[20:45].strip(),
                                                    'subject': line[45:].strip() })
+                        break
                 except:
                     # Ignore decoding errors
                     pass
@@ -309,6 +310,7 @@ class Changelog(QDialog):
                                                    'date': line[9:20].strip(),
                                                    'author': line[20:45].strip(),
                                                    'subject': line[45:].strip() })
+                        break
                 except:
                     # Ignore decoding errors
                     pass


### PR DESCRIPTION
When testing different charsets, we were not breaking out of the loop when the correct one was found, causing some strange data (and duplicate data) to appear on official release changelogs.