### PR TITLE
freeze.py: Add paths to moved Windows DLLs

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -108,8 +108,12 @@ if os.path.exists(os.path.join(PATH, "openshot_qt")):
     print("Loaded modules from openshot_qt directory: %s" % os.path.join(PATH, "openshot_qt"))
 
 # Append possible build server paths
+
 sys.path.insert(0, os.path.join(PATH, "build", "install-x86", "lib"))
+sys.path.insert(0, os.path.join(PATH, "build", "install-x86", "bin"))
+
 sys.path.insert(0, os.path.join(PATH, "build", "install-x64", "lib"))
+sys.path.insert(0, os.path.join(PATH, "build", "install-x64", "bin"))
 
 
 from classes import info


### PR DESCRIPTION
This branch fixes the Windows builders' freezing of the application, after the DLL files are relocated from `lib` to `bin` under the install prefix. `bin/` is the correct install subdirectory for Windows DLLs (and every system DLL is in `C:\msys64\mingw64\bin`), so we would do better to follow convention.