### PR TITLE
Overhaul of models, views, data management

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -243,7 +243,7 @@ class OpenShotApp(QApplication):
             else:
                 # Apply the default settings and Auto import media file
                 self.project.load("")
-                self.window.filesTreeView.add_file(path)
+                self.window.filesView.add_file(path)
         else:
             # Recover backup file (this can't happen until after the Main Window has completely loaded)
             self.window.RecoverBackup.emit()

--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -85,6 +85,9 @@ DESKTOP_ID = "org.openshot.OpenShot.desktop"
 # Blender minimum version required (a string value)
 BLENDER_MIN_VERSION = "2.80"
 
+# Data-model debugging enabler
+MODEL_TEST = False
+
 # Languages
 CMDLINE_LANGUAGE = None
 CURRENT_LANGUAGE = 'en_US'

--- a/src/launch.py
+++ b/src/launch.py
@@ -59,18 +59,21 @@ def main():
 
     parser = argparse.ArgumentParser(description = 'OpenShot version ' + info.SETUP['version'])
     parser.add_argument('-l', '--lang', action='store',
-                        help='language code for interface (overrides '
-                        'preferences and system environment)')
+        help='language code for interface (overrides '
+             'preferences and system environment)')
     parser.add_argument('--list-languages', dest='list_languages',
-                        action='store_true', help='List all language '
-                        'codes supported by OpenShot')
-    parser.add_argument('--path', dest='py_path',
-                        action='append',
-                        help='Additional locations to search for modules '
-                        '(PYTHONPATH). Can be used multiple times.')
+        action='store_true',
+        help='List all language codes supported by OpenShot')
+    parser.add_argument('--path', dest='py_path', action='append',
+        help='Additional locations to search for modules '
+              '(PYTHONPATH). Can be used multiple times.')
+    parser.add_argument('--test-models', dest='modeltest',
+       action='store_true',
+       help="Load Qt's QAbstractItemModelTester into data models "
+       '(requires Qt 5.11+)')
     parser.add_argument('-V', '--version', action='store_true')
     parser.add_argument('remain', nargs=argparse.REMAINDER,
-                        help=argparse.SUPPRESS)
+       help=argparse.SUPPRESS)
 
     args = parser.parse_args()
 
@@ -97,6 +100,12 @@ def main():
             except TypeError as ex:
                     print("Bad path {}: {}".format(p, ex))
                     continue
+
+    if args.modeltest:
+        info.MODEL_TEST = True
+        # Set default logging rules, if the user didn't
+        if os.getenv('QT_LOGGING_RULES') is None:
+            os.putenv('QT_LOGGING_RULES', 'qt.modeltest.debug=true')
 
     if args.lang:
         if args.lang in info.SUPPORTED_LANGUAGES:

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -403,6 +403,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         for f in self.selected_files():
             if f.data.get("path").endswith(".svg"):
                 file_path = f.data.get("path")
+                file_id = f.id
                 break
 
         if not file_path:
@@ -415,11 +416,10 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         result = win.exec_()
 
         # Update file thumbnail
-        self.FileUpdated.emit(selected_file_id)
+        self.FileUpdated.emit(file_id)
 
         # Force update of clips
-        clips = Clip.filter(file_id=selected_file_id)
-        for c in clips:
+        for c in Clip.filter(file_id=file_id):
             # update clip
             c.data["reader"]["path"] = file_path
             c.save()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -449,17 +449,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Run the dialog event loop - blocking interaction on this window during that time
         return win.exec_()
 
-    def actionImportImageSequence_trigger(self, event):
-        # show dialog
-        from windows.Import_image_seq import ImportImageSeq
-        win = ImportImageSeq()
-        # Run the dialog event loop - blocking interaction on this window during that time
-        result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('Import image sequence add confirmed')
-        else:
-            log.info('Import image sequence add cancelled')
-
     def actionClearHistory_trigger(self, event):
         """Clear history for current project"""
         project = get_app().project

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -399,14 +399,14 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
     def actionEditTitle_trigger(self, event):
 
-        # Get requested view item
-        index = self.filesView.indexAt(event.pos())
+        # Loop through selected files (set 1 selected file if more than 1)
+        for f in self.selected_files():
+            if f.data.get("path").endswith(".svg"):
+                file_path = f.data.get("path")
+                break
 
-        # look up svg title file ID from column 5 of that row
-        selected_id = index.model().sibling(index.row(), 5, index.parent()).data()
-
-        file = File.get(id=selected_id)
-        file_path = file.data.get("path")
+        if not file_path:
+            return
 
         # show dialog for editing title
         from windows.title_editor import TitleEditor

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1926,22 +1926,22 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         if app.context_menu_object == "files":
             s.set("file_view", "details")
             self.filesListView.hide()
-            self.filesTreeView.show()
-            self.filesTreeView.clearSelection()
+            self.filesView = self.filesTreeView
+            self.filesView.show()
 
         # Transitions
         elif app.context_menu_object == "transitions":
             s.set("transitions_view", "details")
             self.transitionsListView.hide()
-            self.transitionsTreeView.show()
-            self.transitionsTreeView.clearSelection()
+            self.transitionsView = self.transitionsTreeView
+            self.transitionsView.show()
 
         # Effects
         elif app.context_menu_object == "effects":
             s.set("effects_view", "details")
             self.effectsListView.hide()
-            self.effectsTreeView.show()
-            self.effectsTreeView.clearSelection()
+            self.effectsView = self.effectsTreeView
+            self.effectsView.show()
 
     def actionThumbnailView_trigger(self, event):
         log.info("Switch to Thumbnail View")
@@ -1954,25 +1954,25 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         if app.context_menu_object == "files":
             s.set("file_view", "thumbnail")
             self.filesTreeView.hide()
-            self.filesListView.show()
-            self.filesListView.clearSelection()
+            self.filesView = self.filesListView
+            self.filesView.show()
 
         # Transitions
         elif app.context_menu_object == "transitions":
             s.set("transitions_view", "thumbnail")
             self.transitionsTreeView.hide()
-            self.transitionsListView.show()
-            self.transitionsListView.clearSelection()
+            self.transitionsView = self.transitionsListView
+            self.transitionsView.show()
 
         # Effects
         elif app.context_menu_object == "effects":
             s.set("effects_view", "thumbnail")
             self.effectsTreeView.hide()
-            self.effectsListView.show()
-            self.effectsListView.clearSelection()
+            self.effectsView = self.effectsListView
+            self.effectsView.show()
 
     def resize_contents(self):
-        if self.filesTreeView:
+        if self.filesView == self.filesTreeView:
             self.filesTreeView.resize_contents()
 
     def getDocks(self):
@@ -2625,28 +2625,30 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.tabFiles.layout().insertWidget(-1, self.filesTreeView)
         self.tabFiles.layout().insertWidget(-1, self.filesListView)
         if s.get("file_view") == "details":
+            self.filesView = self.filesTreeView
             self.filesListView.hide()
-            self.filesTreeView.show()
-            self.filesTreeView.setFocus()
         else:
+            self.filesView = self.filesListView
             self.filesTreeView.hide()
-            self.filesListView.show()
-            self.filesListView.setFocus()
+        # Show our currently-enabled project files view
+        self.filesView.show()
+        self.filesView.setFocus()
 
