### PR TITLE
appdata: add <provides>

### DIFF
--- a/xdg/org.openshot.OpenShot.appdata.xml
+++ b/xdg/org.openshot.OpenShot.appdata.xml
@@ -68,6 +68,10 @@
     <content_attribute id="money-purchasing">none</content_attribute>
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
+  <provides>
+    <binary>openshot-qt</binary>
+    <id>openshot-qt.desktop</id>
+  </provides>
   <releases>
     <release version="2.5.1" date="2020-02-28"/>
     <release version="2.5.0" date="2020-02-07"/>

--- a/xdg/org.openshot.OpenShot.appdata.xml
+++ b/xdg/org.openshot.OpenShot.appdata.xml
@@ -70,7 +70,7 @@
   </content_rating>
   <provides>
     <binary>openshot-qt</binary>
-    <id>openshot-qt.desktop</id>
+    <id>openshot-qt</id>
   </provides>
   <releases>
     <release version="2.5.1" date="2020-02-28"/>


### PR DESCRIPTION
A search for "openshot"  in the software manager `plasma-discover` on distributions with a not up-to-date version of Openshot, returns two entries: one for the flatpak, the other for the (old) distro package, that uses the former `<id>`. This PR makes sure, the manager recognizes, they are the same application and you only get one entry (with the option to choose the source).