### PR TITLE
Titles: Re-establish user template location

### DIFF
--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -56,22 +56,23 @@ RECOVERY_PATH = os.path.join(USER_PATH, "recovery")
 THUMBNAIL_PATH = os.path.join(USER_PATH, "thumbnail")
 CACHE_PATH = os.path.join(USER_PATH, "cache")
 BLENDER_PATH = os.path.join(USER_PATH, "blender")
-ASSETS_PATH = os.path.join(USER_PATH, "assets")
 TITLE_PATH = os.path.join(USER_PATH, "title")
 TRANSITIONS_PATH = os.path.join(USER_PATH, "transitions")
 PREVIEW_CACHE_PATH = os.path.join(USER_PATH, "preview-cache")
 USER_PROFILES_PATH = os.path.join(USER_PATH, "profiles")
 USER_PRESETS_PATH = os.path.join(USER_PATH, "presets")
-
+USER_TITLES_PATH = os.path.join(USER_PATH, "title_templates")
 # User files
 BACKUP_FILE = os.path.join(BACKUP_PATH, "backup.osp")
 USER_DEFAULT_PROJECT = os.path.join(USER_PATH, "default.project")
 
 # Create user paths if they do not exist
 # (this is where temp files are stored... such as cached thumbnails)
-for folder in [USER_PATH, BACKUP_PATH, RECOVERY_PATH, THUMBNAIL_PATH, CACHE_PATH,
-               BLENDER_PATH, ASSETS_PATH, TITLE_PATH, TRANSITIONS_PATH,
-               PREVIEW_CACHE_PATH, USER_PROFILES_PATH, USER_PRESETS_PATH]:
+for folder in [
+    USER_PATH, BACKUP_PATH, RECOVERY_PATH, THUMBNAIL_PATH, CACHE_PATH,
+    BLENDER_PATH, TITLE_PATH, TRANSITIONS_PATH, PREVIEW_CACHE_PATH,
+    USER_PROFILES_PATH, USER_PRESETS_PATH, USER_TITLES_PATH,
+]:
     if not os.path.exists(os.fsencode(folder)):
         os.makedirs(folder, exist_ok=True)
 

--- a/src/windows/models/titles_model.py
+++ b/src/windows/models/titles_model.py
@@ -86,17 +86,18 @@ class TitlesModel():
             titles_list.append(os.path.join(titles_dir, filename))
 
         # Add user-defined titles (if any)
-        for file in sorted(os.listdir(info.TITLE_PATH)):
-            # pretty up the filename for display purposes
-            if fnmatch.fnmatch(file, '*.svg'):
-                titles_list.append(os.path.join(info.TITLE_PATH, file))
+        for filename in sorted(os.listdir(info.USER_TITLES_PATH)):
+            if fnmatch.fnmatch(filename, '*.svg'):
+                titles_list.append(os.path.join(info.USER_TITLES_PATH, filename))
 
         for path in sorted(titles_list):
             filename = os.path.basename(path)
             fileBaseName = os.path.splitext(filename)[0]
 
             # Skip hidden files (such as .DS_Store, etc...)
-            if filename[0] == "." or "thumbs.db" in filename.lower() or filename.lower() == "temp.svg":
+            if (filename[0] == "."
+               or "thumbs.db" in filename.lower()
+               or filename.lower() == "temp.svg"):
                 continue
 
             # split the name into parts (looking for a number)
@@ -135,16 +136,19 @@ class TitlesModel():
                     reader.Open()
 
                     # Save thumbnail
-                    reader.GetFrame(0).Thumbnail(thumb_path, 98, 64, os.path.join(info.IMAGES_PATH, "mask.png"),
-                                                 "", "#000", True, "png", 85)
+                    reader.GetFrame(0).Thumbnail(
+                        thumb_path, 98, 64,
+                        os.path.join(info.IMAGES_PATH, "mask.png"),
+                        "", "#000", True, "png", 85
+                    )
                     reader.Close()
                     clip.Close()
 
-                except:
+                except Exception as ex:
                     # Handle exception
-                    log.info('Invalid title image file: %s' % filename)
+                    log.info('Failed to open {} as title: {}'.format(filename, ex))
                     msg = QMessageBox()
-                    msg.setText(_("{} is not a valid image file.".format(filename)))
+                    msg.setText(_("%s is not a valid image file." % filename))
                     msg.exec_()
                     continue
 


### PR DESCRIPTION
This PR adds an `info.USER_TITLES_PATH` to the standard set, pointing to `$HOME/.openshot_qt/title_templates`. This is the location for user-created title files, and its SVG contents will be included when building the titles model.

(Prior to 2.5.0 `info.TITLE_PATH` was that location, but when things got re-worked that became the generated title _output_ path.)

Fixes #3375