### PR TITLE
Ignore file model update during files remove

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1578,6 +1578,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
     def actionRemove_from_Project_trigger(self, event):
         log.info("actionRemove_from_Project_trigger")
 
+        # Tell file model to ignore updates
+        self.filesTreeView.files_model.ignore_update_signal = True
+
         # Loop through selected files
         for file_id in self.selected_files:
             # Find matching file
@@ -1594,6 +1597,10 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # Clear selected files
         self.selected_files = []
+
+        # Re-enable updates and refresh view
+        self.filesTreeView.files_model.ignore_update_signal = False
+        self.filesTreeView.refresh_view()
 
         # Refresh preview
         get_app().window.refreshFrameSignal.emit()


### PR DESCRIPTION
Fixes the performance issue during group of files delete.

Steps to reproduce the issue:
1) Add 40 image files to the Project files list
2) Select any 6 of them
3) In right-click menu over the files click _Remove from Project_
4) Notice that list updates one by one in very slow manner (even slower than during adding them).

If you don't see changes after this fix, probably you forgot to apply the: https://github.com/OpenShot/openshot-qt/pull/3264