### PR TITLE
Adjust position of tutorial message (for smaller screens)

### DIFF
--- a/src/windows/views/tutorial.py
+++ b/src/windows/views/tutorial.py
@@ -231,7 +231,7 @@ class TutorialManager(object):
             return self.win.filesView
         elif object_id == "timeline":
             return self.win.timeline
-        elif object_id == "dockVideoContents":
+        elif object_id == "dockVideo":
             return self.win.dockVideo
         elif object_id == "propertyTableView":
             return self.win.propertyTableView
@@ -243,9 +243,9 @@ class TutorialManager(object):
             return self.win.emojiListView
         elif object_id == "actionPlay":
             play_button = None
-            for toolbutton in self.win.videoToolbar.children():
-                if type(toolbutton) == QToolButton and toolbutton.defaultAction() and toolbutton.defaultAction().objectName() == "actionPlay":
-                    return toolbutton
+            for w in self.win.actionPlay.associatedWidgets():
+                if type(w) == QToolButton:
+                    return w
         elif object_id == "export_button":
             # Find export toolbar button on main window
             export_button = None
@@ -357,7 +357,7 @@ class TutorialManager(object):
             {"id": "0",
              "x": 0,
              "y": 0,
-             "object_id": "dockVideoContents",
+             "object_id": "dockVideo",
              "text": _("<b>Welcome!</b> OpenShot Video Editor is an award-winning, open-source video editing application! This tutorial will walk you through the basics.<br><br>Would you like to automatically send errors and metrics to help improve OpenShot?"),
              "arrow": False
              },

--- a/src/windows/views/tutorial.py
+++ b/src/windows/views/tutorial.py
@@ -283,6 +283,9 @@ class TutorialManager(object):
             self.tutorial_enabled = False
             s.set("tutorial_enabled", False)
 
+        # Forgot current tutorial
+        self.current_dialog = None
+
     def close_dialogs(self):
         """ Close any open tutorial dialogs """
         if self.current_dialog:


### PR DESCRIPTION
Adjust position of tutorial message for smaller screens, or when OpenShot is moved past the edge of the screen. For example:
![Screenshot from 2020-05-26 18-40-02](https://user-images.githubusercontent.com/5551883/82960506-580b7e80-9f80-11ea-9161-77681e307bf2.png)
