### PR TITLE
Fix Blender subprocess pipe decoding

### DIFF
--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -745,11 +745,12 @@ class Worker(QObject):
             # Run real command to render Blender project
             self.process = subprocess.Popen(command_render, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, startupinfo=startupinfo, universal_newlines=True)
 
-        except:
+        except Exception as ex:
             # Error running command.  Most likely the blender executable path in
             # the settings is incorrect, or is not a supported Blender version
             self.is_running = False
             self.blender_error_nodata.emit()
+            log.error("Could not execute Blender: {}".format(ex))
             return
 
         while self.is_running and self.process.poll() is None:

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -33,9 +33,14 @@ import re
 import xml.dom.minidom as xml
 import functools
 
-from PyQt5.QtCore import QSize, Qt, QEvent, QObject, QThread, pyqtSlot, pyqtSignal, QMetaObject, Q_ARG, QTimer
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+from PyQt5.QtCore import (
+    Qt, QObject, pyqtSlot, pyqtSignal, QMetaObject, Q_ARG, QThread, QTimer, QSize,
+)
+from PyQt5.QtWidgets import (
+    QApplication, QListView, QMessageBox, QColorDialog,
+    QComboBox, QDoubleSpinBox, QLabel, QPushButton, QLineEdit, QPlainTextEdit,
+)
+from PyQt5.QtGui import QColor, QImage, QPixmap
 
 from classes import info
 from classes.logger import log
@@ -44,11 +49,9 @@ from classes.query import File
 from classes.app import get_app
 from windows.models.blender_model import BlenderModel
 
-import json
-
 
 class BlenderListView(QListView):
-    """ A TreeView QWidget used on the animated title window """
+    """ A ListView QWidget used on the animated title window """
 
     def currentChanged(self, selected, deselected):
         # Get selected item
@@ -74,7 +77,7 @@ class BlenderListView(QListView):
         self.generateUniqueFolder()
 
         # Loop through params
-        for param in animation.get("params",[]):
+        for param in animation.get("params", []):
             log.info('Using parameter %s: %s' % (param["name"], param["title"]))
 
             # Is Hidden Param?
@@ -588,7 +591,7 @@ class BlenderListView(QListView):
 
     def __init__(self, *args):
         # Invoke parent init
-        QTreeView.__init__(self, *args)
+        super().__init__(*args)
 
         # Get a reference to the window object
         self.app = get_app()
@@ -632,7 +635,6 @@ class BlenderListView(QListView):
 
         # Refresh view
         self.refresh_view()
-
 
         # Background Worker Thread (for Blender process)
         self.background = QThread(self)
@@ -722,9 +724,14 @@ class Worker(QObject):
 
             # Check the version of Blender
             import shlex
-            log.info("Checking Blender version, command: {}".format(" ".join([shlex.quote(x) for x in command_get_version])))
+            log.info("Checking Blender version, command: {}".format(
+                " ".join([shlex.quote(x) for x in command_get_version])))
 
-            self.process = subprocess.Popen(command_get_version, stdout=subprocess.PIPE, stderr=subprocess.PIPE, startupinfo=startupinfo, universal_newlines=True)
+            self.process = subprocess.Popen(
+                command_get_version,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                startupinfo=startupinfo, universal_newlines=True,
+            )
 
             # Check the version of Blender
             self.version = self.blender_version.findall(self.process.stdout.readline())
@@ -739,11 +746,16 @@ class Worker(QObject):
                     return
 
             # debug info
-            log.info("Running Blender, command: {}".format(" ".join([shlex.quote(x) for x in command_render])))
+            log.info("Running Blender, command: {}".format(
+                " ".join([shlex.quote(x) for x in command_render])))
             log.info("Blender output:")
 
             # Run real command to render Blender project
-            self.process = subprocess.Popen(command_render, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, startupinfo=startupinfo, universal_newlines=True)
+            self.process = subprocess.Popen(
+                command_render,
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                startupinfo=startupinfo, universal_newlines=True,
+            )
 
         except Exception as ex:
             # Error running command.  Most likely the blender executable path in


### PR DESCRIPTION
Second attempt at a PR that fixes #3408. 

My first attempt (#3413) tried to work around the fact that we can't set `encoding` for the `subprocess.PIPE` streams until Python 3.6, by using `.reconfigure()` on them after opening. Problem is, `.reconfigure()` isn't supported until Python **3.7**.

So, it's back to bytes streams for the subprocesses, because text mode in Python < 3.6 is always beholden to whatever's detected as the default locale — and in the case of the reporter's system from #3408, that turned out to be `'ascii'`. Now, we read as bytes and decode to `utf-8` unconditionally.

I also:
* Fixed `BlenderListView.__init__()`, which is subclassed from `QListView` but was calling `QTreeView.__init__()`! We need to start using `super()` more to avoid that kind of thing (as `BlenderListView.__init__()` now does).
* Made sure we aren't silently discarding errors from the Blender process runs, by logging and/or raising exceptions when warranted. (Something that would have revealed the problem with my #3413 attempt instantly, instead of making me hunt for it.)
* Streamlined the XML parsing heavily, and added an `unlink()` after processing to free up the memory consumed ([highly recommended](https://docs.python.org/3.8/library/xml.dom.minidom.html?highlight=xml%20dom%20minidom#xml.dom.minidom.Node.unlink) in the docs) — I'm going to check the rest of our XML-parsing routines now and do the same there, if needed.
* Cleaned up the `blender_listview.py` imports, getting rid of any `*` imports and anything unused
* Demoted a lot of unnecessary class variables in the render worker to be just local variables
