### PR TITLE
Allow *.osp project files to be imported as a Clip

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -128,6 +128,9 @@ class OpenShotApp(QApplication):
             # Stop launching and exit
             sys.exit()
 
+        # Set location of OpenShot program (for libopenshot)
+        openshot.Settings.Instance().PATH_OPENSHOT_INSTALL = info.PATH
+
         # Tests of project data loading/saving
         self.project = project_data.ProjectDataStore()
 

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -447,6 +447,8 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     def actionClearHistory_trigger(self, event):
         """Clear history for current project"""
+        project = get_app().project
+        project.has_unsaved_changes = True
         get_app().updates.reset()
         log.info('History cleared')
 

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -1,27 +1,27 @@
-""" 
+"""
  @file
  @brief This file contains the project file listview, used by the main window
  @author Noah Figg <eggmunkee@hotmail.com>
  @author Jonathan Thomas <jonathan@openshot.org>
- 
+
  @section LICENSE
- 
+
  Copyright (c) 2008-2018 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
@@ -151,6 +151,9 @@ class FilesListView(QListView):
                 file_data["media_type"] = "image"
             elif file_data["has_audio"] and not file_data["has_video"]:
                 file_data["media_type"] = "audio"
+            else:
+                # If neither set, just assume video
+                file_data["media_type"] = "video"
 
             # Save new file to the project data
             file = File()

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -1,28 +1,28 @@
-""" 
+"""
  @file
  @brief This file contains the project file treeview, used by the main window
  @author Noah Figg <eggmunkee@hotmail.com>
  @author Jonathan Thomas <jonathan@openshot.org>
  @author Olivier Girard <eolinwen@gmail.com>
- 
+
  @section LICENSE
- 
+
  Copyright (c) 2008-2018 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
@@ -150,6 +150,9 @@ class FilesTreeView(QTreeView):
                 file_data["media_type"] = "image"
             elif file_data["has_audio"] and not file_data["has_video"]:
                 file_data["media_type"] = "audio"
+            else:
+                # If neither set, just assume video
+                file_data["media_type"] = "video"
 
             # Save new file to the project data
             file = File()


### PR DESCRIPTION
- Allow *.osp project files to be imported as a Clip. 
- Better handle unknown "media_type"'s.  
- Trigger "has unsaved changes" when clearing history from a Project, so the user can immediately save the *.osp file without history.

A few misc things, but all related to my work on allowing *.osp files to be imported as a Clip, without deadlocking the system, or crashing anything. :wink: 

Related PR for `libopenshot`: https://github.com/OpenShot/libopenshot/pull/459