-        # Setup transitions tree
+        # Setup transitions tree and list views
         self.transition_model = TransitionsModel()
         self.transitionsTreeView = TransitionsTreeView(self.transition_model)
         self.transitionsListView = TransitionsListView(self.transition_model)
         self.tabTransitions.layout().insertWidget(-1, self.transitionsTreeView)
         self.tabTransitions.layout().insertWidget(-1, self.transitionsListView)
         if s.get("transitions_view") == "details":
+            self.transitionsView = self.transitionsTreeView
             self.transitionsListView.hide()
-            self.transitionsTreeView.show()
-            self.transitionsTreeView.setFocus()
         else:
+            self.transitionsView = self.transitionsListView
             self.transitionsTreeView.hide()
-            self.transitionsListView.show()
-            self.transitionsListView.setFocus()
+        # Show our currently-enabled transitions view
+        self.transitionsView.show()
+        self.transitionsView.setFocus()
 
         # Setup effects tree
         self.effects_model = EffectsModel()
@@ -2655,13 +2657,14 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.tabEffects.layout().insertWidget(-1, self.effectsTreeView)
         self.tabEffects.layout().insertWidget(-1, self.effectsListView)
         if s.get("effects_view") == "details":
+            self.effectsView = self.effectsTreeView
             self.effectsListView.hide()
-            self.effectsTreeView.show()
-            self.effectsTreeView.setFocus()
         else:
+            self.effectsView = self.effectsListView
             self.effectsTreeView.hide()
-            self.effectsListView.show()
-            self.effectsListView.setFocus()
+        # Show our currently-enabled effects view
+        self.effectsView.show()
+        self.effectsView.setFocus()
 
         # Setup emojis view
         self.emoji_model = EmojisModel()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -447,7 +447,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         from windows.title_editor import TitleEditor
         win = TitleEditor(file_path, duplicate=True)
         # Run the dialog event loop - blocking interaction on this window during that time
-        result = win.exec_()
+        return win.exec_()
 
     def actionImportImageSequence_trigger(self, event):
         # show dialog
@@ -719,16 +719,50 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Set cursor to waiting
         get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
 
-        for file_path in files:
-            self.filesTreeView.add_file(file_path)
-            app.updates.update_untracked(["import_path"], os.path.dirname(file_path))
-            log.info("Imported media file {}".format(file_path))
+        # Import list of files
+        self.files_model.add_files(files)
 
         # Restore cursor
         get_app().restoreOverrideCursor()
 
         # Refresh files views
         self.refreshFilesSignal.emit()
+
+    def invalidImage(self, filename=None):
+        """ Show a popup when an image file can't be loaded """
+        if not filename:
+            return
+
+        # Translations
+        _ = get_app()._tr
+
+        # Show message to user
+        QMessageBox.warning(
+            self,
+            None,
+            _("%s is not a valid video, audio, or image file.") % filename,
+            QMessageBox.Ok
+        )
+
+    def promptImageSequence(self, filename=None):
+        """ Ask the user whether to import an image sequence """
+        if not filename:
+            return False
+
+        # Get translations
+        _ = get_app()._tr
+
+        # Handle exception
+        ret = QMessageBox.question(
+            self,
+            _("Import Image Sequence"),
+            _("Would you like to import %s as an image sequence?") % filename,
+            QMessageBox.No | QMessageBox.Yes
+        )
+        if ret == QMessageBox.Yes:
+            return True
+        else:
+            return False
 
     def actionAdd_to_Timeline_trigger(self, event):
         # Loop through selected files

--- a/src/windows/models/effects_model.py
+++ b/src/windows/models/effects_model.py
@@ -216,3 +216,19 @@ class EffectsModel(QObject):
 
         # Create selection model to share between views
         self.selection_model = QItemSelectionModel(self.proxy_model)
+
+        # Attempt to load model testing interface, if requested
+        # (will only succeed with Qt 5.11+)
+        if info.MODEL_TEST:
+            try:
+                # Create model tester objects
+                from PyQt5.QtTest import QAbstractItemModelTester
+                self.model_tests = []
+                for m in [self.proxy_model, self.model]:
+                    self.model_tests.append(
+                        QAbstractItemModelTester(
+                            m, QAbstractItemModelTester.FailureReportingMode.Warning)
+                    )
+                log.info("Enabled {} model tests for effects data".format(len(self.model_tests)))
+            except ImportError:
+                pass

--- a/src/windows/models/emoji_model.py
+++ b/src/windows/models/emoji_model.py
@@ -195,3 +195,19 @@ class EmojisModel():
         self.proxy_model.setSortCaseSensitivity(Qt.CaseSensitive)
         self.proxy_model.setSourceModel(self.group_model)
         self.proxy_model.setSortLocaleAware(True)
+
+        # Attempt to load model testing interface, if requested
+        # (will only succeed with Qt 5.11+)
+        if info.MODEL_TEST:
+            try:
+                # Create model tester objects
+                from PyQt5.QtTest import QAbstractItemModelTester
+                self.model_tests = []
+                for m in [self.proxy_model, self.group_model, self.model]:
+                    self.model_tests.append(
+                        QAbstractItemModelTester(
+                            m, QAbstractItemModelTester.FailureReportingMode.Warning)
+                    )
+                log.info("Enabled {} model tests for emoji data".format(len(self.model_tests)))
+            except ImportError:
+                pass

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -60,14 +60,14 @@ class FileFilterProxyModel(QSortFilterProxyModel):
                 or get_app().window.filesFilter.text():
             # Fetch the file name
             index = self.sourceModel().index(sourceRow, 0, sourceParent)
-            file_name = self.sourceModel().data(index) # file name (i.e. MyVideo.mp4)
+            file_name = self.sourceModel().data(index)  # file name (i.e. MyVideo.mp4)
 
             # Fetch the media_type
             index = self.sourceModel().index(sourceRow, 3, sourceParent)
-            media_type = self.sourceModel().data(index) # media type (i.e. video, image, audio)
+            media_type = self.sourceModel().data(index)  # media type (i.e. video, image, audio)
 
             index = self.sourceModel().index(sourceRow, 2, sourceParent)
-            tags = self.sourceModel().data(index) # tags (i.e. intro, custom, etc...)
+            tags = self.sourceModel().data(index)  # tags (i.e. intro, custom, etc...)
 
             if get_app().window.actionFilesShowVideo.isChecked():
                 if not media_type == "video":
@@ -134,8 +134,7 @@ class FilesModel(QObject, updates.UpdateInterface):
 
         self.ignore_updates = True
 
-        # Get window to check filters
-        win = app.window
+        # Translations
         _ = app._tr
 
         # Delete a file (if delete_file_id passed in)
@@ -298,6 +297,36 @@ class FilesModel(QObject, updates.UpdateInterface):
             self.ModelRefreshed.emit()
 
         self.ignore_updates = False
+
+    def selected_file_ids(self):
+        """ Get a list of file IDs for all selected files """
+        # Get the indexes for column 5 of all selected rows
+        selected = self.selection_model.selectedRows(5)
+
+        return [idx.data() for idx in selected]
+
+    def selected_files(self):
+        """ Get a list of File objects representing the current selection """
+        files = []
+        for id in self.selected_file_ids():
+            files.append(File.get(id=id))
+        return files
+
+    def current_file_id(self):
+        """ Get the file ID of the current files-view item, or the first selection """
+        cur = self.selection_model.currentIndex()
+
+        if not cur or not cur.isValid() and self.selection_model.hasSelection():
+            cur = self.selection_model.selectedIndexes()[0]
+
+        if cur and cur.isValid():
+            return cur.sibling(cur.row(), 5).data()
+
+    def current_file(self):
+        """ Get the File object for the current files-view item, or the first selection """
+        cur_id = self.current_file_id()
+        if cur_id:
+            return File.get(id=cur_id)
 
     def __init__(self, *args):
 

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -523,3 +523,19 @@ class FilesModel(QObject, updates.UpdateInterface):
 
         # Call init for superclass QObject
         super(QObject, FilesModel).__init__(self, *args)
