### PR TITLE
Travis: Re-enable QtWebKit for Xenial builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
   apt:
     sources:
     - sourceline: 'ppa:openshot.developers/libopenshot-daily'
-    packages:
+    packages: &p_common
     - libopenshot-audio-dev
     - libopenshot-dev
     - libssl-dev
@@ -15,10 +15,7 @@ addons:
     - python3-pip
     - python3-setuptools
     - python3-pyqt5
-    - python3-pyqt5.qtmultimedia
-    - python3-pyqt5.qtopengl
     - python3-pyqt5.qtsvg
-    - python3-pyqt5.qtwebengine
     - python3-requests
     - python3-xdg
     - python3-zmq
@@ -28,20 +25,42 @@ addons:
 jobs:
   allow_failures:
     - name: "Python 3.5 (Ubuntu 16.04 Xenial)"
-
   include:
     - name: "Python 3.5 (Ubuntu 16.04 Xenial)"
       os: linux
       dist: xenial
       python: 3.5
+      addons:
+        apt:
+          sources:
+          - sourceline: 'ppa:openshot.developers/libopenshot-daily'
+          packages:
+          - *p_common
+          - python3-pyqt5.qtwebkit
     - name: "Python 3.6 (Ubuntu 18.04 Bionic)"
       os: linux
       dist: bionic
       python: 3.6
+      addons:
+        apt:
+          sources:
+          - sourceline: 'ppa:openshot.developers/libopenshot-daily'
+          packages:
+          - *p_common
+          - python3-pyqt5.qtwebengine
+          - python3-pyqt5.qtopengl
     - name: "Python 3.8 (Ubuntu 20.04 Focal)"
       os: linux
       dist: focal
       python: 3.8
+      addons:
+        apt:
+          sources:
+          - sourceline: 'ppa:openshot.developers/libopenshot-daily'
+          packages:
+          - *p_common
+          - python3-pyqt5.qtwebengine
+          - python3-pyqt5.qtopengl
 
 install:
   - pip3 install 'cx-freeze==6.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ addons:
     - xvfb
 
 jobs:
-  allow_failures:
-    - name: "Python 3.5 (Ubuntu 16.04 Xenial)"
   include:
     - name: "Python 3.5 (Ubuntu 16.04 Xenial)"
       os: linux

--- a/freeze.py
+++ b/freeze.py
@@ -262,8 +262,8 @@ elif sys.platform == "linux":
         try:
             mod = import_module(mod_name)
             pyqt5_mod_files.append(inspect.getfile(mod))
-        except ImportError as ex;
-            log.warning("Skipping {}: {}".format(mod_name, ex)
+        except ImportError as ex:
+            log.warning("Skipping {}: {}".format(mod_name, ex))
 
 
     lib_list = [os.path.join(libopenshot_path, "libopenshot.so"),

--- a/freeze.py
+++ b/freeze.py
@@ -216,7 +216,9 @@ elif sys.platform == "linux":
 
     # Add QtWebEngineProcess (if found)
     web_process_path = ARCHLIB + "qt5/libexec/QtWebEngineProcess"
-    external_so_files.append((web_process_path, os.path.basename(web_process_path)))
+    if os.path.exists(web_process_path):
+        external_so_files.append(
+            (web_process_path, os.path.basename(web_process_path)))
 
     # Add QtWebEngineProcess Resources & Local
     qt5_path = "/usr/share/qt5/"
@@ -266,10 +268,14 @@ elif sys.platform == "linux":
             log.warning("Skipping {}: {}".format(mod_name, ex))
 
 
-    lib_list = [os.path.join(libopenshot_path, "libopenshot.so"),
-                "/usr/local/lib/libresvg.so",
-                ARCHLIB + "qt5/plugins/platforms/libqxcb.so"
-                ] + pyqt5_mod_files
+    lib_list = pyqt5_mod_files
+    for lib_name in [
+            os.path.join(libopenshot_path, "libopenshot.so"),
+            "/usr/local/lib/libresvg.so",
+            ARCHLIB + "qt5/plugins/platforms/libqxcb.so"
+            ]:
+        if os.path.exists(lib_name):
+            lib_list.append(lib_name)
 
     import subprocess
     for library in lib_list:

--- a/freeze.py
+++ b/freeze.py
@@ -248,10 +248,23 @@ elif sys.platform == "linux":
     # Get a list of all openshot.so dependencies (scan these libraries for their dependencies)
     pyqt5_mod_files = []
     from importlib import import_module
-    for submod in ['Qt', 'QtWebEngine', 'QtWebEngineWidgets', 'QtSvg', 'QtWidgets', 'QtCore', 'QtGui', 'QtDBus']:
+    for submod in ['Qt', 'QtSvg', 'QtWidgets', 'QtCore', 'QtGui', 'QtDBus']:
         mod_name  = "PyQt5.{}".format(submod)
         mod = import_module(mod_name)
         pyqt5_mod_files.append(inspect.getfile(mod))
+    # Optional additions
+    for mod_name in [
+            'PyQt5.QtWebEngine',
+            'PyQt5.QtWebEngineWidgets',
+            'PyQt5.QtWebKit',
+            'PyQt5.QtWebKitWidgets',
+            ]:
+        try:
+            mod = import_module(mod_name)
+            pyqt5_mod_files.append(inspect.getfile(mod))
+        except ImportError as ex;
+            log.warning("Skipping {}: {}".format(mod_name, ex)
+
 
     lib_list = [os.path.join(libopenshot_path, "libopenshot.so"),
                 "/usr/local/lib/libresvg.so",


### PR DESCRIPTION
Since we ended up retaining QtWebKit support, we can use that when running CI builds on Xenial.