### PR TITLE
Update launch-win.bat

### DIFF
--- a/installer/launch-win.bat
+++ b/installer/launch-win.bat
@@ -12,4 +12,4 @@ SET QT_PLUGIN_PATH=%cd%
 SET QT_DEBUG_PLUGINS=1
 
 :: Launch application
-openshot-qt.exe
+start "" "%~dp0openshot-qt.exe"


### PR DESCRIPTION
Fixes #3431 

- Add start command to last line
  - This continues execution of the script after launching the exe.
- Add %~dp0 to the launch of exe
  - This is batch shorthand for Drive and Path of argument 0 (file being called) equivalent to $PSScriptRoot in PowerShell