### PR TITLE
Improved new codec handling

### DIFF
--- a/src/presets/format_webm_libav1.xml
+++ b/src/presets/format_webm_libav1.xml
@@ -9,9 +9,9 @@
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>
 	<videobitrate
-	 low="384 kb/s"
-	 med="1.5 Mb/s"
-	 high="15.00 Mb/s"></videobitrate>
+	 low="50 crf"
+	 med="35 crf"
+	 high="10 crf"></videobitrate>
 	<audiobitrate
 	 low="96 kb/s"
 	 med="128 kb/s"

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -913,7 +913,10 @@ class Export(QDialog):
                     if ((( frame - start_frame_export ) != 0) & (( end_time_export - start_time_export ) != 0)):
                         seconds_left = round(( start_time_export - end_time_export )*( frame - end_frame_export )/( frame - start_frame_export ))
                         fps_encode = ((frame - start_frame_export)/(end_time_export-start_time_export))
-                        title_message = _("%(hours)d:%(minutes)02d:%(seconds)02d Remaining (%(fps)5.2f FPS)") % {
+                        if frame == end_frame_export:
+                            title_message = _("FINALIZING please wait")
+                        else:
+                            title_message = _("%(hours)d:%(minutes)02d:%(seconds)02d Remaining (%(fps)5.2f FPS)") % {
                             'hours': seconds_left / 3600,
                             'minutes': (seconds_left / 60) % 60,
                             'seconds': seconds_left % 60,
@@ -1007,6 +1010,16 @@ class Export(QDialog):
 
             # Reveal done button
             self.close_button.setVisible(True)
+
+            # Restore windows title to show elapsed time
+            title_message = _("%(hours)d:%(minutes)02d:%(seconds)02d Elapsed (%(fps)5.2f FPS)") % {
+                'hours': seconds_run / 3600,
+                'minutes': (seconds_run / 60) % 60,
+                'seconds': seconds_run % 60,
+                'fps': fps_encode}
+
+            get_app().window.ExportFrame.emit(title_message, video_settings.get("start_frame"),
+                                              video_settings.get("end_frame"), frame)
 
             # Make progress bar green (to indicate we are done)
             from PyQt5.QtGui import QPalette

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -914,7 +914,7 @@ class Export(QDialog):
                         seconds_left = round(( start_time_export - end_time_export )*( frame - end_frame_export )/( frame - start_frame_export ))
                         fps_encode = ((frame - start_frame_export)/(end_time_export-start_time_export))
                         if frame == end_frame_export:
-                            title_message = _("FINALIZING please wait")
+                            title_message = _("Finalizing video export, please wait...")
                         else:
                             title_message = _("%(hours)d:%(minutes)02d:%(seconds)02d Remaining (%(fps)5.2f FPS)") % {
                             'hours': seconds_left / 3600,


### PR DESCRIPTION
The presets for the libaom-av1 codec were improved and the title of the export window now shows a message requesting the user to wait when 100% are reached but the clip is not finished due to finalising work to be done by the codec.