### PR TITLE
WIP: Add color settings to Export dialog

### DIFF
--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -478,6 +478,41 @@ class Export(QDialog):
         else:
             self.cboInterlaced.setCurrentIndex(1)
 
+        # Load color options
+        # Here userData of the Item = Enum number in FFmpeg
+        self.cboColorSpace.clear()
+        self.cboColorSpace.addItem( _("Unspecified") , 2) # UNSPECIFIED
+        self.cboColorSpace.addItem("BT.709", 1)
+        # Set BT.709
+        self.cboColorSpace.setCurrentIndex(1)
+
+        self.cboColorTRC.clear()
+        self.cboColorTRC.addItem( _("Unspecified") , 2) # UNSPECIFIED
+        self.cboColorTRC.addItem("BT.709", 1)
+        # Set BT.709
+        self.cboColorTRC.setCurrentIndex(1)
+
+        self.cboColorPrim.clear()
+        self.cboColorPrim.addItem( _("Unspecified") , 2) # UNSPECIFIED
+        self.cboColorPrim.addItem("BT.709", 1)
+        # Set BT.709
+        self.cboColorPrim.setCurrentIndex(1)
+
+        self.cboColorRange.clear()
+        self.cboColorRange.addItem( _("Unspecified") , 0)  # UNSPECIFIED
+        self.cboColorRange.addItem( _("Partial (TV)") , 1) # MPEG
+        self.cboColorRange.addItem( _("Full (PC)") , 2)    # JPEG
+        # Set Partial
+        self.cboColorRange.setCurrentIndex(1)
+
+        self.cboChromaSampleLoc.clear()
+        self.cboChromaSampleLoc.addItem( _("Unspecified") , 0) # UNSPECIFIED
+        self.cboChromaSampleLoc.addItem("H.264", 1)            # Left
+        self.cboChromaSampleLoc.addItem("JPEG", 2)             # Center
+        self.cboChromaSampleLoc.addItem("ITU-R 601", 3)        # TopLeft
+        # Set Left
+        self.cboChromaSampleLoc.setCurrentIndex(1)
+
     def cboSimpleTarget_index_changed(self, widget, index):
         selected_target = widget.itemData(index)
         log.info(selected_target)
@@ -893,6 +928,12 @@ class Export(QDialog):
                 if "qp" in self.txtVideoBitRate.text():
                     w.SetOption(openshot.VIDEO_STREAM, "qp", str(int(video_settings.get("video_bitrate"))) )
 
+                # Set color details
+                w.SetOption(openshot.VIDEO_STREAM, "colorspace", str(int(self.cboColorSpace.itemData(self.cboColorSpace.currentIndex()))))
+                w.SetOption(openshot.VIDEO_STREAM, "color_trc", str(int(self.cboColorTRC.itemData(self.cboColorTRC.currentIndex()))))
+                w.SetOption(openshot.VIDEO_STREAM, "color_primaries", str(int(self.cboColorPrim.itemData(self.cboColorPrim.currentIndex()))))
+                w.SetOption(openshot.VIDEO_STREAM, "color_range", str(int(self.cboColorRange.itemData(self.cboColorRange.currentIndex()))))
+                w.SetOption(openshot.VIDEO_STREAM, "chroma_sample_location", str(int(self.cboChromaSampleLoc.itemData(self.cboChromaSampleLoc.currentIndex()))))
 
             # Open the writer
             w.Open()

--- a/src/windows/ui/export.ui
+++ b/src/windows/ui/export.ui
@@ -766,6 +766,172 @@
              </item>
             </layout>
            </item>
+           <item row="3" column="0">
+            <widget class="QFrame" name="frameColorSetSeparator">
+             <property name="minimumSize">
+              <size>
+               <width>100</width>
+               <height>10</height>
+              </size>
+             </property>
+             <property name="frameShape">
+              <enum>QFrame::HLine</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Sunken</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <layout class="QHBoxLayout" name="horizontalLayout_19_1">
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="lblColorSpace">
+               <property name="minimumSize">
+                <size>
+                 <width>100</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Color Space:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="cboColorSpace">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="5" column="0">
+            <layout class="QHBoxLayout" name="horizontalLayout_19_2">
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="lblColorTRC">
+               <property name="minimumSize">
+                <size>
+                 <width>100</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Color Transfer:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="cboColorTRC">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="6" column="0">
+            <layout class="QHBoxLayout" name="horizontalLayout_19_3">
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="lblColorPrim">
+               <property name="minimumSize">
+                <size>
+                 <width>100</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Color Primaries:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="cboColorPrim">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="7" column="0">
+            <layout class="QHBoxLayout" name="horizontalLayout_19_4">
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="lblColorRange">
+               <property name="minimumSize">
+                <size>
+                 <width>100</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Color Range:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="cboColorRange">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="8" column="0">
+            <layout class="QHBoxLayout" name="horizontalLayout_19_5">
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="lblChromaSampleLoc">
+               <property name="minimumSize">
+                <size>
+                 <width>100</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Chroma Location:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="cboChromaSampleLoc">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
           </layout>
          </widget>
          <widget class="QWidget" name="pageAudioSettings">


### PR DESCRIPTION
New settings to the Export dialog:

![OpenShot Color Export Settings](https://user-images.githubusercontent.com/19683044/78817961-99e66280-79dc-11ea-8ad4-22487646f162.png)


To settings take effect the _libopenshot_ requires corresponding implementations (that are not ready yet). Thus, **work-in-progress** right now...
**Edit:** ...let's say not merged yet - https://github.com/OpenShot/libopenshot/pull/495