### PR TITLE
Fix lib mangling script (correctly)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,8 @@ linux-builder:
     - cd doc; make html SPHINXOPTS="-D html_theme_options.analytics_id=UA-4381101-5"; cd ..;
     - ~/auto-update-sphinx "$CI_PROJECT_DIR/build" "$CI_COMMIT_REF_NAME"
     - python3 -u freeze.py build
-    - /bin/sh ./installer/mangle-hw-libs.sh "build/exe.linux-x86_64-3.4/"
+    - for dir in "build/*/"; do /bin/sh ./installer/mangle-hw-libs.sh $(realpath "${dir}"); done 
+    - 
     - python3 -u installer/build-server.py "$SLACK_TOKEN" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "False" "$CI_COMMIT_REF_NAME"
   when: always
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,6 @@ linux-builder:
     - ~/auto-update-sphinx "$CI_PROJECT_DIR/build" "$CI_COMMIT_REF_NAME"
     - python3 -u freeze.py build
     - for dir in "build/*/"; do /bin/sh ./installer/mangle-hw-libs.sh $(realpath "${dir}"); done 
-    - 
     - python3 -u installer/build-server.py "$SLACK_TOKEN" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "False" "$CI_COMMIT_REF_NAME"
   when: always
   except:

--- a/installer/mangle-hw-libs.sh
+++ b/installer/mangle-hw-libs.sh
@@ -20,7 +20,28 @@ __EOM__
 # We take one argument, the path in which to look for target libraries
 if [ -d "$1" ]; then
   hw_lib_dir="$1"
+else
+  usage && exit -1
 fi
+
+fix_va_lib()
+{
+  lname="$1"
+  echo -n "Looking for ${lname}..."
+  hwlib="${hw_lib_dir}/${lname}"
+  if [ -w "${hwlib}" ]; then
+    echo -n " found, processing..."
+    # /usr/lib/x86_64-linux-gnu/dri => ./../lib/x86_64-linux-gnu/dri
+    sed -i -e 's,/usr\(/lib/x86_64-linux-gnu/dri\),\./\.\.\1,g' "${hwlib}"
+    echo " done."
+  else
+    echo " NOT found, skipping."
+  fi
+}
+
+for libname in "libva.so.1" "libva.so.2"; do
+  fix_va_lib $libname;
+done
 
 echo -n "Looking for libvdpau.so.1..."
 hwlib="${hw_lib_dir}/libvdpau.so.1"
@@ -37,16 +58,4 @@ else
   echo " NOT found, skipping."
 fi
 
-echo -n "Looking for libva.so.1..."
-hwlib="${hw_lib_dir}/libva.so.1"
-if [ -w "${hwlib}" ]; then
-  echo -n " found, processing..."
-  # /usr/lib/x86_64-linux-gnu/dri => ./../lib/x86_64-linux-gnu/dri
-  sed -i -e 's,/usr\(/lib/x86_64-linux-gnu/dri\),\./\.\.\1,g' "${hwlib}"
-  echo " done."
-else
-  echo " NOT found, skipping."
-fi
-
 exit 0
-


### PR DESCRIPTION
This PR also adds `libva.so.2` to the list of libs to be mangled, since the linux builder now has it installed instead of `libva.so.1`