### PR TITLE
Fix background color of the Preview widget

### DIFF
--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -81,7 +81,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         painter.setRenderHints(QPainter.Antialiasing | QPainter.SmoothPixmapTransform | QPainter.TextAntialiasing, True)
 
         # Fill the whole widget with the solid color
-        painter.fillRect(event.rect(), QColor("#191919"))
+        painter.fillRect(event.rect(), self.palette().window())
 
         # Find centered viewport
         viewport_rect = self.centeredViewport(self.width(), self.height())


### PR DESCRIPTION
The widget itself occupies whole Preview window and for bright UI themes (and for any) it should be painted into the window color first. Later, the painter will fill the actual video area.

Before (16:9 preview. Theme: _No Theme_):

![OpenShot Preview background color Before](https://user-images.githubusercontent.com/19683044/82894372-246a2d80-9f5b-11ea-86bb-1a2a39caa2b5.png)

After (16:9 preview. Theme: _No Theme_):

![OpenShot Preview background color After](https://user-images.githubusercontent.com/19683044/82894386-28964b00-9f5b-11ea-9efb-f501436f58fb.png)
