### PR TITLE
Ability to not store the history in the project

### DIFF
--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -172,6 +172,9 @@ class UpdateManager:
         # Loop through each updateAction object and serialize
         # Ignore any load actions or history update actions
         history_length_int = int(history_length)
+        if history_length_int == 0:
+            self.update_untracked(["history"], {"redo": [], "undo": []})
+            return
         for action in self.redoHistory[-history_length_int:]:
             if action.type != "load" and action.key[0] != "history":
                 actionDict = json.loads(action.json(), strict=False)


### PR DESCRIPTION
If save history is set to 0 - it will not work properly and store the entire history in the project. Not sure if openshot should store history by default in the project (maybe only in backups?), but this is useful if I don't want to store megabytes of history.