### PR TITLE
Add Sorting for project files Views

### DIFF
--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -106,6 +106,20 @@
     "setting": "file_view"
   },
   {
+    "value": -1,
+    "title": "",
+    "type": "hidden",
+    "category": "UI",
+    "setting": "files_view_sorting"
+  },
+  {
+    "value": 0,
+    "title": "",
+    "type": "hidden",
+    "category": "UI",
+    "setting": "files_view_sorting_order"
+  },
+  {
     "value": "thumbnail",
     "title": "",
     "type": "hidden",

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -30,7 +30,7 @@ import os
 
 from PyQt5.QtCore import QSize, Qt, QPoint, QRegExp
 from PyQt5.QtGui import QDrag, QCursor
-from PyQt5.QtWidgets import QListView, QAbstractItemView, QMenu
+from PyQt5.QtWidgets import QListView, QAbstractItemView, QMenu, QActionGroup
 
 from classes.app import get_app
 from classes.logger import log
@@ -49,11 +49,79 @@ class FilesListView(QListView):
 
         index = self.indexAt(event.pos())
 
+        # Get translation function
+        _ = get_app()._tr
+
         # Build menu
         menu = QMenu(self)
 
         menu.addAction(self.win.actionImportFiles)
         menu.addAction(self.win.actionDetailsView)
+
+        # Sub-menu
+        menu.addSeparator()
+        sort_menu = QMenu(_("Sort by"), menu)
+
+        # -1 - Unsorted (from original model)
+        #  1 - Name
+        #  2 - Tags
+        #  3 - Type
+        #  4 - Path
+        #  5 - ID
+
+        all_sorting = [
+                        _("Unsorted"),
+                        _("Name"),
+                        _("Tags"),
+                        _("Type"),
+                        _("Path"),
+                        _("ID")
+                    ]
+
+        # Exclusive group
+        sorting_type_group = QActionGroup(menu)
+
+        sort_option = None
+        for i, sort_by in enumerate(all_sorting):
+            sort_option = sort_menu.addAction(sort_by)
+            sort_option.setCheckable(True)
+            # Store option number inside the action itself
+            # Python handles the QVariant conversion here
+            if i == 0:
+                sort_option.setData(-1)
+                if self.sort_column == -1:
+                    sort_option.setChecked(True)
+            else:
+                sort_option.setData(i)
+                if self.sort_column == i:
+                    sort_option.setChecked(True)
+
+            # Add each to exclusive group
+            sort_option.setActionGroup(sorting_type_group)
+
+        # Use menu triggered signal for closely related actions, it carries pointer to the action
+        sort_menu.triggered.connect(self.update_sorting)
+        menu.addMenu(sort_menu)
+        menu.addSeparator()
+        menu.addAction
+        sort_up = menu.addAction( _("Ascending") )
+        sort_down = menu.addAction( _("Descending") )
+
+        sort_down.setCheckable(True)
+        sort_up.setCheckable(True)
+
+        # Exclusive group
+        sorting_order_group = QActionGroup(menu)
+        sort_up.setActionGroup(sorting_order_group)
+        sort_down.setActionGroup(sorting_order_group)
+
+        if self.sort_order == Qt.AscendingOrder:
+            sort_up.setChecked(True)
+        else:
+            sort_down.setChecked(True)
+
+        sort_up.toggled.connect(self.sort_ascending)
+        sort_down.toggled.connect(self.sort_descending)
 
         if index.isValid():
             # Look up the model item and our unique ID
@@ -83,6 +151,11 @@ class FilesListView(QListView):
 
         # Show menu
         menu.exec_(event.globalPos())
+
+        # The menu may be closed without action taken, thus disconnect old signals
+        sort_menu.triggered.disconnect(self.update_sorting)
+        sort_up.toggled.disconnect(self.sort_ascending)
+        sort_down.toggled.disconnect(self.sort_descending)
 
     def dragEnterEvent(self, event):
         # If dragging urls onto widget, accept
@@ -152,14 +225,41 @@ class FilesListView(QListView):
     def filter_changed(self):
         self.refresh_view()
 
+    def sort_ascending(self, checked=False):
+        if checked:
+            self.sort_order = Qt.AscendingOrder
+            self.apply_items_sorting()
+
+    def sort_descending(self, checked=False):
+        if checked:
+            self.sort_order = Qt.DescendingOrder
+            self.apply_items_sorting()
+
+    def update_sorting(self, action):
+        # Column:
+        # -1 - Unsorted (from original model)
+        #  1 - Name
+        #  2 - Tags
+        #  3 - Type
+        #  4 - Path
+        #  5 - ID
+
+        # Get what sorting was triggered
+        self.sort_column = action.data()
+        self.apply_items_sorting()
+
+    def apply_items_sorting(self):
+        self.model().sort(self.sort_column, self.sort_order)
+
     def refresh_view(self):
         """Filter files with proxy class"""
         model = self.model()
         filter_text = self.win.filesFilter.text()
         model.setFilterRegExp(QRegExp(filter_text.replace(' ', '.*'), Qt.CaseInsensitive))
 
-        col = model.sortColumn()
-        model.sort(col)
+        self.sort_column = model.sortColumn()
+        self.sort_order = model.sortOrder()
+        self.apply_items_sorting()
 
     def resize_contents(self):
         pass
@@ -174,6 +274,10 @@ class FilesListView(QListView):
         # Get Model data
         self.files_model = model
         self.setModel(self.files_model.proxy_model)
+
+        # Column from the files model to sort by (-1 is unsorted)
+        self.sort_column = self.files_model.proxy_model.sortColumn()
+        self.sort_order = self.files_model.proxy_model.sortOrder()
 
         # Remove the default selection model and wire up to the shared one
         self.selectionModel().deleteLater()

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -31,7 +31,7 @@ import os
 
 from PyQt5.QtCore import QSize, Qt, QPoint
 from PyQt5.QtGui import QDrag, QCursor
-from PyQt5.QtWidgets import QTreeView, QAbstractItemView, QMenu, QSizePolicy, QHeaderView
+from PyQt5.QtWidgets import QTreeView, QAbstractItemView, QMenu, QSizePolicy, QHeaderView, QActionGroup
 
 from classes.app import get_app
 from classes.logger import log
@@ -50,11 +50,79 @@ class FilesTreeView(QTreeView):
 
         index = self.indexAt(event.pos())
 
+        # Get translation function
+        _ = get_app()._tr
+
         # Build menu
         menu = QMenu(self)
 
         menu.addAction(self.win.actionImportFiles)
         menu.addAction(self.win.actionThumbnailView)
+
+        # Sub-menu
+        menu.addSeparator()
+        sort_menu = QMenu(_("Sort by"), menu)
+
+        # -1 - Unsorted (from original model)
+        #  1 - Name
+        #  2 - Tags
+        #  3 - Type
+        #  4 - Path
+        #  5 - ID
+
+        all_sorting = [
+                        _("Unsorted"),
+                        _("Name"),
+                        _("Tags"),
+                        _("Type"),
+                        _("Path"),
+                        _("ID")
+                    ]
+
+        # Exclusive group
+        sorting_type_group = QActionGroup(menu)
+
+        sort_option = None
+        for i, sort_by in enumerate(all_sorting):
+            sort_option = sort_menu.addAction(sort_by)
+            sort_option.setCheckable(True)
+            # Store option number inside the action itself
+            # Python handles the QVariant conversion here
+            if i == 0:
+                sort_option.setData(-1)
+                if self.sort_column == -1:
+                    sort_option.setChecked(True)
+            else:
+                sort_option.setData(i)
+                if self.sort_column == i:
+                    sort_option.setChecked(True)
+
+            # Add each to exclusive group
+            sort_option.setActionGroup(sorting_type_group)
+
+        # Use menu triggered signal for closely related actions, it carries pointer to the action
+        sort_menu.triggered.connect(self.update_sorting)
+        menu.addMenu(sort_menu)
+        menu.addSeparator()
+        menu.addAction
+        sort_up = menu.addAction( _("Ascending") )
+        sort_down = menu.addAction( _("Descending") )
+
+        sort_down.setCheckable(True)
+        sort_up.setCheckable(True)
+
+        # Exclusive group
+        sorting_order_group = QActionGroup(menu)
+        sort_up.setActionGroup(sorting_order_group)
+        sort_down.setActionGroup(sorting_order_group)
+
+        if self.sort_order == Qt.AscendingOrder:
+            sort_up.setChecked(True)
+        else:
+            sort_down.setChecked(True)
+
+        sort_up.toggled.connect(self.sort_ascending)
+        sort_down.toggled.connect(self.sort_descending)
 
         if index.isValid():
             # Look up the model item and our unique ID
@@ -84,6 +152,11 @@ class FilesTreeView(QTreeView):
 
         # Show menu
         menu.exec_(event.globalPos())
+
+        # The menu may be closed without action taken, thus disconnect old signals
+        sort_menu.triggered.disconnect(self.update_sorting)
+        sort_up.toggled.disconnect(self.sort_ascending)
+        sort_down.toggled.disconnect(self.sort_descending)
 
     def dragEnterEvent(self, event):
         # If dragging urls onto widget, accept
@@ -156,12 +229,44 @@ class FilesTreeView(QTreeView):
     def filter_changed(self):
         self.refresh_view()
 
+    def sort_ascending(self, checked=False):
+        if checked:
+            self.sort_order = Qt.AscendingOrder
+            self.apply_items_sorting()
+
+    def sort_descending(self, checked=False):
+        if checked:
+            self.sort_order = Qt.DescendingOrder
+            self.apply_items_sorting()
+
+    def update_sorting(self, action):
+        # Column:
+        # -1 - Unsorted (from original model)
+        #  1 - Name
+        #  2 - Tags
+        #  3 - Type
+        #  4 - Path
+        #  5 - ID
+
+        # Get what sorting was triggered
+        self.sort_column = action.data()
+        self.apply_items_sorting()
+
+    def apply_items_sorting(self):
+        self.model().sort(self.sort_column, self.sort_order)
+
     def refresh_view(self):
         """Resize and hide certain columns"""
         self.hideColumn(3)
         self.hideColumn(4)
         self.hideColumn(5)
         self.resize_contents()
+
+        # Update sorting
+        model = self.model()
+        self.sort_column = model.sortColumn()
+        self.sort_order = model.sortOrder()
+        self.apply_items_sorting()
 
     def resize_contents(self):
         # Get size of widget
@@ -219,6 +324,10 @@ class FilesTreeView(QTreeView):
         # Get Model data
         self.files_model = model
         self.setModel(self.files_model.proxy_model)
+
+        # Column from the files model to sort by (-1 is unsorted)
+        self.sort_column = self.files_model.proxy_model.sortColumn()
+        self.sort_order = self.files_model.proxy_model.sortOrder()
 
         # Remove the default selection model and wire up to the shared one
         self.selectionModel().deleteLater()


### PR DESCRIPTION
**Edit 2:** Add sorting for Project Files (by Name, Path etc.). Nothing else is here. Other will be in other PRs.

Some ideas were adopted in current _develop_, so no sense to read below.

---------------

This removes excessive listener (double of the FilesModel) from the updateListeners list.

This is first step to resolve the https://github.com/OpenShot/openshot-qt/issues/444 **Edit:** ~~(it wouldn't be solved in this PR in part of add files but at remove).~~ ready for multiprocessing

---------------

The FilesModel adds itself to the listeners during initialization:

https://github.com/OpenShot/openshot-qt/blob/777cf1f1547f48bcddf55da2a766c05e9d28376f/src/windows/models/files_model.py#L216-L218

Thus, the first copy of FilesModel class is added in:

https://github.com/OpenShot/openshot-qt/blob/777cf1f1547f48bcddf55da2a766c05e9d28376f/src/windows/views/files_listview.py#L320-L321

or

https://github.com/OpenShot/openshot-qt/blob/777cf1f1547f48bcddf55da2a766c05e9d28376f/src/windows/views/files_treeview.py#L370-L371

via main window creation on application startup:

https://github.com/OpenShot/openshot-qt/blob/777cf1f1547f48bcddf55da2a766c05e9d28376f/src/windows/main_window.py#L2530-L2534

Everything else (from PropertiesTableView initialization) - just result of action updates (it seems that it works good and keeps both copies up to date whole time).

It can reduce twice the number of messages `updating files model` in the log.