### PR TITLE
Add --debug flag(s) to launch.py

### DIFF
--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -88,6 +88,10 @@ BLENDER_MIN_VERSION = "2.80"
 # Data-model debugging enabler
 MODEL_TEST = False
 
+# Default/initial logging levels
+LOG_LEVEL_FILE = 'INFO'
+LOG_LEVEL_CONSOLE = 'INFO'
+
 # Languages
 CMDLINE_LANGUAGE = None
 CURRENT_LANGUAGE = 'en_US'

--- a/src/classes/logger.py
+++ b/src/classes/logger.py
@@ -1,35 +1,39 @@
-""" 
+"""
  @file
  @brief This file sets the default logging settings
  @author Noah Figg <eggmunkee@hotmail.com>
  @author Jonathan Thomas <jonathan@openshot.org>
- 
+
  @section LICENSE
- 
+
  Copyright (c) 2008-2018 OpenShot Studios, LLC
  (http://www.openshotstudios.com). This file is part of
  OpenShot Video Editor (http://www.openshot.org), an open-source project
  dedicated to delivering high quality video editing and animation solutions
  to the world.
- 
+
  OpenShot Video Editor is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  OpenShot Video Editor is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-import logging
 import os, sys
-from logging.handlers import RotatingFileHandler
+import logging
+import logging.handlers
+
 from classes import info
+
+# Dictionary of logging handlers we create, keyed by type
+handlers = {}
 
 
 class StreamToLogger(object):
@@ -49,30 +53,42 @@ class StreamToLogger(object):
     def errors(self):
         pass
 
-# Initialize logging module, give basic formats and level we want to report
-logging.basicConfig(format="%(module)12s:%(levelname)s %(message)s",
-                    datefmt='%H:%M:%S',
-                    level=logging.INFO)
 
-# Create a formatter
-formatter = logging.Formatter('%(module)12s:%(levelname)s %(message)s')
+# Create logger instance
+log = logging.Logger('OpenShot')
 
-# Get logger instance & set level
-log = logging.getLogger('OpenShot')
-log.setLevel(logging.INFO)
+# Set up a log formatter
+formatter = logging.Formatter('%(module)12s:%(levelname)s %(message)s', datefmt='%H:%M:%S')
 
-# Add rotation file handler
-fh = RotatingFileHandler(
+# Add normal stderr stream handler
+sh = logging.StreamHandler()
+sh.setFormatter(formatter)
+sh.setLevel(info.LOG_LEVEL_CONSOLE)
+log.addHandler(sh)
+handlers['stream'] = sh
+
+# Add rotating file handler
+fh = logging.handlers.RotatingFileHandler(
     os.path.join(info.USER_PATH, 'openshot-qt.log'), encoding="utf-8", maxBytes=25*1024*1024, backupCount=3)
 fh.setFormatter(formatter)
+fh.setLevel(info.LOG_LEVEL_FILE)
 log.addHandler(fh)
+handlers['file'] = fh
+
 
 def reroute_output():
     """Route stdout and stderr to logger (custom handler)"""
     if not getattr(sys, 'frozen', False):
-        so = StreamToLogger(log, logging.INFO)
-        sys.stdout = so
+        handlers['stdout'] = StreamToLogger(log, logging.INFO)
+        sys.stdout = handlers['stdout']
 
-        se = StreamToLogger(log, logging.ERROR)
-        sys.stderr = se
+        handlers['stderr'] = StreamToLogger(log, logging.ERROR)
+        sys.stderr = handlers['stderr']
 
+
+def set_level_file(level=logging.INFO):
+    handlers['file'].setLevel(level)
+
+
+def set_level_console(level=logging.INFO):
+    handlers['stream'].setLevel(level)

--- a/src/launch.py
+++ b/src/launch.py
@@ -75,7 +75,6 @@ def main():
         help='Debugging output (logfile only)')
     parser.add_argument('--debug-console', action='store_true',
         help='Debugging output (console only)')
-    # Hidden processing for short-form '-d' synonym for --debug
     parser.add_argument('-V', '--version', action='store_true')
     parser.add_argument('remain', nargs=argparse.REMAINDER,
        help=argparse.SUPPRESS)

--- a/src/launch.py
+++ b/src/launch.py
@@ -46,12 +46,10 @@ import argparse
 
 try:
     from classes import info
-    print("Loaded modules from current directory: %s" % info.PATH)
 except ImportError:
     import openshot_qt
     sys.path.append(openshot_qt.OPENSHOT_PATH)
     from classes import info
-    print("Loaded modules from installed directory: %s" % info.PATH)
 
 
 def main():
@@ -71,6 +69,13 @@ def main():
        action='store_true',
        help="Load Qt's QAbstractItemModelTester into data models "
        '(requires Qt 5.11+)')
+    parser.add_argument('-d', '--debug', action='store_true',
+        help='Enable debugging output')
+    parser.add_argument('--debug-file', action='store_true',
+        help='Debugging output (logfile only)')
+    parser.add_argument('--debug-console', action='store_true',
+        help='Debugging output (console only)')
+    # Hidden processing for short-form '-d' synonym for --debug
     parser.add_argument('-V', '--version', action='store_true')
     parser.add_argument('remain', nargs=argparse.REMAINDER,
        help=argparse.SUPPRESS)
@@ -81,6 +86,12 @@ def main():
     if args.version:
         print("OpenShot version %s" % info.SETUP['version'])
         sys.exit()
+
+    # Set up debugging log level to requested streams
+    if args.debug or args.debug_file:
+            info.LOG_LEVEL_FILE = 'DEBUG'
+    if args.debug or args.debug_console:
+            info.LOG_LEVEL_CONSOLE = 'DEBUG'
 
     if args.list_languages:
         from classes.language import get_all_languages
@@ -113,6 +124,9 @@ def main():
         else:
             print("Unsupported language '{}'! (See --list-languages)".format(args.lang))
             sys.exit(-1)
+
+    # Normal startup, print module path and lauch application
+    print("Loaded modules from: %s" % info.PATH)
 
     # Create Qt application, pass any unprocessed arguments
     from classes.app import OpenShotApp


### PR DESCRIPTION
This PR adds three new command-line options for debugging: `-d|--debug`, `--debug-file`, and `--debug-console`:
<pre><code>$ ./launch.py --help
usage: launch.py [-h] [-l LANG] [--list-languages] [--path PY_PATH]
                 [--test-models] [-d] [--debug-file] [--debug-console] [-V]

OpenShot version 2.5.1-dev2

optional arguments:
  -h, --help            show this help message and exit
  -l LANG, --lang LANG  language code for interface (overrides preferences and
                        system environment)
  --list-languages      List all language codes supported by OpenShot
  --path PY_PATH        Additional locations to search for modules
                        (PYTHONPATH). Can be used multiple times.
  --test-models         Load Qt's QAbstractItemModelTester into data models
                        (requires Qt 5.11+)
<b>  -d, --debug           Enable debugging output
  --debug-file          Debugging output (logfile only)
  --debug-console       Debugging output (console only)</b>
  -V, --version
</code></pre>

When enabled, the logging level to the requested stream(s) will be set to `logging.DEBUG`, meaning that `log.debug()` messages will be captured in addition to the normal `INFO`-through-`CRITICAL` capturing.

To facilitate this, two new `info` variables are added, `info.LOG_LEVEL_FILE` and `info.LOG_LEVEL_CONSOLE`. Both default to `"INFO"` but are raised to `"DEBUG"` by the command-line processing.

This isn't currently tied in to the Preferences interface at all, it's only available as a startup option. However, `classes.logger` contains two new functions (currently unused): `set_level_file()` and `set_level_console()`. These should make runtime modification of the logging level trivial to add.