### PR TITLE
Update models only once on init

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2677,6 +2677,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.files_model = FilesModel()
         self.filesTreeView = FilesTreeView(self.files_model)
         self.filesListView = FilesListView(self.files_model)
+        self.files_model.update_model()
         self.tabFiles.layout().insertWidget(-1, self.filesTreeView)
         self.tabFiles.layout().insertWidget(-1, self.filesListView)
         if s.get("file_view") == "details":
@@ -2693,6 +2694,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.transition_model = TransitionsModel()
         self.transitionsTreeView = TransitionsTreeView(self.transition_model)
         self.transitionsListView = TransitionsListView(self.transition_model)
+        self.transition_model.update_model()
         self.tabTransitions.layout().insertWidget(-1, self.transitionsTreeView)
         self.tabTransitions.layout().insertWidget(-1, self.transitionsListView)
         if s.get("transitions_view") == "details":
@@ -2709,6 +2711,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.effects_model = EffectsModel()
         self.effectsTreeView = EffectsTreeView(self.effects_model)
         self.effectsListView = EffectsListView(self.effects_model)
+        self.effects_model.update_model()
         self.tabEffects.layout().insertWidget(-1, self.effectsTreeView)
         self.tabEffects.layout().insertWidget(-1, self.effectsListView)
         if s.get("effects_view") == "details":
@@ -2722,8 +2725,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.effectsView.setFocus()
 
         # Setup emojis view
-        self.emoji_model = EmojisModel()
-        self.emojiListView = EmojisListView(self.emoji_model)
+        self.emojis_model = EmojisModel()
+        self.emojiListView = EmojisListView(self.emojis_model)
+        self.emojis_model.update_model()
         self.tabEmojis.layout().addWidget(self.emojiListView)
 
         # Set up status bar

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2726,8 +2726,8 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # Setup emojis view
         self.emojis_model = EmojisModel()
-        self.emojiListView = EmojisListView(self.emojis_model)
         self.emojis_model.update_model()
+        self.emojiListView = EmojisListView(self.emojis_model)
         self.tabEmojis.layout().addWidget(self.emojiListView)
 
         # Set up status bar

--- a/src/windows/views/effects_listview.py
+++ b/src/windows/views/effects_listview.py
@@ -115,9 +115,6 @@ class EffectsListView(QListView):
         self.setTextElideMode(Qt.ElideRight)
         self.setStyleSheet('QListView::item { padding-top: 2px; }')
 
-        # Load initial effects model data
-        self.effects_model.update_model()
-
         # setup filter events
         app = get_app()
         app.window.effectsFilter.textChanged.connect(self.filter_changed)

--- a/src/windows/views/effects_treeview.py
+++ b/src/windows/views/effects_treeview.py
@@ -110,6 +110,4 @@ class EffectsTreeView(QTreeView):
         self.setStyleSheet('QTreeView::item { padding-top: 2px; }')
         self.effects_model.ModelRefreshed.connect(self.refresh_columns)
 
-        # Load initial effects model data
-        self.effects_model.update_model()
         self.refresh_columns()

--- a/src/windows/views/emojis_listview.py
+++ b/src/windows/views/emojis_listview.py
@@ -169,9 +169,6 @@ class EmojisListView(QListView):
         s = get_settings()
         default_type = s.get('emoji_group_filter') or 'smileys-emotion'
 
-        # Load initial emoji model data
-        self.emojis_model.update_model()
-
         # setup filter events
         self.win.emojisFilter.textChanged.connect(self.filter_changed)
 

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -200,9 +200,6 @@ class FilesListView(QListView):
 
         self.files_model.ModelRefreshed.connect(self.refresh_view)
 
-        # Load initial files model data
-        self.files_model.update_model()
-
         # setup filter events
         app = get_app()
         app.window.filesFilter.textChanged.connect(self.filter_changed)

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -242,8 +242,5 @@ class FilesTreeView(QTreeView):
 
         self.files_model.ModelRefreshed.connect(self.refresh_view)
 
-        # Load initial files model data
-        self.files_model.update_model()
-
         # setup filter events
         # self.files_model.model.itemChanged.connect(self.value_updated)

--- a/src/windows/views/transitions_listview.py
+++ b/src/windows/views/transitions_listview.py
@@ -118,9 +118,6 @@ class TransitionsListView(QListView):
         self.setTextElideMode(Qt.ElideRight)
         self.setStyleSheet('QListView::item { padding-top: 2px; }')
 
-        # Load initial transition model data
-        self.transition_model.update_model()
-
         # setup filter events
         app = get_app()
         app.window.transitionsFilter.textChanged.connect(self.filter_changed)

--- a/src/windows/views/transitions_treeview.py
+++ b/src/windows/views/transitions_treeview.py
@@ -110,6 +110,4 @@ class TransitionsTreeView(QTreeView):
         self.setStyleSheet('QTreeView::item { padding-top: 2px; }')
         self.transition_model.ModelRefreshed.connect(self.refresh_columns)
 
-        # Load initial transition model data
-        self.transition_model.update_model()
         self.refresh_columns()


### PR DESCRIPTION
Because view models has same origin, there is no sense to update models from the each view during initialization.

Now log-file shows that same models are updated twice on init (one for each View). This PR removes this excessive update on View init.