### PR TITLE
Fix formatting for the json_data Autorepair output

### DIFF
--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -165,7 +165,7 @@ class JsonDataStore:
                 else:
                     # We have to de- and re-serialize the data, to complete repairs
                     temp_data = json.loads(contents)
-                    contents = json.dumps(temp_data, ensure_ascii=False)
+                    contents = json.dumps(temp_data, ensure_ascii=False, indent=1)
                     temp_data = {}
 
                     # Save the repaired data back to the original file


### PR DESCRIPTION
Fixes an issue where repaired file saved as single line of symbols on Windows (no CR LF endings).

Quick fix to: https://github.com/OpenShot/openshot-qt/pull/3259