### PR TITLE
File Properties: Some tweaks to raise the profile of the JSON data dump

### DIFF
--- a/src/windows/ui/file-properties.ui
+++ b/src/windows/ui/file-properties.ui
@@ -191,8 +191,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>354</width>
-            <height>222</height>
+            <width>367</width>
+            <height>245</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -502,9 +502,9 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>-28</y>
-            <width>354</width>
-            <height>117</height>
+            <y>0</y>
+            <width>367</width>
+            <height>127</height>
            </rect>
           </property>
           <attribute name="label">
@@ -616,9 +616,9 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>-98</y>
-            <width>354</width>
-            <height>187</height>
+            <y>0</y>
+            <width>367</width>
+            <height>205</height>
            </rect>
           </property>
           <attribute name="label">
@@ -816,7 +816,7 @@
             <x>0</x>
             <y>0</y>
             <width>367</width>
-            <height>89</height>
+            <height>90</height>
            </rect>
           </property>
           <attribute name="label">
@@ -897,20 +897,46 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="pageOutput">
-          <attribute name="label">
-           <string>Output</string>
-          </attribute>
-          <layout class="QGridLayout" name="gridLayout_2">
-           <item row="0" column="0">
-            <widget class="QTextEdit" name="txtOutput">
-             <property name="readOnly">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="Output">
+      <attribute name="title">
+       <string>JSON</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="0">
+        <widget class="QTextEdit" name="txtOutput">
+         <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>0</y>
+          <width>391</width>
+          <height>411</height>
+         </rect>
+        </property>
+         <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>1</horstretch>
+          <verstretch>1</verstretch>
+         </sizepolicy>
+        </property>
+         <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustToContents</enum>
+        </property>
+         <property name="undoRedoEnabled">
+         <bool>false</bool>
+        </property>
+         <property name="lineWrapMode">
+          <enum>QTextEdit::NoWrap</enum>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
- Move the JSON text from being buried in a too-small widget stuffed at the bottom of the QToolBox, to having its own tab next to 'Details'
- Retitle the tab/section from 'Output' to 'JSON'
- Allow text selection via mouse AND(/or) keyboard
- Disable hard-to-read line wrapping; the dialog can be widened

All together this has the effect of making it a realistic option to read the JSON-formatted data dump for the project file in question, a frustrating prospect with the old layout.

#### "Before"
(Even if you made the window larger!)
![image](https://user-images.githubusercontent.com/538020/80910601-7aeaa000-8cfe-11ea-91df-623f19b9aa4d.png)

#### "After"s
![image](https://user-images.githubusercontent.com/538020/80910565-3f4fd600-8cfe-11ea-87a4-33d64fc835e9.png)
![image](https://user-images.githubusercontent.com/538020/80910575-4bd42e80-8cfe-11ea-908a-ba48ccd01fd1.png)
![image](https://user-images.githubusercontent.com/538020/80910606-8d64d980-8cfe-11ea-827f-557bd14e3063.png)
