### PR TITLE
Fixing Mac notarization to wait until --notarization-history contains the record

### DIFF
--- a/installer/build-mac-dmg.sh
+++ b/installer/build-mac-dmg.sh
@@ -91,16 +91,17 @@ while [ "$(( $(date +%s) - 3600 ))" -lt "$START" ]; do
     notarize_status="${BASH_REMATCH[1]}"
 
     if [ "$notarize_status" != "in progress" ] && [ "$notarize_status" != "" ]; then
-      echo "Notarization Status Found: $notarize_status"
-      break
+      echo "Notarization Status Found: $notarize_status. Wait for notarization to appear in --notarization-history/"
+      verify_output=$(xcrun altool --notarization-history 0 -u "jonathan@openshot.org" -p "@keychain:NOTARIZE_AUTH" | grep "$REQUEST_UUID")
+      if [ "$verify_output" != "" ]; then
+        echo "Notarization record found, and ready for stapling!"
+        break
+      fi
     fi
 
     # Wait a few seconds
     sleep 60
 done
-
-echo "Check Notarization Progress... (list recent notarization records)"
-xcrun altool --notarization-history 0 -u "jonathan@openshot.org" -p "@keychain:NOTARIZE_AUTH" | head -n 10
 
 echo "Staple Notarization Ticket to DMG"
 xcrun stapler staple "build/$OS_DMG_NAME"


### PR DESCRIPTION
For some reason, after the Mac notarization status is reported as "Succeeded", it can take up to 30 minutes before we can download the resulting ticket, and if we don't wait, we can't staple the ticket to our App and DMG. So, this seems to help in my testing so far!