### PR TITLE
Filter properties using localized label

### DIFF
--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -605,7 +605,7 @@ class PropertiesModel(updates.UpdateInterface):
                     selected_choice = [c for c in choices if c["selected"] == True][0]["name"]
 
                 # Hide filtered out properties
-                if filter and filter.lower() not in name.lower():
+                if filter and filter.lower() not in _(label).lower():
                     continue
 
                 # Hide unused base properties (if any)


### PR DESCRIPTION
The properties filter field should match on the translated display string, not the English property name.

Fixes #3287 