+
+        # Attempt to load model testing interface, if requested
+        # (will only succeed with Qt 5.11+)
+        if info.MODEL_TEST:
+            try:
+                # Create model tester objects
+                from PyQt5.QtTest import QAbstractItemModelTester
+                self.model_tests = []
+                for m in [self.proxy_model, self.model]:
+                    self.model_tests.append(
+                        QAbstractItemModelTester(
+                            m, QAbstractItemModelTester.FailureReportingMode.Warning)
+                    )
+                log.info("Enabled {} model tests for emoji data".format(len(self.model_tests)))
+            except ImportError:
+                pass

--- a/src/windows/models/transition_model.py
+++ b/src/windows/models/transition_model.py
@@ -50,12 +50,12 @@ class TransitionFilterProxyModel(QSortFilterProxyModel):
 
         if get_app().window.actionTransitionsShowCommon.isChecked():
             # Fetch the group name
-            index = self.sourceModel().index(sourceRow, 2, sourceParent) # group name column
-            group_name = self.sourceModel().data(index) # group name (i.e. common)
+            index = self.sourceModel().index(sourceRow, 2, sourceParent)  # group name column
+            group_name = self.sourceModel().data(index)  # group name (i.e. common)
 
             # Fetch the transitions name
-            index = self.sourceModel().index(sourceRow, 0, sourceParent) # transition name column
-            trans_name = self.sourceModel().data(index) # transition name (i.e. Fade In)
+            index = self.sourceModel().index(sourceRow, 0, sourceParent)  # transition name column
+            trans_name = self.sourceModel().data(index)  # transition name (i.e. Fade In)
 
             # Return, if regExp match in displayed format.
             return "common" == group_name and self.filterRegExp().indexIn(trans_name) >= 0
@@ -66,7 +66,7 @@ class TransitionFilterProxyModel(QSortFilterProxyModel):
     def lessThan(self, left, right):
         """Sort with both group name and transition name"""
         leftData = self.sourceModel().data(left)
-        leftGroup = self.sourceModel().data(left, 257) # Strange way to access 'type' column in model
+        leftGroup = self.sourceModel().data(left, 257)  # Strange way to access 'type' column in model
         rightData = self.sourceModel().data(right)
         rightGroup = self.sourceModel().data(right, 257)
 
@@ -92,8 +92,7 @@ class TransitionsModel(QObject):
         log.info("updating transitions model.")
         app = get_app()
 
-        # Get window to check filters
-        win = app.window
+        # Translations
         _ = app._tr
 
         # Clear all items
@@ -108,12 +107,22 @@ class TransitionsModel(QObject):
         transitions_dir = os.path.join(info.PATH, "transitions")
         common_dir = os.path.join(transitions_dir, "common")
         extra_dir = os.path.join(transitions_dir, "extra")
-        transition_groups = [{"type": "common", "dir": common_dir, "files": os.listdir(common_dir)},
-                             {"type": "extra", "dir": extra_dir, "files": os.listdir(extra_dir)}]
+        transition_groups = [
+            {"type": "common",
+             "dir": common_dir,
+             "files": os.listdir(common_dir)},
+            {"type": "extra",
+             "dir": extra_dir,
+             "files": os.listdir(extra_dir)},
+        ]
 
         # Add optional user-defined transitions folder
         if (os.path.exists(info.TRANSITIONS_PATH) and os.listdir(info.TRANSITIONS_PATH)):
-            transition_groups.append({"type": "user", "dir": info.TRANSITIONS_PATH, "files": os.listdir(info.TRANSITIONS_PATH)})
+            transition_groups.append(
+                {"type": "user",
+                 "dir": info.TRANSITIONS_PATH,
+                 "files": os.listdir(info.TRANSITIONS_PATH)}
+            )
 
         for group in transition_groups:
             type = group["type"]
@@ -145,7 +154,7 @@ class TransitionsModel(QObject):
                     trans_name = self.app._tr(trans_name)
 
                 # Check for thumbnail path (in build-in cache)
-                thumb_path = os.path.join(info.IMAGES_PATH, "cache",  "{}.png".format(fileBaseName))
+                thumb_path = os.path.join(info.IMAGES_PATH, "cache", "{}.png".format(fileBaseName))
 
                 # Check built-in cache (if not found)
                 if not os.path.exists(thumb_path):
@@ -169,11 +178,11 @@ class TransitionsModel(QObject):
                         reader.Close()
                         clip.Close()
 
-                    except:
+                    except Exception as ex:
                         # Handle exception
-                        log.info('Invalid transition image file: %s' % filename)
+                        log.warning('Invalid transition image file {}: {}'.format(filename, ex))
                         msg = QMessageBox()
-                        msg.setText(_("{} is not a valid image file.".format(filename)))
+                        msg.setText(_("{} is not a valid transition file.".format(filename)))
                         msg.exec_()
                         continue
 
@@ -210,9 +219,9 @@ class TransitionsModel(QObject):
                 row.append(col)
 
                 # Append ROW to MODEL (if does not already exist in model)
-                if not path in self.model_paths:
+                if path not in self.model_paths:
                     self.model.appendRow(row)
-                    self.model_paths[path] = path
+                    self.model_paths[path] = QPersistentModelIndex(row[3].index())
 
         # Emit signal when model is updated
         self.ModelRefreshed.emit()

--- a/src/windows/models/transition_model.py
+++ b/src/windows/models/transition_model.py
@@ -246,3 +246,19 @@ class TransitionsModel(QObject):
 
         # Create selection model to share between views
         self.selection_model = QItemSelectionModel(self.proxy_model)
+
+        # Attempt to load model testing interface, if requested
+        # (will only succeed with Qt 5.11+)
+        if info.MODEL_TEST:
+            try:
+                # Create model tester objects
+                from PyQt5.QtTest import QAbstractItemModelTester
+                self.model_tests = []
+                for m in [self.proxy_model, self.model]:
+                    self.model_tests.append(
+                        QAbstractItemModelTester(
+                            m, QAbstractItemModelTester.FailureReportingMode.Warning)
+                    )
+                log.info("Enabled {} model tests for transition data".format(len(self.model_tests)))
+            except ImportError:
+                pass

--- a/src/windows/models/transition_model.py
+++ b/src/windows/models/transition_model.py
@@ -27,8 +27,11 @@
 
 import os
 
-from PyQt5.QtCore import QMimeData, Qt, QSortFilterProxyModel, pyqtSignal
-from PyQt5.QtGui import *
+from PyQt5.QtCore import (
+    QObject, QMimeData, Qt, pyqtSignal,
+    QSortFilterProxyModel, QPersistentModelIndex, QItemSelectionModel,
+)
+from PyQt5.QtGui import QIcon, QStandardItemModel, QStandardItem
 from PyQt5.QtWidgets import QMessageBox
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 
@@ -37,27 +40,6 @@ from classes.logger import log
 from classes.app import get_app
 
 import json
