### PR TITLE
Free xml.dom.mindom parsers when finished

### DIFF
--- a/src/classes/exporters/final_cut_pro.py
+++ b/src/classes/exporters/final_cut_pro.py
@@ -57,7 +57,7 @@ def createEffect(xmldoc, name, node, points, scale):
             first_value = None
             for keyframeTime in sorted(keyframes.keys()):
                 keyframeValue = keyframes.get(keyframeTime)
-                if first_value == None:
+                if first_value is None:
                     first_value = keyframeValue
 
                 # Create keyframe element for each point
@@ -230,4 +230,6 @@ def export_xml():
         file.close()
     except IOError as inst:
         log.error("Error writing XML export: {}".format(str(inst)))
-
+    finally:
+        # Free up DOM memory
+        xmldoc.unlink()

--- a/src/classes/importers/final_cut_pro.py
+++ b/src/classes/importers/final_cut_pro.py
@@ -201,3 +201,6 @@ def import_xml():
             # Update the preview and reselect current frame in properties
             app.window.refreshFrameSignal.emit()
             app.window.propertyTableView.select_frame(app.window.preview_thread.player.Position())
+
+    # Free up DOM memory
+    xmldoc.unlink()

--- a/src/windows/file_properties.py
+++ b/src/windows/file_properties.py
@@ -26,20 +26,18 @@
  """
 
 import os
-import locale
-import xml.dom.minidom as xml
-import functools
 
-from PyQt5.QtCore import *
-from PyQt5.QtWidgets import *
+from PyQt5.QtWidgets import QDialog, QFileDialog, QDialogButtonBox, QPushButton
+
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 
 from classes import info, ui_util, settings
 from classes.app import get_app
 from classes.logger import log
-from classes.metrics import *
+from classes.metrics import track_metric_screen
 
 import json
+
 
 class FileProperties(QDialog):
     """ File Properties Dialog """
@@ -183,7 +181,7 @@ class FileProperties(QDialog):
         self.file.data["name"] = self.txtFileName.text()
         self.file.data["tags"] = self.txtTags.text()
 
-        #experimental: update file path
+        # experimental: update file path
         self.file.data["path"] = self.txtFilePath.text()
 
         # Update Framerate

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -26,7 +26,6 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import sys
 import os
 import re
 import shutil
@@ -35,17 +34,20 @@ import subprocess
 import tempfile
 from xml.dom import minidom
 
-from PyQt5.QtCore import *
-from PyQt5.QtGui import QIcon, QStandardItemModel, QStandardItem, QFont
-from PyQt5.QtWidgets import *
-from PyQt5 import uic, QtSvg, QtGui
+from PyQt5.QtCore import Qt, QTimer
+from PyQt5 import QtGui
+from PyQt5.QtWidgets import (
+    QGraphicsScene, QMessageBox, QDialog, QColorDialog, QFontDialog,
+    QPushButton, QTextEdit, QLabel
+)
+
 import openshot
 
-from classes import info, ui_util, settings, qt_types, updates
+from classes import info, ui_util, settings
 from classes.logger import log
 from classes.app import get_app
 from classes.query import File
-from classes.metrics import *
+from classes.metrics import track_metric_screen
 from windows.views.titles_listview import TitlesListView
 
 import json
@@ -102,7 +104,7 @@ class TitleEditor(QDialog):
         self.font_family = "Bitstream Vera Sans"
         self.tspan_node = None
 
-        self.qfont = QFont(self.font_family)
+        self.qfont = QtGui.QFont(self.font_family)
 
         # Add titles list view
         self.titlesTreeView = TitlesListView(self)
@@ -202,7 +204,7 @@ class TitleEditor(QDialog):
         self.font_family = "Bitstream Vera Sans"
         if self.qfont:
             del self.qfont
-        self.qfont = QFont(self.font_family)
+        self.qfont = QtGui.QFont(self.font_family)
 
         # Loop through child widgets (and remove them)
         for child in self.settingsContainer.children():
@@ -276,7 +278,6 @@ class TitleEditor(QDialog):
                 widget.textChanged.connect(functools.partial(self.txtLine_changed, widget))
                 self.settingsContainer.layout().addRow(label, widget)
 
-
         # Add Font button
         label = QLabel()
         label.setText(_("Font:"))
@@ -340,7 +341,7 @@ class TitleEditor(QDialog):
             file.write(bytes(xmldoc.toxml(), 'UTF-8'))
             file.close()
         except IOError as inst:
-            log.error("Error writing SVG title")
+            log.error("Error writing SVG title: {}".format(inst))
 
     def btnFontColor_clicked(self):
         app = get_app()
@@ -624,7 +625,6 @@ class TitleEditor(QDialog):
             t = ";"
             text_child.setAttribute("style", t.join(ar))
 
-
             # Loop through each TSPAN
             for tspan_child in self.tspan_node:
 
@@ -660,8 +660,11 @@ class TitleEditor(QDialog):
             if self.txtFileName.toPlainText().strip():
                 # Do we have unsaved changes?
                 if os.path.exists(file_path) and not self.edit_file_path:
-                    ret = QMessageBox.question(self, _("Title Editor"), _("%s already exists.\nDo you want to replace it?") % file_name,
-                                               QMessageBox.No | QMessageBox.Yes)
+                    ret = QMessageBox.question(
+                        self, _("Title Editor"),
+                        _("%s already exists.\nDo you want to replace it?") % file_name,
+                        QMessageBox.No | QMessageBox.Yes
+                    )
                     if ret == QMessageBox.No:
                         # Do nothing
                         return
@@ -682,7 +685,6 @@ class TitleEditor(QDialog):
         filename = os.path.basename(filepath)
 
         # Add file into project
-        app = get_app()
         _ = get_app()._tr
 
         # Check for this path in our existing project data


### PR DESCRIPTION
As I mentioned in #3416, after doing this in `blender_listview.py` (part of that PR) I scanned over the rest of the code to find more places that could benefit from the same fix:
- A strongly recommended practice (see Python official docs) that we haven't been following, the objects returned by `xml.dom.minidom.parser()` should be `unlink()`ed as soon as they're no longer needed
- Also cleaned up some * imports, logging, formatting in affected files