### PR TITLE
Deselect Timeline's item on mouse click

### DIFF
--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -472,7 +472,6 @@ App.controller("TimelineCtrl", function ($scope) {
   $scope.clearAllSelections = function () {
     // Clear the selections on the main window
     $scope.selectTransition("", true);
-    $scope.selectEffect("", true);
 
     // Update scope
     $scope.$apply(function () {
@@ -506,11 +505,17 @@ App.controller("TimelineCtrl", function ($scope) {
     // Trim clip_id
     var id = clip_id.replace("clip_", "");
 
-    // Clear transitions also (if needed)
-    if (id !== "" && clear_selections) {
-      $scope.selectTransition("", clear_selections);
-      $scope.selectEffect("", clear_selections);
+    // Is CTRL pressed?
+    var is_ctrl = false;
+    if (event && event.ctrlKey) {
+      is_ctrl = true;
     }
+
+    // Clear transitions selection if needed
+    if (id !== "" && clear_selections && !is_ctrl) {
+      $scope.selectTransition("", true);
+    }
+
     // Call slice method and exit (don't actually select the clip)
     if (id !== "" && $scope.enable_razor) {
       if ($scope.Qt) {
@@ -520,18 +525,28 @@ App.controller("TimelineCtrl", function ($scope) {
       // Don't actually select clip
       return;
     }
-    // Is CTRL pressed?
-    var is_ctrl = false;
-    if (event && event.ctrlKey) {
-      is_ctrl = true;
-    }
 
-    // Unselect all clips
+    // Update selection for clips
     for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
       if ($scope.project.clips[clip_index].id === id) {
-        $scope.project.clips[clip_index].selected = true;
-        if ($scope.Qt) {
-          timeline.addSelection(id, "clip", clear_selections);
+        // Invert selection if CTRL is pressed and not forced add and already selected
+        if (is_ctrl && clear_selections && ($scope.project.clips[clip_index].selected === true)) {
+          $scope.project.clips[clip_index].selected = false;
+          if ($scope.Qt) {
+            timeline.removeSelection($scope.project.clips[clip_index].id, "clip");
+          }
+        }
+        else {
+          $scope.project.clips[clip_index].selected = true;
+          if ($scope.Qt) {
+            // Do not clear selection if CTRL is pressed
+            if (is_ctrl) {
+              timeline.addSelection(id, "clip", false);
+            }
+            else {
+              timeline.addSelection(id, "clip", clear_selections);
+            }
+          }
         }
       }
       else if (clear_selections && !is_ctrl) {
@@ -548,11 +563,17 @@ App.controller("TimelineCtrl", function ($scope) {
     // Trim tran_id
     var id = tran_id.replace("transition_", "");
 
-    // Clear clips also (if needed)
-    if (id !== "" && clear_selections) {
-      $scope.selectClip("", true);
-      $scope.selectEffect("", true);
+    // Is CTRL pressed?
+    var is_ctrl = false;
+    if (event && event.ctrlKey) {
+      is_ctrl = true;
     }
+
+    // Clear clips selection if needed
+    if (id !== "" && clear_selections && !is_ctrl) {
+      $scope.selectClip("", true);
+    }
+
     // Call slice method and exit (don't actually select the transition)
     if (id !== "" && $scope.enable_razor) {
       if ($scope.Qt) {
@@ -563,18 +584,27 @@ App.controller("TimelineCtrl", function ($scope) {
       return;
     }
 
-    // Is CTRL pressed?
-    var is_ctrl = false;
-    if (event && event.ctrlKey) {
-      is_ctrl = true;
-    }
-
-    // Unselect all transitions
+    // Update selection for transitions
     for (var tran_index = 0; tran_index < $scope.project.effects.length; tran_index++) {
       if ($scope.project.effects[tran_index].id === id) {
-        $scope.project.effects[tran_index].selected = true;
-        if ($scope.Qt) {
-          timeline.addSelection(id, "transition", clear_selections);
+        // Invert selection if CTRL is pressed and not forced add and already selected
+        if (is_ctrl && clear_selections && ($scope.project.effects[tran_index].selected === true)) {
+          $scope.project.effects[tran_index].selected = false;
+          if ($scope.Qt) {
+            timeline.removeSelection($scope.project.effects[tran_index].id, "transition");
+          }
+        }
+        else {
+          $scope.project.effects[tran_index].selected = true;
+          if ($scope.Qt) {
+            // Do not clear selection if CTRL is pressed
+            if (is_ctrl) {
+              timeline.addSelection(id, "transition", false);
+            }
+            else {
+              timeline.addSelection(id, "transition", clear_selections);
+            }
+          }
         }
       }
       else if (clear_selections && !is_ctrl) {


### PR DESCRIPTION
1) Add ability to deselect items on mouse click if already was selected and Ctrl key is pressed.

2) Fixes: https://github.com/OpenShot/openshot-qt/issues/2911
Do not clear selection if multiply items selected. Fixes an issue where context menu over the multiply items selected shows only single item selected menu (unlike the mouse rectangle selection, where all is OK).
Next part of the code (and similar change to the transition's code) fixes the issue itself:
```
// Do not clear selection if CTRL is pressed
if (is_ctrl)
	timeline.addSelection(id, "clip", false);
else
	timeline.addSelection(id, "clip", clear_selections);
```

3) Remove all unused _SelectEffect()_ call with two arguments. Rudiment of old changes.

Now Transitions + Clip selection with the <kbd>Ctrl</kbd> pressed acts similar to the rectangle selection by mouse move (no deselection of either transitions or clips).