-
-class TransitionStandardItemModel(QStandardItemModel):
-    ModelRefreshed = pyqtSignal()
-
-    def __init__(self, parent=None):
-        QStandardItemModel.__init__(self)
-
-    def mimeData(self, indexes):
-        # Create MimeData for drag operation
-        data = QMimeData()
-
-        # Get list of all selected file ids
-        files = []
-        for item in indexes:
-            selected_row = self.itemFromIndex(item).row()
-            files.append(self.item(selected_row, 3).text())
-        data.setText(json.dumps(files))
-        data.setHtml("transition")
-
-        # Return Mimedata
-        return data
 
 
 class TransitionFilterProxyModel(QSortFilterProxyModel):
@@ -90,8 +72,22 @@ class TransitionFilterProxyModel(QSortFilterProxyModel):
 
         return leftGroup < rightGroup and leftData < rightData
 
+    def mimeData(self, indexes):
+        # Create MimeData for drag operation
+        data = QMimeData()
 
-class TransitionsModel():
+        # Create list from requested transition indexes
+        items = [i.sibling(i.row(), 3).data() for i in indexes]
+        data.setText(json.dumps(items))
+        data.setHtml("transition")
+
+        # Return Mimedata
+        return data
+
+
+class TransitionsModel(QObject):
+    ModelRefreshed = pyqtSignal()
+
     def update_model(self, clear=True):
         log.info("updating transitions model.")
         app = get_app()
@@ -219,13 +215,15 @@ class TransitionsModel():
                     self.model_paths[path] = path
 
         # Emit signal when model is updated
-        self.model.ModelRefreshed.emit()
+        self.ModelRefreshed.emit()
 
     def __init__(self, *args):
+        # Init QObject superclass
+        super().__init__(*args)
 
         # Create standard model
         self.app = get_app()
-        self.model = TransitionStandardItemModel()
+        self.model = QStandardItemModel()
         self.model.setColumnCount(4)
         self.model_paths = {}
 
@@ -236,3 +234,6 @@ class TransitionsModel():
         self.proxy_model.setSortCaseSensitivity(Qt.CaseSensitive)
         self.proxy_model.setSourceModel(self.model)
         self.proxy_model.setSortLocaleAware(True)
+
+        # Create selection model to share between views
+        self.selection_model = QItemSelectionModel(self.proxy_model)

