### PR TITLE
Slice shortcuts

### DIFF
--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -797,6 +797,30 @@
   },
   {
     "category": "Keyboard",
+    "title": "Slice Selected: Keep Both Sides",
+    "restart": true,
+    "setting": "sliceSelectedKeepBothSides",
+    "value": "s",
+    "type": "text"
+  },
+  {
+    "category": "Keyboard",
+    "title": "Slice Selected: Keep Left Side",
+    "restart": true,
+    "setting": "sliceSelectedKeepLeftSide",
+    "value": "d",
+    "type": "text"
+  },
+  {
+    "category": "Keyboard",
+    "title": "Slice Selected: Keep Right Side",
+    "restart": true,
+    "setting": "sliceSelectedKeepRightSide",
+    "value": "a",
+    "type": "text"
+  },
+  {
+    "category": "Keyboard",
     "title": "Copy",
     "restart": true,
     "setting": "copyAll",

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1529,7 +1529,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             if intersecting_clips or intersecting_trans:
                 # Get list of clip ids
                 clip_ids = [c.id for c in intersecting_clips if c.id in self.selected_clips]
-                trans_ids = [t.id for t in intersecting_trans if t.id in self.selected_transitons]
+                trans_ids = [t.id for t in intersecting_trans if t.id in self.selected_transitions]
                 self.timeline.Slice_Triggered(0, clip_ids, trans_ids, playhead_position)
         elif key.matches(self.getShortcutByName("sliceSelectedKeepLeftSide")) == QKeySequence.ExactMatch:
             intersecting_clips = Clip.filter(intersect=playhead_position)
@@ -1537,7 +1537,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             if intersecting_clips or intersecting_trans:
                 # Get list of clip ids
                 clip_ids = [c.id for c in intersecting_clips if c.id in self.selected_clips]
-                trans_ids = [t.id for t in intersecting_trans if t.id in self.selected_transitons]
+                trans_ids = [t.id for t in intersecting_trans if t.id in self.selected_transitions]
                 self.timeline.Slice_Triggered(1, clip_ids, trans_ids, playhead_position)
         elif key.matches(self.getShortcutByName("sliceSelectedKeepRightSide")) == QKeySequence.ExactMatch:
             intersecting_clips = Clip.filter(intersect=playhead_position)
@@ -1545,7 +1545,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             if intersecting_clips or intersecting_trans:
                 # Get list of ids that are also selected
                 clip_ids = [c.id for c in intersecting_clips if c.id in self.selected_clips]
-                trans_ids = [t.id for t in intersecting_trans if t.id in self.selected_transitons]
+                trans_ids = [t.id for t in intersecting_trans if t.id in self.selected_transitions]
                 self.timeline.Slice_Triggered(2, clip_ids, trans_ids, playhead_position)
 
         elif key.matches(self.getShortcutByName("copyAll")) == QKeySequence.ExactMatch:

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1523,6 +1523,31 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 clip_ids = [c.id for c in intersecting_clips]
                 trans_ids = [t.id for t in intersecting_trans]
                 self.timeline.Slice_Triggered(2, clip_ids, trans_ids, playhead_position)
+        elif key.matches(self.getShortcutByName("sliceSelectedKeepBothSides")) == QKeySequence.ExactMatch:
+            intersecting_clips = Clip.filter(intersect=playhead_position)
+            intersecting_trans = Transition.filter(intersect=playhead_position)
+            if intersecting_clips or intersecting_trans:
+                # Get list of clip ids
+                clip_ids = [c.id for c in intersecting_clips if c.id in self.selected_clips]
+                trans_ids = [t.id for t in intersecting_trans if t.id in self.selected_transitons]
+                self.timeline.Slice_Triggered(0, clip_ids, trans_ids, playhead_position)
+        elif key.matches(self.getShortcutByName("sliceSelectedKeepLeftSide")) == QKeySequence.ExactMatch:
+            intersecting_clips = Clip.filter(intersect=playhead_position)
+            intersecting_trans = Transition.filter(intersect=playhead_position)
+            if intersecting_clips or intersecting_trans:
+                # Get list of clip ids
+                clip_ids = [c.id for c in intersecting_clips if c.id in self.selected_clips]
+                trans_ids = [t.id for t in intersecting_trans if t.id in self.selected_transitons]
+                self.timeline.Slice_Triggered(1, clip_ids, trans_ids, playhead_position)
+        elif key.matches(self.getShortcutByName("sliceSelectedKeepRightSide")) == QKeySequence.ExactMatch:
+            intersecting_clips = Clip.filter(intersect=playhead_position)
+            intersecting_trans = Transition.filter(intersect=playhead_position)
+            if intersecting_clips or intersecting_trans:
+                # Get list of ids that are also selected
+                clip_ids = [c.id for c in intersecting_clips if c.id in self.selected_clips]
+                trans_ids = [t.id for t in intersecting_trans if t.id in self.selected_transitons]
+                self.timeline.Slice_Triggered(2, clip_ids, trans_ids, playhead_position)
+
         elif key.matches(self.getShortcutByName("copyAll")) == QKeySequence.ExactMatch:
             self.timeline.Copy_Triggered(-1, self.selected_clips, self.selected_transitions)
         elif key.matches(self.getShortcutByName("pasteAll")) == QKeySequence.ExactMatch:


### PR DESCRIPTION
This PR adds slight variations on the "Slice All: (mode)" actions, named "Slice Selected: (mode)", which just like "Slice All" use the playhead as the slice point. However, where "Slice All..." acts on all intersecting clips, "Slice Selected" slices _only_ the intersecting clips which are also currently selected.

As requested, "Slice Selected: Keep Both Sides" is bound to the <kbd>s</kbd> key by default (modifiable in the Preferences). For symmetry with the "Slice All" bindings, the other two modes are therefore bound to <kbd>a</kbd> and <kbd>d</kbd>.

These actions are currently keyboard-shortcut-only, they do not appear on any context menu. (TBH I'm just not sure where they _could_ go, having context menu choices that operate on the active selection — even multi-selection, possibly — _and_ also depend on the playhead positioning... it just feels like it could get pretty messy.)

Fixes #1764