### PR TITLE
json_data: Correct for lost slashes, pre-repair

### DIFF
--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -60,6 +60,9 @@ class JsonDataStore:
         # Regular expression matching likely corruption in project files
         self.damage_re = re.compile(r'/u([0-9a-fA-F]{4})')
 
+        # Regular expression used to detect lost slashes, when repairing data
+        self.slash_repair_re = re.compile(r'(["/][.]+)(/u[0-9a-fA-F]{4})')
+
         # Connection to Qt main window, used in recovery alerts
         app = get_app()
         if app:
@@ -156,7 +159,8 @@ class JsonDataStore:
                 # File contains corruptions, backup and repair
                 self.make_repair_backup(file_path, contents)
 
-                # Repair all corrupted escapes
+                # Repair lost slashes, then fix all corrupted escapes
+                contents = self.slash_repair_re.sub(r'\1/\2', contents)
                 contents, subs_count = self.damage_re.subn(r'\\u\1', contents)
 
                 if subs_count < 1:


### PR DESCRIPTION
An adjustment to the repair functionality, as outlined in https://github.com/OpenShot/openshot-qt/pull/3259#issuecomment-593133641

This adds an additional potential false-positive exposure, in that dotfile names that start with a unicode character (e.g. `../.öpenshot_qt/video.mp4`) will now be incorrectly repaired (e.g. to `.././öpenshot_qt/video.mp4`).

Do I really think that there are users out there who have project files containing imported media located in dotfiles or within dotfolders named so strangely? Honestly, anything's possible.

Am I _worried_ about misinterpreting their crazy paths? Not in the slightest.