### PR TITLE
Enhance security by preferring defusedxml to the standard xml, if it's available

### DIFF
--- a/src/classes/ui_util.py
+++ b/src/classes/ui_util.py
@@ -1,35 +1,40 @@
-""" 
+"""
  @file
  @brief This file contains PyQt help functions, to translate the interface, load icons, and connect signals
  @author Noah Figg <eggmunkee@hotmail.com>
  @author Jonathan Thomas <jonathan@openshot.org>
  @author Olivier Girard <eolinwen@gmail.com>
- 
+
  @section LICENSE
- 
+
  Copyright (c) 2008-2018 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
 import os
-import xml.etree.ElementTree
 import time
+
+# Try to get the security-patched XML functions from defusedxml
+try:
+  from defusedxml import ElementTree
+except ImportError:
+  from xml.etree import ElementTree
 
 from PyQt5.QtCore import QDir, QLocale
 from PyQt5.QtGui import QIcon
@@ -85,7 +90,7 @@ def load_ui(window, path):
         raise error
 
     # Save xml tree for ui
-    window.uiTree = xml.etree.ElementTree.parse(path)
+    window.uiTree = ElementTree.parse(path)
 
 
 def get_default_icon(theme_name):

--- a/src/language/generate_translations.py
+++ b/src/language/generate_translations.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
-""" 
+"""
  @file
  @brief This file updates the OpenShot.POT (language translation template) by scanning all source files.
  @author Jonathan Thomas <jonathan@openshot.org>
- 
+
  This file helps you generate the POT file that contains all of the translatable
  strings / text in OpenShot.  Because some of our text is in custom XML files,
- the xgettext command can't correctly generate the POT file.  Thus... the 
+ the xgettext command can't correctly generate the POT file.  Thus... the
  existence of this file. =)
 
  Command to create the individual language PO files (Ascii files)
@@ -28,23 +28,23 @@
        $ msgcat ~/openshot/locale/OpenShot/OpenShot_source.pot ~/openshot/openshot/locale/OpenShot/OpenShot_glade.pot -o ~/openshot/main/locale/OpenShot/OpenShot.pot
 
  @section LICENSE
- 
+
  Copyright (c) 2008-2018 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
@@ -54,8 +54,14 @@ import datetime
 import os
 import subprocess
 import sys
-import xml.dom.minidom as xml
 import json
+
+# Try to get the security-patched XML functions from defusedxml
+try:
+  from defusedxml import minidom as xml
+except ImportError:
+  from xml.dom import minidom as xml
+
 import openshot
 
 # Get the absolute path of this project

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -28,9 +28,13 @@ import functools
 import locale
 import os
 import time
-import xml.dom.minidom as xml
 import tempfile
 
+# Try to get the security-patched XML functions from defusedxml
+try:
+  from defusedxml import minidom as xml
+except ImportError:
+  from xml.dom import minidom as xml
 
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *

--- a/src/windows/file_properties.py
+++ b/src/windows/file_properties.py
@@ -27,19 +27,26 @@
 
 import os
 import locale
-import xml.dom.minidom as xml
 import functools
+import json
+
+# Try to get the security-patched XML functions from defusedxml
+try:
+  from defusedxml import minidom as xml
+except ImportError:
+  from xml.dom import minidom as xml
 
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
-import openshot  # Python module for libopenshot (required video editing module installed separately)
+
+# Python module for libopenshot (required video editing module installed separately)
+import openshot
 
 from classes import info, ui_util, settings
 from classes.app import get_app
 from classes.logger import log
 from classes.metrics import *
 
-import json
 
 class FileProperties(QDialog):
     """ File Properties Dialog """

--- a/src/windows/models/blender_model.py
+++ b/src/windows/models/blender_model.py
@@ -26,7 +26,12 @@
  """
 
 import os
-import xml.dom.minidom as xml
+
+# Try to get the security-patched XML functions from defusedxml
+try:
+  from defusedxml import minidom as xml
+except ImportError:
+  from xml.dom import minidom as xml
 
 from PyQt5.QtCore import Qt, QSize
 from PyQt5.QtGui import *

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -30,8 +30,14 @@ import shutil
 import subprocess
 import sys
 import re
-import xml.dom.minidom as xml
 import functools
+import json
+
+# Try to get the security-patched XML functions from defusedxml
+try:
+  from defusedxml import minidom as xml
+except ImportError:
+  from xml.dom import minidom as xml
 
 from PyQt5.QtCore import QSize, Qt, QEvent, QObject, QThread, pyqtSlot, pyqtSignal, QMetaObject, Q_ARG, QTimer
 from PyQt5.QtGui import *
@@ -43,8 +49,6 @@ from classes import settings
 from classes.query import File
 from classes.app import get_app
 from windows.models.blender_model import BlenderModel
-
-import json
 
 
 class BlenderListView(QListView):


### PR DESCRIPTION
The Python stdlib xml module has several known vulnerabilities in its XML parsing code, which defusedxml corrects. We attempt to load defused, and if it fails to import, just continue with stdlib.

Python docs for the `xml` module, noting its vulnerabilities to maliciously-crafted XML: https://docs.python.org/3/library/xml.html
