### PR TITLE
Travis: Add Ubuntu Focal (Python 3.8) build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ matrix:
       os: linux
       dist: bionic
       python: 3.6
+    - name: "Python 3.8 (Ubuntu 20.04 Focal)"
+      os: linux
+      dist: focal
+      python: 3.8
 
 install:
   - pip3 install 'cx-freeze==6.1'


### PR DESCRIPTION
We've been building `libopenshot` and `libopenshot-audio` on Ubuntu Focal for a little while now, since our FFmpeg 4 backport PPA went bye-bye. For some reason, I never thought to add it to OpenShot's build matrix. But it makes sense now, especially as Xenial will have to go away when WebEngine gets merged (its Qt is too old).