### PR TITLE
[#1363] Keyframe navigation as marker

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1247,7 +1247,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             if selected_clip:
                 all_marker_positions.append(selected_clip.data["position"])
                 all_marker_positions.append(selected_clip.data["position"] + (selected_clip.data["end"] - selected_clip.data["start"]))
-                # add all keyframes. itterate on all properties of Data,, and for each every Points
+                # add all keyframes. itterate on all properties of Data, look for each points
                 for property in selected_clip.data :
                     try :
                         for point in selected_clip.data[property]["Points"] :
@@ -1313,6 +1313,19 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             if selected_clip:
                 all_marker_positions.append(selected_clip.data["position"])
                 all_marker_positions.append(selected_clip.data["position"] + (selected_clip.data["end"] - selected_clip.data["start"]))
+                # add all keyframes. itterate on all properties of Data, look for each points
+                for property in selected_clip.data :
+                    try :
+                        for point in selected_clip.data[property]["Points"] :
+                            keyframe=(point["co"]["X"]-1)/fps_float - selected_clip.data["start"] + selected_clip.data["position"]
+                            if keyframe > start and keyframe < stop :
+                                all_marker_positions.append(keyframe)
+                    except TypeError:
+                        log.info("%s : %s : not itterable", property, selected_clip.data[property])
+                        pass
+                    except KeyError:
+                        log.info("%s : %s : has no points", property, selected_clip.data[property])
+                        pass
 
         # Loop through selected transitions (and add key positions)
         for tran_id in self.selected_transitions:

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1247,6 +1247,19 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             if selected_clip:
                 all_marker_positions.append(selected_clip.data["position"])
                 all_marker_positions.append(selected_clip.data["position"] + (selected_clip.data["end"] - selected_clip.data["start"]))
+                # add all keyframes. itterate on all properties of Data,, and for each every Points
+                for property in selected_clip.data :
+                    try :
+                        for point in selected_clip.data[property]["Points"] :
+                            log.info("point : %s", point)
+                            keyframe=(point["co"]["X"]-1)/fps_float - selected_clip.data["start"] + selected_clip.data["position"]
+                            if keyframe > start and keyframe < stop :
+                                all_marker_positions.append(keyframe)
+                    except TypeError:
+                        log.info("%s : %s : not itterable", property, selected_clip.data[property])
+                        pass-                    except KeyError:
+                        log.info("%s : %s : has no points", property, selected_clip.data[property])
+                        pass
 
         # Loop through selected transitions (and add key positions)
         for tran_id in self.selected_transitions:

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1248,18 +1248,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 all_marker_positions.append(selected_clip.data["position"])
                 all_marker_positions.append(selected_clip.data["position"] + (selected_clip.data["end"] - selected_clip.data["start"]))
                 # add all keyframes. itterate on all properties of Data, look for each points
-                for property in selected_clip.data :
-                    try :
-                        for point in selected_clip.data[property]["Points"] :
-                            log.info("point : %s", point)
-                            keyframe=(point["co"]["X"]-1)/fps_float - selected_clip.data["start"] + selected_clip.data["position"]
-                            if keyframe > start and keyframe < stop :
-                                all_marker_positions.append(keyframe)
-                    except TypeError:
-                        log.info("%s : %s : not itterable", property, selected_clip.data[property])
-                        pass-                    except KeyError:
-                        log.info("%s : %s : has no points", property, selected_clip.data[property])
-                        pass
+                addKeyframesToMarkers(selected_clip.data)
 
         # Loop through selected transitions (and add key positions)
         for tran_id in self.selected_transitions:
@@ -1314,19 +1303,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 all_marker_positions.append(selected_clip.data["position"])
                 all_marker_positions.append(selected_clip.data["position"] + (selected_clip.data["end"] - selected_clip.data["start"]))
                 # add all keyframes. itterate on all properties of Data, look for each points
-                for property in selected_clip.data :
-                    try :
-                        for point in selected_clip.data[property]["Points"] :
-                            keyframe=(point["co"]["X"]-1)/fps_float - selected_clip.data["start"] + selected_clip.data["position"]
-                            if keyframe > start and keyframe < stop :
-                                all_marker_positions.append(keyframe)
-                    except TypeError:
-                        log.info("%s : %s : not itterable", property, selected_clip.data[property])
-                        pass
-                    except KeyError:
-                        log.info("%s : %s : has no points", property, selected_clip.data[property])
-                        pass
-
+                addKeyframesToMarkers(selected_clip.data)
         # Loop through selected transitions (and add key positions)
         for tran_id in self.selected_transitions:
             # Get selected object
@@ -1357,6 +1334,20 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             # Update the preview and reselct current frame in properties
             get_app().window.refreshFrameSignal.emit()
             get_app().window.propertyTableView.select_frame(frame_to_seek)
+
+    def addKeyframesToMarkers(self, data):
+        for property in data :
+            try :
+                for point in data[property]["Points"] :
+                    keyframe=(point["co"]["X"]-1)/fps_float - data["start"] + data["position"]
+                    if keyframe > start and keyframe < stop :
+                        all_marker_positions.append(keyframe)
+            except TypeError:
+                log.info("%s : %s : not itterable", property, data[property])
+                pass
+            except KeyError:
+                log.info("%s : %s : has no points", property, data[property])
+                pass
 
     def actionCenterOnPlayhead_trigger(self, event):
         """ Center the timeline on the current playhead position """

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -876,10 +876,10 @@
      <normaloff>:/icons/Humanity/actions/16/go-first.svg</normaloff>:/icons/Humanity/actions/16/go-first.svg</iconset>
    </property>
    <property name="text">
-    <string>Previous Marker/Keyframe</string>
+    <string>Previous Key Point</string>
    </property>
    <property name="toolTip">
-    <string>Previous Marker/Keyframe</string>
+    <string>Previous Key Point</string>
    </property>
   </action>
   <action name="actionNextMarker">
@@ -888,10 +888,10 @@
      <normaloff>:/icons/Humanity/actions/16/go-last.svg</normaloff>:/icons/Humanity/actions/16/go-last.svg</iconset>
    </property>
    <property name="text">
-    <string>Next Marker/Keyframe</string>
+    <string>Next Key Point</string>
    </property>
    <property name="toolTip">
-    <string>Next Marker/Keyframe</string>
+    <string>Next Key Point</string>
    </property>
   </action>
   <action name="actionCenterOnPlayhead">

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -876,10 +876,10 @@
      <normaloff>:/icons/Humanity/actions/16/go-first.svg</normaloff>:/icons/Humanity/actions/16/go-first.svg</iconset>
    </property>
    <property name="text">
-    <string>Previous Marker</string>
+    <string>Previous Marker/Keyframe</string>
    </property>
    <property name="toolTip">
-    <string>Previous Marker</string>
+    <string>Previous Marker/Keyframe</string>
    </property>
   </action>
   <action name="actionNextMarker">
@@ -888,10 +888,10 @@
      <normaloff>:/icons/Humanity/actions/16/go-last.svg</normaloff>:/icons/Humanity/actions/16/go-last.svg</iconset>
    </property>
    <property name="text">
-    <string>Next Marker</string>
+    <string>Next Marker/Keyframe</string>
    </property>
    <property name="toolTip">
-    <string>Next Marker</string>
+    <string>Next Marker/Keyframe</string>
    </property>
   </action>
   <action name="actionCenterOnPlayhead">


### PR DESCRIPTION
A suggested in issue #1363, It would be nice to be able to navigate precisely between keyframes. 

This patch allows user to use arrow buttons or Ctrl-L/R to navigate to keyframes of selected clips as well as the normal markers and clip beginning/end.

Fixes #1363