### PR TITLE
Add Timeline frame number display to Preview

### DIFF
--- a/src/images/Humanity/actions/custom/media-frame-backward.svg
+++ b/src/images/Humanity/actions/custom/media-frame-backward.svg
@@ -1,0 +1,28 @@
+<svg width="16" height="16" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <defs>
+  <linearGradient id="linearGradient4518" x1="10" x2="7" y1="5" y2="13" gradientTransform="matrix(-1,0,0,1,15,19.864)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#eeeeec" offset="0"/>
+   <stop stop-color="#babdb6" offset=".6958"/>
+   <stop stop-color="#a1a59b" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4520" x1="3.5" x2="12.5" y1="-14.5" y2="-13.5" gradientTransform="translate(20.349,15.471)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#eeeeec" offset="0"/>
+   <stop stop-color="#babdb6" offset=".6958"/>
+   <stop stop-color="#a1a59b" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4522" x1="14.978" x2="15.139" y1="5.9683" y2="15.736" gradientTransform="matrix(-1 0 0 .88732 14.971 21.23)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#fff" offset="0"/>
+   <stop stop-color="#fff" stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4524" x1="8" x2="8" y1="4" y2="13" gradientTransform="matrix(-1,0,0,1,15,19.864)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#fff" offset="0"/>
+   <stop stop-color="#fff" stop-opacity="0" offset="1"/>
+  </linearGradient>
+ </defs>
+ <g transform="translate(3.029 -19.864)">
+  <path d="m8.497 23.366v9.9951l-7.997-4.997 7.997-4.998z" display="block" fill="url(#linearGradient4518)" stroke="#888a86" stroke-linejoin="round" stroke-width="1.0053"/>
+  <rect transform="matrix(0,1,1,0,0,0)" x="23.349" y=".47099" width="10" height="2" rx="0" ry="0" display="block" fill="url(#linearGradient4520)" stroke="#888a86" stroke-linejoin="round"/>
+  <path d="m1.471 24.335v7.996" display="block" fill="none" opacity=".3" stroke="url(#linearGradient4522)" stroke-linecap="square" stroke-width=".94198"/>
+  <path d="m7.4997 25.302v6.125l-5.2817-3.062 5.2817-3.0625z" display="block" fill="none" opacity=".5" stroke="url(#linearGradient4524)" stroke-linejoin="round" stroke-width="1.0053"/>
+ </g>
+</svg>

--- a/src/images/Humanity/actions/custom/media-frame-forward.svg
+++ b/src/images/Humanity/actions/custom/media-frame-forward.svg
@@ -1,0 +1,28 @@
+<svg width="16" height="16" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <defs>
+  <linearGradient id="linearGradient4518" x1="10" x2="7" y1="5" y2="13" gradientTransform="matrix(-1,0,0,1,15,19.864)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#eeeeec" offset="0"/>
+   <stop stop-color="#babdb6" offset=".6958"/>
+   <stop stop-color="#a1a59b" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4520" x1="3.5" x2="12.5" y1="-14.5" y2="-13.5" gradientTransform="translate(20.349,15.471)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#eeeeec" offset="0"/>
+   <stop stop-color="#babdb6" offset=".6958"/>
+   <stop stop-color="#a1a59b" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4522" x1="14.978" x2="15.139" y1="5.9683" y2="15.736" gradientTransform="matrix(-1 0 0 .88732 14.971 21.23)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#fff" offset="0"/>
+   <stop stop-color="#fff" stop-opacity="0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4524" x1="8" x2="8" y1="4" y2="13" gradientTransform="matrix(-1,0,0,1,15,19.864)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#fff" offset="0"/>
+   <stop stop-color="#fff" stop-opacity="0" offset="1"/>
+  </linearGradient>
+ </defs>
+ <g transform="matrix(-1 0 0 1 13 -19.864)">
+  <path d="m8.497 23.366v9.9951l-7.997-4.997 7.997-4.998z" display="block" fill="url(#linearGradient4518)" stroke="#888a86" stroke-linejoin="round" stroke-width="1.0053"/>
+  <rect transform="matrix(0,1,1,0,0,0)" x="23.349" y=".47099" width="10" height="2" rx="0" ry="0" display="block" fill="url(#linearGradient4520)" stroke="#888a86" stroke-linejoin="round"/>
+  <path d="m1.471 24.335v7.996" display="block" fill="none" opacity=".3" stroke="url(#linearGradient4522)" stroke-linecap="square" stroke-width=".94198"/>
+  <path d="m7.4997 25.302v6.125l-5.2817-3.062 5.2817-3.0625z" display="block" fill="none" opacity=".5" stroke="url(#linearGradient4524)" stroke-linejoin="round" stroke-width="1.0053"/>
+ </g>
+</svg>

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -143,6 +143,14 @@ App.controller("TimelineCtrl", function ($scope) {
     }
   };
 
