### PR TITLE
Travis: Downgrade to cx_Freeze 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       python: 3.6
 
 install:
-  - pip3 install cx-freeze
+  - pip3 install 'cx-freeze==6.1'
 
 script:
   - python3 freeze.py build


### PR DESCRIPTION
It looks like Travis builds are failing because something about the newly-released cx_Freeze 6.2 (which `pip` is now installing during the setup phase) doesn't like our `freeze.py` code. Until we can get the problem sorted out, Travis can just stay locked on the previous release with `pip install cx_Freeze==6.1`.