### PR TITLE
json_data: Autorepair corrupted project files

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -532,10 +532,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
                 log.info("Loaded project {}".format(file_path))
             else:
-                # Prepare to use status bar
-                self.statusBar = QStatusBar()
-                self.setStatusBar(self.statusBar)
-
                 log.info("File not found at {}".format(file_path))
                 self.statusBar.showMessage(_("Project {} is missing (it may have been moved or deleted). It has been removed from the Recent Projects menu.".format(file_path)), 5000)
                 self.remove_recent_project(file_path)
@@ -2552,6 +2548,10 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         else:
             self.effectsTreeView = EffectsListView(self)
         self.tabEffects.layout().addWidget(self.effectsTreeView)
+
+        # Set up status bar
+        self.statusBar = QStatusBar()
+        self.setStatusBar(self.statusBar)
 
         # Process events before continuing
         # TODO: Figure out why this is needed for a backup recovery to correctly show up on the timeline


### PR DESCRIPTION
If a file is detected as having corrupted unicode escapes, we make
a backup copy as filename.osp.bak (or filename.osp.bak.1...), then
regexp-replace all of the broken escapes with corrected ones. Then
we run the data through json.loads() and json.dumps() again to remove
the escaped characters, and write the results back to the original
file location as UTF-8.

There's a _**slight**_ danger of false positives on the corrupted-file detection, which is why a backup is made of the original data before it's rewritten. 

Also, as an added safety check, the repair will only run on project files matching `"openshot_qt".*"2.5.0` (meaning, they're tagged as created by 2.5.0). That way, we don't accidentally edit users' OpenShot 2.4.4 projects that import files from their `$HOME/Music/ub404eva/` directory.