+  // Set Frame number widget visibility/state
+  $scope.frameNavigationWidgetEnable = function (is_editable) {
+    // Update frame number widget state (enabled/disabled)
+    if ($scope.Qt) {
+      timeline.PreviewFrameNavigationEnable(is_editable);
+    }
+  };
+
   // Get an array of keyframe points for the selected clips
   $scope.getKeyframes = function (object) {
     // List of keyframes

--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -55,6 +55,9 @@ App.directive("tlClip", function ($timeout) {
         start: function (e, ui) {
           dragging = true;
 
+          // Disable frame-navigation widget
+          scope.frameNavigationWidgetEnable(false);
+
           //determine which side is being changed
           var parentOffset = element.offset();
           var mouseLoc = e.pageX - parentOffset.left;
@@ -85,6 +88,9 @@ App.directive("tlClip", function ($timeout) {
         },
         stop: function (e, ui) {
           dragging = false;
+
+          // Enable frame-navigation widget
+          scope.frameNavigationWidgetEnable(true);
 
           if (resize_disabled) {
             // disabled, do nothing

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2444,6 +2444,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Add Video Preview toolbar
         self.videoToolbar = QToolBar("Video Toolbar")
 
+        # Add left spacer
+        self.videoToolbar.addWidget(self.spacerLeft)
+
         # Playback controls
         self.videoToolbar.addAction(self.actionPlay)
         self.videoToolbar.addWidget(self.preview_speed)
@@ -2453,7 +2456,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.videoToolbar.addAction(self.actionSeekNextFrame)
         self.actionPlay.setCheckable(True)
 
-        # Add right spacer
+        # Add center spacer
         spacer = QWidget(self)
         spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.videoToolbar.addWidget(spacer)
@@ -2461,6 +2464,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Other controls (right-aligned)
         self.videoToolbar.addWidget(self.timelines_frame)
         self.videoToolbar.addAction(self.actionSaveFrame)
+
+        # Add right spacer
+        self.videoToolbar.addWidget(self.spacerRight)
 
         self.tabVideo.layout().addWidget(self.videoToolbar)
 
@@ -2505,6 +2511,12 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # Add timeline toolbar to web frame
         self.frameWeb.addWidget(self.timelineToolbar)
+
+    def setPreviewSpacerWidth(self, size):
+        if self.videoPreview.previewAreaSize:
+            dist = (size.width() - self.videoPreview.previewAreaSize.width()) / 2
+            self.spacerLeft.setMinimumWidth(dist)
+            self.spacerRight.setMinimumWidth(dist)
 
     def clearSelections(self):
         """Clear all selection containers"""
@@ -2699,6 +2711,12 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.timelines_frame.setRange(1, 99999999)
         self.timelines_frame.setDecimals(0)
         self.timelines_frame.setAlignment(Qt.AlignRight)
+
+        # Adjustable size Preview tool bar spacers
+        self.spacerLeft = QWidget(self)
+        self.spacerRight = QWidget(self)
+        self.spacerLeft.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
+        self.spacerRight.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
 
         # Setup toolbars that aren't on main window, set initial state of items, etc
         self.setup_toolbars()
@@ -2942,6 +2960,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Preview Speed connections
         self.preview_speed.valueChanged.connect(self.setPreviewSpeed)
         self.preview_speed.editingFinished.connect(self.updPreviewSpeed)
+
+        # Preview widget was changed - adjust UI controls position
+        self.MaxSizeChanged.connect(self.setPreviewSpacerWidth)
 
         # Refresh frame
         QTimer.singleShot(100, self.refreshFrameSignal.emit)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2693,7 +2693,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # Widget to display global frame number of the cursor position on the Timeline
         self.timelines_frame = QDoubleSpinBox(self)
-        self.timelines_frame.setToolTip( _("Frame Number") )
+        self.timelines_frame.setToolTip( _("Current Frame") )
 
         # Upper limit 72h at 60 fps, the Export fields doesn't allow to enter more
         self.timelines_frame.setRange(1, 99999999)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -979,6 +979,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     def navigateToFrameTimeout(self):
         self.movePlayhead(self.navigateToFrame)
+        self.previewFrame(self.navigateToFrame)
 
     def movePlayhead(self, position_frames):
         """Update playhead position"""

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2696,8 +2696,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.timelines_frame.setToolTip( _("Frame Number") )
 
         # Upper limit 72h at 60 fps, the Export fields doesn't allow to enter more
-        self.timelines_frame.setMaximum(99999999)
-        self.timelines_frame.setMinimum(1)
+        self.timelines_frame.setRange(1, 99999999)
         self.timelines_frame.setDecimals(0)
         self.timelines_frame.setAlignment(Qt.AlignRight)
 

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -541,6 +541,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 # Load recent projects again
                 self.load_recent_menu()
 
+                # Reset frame navigation
+                self.timelines_frame.setValue(1)
+
                 log.info("Loaded project {}".format(file_path))
             else:
                 log.info("File not found at {}".format(file_path))

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -978,6 +978,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             self.navigateToFrame_timer.start()
 
     def navigateToFrameTimeout(self):
+        # Skip navigation if already in place
+        if self.navigateToFrame == self.preview_thread.player.Position():
+            return
         self.movePlayhead(self.navigateToFrame)
         self.previewFrame(self.navigateToFrame)
 
@@ -2905,6 +2908,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.navigateToFrame_timer.setInterval(500)
         self.navigateToFrame_timer.timeout.connect(self.navigateToFrameTimeout)
         self.timelines_frame.valueChanged.connect(self.movePlayheadFrames)
+        self.timelines_frame.editingFinished.connect(self.navigateToFrameTimeout)
 
         # Refresh frame
         QTimer.singleShot(100, self.refreshFrameSignal.emit)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -38,7 +38,7 @@ from uuid import uuid4
 from copy import deepcopy
 
 from PyQt5.QtCore import *
-from PyQt5.QtGui import QIcon, QCursor, QKeySequence
+from PyQt5.QtGui import QIcon, QCursor, QKeySequence, QPalette
 from PyQt5.QtWidgets import *
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 
@@ -973,6 +973,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         """Update playhead position"""
         # Notify preview thread
         self.timeline.movePlayhead(position_frames)
+        self.timelines_frame.setValue(position_frames)
 
     def SetPlayheadFollow(self, enable_follow):
         """ Enable / Disable follow mode """
@@ -2422,6 +2423,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.videoToolbar.addWidget(spacer)
 
         # Other controls (right-aligned)
+        self.videoToolbar.addWidget(self.timelines_frame)
         self.videoToolbar.addAction(self.actionSaveFrame)
 
         self.tabVideo.layout().addWidget(self.videoToolbar)
@@ -2642,6 +2644,23 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # Init UI
         ui_util.init_ui(self)
+
+        # Widget to display global frame number of the cursor position on the Timeline
+        self.timelines_frame = QDoubleSpinBox(self)
+        self.timelines_frame.setReadOnly(True)
+        self.timelines_frame.setToolTip( _("Frame Number") )
+
+        # Upper limit 72h at 60 fps, the Export fields doesn't allow to enter more
+        self.timelines_frame.setMaximum(99999999)
+        self.timelines_frame.setMinimum(0)
+        self.timelines_frame.setDecimals(0)
+        self.timelines_frame.setButtonSymbols(QAbstractSpinBox.NoButtons)
+        self.timelines_frame.setAlignment(Qt.AlignRight)
+
+        # Set background color for widget same as main window
+        dsBoxPal = self.timelines_frame.palette()
+        dsBoxPal.setColor(QPalette.Base, dsBoxPal.color(QPalette.Window))
+        self.timelines_frame.setPalette(dsBoxPal)
 
         # Setup toolbars that aren't on main window, set initial state of items, etc
         self.setup_toolbars()

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -813,6 +813,28 @@
     <string>Jump To End</string>
    </property>
   </action>
+  <action name="actionSeekPreviousFrame">
+   <property name="icon">
+    <iconset>../../images/Humanity/actions/custom/media-frame-backward.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Seek to Previous Frame</string>
+   </property>
+   <property name="toolTip">
+    <string>Seek to Next Frame</string>
+   </property>
+  </action>
+  <action name="actionSeekNextFrame">
+   <property name="icon">
+    <iconset>../../images/Humanity/actions/custom/media-frame-forward.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Seek to Next Frame</string>
+   </property>
+   <property name="toolTip">
+    <string>Seek to Next Frame</string>
+   </property>
+  </action>
   <action name="actionSaveFrame">
    <property name="icon">
     <iconset theme="camera-photo-symbolic" resource="../../images/openshot.qrc">

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -821,7 +821,7 @@
     <string>Seek to Previous Frame</string>
    </property>
    <property name="toolTip">
-    <string>Seek to Next Frame</string>
+    <string>Seek to Previous Frame</string>
    </property>
   </action>
   <action name="actionSeekNextFrame">

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -72,6 +72,10 @@ class VideoWidget(QWidget, updates.UpdateInterface):
             if display_ratio_changed or pixel_ratio_changed:
                 get_app().window.timeline_sync.timeline.SetMaxSize(round(self.width() * self.pixel_ratio.ToFloat()), round(self.height() * self.pixel_ratio.ToFloat()))
 
+                # Force update of UI spacers for playback controls
+                # 0.5 + 0.2 sec delay to ensure that painter started
+                QTimer.singleShot(500, self.delayed_resize_timer.start)
+
     def paintEvent(self, event, *args):
         """ Custom paint event """
         self.mutex.lock()
@@ -94,6 +98,8 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
             # Scale image
             scaledPix = self.current_image.scaled(pixSize, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+
+            self.previewAreaSize = scaledPix.size()
 
             # Calculate center of QWidget and Draw image
             painter.drawImage(viewport_rect, scaledPix)
@@ -829,6 +835,9 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
         # Init current frame's QImage
         self.current_image = None
+
+        # Rendered area size
+        self.previewAreaSize = None
 
         # Get a reference to the window object
         self.win = get_app().window

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -2652,6 +2652,11 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
         # Seek to frame
         self.window.SeekSignal.emit(frame_number)
 
+    @pyqtSlot(bool)
+    def PreviewFrameNavigationEnable(self, is_editable):
+        # Enable frame navigation widget
+        self.window.timelines_frame.setEnabled(is_editable)
+
     @pyqtSlot(int)
     def PlayheadMoved(self, position_frames):
 


### PR DESCRIPTION
Requested: https://github.com/OpenShot/openshot-qt/issues/891#issuecomment-608693012

![OpenShot frame_number](https://user-images.githubusercontent.com/19683044/78450684-17cb0680-7689-11ea-85d7-216f2e788db4.png)


Increases convenience of _Export_ usage in case only range of frames are required for final video render (value can be copied).

Later it can be modified into "Go to: Frame Number".