### PR TITLE
Copy/paste optimizations and other small fixes

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -143,8 +143,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
     def _set(self, key, values=None, add=False, partial_update=False, remove=False):
         """ Store setting, but adding isn't allowed. All possible settings must be in default settings file. """
 
-        log.debug(
-            "_set key: {} values: {} add: {} partial: {} remove: {}".format(key, values, add, partial_update, remove))
         parent, my_key = None, ""
 
         # Verify key is valid type

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -143,7 +143,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
     def _set(self, key, values=None, add=False, partial_update=False, remove=False):
         """ Store setting, but adding isn't allowed. All possible settings must be in default settings file. """
 
-        log.info(
+        log.debug(
             "_set key: {} values: {} add: {} partial: {} remove: {}".format(key, values, add, partial_update, remove))
         parent, my_key = None, ""
 

--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -172,6 +172,9 @@ class UpdateManager:
         # Loop through each updateAction object and serialize
         # Ignore any load actions or history update actions
         history_length_int = int(history_length)
+        if history_length_int == 0:
+            self.update_untracked(["history"], {"redo": [], "undo": []})
+            return
         for action in self.redoHistory[-history_length_int:]:
             if action.type != "load" and action.key[0] != "history":
                 actionDict = json.loads(action.json(), strict=False)

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -1355,56 +1355,57 @@ $scope.SetTrackLabel = function (label) {
  // to the timeline. A change can be an insert, update, or delete. The change is passed in
  // as JSON, which represents the change.
  $scope.ApplyJsonDiff = function(jsonDiff) {
+  timeline.qt_log("  !!!! DEBUG: ApplyJsonDiff");
 
-	 // Loop through each UpdateAction
+	// Loop through each UpdateAction
 	for (var action_index = 0; action_index < jsonDiff.length; action_index++) {
 		var action = jsonDiff[action_index];
 
-		 // Iterate through the key levels (looking for a matching element in the $scope.project)
-		 var previous_object = null;
-		 var current_object = $scope.project;
-		 var current_position = 0;
-		 var current_key = "";
-		 for (var key_index = 0; key_index < action.key.length; key_index++) {
-		 	var key_value = action.key[key_index];
+		// Iterate through the key levels (looking for a matching element in the $scope.project)
+		var previous_object = null;
+		var current_object = $scope.project;
+		var current_position = 0;
+		var current_key = "";
+		for (var key_index = 0; key_index < action.key.length; key_index++) {
+			var key_value = action.key[key_index];
 
-		 	// Check the key type
-		 	if (key_value.constructor == String) {
-		 		// Does the key value exist in scope?, No match, bail out
-		 		if (!current_object.hasOwnProperty(key_value)) {
-		 			return false;
-		 		}
-	 			// set current level and previous level
-	 			previous_object = current_object;
-	 			current_object = current_object[key_value];
-	 			current_key = key_value;
+			// Check the key type
+			if (key_value.constructor == String) {
+				// Does the key value exist in scope?, No match, bail out
+				if (!current_object.hasOwnProperty(key_value)) {
+					return false;
+				}
+				// set current level and previous level
+				previous_object = current_object;
+				current_object = current_object[key_value];
+				current_key = key_value;
 
-		 	}
-		 	else if (key_value.constructor == Object) {
-		 		// Get the id from the object (if any)
-		 		var id = null;
-		 		if ("id" in key_value) {
-		 			id = key_value["id"];
-		 		}
-		 		// Be sure the current_object is an Array
-		 		if (current_object.constructor == Array) {
-			 		// Filter the current_object for a specific id
-			 		current_position = 0;
-			 		for (var child_index = 0; child_index < current_object.length; child_index++) {
-			 			var child_object = current_object[child_index];
+			}
+			else if (key_value.constructor == Object) {
+				// Get the id from the object (if any)
+				var id = null;
+				if ("id" in key_value) {
+					id = key_value["id"];
+				}
+				// Be sure the current_object is an Array
+				if (current_object.constructor == Array) {
+					// Filter the current_object for a specific id
+					current_position = 0;
+					for (var child_index = 0; child_index < current_object.length; child_index++) {
+						var child_object = current_object[child_index];
 
 						// Find matching child
 						if (child_object.hasOwnProperty("id") && child_object.id == id) {
-				 			// set current level and previous level
-				 			previous_object = current_object;
-				 			current_object = child_object;
-				 			break; // found child, stop looping
-				 		}
-				 		// increment index
-				 		current_position++;
-			 		}
-		 		}
-		 	}
+							// set current level and previous level
+							previous_object = current_object;
+							current_object = child_object;
+							break; // found child, stop looping
+						}
+						// increment index
+						current_position++;
+					}
+				}
+			}
 		}
 
         // Now that we have a matching object in the $scope.project...
@@ -1455,18 +1456,21 @@ $scope.SetTrackLabel = function (label) {
                 // delete current object from it's parent (previous object)
                 previous_object.splice(current_position, 1);
             }
-            // Resize timeline if it's too small to contain all clips
-            $scope.ResizeTimeline();
-
-            // Re-sort clips and transitions array
-            $scope.SortItems();
-
-            // Re-index Layer Y values
-            $scope.UpdateLayerIndex();
         }
-		$scope.$digest();
 	}
-	// return true
+
+  // Resize timeline if it's too small to contain all clips
+  $scope.ResizeTimeline();
+
+  // Re-sort clips and transitions array
+  $scope.SortItems();
+
+  // Re-index Layer Y values
+  $scope.UpdateLayerIndex();
+
+  $scope.$digest();
+
+  timeline.qt_log("  !!!! DEBUG: ApplyJsonDiff");
 	return true;
  };
 

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -66,7 +66,6 @@ class PropertiesModel(updates.UpdateInterface):
 
         # Handle change
         if action.key and action.key[0] in ["clips", "effects"] and action.type in ["update", "insert"]:
-            log.info(action.values)
             # Update the model data
             self.update_model(get_app().window.txtPropertyFilter.text())
 

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -226,6 +226,8 @@ class FilesListView(QListView):
             extension = match[0][3]
 
             full_base_name = os.path.join(dirName, base_name)
+            if self._add_file_to_ignore_sequence == full_base_name:
+                return None
 
             # Check for images which the file names have the different length
             fixlen = fixlen or not (
@@ -267,6 +269,7 @@ class FilesListView(QListView):
                     }
                     return parameters
                 else:
+                    self._add_file_to_ignore_sequence = full_base_name
                     return None
             else:
                 return None
@@ -343,3 +346,6 @@ class FilesListView(QListView):
         # setup filter events
         app = get_app()
         app.window.filesFilter.textChanged.connect(self.filter_changed)
+
+        # Ignore repeated non-sequence files that was ignored previously
+        self._add_file_to_ignore_sequence = ''

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -225,6 +225,8 @@ class FilesTreeView(QTreeView):
             extension = match[0][3]
 
             full_base_name = os.path.join(dirName, base_name)
+            if self._add_file_to_ignore_sequence == full_base_name:
+                return None
 
             # Check for images which the file names have the different length
             fixlen = fixlen or not (
@@ -266,6 +268,7 @@ class FilesTreeView(QTreeView):
                     }
                     return parameters
                 else:
+                    self._add_file_to_ignore_sequence = full_base_name
                     return None
             else:
                 return None
@@ -397,3 +400,6 @@ class FilesTreeView(QTreeView):
         app = get_app()
         app.window.filesFilter.textChanged.connect(self.filter_changed)
         self.files_model.model.itemChanged.connect(self.value_updated)
+
+        # Ignore repeated non-sequence files that was ignored previously
+        self._add_file_to_ignore_sequence = ''

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -737,6 +737,7 @@ class SelectionLabel(QFrame):
 
         # Look up item for more info
         if self.item_type == "clip":
+            print("  !!!! DEBUG: selecting clip: %s" % (self.item_id,))
             clip = Clip.get(id=self.item_id)
             if clip:
                 self.item_name = clip.title()


### PR DESCRIPTION
A number of fixes for v2.5.1 which requires check before the further development:
* Moved clipboard formatting position and layer to copy phase (paste could be executed multiple times, so we need to spend it only once)
* When user importing sequential files - it's good to ask once for filepath base, not for all the files
* If save history is set to 0 - it will not work properly and store the entire history in the project. Not sure if openshot should store history by default in the project (maybe only in backups?), but this is useful if I don't want to store megabytes of history.
* Removed a couple of too verbose logs
* *Batch processing of clips paste* - this one requires a review. I think the engine is supporting batch processing, and it will seriously improve the performance of pasting multiple clips (or potentially transitions), because we don't wasting time to update the timeline for each clip. This means alot for me - because I'm working with a huge value of small frame-clips.

Probably I want to put here some additional improvements, like clip reference (instead of full copy) and rework the magnet mechanics, but probably later.

Please check this one - if it will work, that's great, if not - I will try to make it better :)