### PR TITLE
files_treeview: Fix context menu view switching

### DIFF
--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -69,7 +69,7 @@ class FilesTreeView(QTreeView):
         menu = QMenu(self)
 
         menu.addAction(self.win.actionImportFiles)
-        menu.addAction(self.win.actionDetailsView)
+        menu.addAction(self.win.actionThumbnailView)
 
         if index.isValid():
             # Look up the model item and our unique ID


### PR DESCRIPTION
Correct a context-menu regression I introduced in #3312

(Made the two view files match up a little _too_ well.)