--- a/src/windows/views/effects_listview.py
+++ b/src/windows/views/effects_listview.py
@@ -26,10 +26,11 @@
  """
 
 from PyQt5.QtCore import QSize, QPoint, Qt, QRegExp
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import QListView, QMenu
+from PyQt5.QtGui import QDrag
+from PyQt5.QtWidgets import QListView, QMenu, QAbstractItemView
 
 from classes.app import get_app
+from classes.logger import log
 
 
 class EffectsListView(QListView):
@@ -43,18 +44,29 @@ class EffectsListView(QListView):
 
         menu = QMenu(self)
         menu.addAction(self.win.actionDetailsView)
-        menu.exec_(QCursor.pos())
+        menu.exec_(event.globalPos())
 
     def startDrag(self, event):
         """ Override startDrag method to display custom icon """
 
-        # Get image of selected item
-        selected_row = self.effects_model.model.itemFromIndex(self.effects_model.proxy_model.mapToSource(self.selectionModel().selectedIndexes()[0])).row()
-        icon = self.effects_model.model.item(selected_row, 0).icon()
+        # Get first column indexes for all selected rows
+        selected = self.selectionModel().selectedRows(0)
+
+        # Get image of current item
+        current = self.selectionModel().currentIndex()
+        if not current.isValid() and selected:
+            current = selected[0]
+
+        if not current.isValid():
+            # We can't find anything to drag
+            log.warning("No draggable items found in model!")
+            return False
+
+        icon = current.data(Qt.DecorationRole)
 
         # Start drag operation
         drag = QDrag(self)
-        drag.setMimeData(self.effects_model.proxy_model.mimeData(self.selectionModel().selectedIndexes()))
+        drag.setMimeData(self.model().mimeData(selected))
         drag.setPixmap(icon.pixmap(QSize(self.drag_item_size, self.drag_item_size)))
         drag.setHotSpot(QPoint(self.drag_item_size / 2, self.drag_item_size / 2))
         drag.exec_()
@@ -65,9 +77,9 @@ class EffectsListView(QListView):
     def refresh_view(self):
         """Filter transitions with proxy class"""
         filter_text = self.win.effectsFilter.text()
-        self.effects_model.proxy_model.setFilterRegExp(QRegExp(filter_text.replace(' ', '.*')))
-        self.effects_model.proxy_model.setFilterCaseSensitivity(Qt.CaseInsensitive)
-        self.effects_model.proxy_model.sort(Qt.AscendingOrder)
+        self.model().setFilterRegExp(QRegExp(filter_text.replace(' ', '.*')))
+        self.model().setFilterCaseSensitivity(Qt.CaseInsensitive)
+        self.model().sort(Qt.AscendingOrder)
 
     def __init__(self, model):
         # Invoke parent init

--- a/src/windows/views/effects_listview.py
+++ b/src/windows/views/effects_listview.py
@@ -62,7 +62,8 @@ class EffectsListView(QListView):
             log.warning("No draggable items found in model!")
             return False
 
-        icon = current.data(Qt.DecorationRole)
+        # Get icon from column 0 on same row as current item
+        icon = current.sibling(current.row(), 0).data(Qt.DecorationRole)
 
         # Start drag operation
         drag = QDrag(self)

--- a/src/windows/views/effects_listview.py
+++ b/src/windows/views/effects_listview.py
@@ -30,9 +30,7 @@ from PyQt5.QtGui import *
 from PyQt5.QtWidgets import QListView, QMenu
 
 from classes.app import get_app
-from windows.models.effects_model import EffectsModel
 
-import json
 
 class EffectsListView(QListView):
     """ A TreeView QWidget used on the main window """
@@ -86,8 +84,15 @@ class EffectsListView(QListView):
         self.setDragEnabled(True)
         self.setDropIndicatorShown(True)
 
-        # Setup header columns
         self.setModel(self.effects_model.proxy_model)
+
+        # Remove the default selection model and wire up to the shared one
+        self.selectionModel().deleteLater()
+        self.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionModel(self.effects_model.selection_model)
+
+        # Setup header columns
         self.setIconSize(QSize(131, 108))
         self.setGridSize(QSize(102, 92))
         self.setViewMode(QListView.IconMode)

--- a/src/windows/views/effects_treeview.py
+++ b/src/windows/views/effects_treeview.py
@@ -62,7 +62,8 @@ class EffectsTreeView(QTreeView):
             log.warning("No draggable items found in model!")
             return False
 
-        icon = current.data(Qt.DecorationRole)
+        # Get icon from column 0 on same row as current item
+        icon = current.sibling(current.row(), 0).data(Qt.DecorationRole)
 
         # Start drag operation
         drag = QDrag(self)

--- a/src/windows/views/effects_treeview.py
+++ b/src/windows/views/effects_treeview.py
@@ -25,14 +25,12 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-from PyQt5.QtCore import QSize, QPoint, Qt, QRegExp
-from PyQt5.QtGui import *
+from PyQt5.QtCore import Qt, QSize, QPoint
+from PyQt5.QtGui import QDrag
 from PyQt5.QtWidgets import QTreeView, QAbstractItemView, QMenu, QSizePolicy
 
 from classes.app import get_app
-from windows.models.effects_model import EffectsModel
 
-import json
 
 class EffectsTreeView(QTreeView):
     """ A TreeView QWidget used on the main window """
@@ -83,19 +81,22 @@ class EffectsTreeView(QTreeView):
         self.setDragEnabled(True)
         self.setDropIndicatorShown(True)
 
-        # Setup header columns
         self.setModel(self.effects_model.proxy_model)
+
+        # Remove the default selection model and wire up to the shared one
+        self.selectionModel().deleteLater()
+        self.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionModel(self.effects_model.selection_model)
+
+        # Setup header columns
         self.setIconSize(QSize(75, 62))
         self.setIndentation(0)
-        self.setSelectionBehavior(QTreeView.SelectRows)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.setWordWrap(True)
         self.setStyleSheet('QTreeView::item { padding-top: 2px; }')
-        self.effects_model.model.ModelRefreshed.connect(self.refresh_columns)
+        self.effects_model.ModelRefreshed.connect(self.refresh_columns)
 
         # Load initial effects model data
         self.effects_model.update_model()
         self.refresh_columns()
-
-        # setup filter events
-        app = get_app()

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -312,15 +312,22 @@ class FilesListView(QListView):
     def resize_contents(self):
         pass
 
-    def __init__(self, model):
+    def __init__(self, model, *args):
         # Invoke parent init
-        QListView.__init__(self)
+        super().__init__(*args)
 
         # Get a reference to the window object
         self.win = get_app().window
 
         # Get Model data
         self.files_model = model
+        self.setModel(self.files_model.proxy_model)
+
+        # Remove the default selection model and wire up to the shared one
+        self.selectionModel().deleteLater()
+        self.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionModel(self.files_model.selection_model)
 
         # Keep track of mouse press start position to determine when to start drag
         self.setAcceptDrops(True)
@@ -329,19 +336,19 @@ class FilesListView(QListView):
         self.selected = []
         self.ignore_image_sequence_paths = []
 
-        # Setup header columns
-        self.setModel(self.files_model.proxy_model)
+        # Setup header columns and layout
         self.setIconSize(QSize(131, 108))
         self.setGridSize(QSize(102, 92))
         self.setViewMode(QListView.IconMode)
         self.setResizeMode(QListView.Adjust)
-        self.setSelectionBehavior(QListView.SelectRows)
-        self.setSelectionMode(QAbstractItemView.ExtendedSelection)
+
         self.setUniformItemSizes(True)
+        self.setStyleSheet('QListView::item { padding-top: 2px; }')
+
         self.setWordWrap(False)
         self.setTextElideMode(Qt.ElideRight)
-        self.setStyleSheet('QListView::item { padding-top: 2px; }')
-        self.files_model.model.ModelRefreshed.connect(self.refresh_view)
+
+        self.files_model.ModelRefreshed.connect(self.refresh_view)
 
         # Load initial files model data
         self.files_model.update_model()

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -47,38 +47,33 @@ class FilesListView(QListView):
     """ A ListView QWidget used on the main window """
     drag_item_size = 48
 
-    def updateSelection(self):
-        # Track selected items
-        self.selected = self.selectionModel().selectedIndexes()
-
-        # Track selected file ids on main window
-        rows = []
-        self.win.selected_files = []
-        for selection in self.selected:
-            selected_row = self.files_model.model.itemFromIndex(self.files_model.proxy_model.mapToSource(selection)).row()
-            if selected_row not in rows:
-                self.win.selected_files.append(self.files_model.model.item(selected_row, 5).text())
-                rows.append(selected_row)
-
     def contextMenuEvent(self, event):
-        # Update selection
-        self.updateSelection()
 
         # Set context menu mode
         app = get_app()
         app.context_menu_object = "files"
 
+        index = self.indexAt(event.pos())
+
+        # Build menu
         menu = QMenu(self)
 
         menu.addAction(self.win.actionImportFiles)
         menu.addAction(self.win.actionDetailsView)
-        if self.selected:
-            # If file selected, show file related options
+
+        if index.isValid():
+            # Look up the model item and our unique ID
+            model = self.model()
+
+            # Look up file_id from 5th column of row
+            id_index = index.sibling(index.row(), 5)
+            file_id = model.data(id_index, Qt.DisplayRole)
+
+            # If a valid file selected, show file related options
             menu.addSeparator()
 
             # Add edit title option (if svg file)
-            selected_file_id = self.win.selected_files[0]
-            file = File.get(id=selected_file_id)
+            file = File.get(id=file_id)
             if file and file.data.get("path").endswith(".svg"):
                 menu.addAction(self.win.actionEditTitle)
                 menu.addAction(self.win.actionDuplicateTitle)
@@ -101,16 +96,19 @@ class FilesListView(QListView):
             event.setDropAction(Qt.CopyAction)
             event.accept()
 
-    def startDrag(self, event):
+    def startDrag(self, supportedActions):
         """ Override startDrag method to display custom icon """
 
+        # The relevant model for index values
+        model = self.model()
+
         # Get image of selected item
-        selected_row = self.files_model.model.itemFromIndex(self.files_model.proxy_model.mapToSource(self.selectionModel().selectedIndexes()[0])).row()
-        icon = self.files_model.model.item(selected_row, 0).icon()
+        selected_rows = self.selectionModel().selectedRows(0)
+        icon = selected_rows[0].data(Qt.DecorationRole)
 
         # Start drag operation
         drag = QDrag(self)
-        drag.setMimeData(self.files_model.proxy_model.mimeData(self.selectionModel().selectedIndexes()))
+        drag.setMimeData(model.mimeData(self.selectionModel().selectedIndexes()))
         drag.setPixmap(icon.pixmap(QSize(self.drag_item_size, self.drag_item_size)))
         drag.setHotSpot(QPoint(self.drag_item_size / 2, self.drag_item_size / 2))
         drag.exec_()
@@ -301,13 +299,12 @@ class FilesListView(QListView):
 
     def refresh_view(self):
         """Filter files with proxy class"""
+        model = self.model()
         filter_text = self.win.filesFilter.text()
-        self.files_model.proxy_model.setFilterRegExp(QRegExp(filter_text.replace(' ', '.*')))
-        self.files_model.proxy_model.setFilterCaseSensitivity(Qt.CaseInsensitive)
-        self.files_model.proxy_model.sort(Qt.AscendingOrder)
+        model.setFilterRegExp(QRegExp(filter_text.replace(' ', '.*'), Qt.CaseInsensitive))
 
-    def currentChanged(self, selected, deselected):
-        self.updateSelection()
+        col = model.sortColumn()
+        model.sort(col)
 
     def resize_contents(self):
         pass
@@ -333,7 +330,6 @@ class FilesListView(QListView):
         self.setAcceptDrops(True)
         self.setDragEnabled(True)
         self.setDropIndicatorShown(True)
-        self.selected = []
         self.ignore_image_sequence_paths = []
 
         # Setup header columns and layout

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -93,16 +93,25 @@ class FilesListView(QListView):
     def startDrag(self, supportedActions):
         """ Override startDrag method to display custom icon """
 
-        # The relevant model for index values
-        model = self.model()
+        # Get first column indexes for all selected rows
+        selected = self.selectionModel().selectedRows(0)
 
-        # Get image of selected item
-        selected_rows = self.selectionModel().selectedRows(0)
-        icon = selected_rows[0].data(Qt.DecorationRole)
+        # Get image of current item
+        current = self.selectionModel().currentIndex()
+        if not current.isValid() and selected:
+            current = selected[0]
+
+        if not current.isValid():
+            # We can't find anything to drag
+            log.warning("No draggable items found in model!")
+            return False
+
+        # Get icon from column 0 on same row as current item
+        icon = current.sibling(current.row(), 0).data(Qt.DecorationRole)
 
         # Start drag operation
         drag = QDrag(self)
-        drag.setMimeData(model.mimeData(self.selectionModel().selectedIndexes()))
+        drag.setMimeData(self.model().mimeData(selected))
         drag.setPixmap(icon.pixmap(QSize(self.drag_item_size, self.drag_item_size)))
         drag.setHotSpot(QPoint(self.drag_item_size / 2, self.drag_item_size / 2))
         drag.exec_()

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -27,22 +27,15 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-import glob
 import os
-import re
 
-import openshot  # Python module for libopenshot (required video editing module installed separately)
-from PyQt5.QtCore import QSize, Qt, QPoint, QRegExp
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import QTreeView, QMessageBox, QAbstractItemView, QMenu, QSizePolicy, QHeaderView
+from PyQt5.QtCore import QSize, Qt, QPoint
+from PyQt5.QtGui import QDrag, QCursor
+from PyQt5.QtWidgets import QTreeView, QAbstractItemView, QMenu, QSizePolicy, QHeaderView
 
 from classes.app import get_app
-from classes.image_types import is_image
 from classes.logger import log
 from classes.query import File
-from windows.models.files_model import FilesModel, FileFilterProxyModel
-
-import json
 
 
 class FilesTreeView(QTreeView):
@@ -118,158 +111,6 @@ class FilesTreeView(QTreeView):
     def dragMoveEvent(self, event):
         pass
 
-    def add_file(self, filepath):
-        filename = os.path.basename(filepath)
-
-        # Add file into project
-        app = get_app()
-        _ = get_app()._tr
-
-        # Check for this path in our existing project data
-        file = File.get(path=filepath)
-
-        # If this file is already found, exit
-        if file:
-            return
-
-        # Load filepath in libopenshot clip object (which will try multiple readers to open it)
-        clip = openshot.Clip(filepath)
-
-        # Get the JSON for the clip's internal reader
-        try:
-            reader = clip.Reader()
-            file_data = json.loads(reader.Json())
-
-            # Determine media type
-            if file_data["has_video"] and not is_image(file_data):
-                file_data["media_type"] = "video"
-            elif file_data["has_video"] and is_image(file_data):
-                file_data["media_type"] = "image"
-            elif file_data["has_audio"] and not file_data["has_video"]:
-                file_data["media_type"] = "audio"
-            else:
-                # If neither set, just assume video
-                file_data["media_type"] = "video"
-
-            # Save new file to the project data
-            file = File()
-            file.data = file_data
-
-            # Is this file an image sequence / animation?
-            image_seq_details = self.get_image_sequence_details(filepath)
-            if image_seq_details:
-                # Update file with correct path
-                folder_path = image_seq_details["folder_path"]
-                file_name = image_seq_details["file_path"]
-                base_name = image_seq_details["base_name"]
-                fixlen = image_seq_details["fixlen"]
-                digits = image_seq_details["digits"]
-                extension = image_seq_details["extension"]
-
-                if not fixlen:
-                    zero_pattern = "%d"
-                else:
-                    zero_pattern = "%%0%sd" % digits
-
-                # Generate the regex pattern for this image sequence
-                pattern = "%s%s.%s" % (base_name, zero_pattern, extension)
-
-                # Split folder name
-                folderName = os.path.basename(folder_path)
-                if not base_name:
-                    # Give alternate name
-                    file.data["name"] = "%s (%s)" % (folderName, pattern)
-
-                # Load image sequence (to determine duration and video_length)
-                image_seq = openshot.Clip(os.path.join(folder_path, pattern))
-
-                # Update file details
-                file.data["path"] = os.path.join(folder_path, pattern)
-                file.data["media_type"] = "video"
-                file.data["duration"] = image_seq.Reader().info.duration
-                file.data["video_length"] = image_seq.Reader().info.video_length
-
-            # Save file
-            file.save()
-            # Reset list of ignored paths
-            self.ignore_image_sequence_paths = []
-
-            return True
-
-        except Exception as ex:
-            # Log exception
-            log.warning("Failed to import file: {}".format(str(ex)))
-            # Show message to user
-            msg = QMessageBox()
-            msg.setText(_("{} is not a valid video, audio, or image file.".format(filename)))
-            msg.exec_()
-            return False
-
-    def get_image_sequence_details(self, file_path):
-        """Inspect a file path and determine if this is an image sequence"""
-
-        # Get just the file name
-        (dirName, fileName) = os.path.split(file_path)
-        extensions = ["png", "jpg", "jpeg", "gif", "tif", "svg"]
-        match = re.findall(r"(.*[^\d])?(0*)(\d+)\.(%s)" % "|".join(extensions), fileName, re.I)
-
-        if not match:
-            # File name does not match an image sequence
-            return None
-        else:
-            # Get the parts of image name
-            base_name = match[0][0]
-            fixlen = match[0][1] > ""
-            number = int(match[0][2])
-            digits = len(match[0][1] + match[0][2])
-            extension = match[0][3]
-
-            full_base_name = os.path.join(dirName, base_name)
-
-            # Check for images which the file names have the different length
-            fixlen = fixlen or not (
-                glob.glob("%s%s.%s" % (full_base_name, "[0-9]" * (digits + 1), extension))
-                or glob.glob("%s%s.%s" % (full_base_name, "[0-9]" * ((digits - 1) if digits > 1 else 3), extension))
-            )
-
-            # Check for previous or next image
-            for x in range(max(0, number - 100), min(number + 101, 50000)):
-                if x != number and os.path.exists(
-                   "%s%s.%s" % (full_base_name, str(x).rjust(digits, "0") if fixlen else str(x), extension)):
-                    is_sequence = True
-                    break
-            else:
-                is_sequence = False
-
-            if is_sequence and dirName not in self.ignore_image_sequence_paths:
-                log.info('Prompt user to import image sequence from {}'.format(dirName))
-                # Ignore this path (temporarily)
-                self.ignore_image_sequence_paths.append(dirName)
-
-                # Translate object
-                _ = get_app()._tr
-
-                # Handle exception
-                ret = QMessageBox.question(self, _("Import Image Sequence"),
-                                           _("Would you like to import %s as an image sequence?") % fileName,
-                                           QMessageBox.No | QMessageBox.Yes)
-                if ret == QMessageBox.Yes:
-                    # Yes, import image sequence
-                    log.info('Importing {} as image sequence {}'.format(file_path, base_name + '*.' + extension))
-                    parameters = {
-                        "file_path": file_path,
-                        "folder_path": dirName,
-                        "base_name": base_name,
-                        "fixlen": fixlen,
-                        "digits": digits,
-                        "extension": extension
-                    }
-                    return parameters
-                else:
-                    return None
-            else:
-                return None
-
     # Handle a drag and drop being dropped on widget
     def dropEvent(self, event):
         # Reset list of ignored image sequences paths
@@ -278,6 +119,7 @@ class FilesTreeView(QTreeView):
         # Set cursor to waiting
         get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
 
+        media_paths = []
         for uri in event.mimeData().urls():
             log.info('Processing drop event for {}'.format(uri))
             filepath = uri.toLocalFile()
@@ -288,21 +130,28 @@ class FilesTreeView(QTreeView):
                     self.win.OpenProjectSignal.emit(filepath)
                     event.accept()
                 else:
-                    # Auto import media file
-                    if self.add_file(filepath):
-                        event.accept()
+                    media_paths.append(filepath)
+
+        # Import all new media files
+        if media_paths and self.files_model.add_files(media_paths):
+            event.accept()
 
         # Restore cursor
         get_app().restoreOverrideCursor()
 
-    def refresh_columns(self):
+    # Forward file-add requests to the model, for legacy code (previous API)
+    def add_file(self, filepath):
+        self.files_model.add_files(filepath)
+
+    def filter_changed(self):
+        self.refresh_view()
+
+    def refresh_view(self):
         """Resize and hide certain columns"""
-        if type(self) == FilesTreeView:
-            # Only execute when the treeview is active
-            self.hideColumn(3)
-            self.hideColumn(4)
-            self.hideColumn(5)
-            self.resize_contents()
+        self.hideColumn(3)
+        self.hideColumn(4)
+        self.hideColumn(5)
+        self.resize_contents()
 
     def resize_contents(self):
         # Get size of widget
@@ -371,7 +220,6 @@ class FilesTreeView(QTreeView):
         self.setAcceptDrops(True)
         self.setDragEnabled(True)
         self.setDropIndicatorShown(True)
-        self.ignore_image_sequence_paths = []
 
         # Setup header columns and layout
         self.setIconSize(QSize(75, 62))

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -93,16 +93,26 @@ class FilesTreeView(QTreeView):
 
     def startDrag(self, supportedActions):
         """ Override startDrag method to display custom icon """
-        # The relevant model for index values
-        model = self.model()
 
-        # Get indexes from column 0 of selected row
-        selected_rows = self.selectionModel().selectedRows(0)
-        icon = selected_rows[0].data(Qt.DecorationRole)
+        # Get first column indexes for all selected rows
+        selected = self.selectionModel().selectedRows(0)
+
+        # Get image of current item
+        current = self.selectionModel().currentIndex()
+        if not current.isValid() and selected:
+            current = selected[0]
+
+        if not current.isValid():
+            # We can't find anything to drag
+            log.warning("No draggable items found in model!")
+            return False
+
+        # Get icon from column 0 on same row as current item
+        icon = current.sibling(current.row(), 0).data(Qt.DecorationRole)
 
         # Start drag operation
         drag = QDrag(self)
-        drag.setMimeData(model.mimeData(self.selectionModel().selectedRows()))
+        drag.setMimeData(self.model().mimeData(selected))
         drag.setPixmap(icon.pixmap(QSize(self.drag_item_size, self.drag_item_size)))
         drag.setHotSpot(QPoint(self.drag_item_size / 2, self.drag_item_size / 2))
         drag.exec_()

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -3002,7 +3002,7 @@ class TimelineWebView(QWebView, updates.UpdateInterface):
 
         elif self.item_type == "os_drop":
             # Add new files to project
-            get_app().window.filesTreeView.dropEvent(event)
+            get_app().window.filesView.dropEvent(event)
 
             # Add clips for each file dropped
             for uri in event.mimeData().urls():

--- a/src/windows/views/transitions_listview.py
+++ b/src/windows/views/transitions_listview.py
@@ -25,14 +25,13 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-from PyQt5.QtCore import QSize, QPoint, Qt, QRegExp
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import QListView, QMenu
+from PyQt5.QtCore import Qt, QSize, QPoint, QRegExp
+from PyQt5.QtGui import QDrag
+from PyQt5.QtWidgets import QListView, QAbstractItemView, QMenu
 
 from classes.app import get_app
-from windows.models.transition_model import TransitionsModel, TransitionFilterProxyModel
+from classes.logger import log
 
-import json
 
 class TransitionsListView(QListView):
     """ A QListView QWidget used on the main window """
@@ -45,7 +44,7 @@ class TransitionsListView(QListView):
 
         menu = QMenu(self)
         menu.addAction(self.win.actionDetailsView)
-        menu.exec_(QCursor.pos())
+        menu.exec_(event.globalPos())
 
         # Ignore event, propagate to parent
         event.ignore()
@@ -53,14 +52,24 @@ class TransitionsListView(QListView):
     def startDrag(self, event):
         """ Override startDrag method to display custom icon """
 
-        # Get image of selected item
-        selected_row = self.transition_model.model.itemFromIndex(self.transition_model.proxy_model.mapToSource(self.selectionModel().selectedIndexes()[0])).row()
-        icon = self.transition_model.model.item(selected_row, 0).icon()
+        # Get first column indexes for all selected rows
+        selected = self.selectionModel().selectedRows(0)
+
+        # Get image of current item
+        current = self.selectionModel().currentIndex()
+        if not current.isValid() and selected:
+            current = selected[0]
+
+        if not current.isValid():
+            # We can't find anything to drag
+            log.warning("No draggable items found in model!")
+            return False
+
+        icon = current.data(Qt.DecorationRole)
 
         # Start drag operation
         drag = QDrag(self)
-        drag.setMimeData(self.transition_model.proxy_model.mimeData(self.selectionModel().selectedIndexes()))
-        # drag.setPixmap(QIcon.fromTheme('document-new').pixmap(QSize(self.drag_item_size,self.drag_item_size)))
+        drag.setMimeData(self.model().mimeData(selected))
         drag.setPixmap(icon.pixmap(QSize(self.drag_item_size, self.drag_item_size)))
         drag.setHotSpot(QPoint(self.drag_item_size / 2, self.drag_item_size / 2))
         drag.exec_()
@@ -71,9 +80,9 @@ class TransitionsListView(QListView):
     def refresh_view(self):
         """Filter transitions with proxy class"""
         filter_text = self.win.transitionsFilter.text()
-        self.transition_model.proxy_model.setFilterRegExp(QRegExp(filter_text.replace(' ', '.*')))
-        self.transition_model.proxy_model.setFilterCaseSensitivity(Qt.CaseInsensitive)
-        self.transition_model.proxy_model.sort(Qt.AscendingOrder)
+        self.model().setFilterRegExp(QRegExp(filter_text.replace(' ', '.*')))
+        self.model().setFilterCaseSensitivity(Qt.CaseInsensitive)
+        self.model().sort(Qt.AscendingOrder)
 
     def __init__(self, model):
         # Invoke parent init

--- a/src/windows/views/transitions_listview.py
+++ b/src/windows/views/transitions_listview.py
@@ -90,8 +90,15 @@ class TransitionsListView(QListView):
         self.setDragEnabled(True)
         self.setDropIndicatorShown(True)
 
-        # Setup header columns
         self.setModel(self.transition_model.proxy_model)
+
+        # Remove the default selection model and wire up to the shared one
+        self.selectionModel().deleteLater()
+        self.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionModel(self.transition_model.selection_model)
+
+        # Setup header columns
         self.setIconSize(QSize(131, 108))
         self.setGridSize(QSize(102, 92))
         self.setViewMode(QListView.IconMode)

--- a/src/windows/views/transitions_listview.py
+++ b/src/windows/views/transitions_listview.py
@@ -65,7 +65,8 @@ class TransitionsListView(QListView):
             log.warning("No draggable items found in model!")
             return False
 
-        icon = current.data(Qt.DecorationRole)
+        # Get icon from column 0 on same row as current item
+        icon = current.sibling(current.row(), 0).data(Qt.DecorationRole)
 
         # Start drag operation
         drag = QDrag(self)

--- a/src/windows/views/transitions_treeview.py
+++ b/src/windows/views/transitions_treeview.py
@@ -83,20 +83,22 @@ class TransitionsTreeView(QTreeView):
         self.setDragEnabled(True)
         self.setDropIndicatorShown(True)
 
-        # Setup header columns
         self.setModel(self.transition_model.proxy_model)
+
+        # Remove the default selection model and wire up to the shared one
+        self.selectionModel().deleteLater()
+        self.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionModel(self.transition_model.selection_model)
+
+        # Setup header columns
         self.setIconSize(QSize(75, 62))
         self.setIndentation(0)
-        self.setSelectionBehavior(QTreeView.SelectRows)
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.setWordWrap(True)
         self.setStyleSheet('QTreeView::item { padding-top: 2px; }')
-        self.transition_model.model.ModelRefreshed.connect(self.refresh_columns)
+        self.transition_model.ModelRefreshed.connect(self.refresh_columns)
 
         # Load initial transition model data
         self.transition_model.update_model()
         self.refresh_columns()
-
-        # setup filter events
-        app = get_app()

--- a/src/windows/views/transitions_treeview.py
+++ b/src/windows/views/transitions_treeview.py
@@ -62,7 +62,9 @@ class TransitionsTreeView(QTreeView):
             log.warning("No draggable items found in model!")
             return False
 
-        icon = current.data(Qt.DecorationRole)
+        # Get icon from column 0 on same row as current item
+        icon = current.sibling(current.row(), 0).data(Qt.DecorationRole)
+
         # Start drag operation
         drag = QDrag(self)
         drag.setMimeData(self.model().mimeData(selected))

--- a/src/windows/views/tutorial.py
+++ b/src/windows/views/tutorial.py
@@ -203,18 +203,18 @@ class TutorialManager(object):
 
     def get_object(self, object_id):
         """Get an object from the main window by object id"""
-        if object_id == "filesTreeView":
-            return self.win.filesTreeView
+        if object_id == "filesView":
+            return self.win.filesView
         elif object_id == "timeline":
             return self.win.timeline
         elif object_id == "dockVideoContents":
             return self.win.dockVideoContents
         elif object_id == "propertyTableView":
             return self.win.propertyTableView
-        elif object_id == "transitionsTreeView":
-            return self.win.transitionsTreeView
-        elif object_id == "effectsTreeView":
-            return self.win.effectsTreeView
+        elif object_id == "transitionsView":
+            return self.win.transitionsView
+        elif object_id == "effectsView":
+            return self.win.effectsView
         elif object_id == "export_button":
             # Find export toolbar button on main window
             export_button = None
@@ -313,14 +313,14 @@ class TutorialManager(object):
             {"id": "0",
              "x": 400,
              "y": 0,
-             "object_id": "filesTreeView",
+             "object_id": "filesView",
              "text": _("<b>Welcome!</b> OpenShot Video Editor is an award-winning, open-source video editing application! This tutorial will walk you through the basics.<br><br>Would you like to automatically send errors and metrics to help improve OpenShot?"),
              "arrow": False
              },
             {"id": "1",
              "x": 20,
              "y": 0,
-             "object_id": "filesTreeView",
+             "object_id": "filesView",
              "text": _("<b>Project Files:</b> Get started with your project by adding video, audio, and image files here. Drag and drop files from your file system."),
              "arrow": True
              },
@@ -347,14 +347,14 @@ class TutorialManager(object):
             {"id": "5",
              "x": 20,
              "y": 10,
-             "object_id": "transitionsTreeView",
+             "object_id": "transitionsView",
              "text": _("<b>Transitions:</b> Create a gradual fade from one clip to another. Drag and drop a transition onto the timeline and position it on top of a clip (usually at the beginning or ending)."),
              "arrow": True
              },
             {"id": "6",
              "x": 20,
              "y": 20,
-             "object_id": "effectsTreeView",
+             "object_id": "effectsView",
              "text": _("<b>Effects:</b> Adjust brightness, contrast, saturation, and add exciting special effects. Drag and drop an effect onto the timeline and position it on top of a clip (or track)"),
              "arrow": True
              },


### PR DESCRIPTION
As invited by @jonoomph (careful what you wish for), this PR against the in-progress `emojis` branch builds on the model/view changes there, extending some nice performance improvements into a fairly extensive overhaul of the entire way data is managed for project asset lists.

### TODO for merge
- [x] remove the `add_file()` implementations from `title_editor.py`, `animated_title.py`, that won't work anymore

There are probably some bugs, still, but I've finally got it to a point where it doesn't keel over as soon as I start testing it, so I wanted to get it out there in the world. The major benefits are:

#### Speed

I just imported a set of (what I subsequently discovered was) 776 image files, mostly PNGs, into a new project as Project Media. It wasn't _instantaneous_, but it took... maybe a minute? A bit more? The way the OpenShot code through 2.5.1 implemented that sort of thing, it would've quickly ground to a halt and taken possibly an hour or more, with each individual file causing a several-minutes-long rebuild of the full model on each addition. With the new code, not only did the import run at ~ 10 files/second right through to the end, but I was able to _delete_ a random 7 of them instantaneously.

#### Reduced <strike>data</strike> code duplication

`add_file()` and `get_image_sequence_data()` or whatever have moved out of the two view classes and into the `files_model`. Not only does that elmiinate duplication, but it allows for some strreamlining — for example, the method is now called `add_files()`, and it takes an entire list of files (like from a File Open dialog) instead of having to be spun over them one-by-one

### Improved user experience

My focus was also on eliminating some long-standing pain points for the users

#### Selection is now preserved in all lists, <strike>always</strike> almost always

There's a persistent `QItemSelectionModel` that's created with each **MODEL** class, and applied to both of the views (shared between them) when they're set up. You can switch modes and etc.,  you still won't lose your selected items.

(I notice that selections _are_ lost if the selected items are filtered out of the list, then restored to visibility again. So, that's a bug that I'd like to fix, if possible.)

#### Image Sequence import is less brain-dead

One of the advantages to `add_files()` is that it can be smarter about groups of files, when discovering for image sequences. Now, when you import a group of images that could be a sequence:
1. OpenShot will prompt you ONCE to import that sequence
1. If you say No, the code tracks which import files fall under the same sequence pattern, and won't ask you again about any of the rest of them.
1. If you say _yes_, the code now **removes** the rest of the matching images from your import list, so that if you happen to try to import a 30-image sequence by selecting all 30 images (which users do **all the time**), you'll end up with only one imported image sequence item, with the other 29 images automatically and _silently_ excluded.

There's a bunch more stuff, too — see the commit messages, and beyond that, the code.

I'm _hopeful_ that, among many others, this...
fixes #3372, fixes #2557, fixes #2341, fixes #2031, fixes #1288
