### PR TITLE
Removing setWindowIcon() from our main window

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -107,7 +107,6 @@ class OpenShotApp(QApplication):
         # Setup application
         self.setApplicationName('openshot')
         self.setApplicationVersion(info.SETUP['version'])
-        self.setWindowIcon(QIcon(":/openshot.svg"))
         try:
             # Qt 5.7+ only
             self.setDesktopFile("org.openshot.OpenShot")


### PR DESCRIPTION
Removing setWindowIcon() from our main window, as it has a crazy side-effect on Windows and prevents our QtImageReader from being able to open certain types of files, such as JPEG. Or at least, that is what appears to be happening. No JPEG transitions of effects can be dropped on the timeline. They both fail when trying to construct the QtImageReader. I've also verified the path is correct going into the QtImageReader constructor. 

Fixes:
https://github.com/OpenShot/openshot-qt/issues/3546
https://github.com/OpenShot/openshot-qt/issues/3401
https://github.com/OpenShot/openshot-qt/issues/3466

Here is the error when dropping a transition on the timeline when `self.setWindowIcon(QIcon(":/openshot.svg"))` is present in `app.py`:
```
timeline_webview:INFO addTransition...
  exceptions:ERROR Unhandled Exception
Traceback (most recent call last):
  File "C:\Program Files (x86)\OpenShot Video Editor\windows\views\timeline_webview.py", line 2802, in dragEnterEvent
    self.addTransition(data, pos)
  File "C:\Program Files (x86)\OpenShot Video Editor\windows\views\timeline_webview.py", line 2907, in addTransition
    transition_reader = openshot.QtImageReader(file_ids[0])
  File "C:\Users\Administrator\builds\7546b651\1\OpenShot\openshot-qt\openshot.py", line 2503, in __init__

```