### PR TITLE
Fix Qt warning message. UI code cleanup

### DIFF
--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -385,9 +385,6 @@
    </widget>
   </widget>
   <widget class="QDockWidget" name="dockTutorial">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
    <property name="sizePolicy">
     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
      <horstretch>0</horstretch>
@@ -405,12 +402,6 @@
    </property>
    <property name="contextMenuPolicy">
     <enum>Qt::NoContextMenu</enum>
-   </property>
-   <property name="visible">
-    <bool>false</bool>
-   </property>
-   <property name="autoFillBackground">
-    <bool>false</bool>
    </property>
    <property name="floating">
     <bool>true</bool>
@@ -434,7 +425,7 @@
     <bool>false</bool>
    </property>
    <attribute name="dockWidgetArea">
-    <number>0</number>
+    <number>1</number>
    </attribute>
    <widget class="QWidget" name="dockTutorialContents">
     <property name="focusPolicy">


### PR DESCRIPTION
1. Fixes "QMainWindow::addDockWidget: invalid 'area' argument" message from Qt.
In _QMainWindow_ any dock should has valid _dockWidgetArea_ when added (even if areas where the dock widget may be placed excludes everything).
Message itself noticeable when running `openshot-qt-cli` application.

2. Removing doubles of some properties.