### PR TITLE
Add thumbnail to the audio only clip

### DIFF
--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -754,6 +754,10 @@ App.controller('TimelineCtrl',function($scope) {
 
   // Format the thumbnail path: http://127.0.0.1:8081/thumbnails/FILE-ID/FRAME-NUMBER/
  $scope.GetThumbPath = function(clip) {
+  var has_video = clip["reader"]["has_video"];
+  var has_audio = clip["reader"]["has_audio"];
+  if (!has_video && has_audio)
+    return "../images/AudioThumbnail.png"
  	var file_fps = clip["reader"]["fps"]["num"] / clip["reader"]["fps"]["den"];
  	return $scope.ThumbServer + clip.file_id + "/" + ((file_fps * clip.start) + 1) + "/";
  };

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -757,7 +757,7 @@ App.controller('TimelineCtrl',function($scope) {
   var has_video = clip["reader"]["has_video"];
   var has_audio = clip["reader"]["has_audio"];
   if (!has_video && has_audio)
-    return "../images/AudioThumbnail.png"
+    return "../images/AudioThumbnail.png";
  	var file_fps = clip["reader"]["fps"]["num"] / clip["reader"]["fps"]["den"];
  	return $scope.ThumbServer + clip.file_id + "/" + ((file_fps * clip.start) + 1) + "/";
  };


### PR DESCRIPTION
The audio only files has thumbnail rendered as black rectangle in the Timeline (v2.5.0).
Screenshot is here: https://github.com/OpenShot/openshot-qt/issues/3248