### PR TITLE
Use Github Actions to auto-generate user guide HTML

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,0 +1,32 @@
+# Github Actions workflow to generate documentation
+# Uses the following shared task definitions:
+# - (checkout, upload artifact) from Github
+# - sphinx-action maintained by @ammaraskar
+name: Sphinx build
+
+# Controls when the action will run.
+# Triggers the workflow on push or pull request events.
+on:
+- push
+- pull_request
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps are a sequence of tasks that will be executed as part of the job
+    steps:
+    # Check out repository under $GITHUB_WORKSPACE
+    - uses: actions/checkout@v2
+    # Builds docs using sphinx
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "doc/"
+    # Create an artifact out of the generated HTML
+    - uses: actions/upload-artifact@v1
+      with:
+        name: UserGuideHTML
+        path: "doc/_build/html/"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,3 @@
+sphinx_rtd_theme
+sphinx_copybutton
+

--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -28,8 +28,6 @@
 import os
 from time import strftime
 
-from PyQt5.QtCore import QDir
-
 VERSION = "2.5.1-dev2"
 MINIMUM_LIBOPENSHOT_VERSION = "0.2.5"
 DATE = "20200228000000"
@@ -98,11 +96,18 @@ except ImportError:
     print("Loading translations from: {}".format(language_path))
 
 # Compile language list from :/locale resource
-langdir = QDir(language_path)
-langs = langdir.entryList(['OpenShot.*.qm'], QDir.NoDotAndDotDot | QDir.Files,
-                          sort=QDir.Name)
-for trpath in langs:
-    SUPPORTED_LANGUAGES.append(trpath.split('.')[1])
+try:
+    from PyQt5.QtCore import QDir
+    langdir = QDir(language_path)
+    langs = langdir.entryList(
+        ['OpenShot.*.qm'],
+        QDir.NoDotAndDotDot | QDir.Files,
+        sort=QDir.Name)
+    for trpath in langs:
+        SUPPORTED_LANGUAGES.append(trpath.split('.')[1])
+except ImportError:
+    # Fail gracefully if we're running without PyQt5 (e.g. CI tasks)
+    pass
 
 SETUP = {
     "name": NAME,


### PR DESCRIPTION
We're running the docs build at the end of each Travis run right now, which is fine for CI purposes, but not very convenient.

Using Github Actions, instead, lets the results of the run be exported as an Artifact from the job, so that the generated HTML tree can be downloaded as a ZIP file right from the Actions status page. Handy for documentation contributors, so they don't have to go through the hassle of setting up to run Sphinx on their own PCs.

A tweak to `src/classes/info.py` makes it handle PyQt5 being unavailable (as it will be, in the Actions environment), and the `requirements.txt` file added to `doc/` is a standard config defining the Python module dependencies for our Sphinx config. The Actions task will ensure that all dependencies are met before starting the build.