### PR TITLE
dissolve.py: Keep track of particles for duration

### DIFF
--- a/src/blender/scripts/dissolve.py
+++ b/src/blender/scripts/dissolve.py
@@ -113,7 +113,7 @@ def createDissolveText(title, extrude, bevel_depth, spacemode, textsize, width, 
     ActiveObjectText.particle_systems[0].settings.count = NbQuads
     ActiveObjectText.particle_systems[0].settings.frame_start = 10
     ActiveObjectText.particle_systems[0].settings.frame_end = 60
-    ActiveObjectText.particle_systems[0].settings.lifetime = 80
+    ActiveObjectText.particle_systems[0].settings.lifetime = 120
     ActiveObjectText.particle_systems[0].point_cache.frame_step = 1
     ActiveObjectText.particle_systems[0].settings.normal_factor = 0.0
     # not useful


### PR DESCRIPTION
Because the particle system starts affecting particles in frame 10, a lifetime of 80 means that some of the earliest particles will begin to die off at frame 90, well before the 128-frame animation is complete. It appears that, when particles die, they "reset" to their starting point.

This change raises the lifetime to 120, to ensure that the particle system keeps control of all particles for the entire duration of the animation.

Fixes #3350 