### PR TITLE
Fix hide tutorial QAction syntax for older Qt versions

### DIFF
--- a/src/windows/views/tutorial.py
+++ b/src/windows/views/tutorial.py
@@ -132,7 +132,7 @@ class TutorialDialog(QWidget):
         hbox.setContentsMargins(20, 10, 0, 0)
 
         # Close action
-        self.close_action = QAction(_("Hide Tutorial"))
+        self.close_action = QAction(_("Hide Tutorial"), self)
         self.close_action.setShortcut(QKeySequence(Qt.Key_Escape))
         self.close_action.setShortcutContext(Qt.ApplicationShortcut)
 


### PR DESCRIPTION
Related fix for https://github.com/OpenShot/openshot-qt/pull/3519