### PR TITLE
Fix Edit Title, Duplicate Title shortcut overlap with Add Track

### DIFF
--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -687,10 +687,6 @@
     "value": "-",
     "type": "text"
   },
-
-
-
-
   {
     "category": "Keyboard",
     "title": "Previous Frame",
@@ -905,6 +901,22 @@
     "restart": true,
     "setting": "nudgeRight",
     "value": "Shift+Right",
+    "type": "text"
+  },
+  {
+    "category": "Keyboard",
+    "title": "Edit Title",
+    "restart": true,
+    "setting": "actionEditTitle",
+    "value": "",
+    "type": "text"
+  },
+  {
+    "category": "Keyboard",
+    "title": "Duplicate Title",
+    "restart": true,
+    "setting": "actionDuplicateTitle",
+    "value": "Ctrl+Shift+C",
     "type": "text"
   }
 ]

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -395,20 +395,13 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         file = File.get(id=selected_file_id)
         file_path = file.data.get("path")
 
-        # Delete thumbnail for this file (it will be recreated soon)
-        thumb_path = os.path.join(info.THUMBNAIL_PATH, "{}.png".format(file.id))
-
-        # Check if thumb exists (and delete it)
-        if os.path.exists(thumb_path):
-            os.remove(thumb_path)
-
         # show dialog for editing title
         from windows.title_editor import TitleEditor
         win = TitleEditor(file_path)
         # Run the dialog event loop - blocking interaction on this window during that time
         result = win.exec_()
 
-        # Force update of files model (which will rebuild missing thumbnails)
+        # Force update of files model (which will rebuild thumbnails)
         get_app().window.filesTreeView.refresh_view()
 
         # Force update of clips
@@ -919,7 +912,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # Bail out if no file selected
         if not f:
-            log.info(self.selected_files)
+            log.info("Preview action failed, selected files: {}".format(self.selected_files))
             return
 
         # show dialog
@@ -1205,7 +1198,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     def actionSnappingTool_trigger(self, event):
         log.info("actionSnappingTool_trigger")
-        log.info(self.actionSnappingTool.isChecked())
 
         # Enable / Disable snapping mode
         self.timeline.SetSnappingMode(self.actionSnappingTool.isChecked())
@@ -1289,7 +1281,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     def actionNextMarker_trigger(self, event):
         log.info("actionNextMarker_trigger")
-        log.info(self.preview_thread.current_frame)
 
         # Calculate current position (in seconds)
         fps = get_app().project.get("fps")
@@ -1432,7 +1423,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             self.actionRemoveClip.trigger()
             self.actionRemoveTransition.trigger()
 
-        # Boiler plate key mappings (mostly for menu support on Ubuntu/Unity)
+        # Menu shortcuts
         elif key.matches(self.getShortcutByName("actionNew")) == QKeySequence.ExactMatch:
             self.actionNew.trigger()
         elif key.matches(self.getShortcutByName("actionOpen")) == QKeySequence.ExactMatch:
@@ -1552,8 +1543,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         elif key.matches(self.getShortcutByName("selectNone")) == QKeySequence.ExactMatch:
             self.timeline.ClearAllSelections()
 
-        # Bubble event on
-        event.ignore()
+        # If we didn't act on the event, forward it to the base class
+        else:
+            super(MainWindow, self).keyPressEvent(event)
 
 
     def actionProfile_trigger(self, event):
@@ -1577,7 +1569,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # Bail out if no file selected
         if not f:
-            log.info(self.selected_files)
+            log.warn("Split clip action failed, selected files: {}".format(self.selected_files))
             return
 
         # show dialog

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -423,10 +423,18 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     def actionDuplicateTitle_trigger(self, event):
 
-        # Get selected svg title file
-        selected_file_id = self.selected_files[0]
-        file = File.get(id=selected_file_id)
-        file_path = file.data.get("path")
+        file_path = None
+
+        # Loop through selected files (set 1 selected file if more than 1)
+        for file_id in self.selected_files:
+            # Find matching file
+            f = File.get(id=file_id)
+            if f.data.get("path").endswith(".svg"):
+                file_path = f.data.get("path")
+                break
+
+        if not file_path:
+            return
 
         # show dialog for editing title
         from windows.title_editor import TitleEditor
@@ -1463,6 +1471,11 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             self.actionTitle.trigger()
         elif key.matches(self.getShortcutByName("actionAnimatedTitle")) == QKeySequence.ExactMatch:
             self.actionAnimatedTitle.trigger()
+        elif key.matches(self.getShortcutByName("actionDuplicateTitle")) == QKeySequence.ExactMatch:
+            log.info("Duplicating title, {}".format(event))
+            self.actionDuplicateTitle.trigger()
+        elif key.matches(self.getShortcutByName("actionEditTitle")) == QKeySequence.ExactMatch:
+            self.actionEditTitle.trigger()
         elif key.matches(self.getShortcutByName("actionFullscreen")) == QKeySequence.ExactMatch:
             self.actionFullscreen.trigger()
         elif key.matches(self.getShortcutByName("actionAbout")) == QKeySequence.ExactMatch:

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -897,7 +897,7 @@
   <action name="actionCenterOnPlayhead">
    <property name="icon">
     <iconset resource="../../images/openshot.qrc">
-	    <normaloff>:/icons/Humanity/actions/custom/center-on-playhead.svg</normaloff>:/icons/Humanity/actions/custom/center-on-playhead.svg</iconset>
+     <normaloff>:/icons/Humanity/actions/custom/center-on-playhead.svg</normaloff>:/icons/Humanity/actions/custom/center-on-playhead.svg</iconset>
    </property>
    <property name="text">
     <string>Center on Playhead</string>
@@ -1561,9 +1561,6 @@
    <property name="toolTip">
     <string>Edit Title</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+Shift+T</string>
-   </property>
   </action>
   <action name="actionDuplicateTitle">
    <property name="icon">
@@ -1577,7 +1574,7 @@
     <string>Duplicate Title</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+T</string>
+    <string>Ctrl+Shift+C</string>
    </property>
   </action>
   <action name="actionClearHistory">


### PR DESCRIPTION
A user reported that the Duplicate Title shortcut both (a) didn't work, and (b) wasn't editable. Turned out, it was set to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd>, which is a problem because so was Edit Title. Worse, _neither_ of those actually responded to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd>, because <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd> is Add Track! They also appeared nowhere in the settings file.

I managed to fix that, made them both configurable, with Duplicate Track set to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> — it was free — and Edit Title not set by default.

As part of making the shortcuts properly react to selection in the file views, I rewrote a bunch of the selection-handling logic so it's less easily confused, and accidentally fixed #3240 in the process.

Fixes #3310 
Fixes #3240