### PR TITLE
Docs: Generate User Manual HTML without Google Analytics (which is only needed for the official website version)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ linux-builder:
     - export LD_LIBRARY_PATH=$CI_PROJECT_DIR/build/install-x64/lib:$LD_LIBRARY_PATH
     - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID" > "build/install-x64/share/$CI_PROJECT_NAME"
     - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"
-    - cd doc; make html; cd ..;
+    - cd doc; make html SPHINXOPTS="-D html_theme_options.analytics_id=UA-4381101-5"; cd ..;
     - ~/auto-update-sphinx "$CI_PROJECT_DIR/build" "$CI_COMMIT_REF_NAME"
     - python3 freeze.py build
     - python3 installer/build-server.py "$SLACK_TOKEN" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "False" "$CI_COMMIT_REF_NAME"

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,18 +1,2 @@
 {% extends "!layout.html" %}
 {% set css_files = css_files + ["_static/tablefix.css"] %}
-
-{% block footer %}
-    {{ super() }}
-    <script type="text/javascript">
-      // Google Analytics
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', 'UA-4381101-5']);
-      _gaq.push(['_trackPageview']);
-
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-    </script>
-{% endblock %}


### PR DESCRIPTION
Working on fixes to the OpenShot PPA definition (see #3280), one of the things I'd like to do is fix `openshot-qt-doc` so that it actually contains a local copy of the User Guide HTML.

However, `lintian` complains about the generated docs, because they include Google Analytics tracking.

With these changes, instead of unconditionally including GA in the generated output, we revert to using the theme's built-in support for conditional analytics (controlled by the
`html_theme_options` config dictionary).

Instead of hardcoding the analytics embed, `html_theme_options.analytics_id` is set on the documentation-rebuild command line for the official OpenShot site updates, in `.gitlab-ci.yml`. This ensures that GA will only be included in _those_ documentation builds, not local/user copies of the manual.