### PR TITLE
AppImage: Fix a crash issue running on systems with newer OpenSSL

### DIFF
--- a/installer/launch-linux.sh
+++ b/installer/launch-linux.sh
@@ -3,8 +3,13 @@
 # Add the current folder the library path
 LD_LIBRARY_PATH="."
 
-# Set some environment variables for ImageMagick and Qt5
+# Set some environment variables
 export QT_PLUGIN_PATH="."
+
+# For Debian-based systems with newer openssl, see:
+# https://github.com/OpenShot/openshot-qt/issues/3242
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=918727 
+export OPENSSL_CONF=/dev/null
 
 # Launch application
 HERE="$(dirname "$(readlink -f "${0}")")"


### PR DESCRIPTION
On systems with newer versions of openssl, the installed file `/etc/ssl/openssl.cnf` is incompatible with our bundled version of `libssl.so`. But it will be loaded by default, leading to a crash, unless `OPENSSL_CONF` is set to `/dev/null` (or some other invalid path) in the AppImage environment.

Fixes #3242 