### PR TITLE
title editor: Fix name-duplication regex

### DIFF
--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -249,13 +249,19 @@ class TitleEditor(QDialog):
             if self.duplicate and self.edit_file_path:
                 # Re-use current name
                 name = os.path.basename(self.edit_file_path)
-                # Splits the filename into "[base-part][optional space]([number]).svg
-                match = re.match(r"^(.*?)(\s*)\(([0-9]*)\)\.svg$", name)
+                # Splits the filename into:
+                #  [base-part][optional space][([number])].svg
+                # Match groups are:
+                #  1: Base name ("title", "Title-2", "Title number 3000")
+                #  2: Space(s) preceding groups 3+4, IFF 3/4 are a match
+                #  3: The entire parenthesized number ("(1)", "(20)", "(1000)")
+                #  4: Just the number inside the parens ("1", "20", "1000")
+                match = re.match(r"^(.+?)(\s*)(\(([0-9]*)\))?\.svg$", name)
                 # Make sure the new title has " (%d)" appended by default
                 name = match.group(1) + " (%d)"
-                if match.group(3):
+                if match.group(4):
                     # Filename already contained a number -> start counting from there
-                    offset = int(match.group(3))
+                    offset = int(match.group(4))
                     # -> only include space(s) if there before
                     name = match.group(1) + match.group(2) + "(%d)"
             # Find an unused file name


### PR DESCRIPTION
The previous version was treating the parentheses as non-optional, and could come out with no match at all if the input name lacked them, leading to a traceback instead of the expected title editor window.

The new code will guarantee that `match.group(1)` always has some contents, even if — in the very degenerate case — the filename is something insane like `(1).svg`.

(In which case, `match.group(1) == '(1)'` and the rest of the match groups are empty. This would result in the output filename for the copy being generated as `(1) (1).svg`. Which I would argue is actually more correct than / preferable to `(2).svg`, in that admittedly pathological case.)