### PR TITLE
Blender: Use self.process consistently, fix project file discovery for Picture Frame

### DIFF
--- a/src/blender/picture_frames_4.xml
+++ b/src/blender/picture_frames_4.xml
@@ -11,28 +11,28 @@
 		<default>TitleFileName</default>
 	</param>
 	
-	<param name="project_files1" type="dropdown" title="Picture 1 Path" description="">
+	<param name="project_files1" type="dropdown" title="Picture 1" description="">
 		<values>
 			<value name="" num=""/>
 		</values>
 		<default></default>
 	</param>
 	
-	<param name="project_files2" type="dropdown" title="Picture 2 Path" description="">
+	<param name="project_files2" type="dropdown" title="Picture 2" description="">
 		<values>
 			<value name="" num=""/>
 		</values>
 		<default></default>
 	</param>
 	
-	<param name="project_files3" type="dropdown" title="Picture 3 Path" description="">
+	<param name="project_files3" type="dropdown" title="Picture 3" description="">
 		<values>
 			<value name="" num=""/>
 		</values>
 		<default></default>
 	</param>
 	
-	<param name="project_files4" type="dropdown" title="Picture 4 Path" description="">
+	<param name="project_files4" type="dropdown" title="Picture 4" description="">
 		<values>
 			<value name="" num=""/>
 		</values>

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -705,7 +705,7 @@ class Worker(QObject):
             log.info("Checking Blender version, command: {}".format(
                 " ".join([shlex.quote(x) for x in command_get_version])))
 
-            proc = subprocess.Popen(
+            self.process = subprocess.Popen(
                 command_get_version,
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                 startupinfo=startupinfo,
@@ -714,7 +714,7 @@ class Worker(QObject):
             # Check the version of Blender
             try:
                 # Give Blender up to 10 seconds to respond
-                (out, err) = proc.communicate(timeout=10)
+                (out, err) = self.process.communicate(timeout=10)
             except subprocess.TimeoutExpired:
                 self.blender_error_nodata.emit()
                 return
@@ -739,12 +739,11 @@ class Worker(QObject):
             log.info("Blender output:")
 
             # Run real command to render Blender project
-            proc = subprocess.Popen(
+            self.process = subprocess.Popen(
                 command_render, bufsize=512,
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                 startupinfo=startupinfo,
             )
-            self.process = proc
             self.is_running = True
 
         except subprocess.SubprocessError:
@@ -757,8 +756,8 @@ class Worker(QObject):
             log.error("{}".format(ex))
             return
 
-        while self.is_running and proc.poll() is None:
-            for outline in iter(proc.stdout.readline, b''):
+        while self.is_running and self.process.poll() is None:
+            for outline in iter(self.process.stdout.readline, b''):
                 line = outline.decode('utf-8').strip()
 
                 # Skip blank output

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -148,9 +148,12 @@ class BlenderListView(QListView):
                             continue
 
                         param["values"][fileName] = "|".join(
-                            file.data["path"], str(file.data["height"]),
-                            str(file.data["width"]), file.data["media_type"],
-                            str(file.data["fps"]["num"] / file.data["fps"]["den"])
+                            (file.data["path"],
+                             str(file.data["height"]),
+                             str(file.data["width"]),
+                             file.data["media_type"],
+                             str(file.data["fps"]["num"] / file.data["fps"]["den"])
+                             )
                         )
 
                 # Add normal values


### PR DESCRIPTION
Fixing one bug I created the other day with subprocess handle management, and another one I created more than six _months_ ago that was only just noticed!

Fixes #3420 