### PR TITLE
Fix large canvas rendering (at closest zoom levels), with WebEngine

### DIFF
--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -48,7 +48,7 @@
 				<div class="playhead-line-small"></div>
 			</div>
 			<!-- Ruler extends beyond tracks area at least for a width of vertical scroll bar (or more, like 50px here) -->
-			<canvas tl-ruler id="ruler" width="{{(getTimelineWidth(1024) < 32717) ? (getTimelineWidth(1024) + 50) : 32767}}px" height="39"></canvas>
+			<canvas tl-ruler id="ruler" width="{{canvasMaxWidth(getTimelineWidth(1024) + 50)}}px" height="39"></canvas>
 
 			<!-- MARKERS --> 
 			<span class="ruler_marker" id="marker_for_{{marker.id}}">
@@ -57,7 +57,7 @@
 			<br class="cleared">
 			
 			<!-- PROGRESS BAR -->
-			<canvas id="progress" width="{{project.duration * pixelsPerSecond}}px" height="3px"></canvas>
+			<canvas id="progress" width="{{canvasMaxWidth(project.duration * pixelsPerSecond)}}px" height="3px"></canvas>
  		</div>
  		<div class="cleared"></div>
 
@@ -102,7 +102,7 @@
 						<img class="thumb thumb-start" ng-show="getThumbPath(clip)" ng-src="{{ getThumbPath(clip) }}"/>
 					</div>
 					<div ng-show="clip.show_audio" class="audio-container">
-						<canvas tl-audio height="46px" width="{{ (clip.end - clip.start) * pixelsPerSecond}}px" class="audio"></canvas>
+						<canvas tl-audio height="46px" width="{{canvasMaxWidth((clip.end - clip.start) * pixelsPerSecond)}}px" class="audio"></canvas>
 					</div>
 				</div>
 
@@ -178,5 +178,3 @@
 		<!-- END DEBUG SECTION -->
 </body>
 </html>
-
-

--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -48,7 +48,7 @@
 				<div class="playhead-line-small"></div>
 			</div>
 			<!-- Ruler extends beyond tracks area at least for a width of vertical scroll bar (or more, like 50px here) -->
-			<canvas tl-ruler id="ruler" width="{{getTimelineWidth(1024) + 50}}" height="39"></canvas>
+			<canvas tl-ruler id="ruler" width="{{(getTimelineWidth(1024) < 32717) ? (getTimelineWidth(1024) + 50) : 32767}}px" height="39"></canvas>
 
 			<!-- MARKERS --> 
 			<span class="ruler_marker" id="marker_for_{{marker.id}}">

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -467,8 +467,8 @@ App.controller("TimelineCtrl", function ($scope) {
       var stop_second = parseFloat(progress[p]["end"]) / fps;
 
       //figure out the actual pixel position, constrained by max width
-      var start_pixel = canvasMaxWidth(start_second * $scope.pixelsPerSecond);
-      var stop_pixel = canvasMaxWidth(stop_second * $scope.pixelsPerSecond);
+      var start_pixel = $scope.canvasMaxWidth(start_second * $scope.pixelsPerSecond);
+      var stop_pixel = $scope.canvasMaxWidth(stop_second * $scope.pixelsPerSecond);
       var rect_length = stop_pixel - start_pixel;
       if (rect_length < 1) {
         break;
@@ -620,6 +620,12 @@ App.controller("TimelineCtrl", function ($scope) {
       timeline.addSelection(effect_id, "effect", true);
     }
   };
+
+  // Constrain canvas width values to under 32Kpixels
+  $scope.canvasMaxWidth = function (desired_width) {
+    return Math.min(32767, desired_width);
+  };
+
 
 // Find the furthest right edge on the timeline (and resize it if too small)
   $scope.resizeTimeline = function () {

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -626,7 +626,6 @@ App.controller("TimelineCtrl", function ($scope) {
     return Math.min(32767, desired_width);
   };
 
-
 // Find the furthest right edge on the timeline (and resize it if too small)
   $scope.resizeTimeline = function () {
     // Unselect all clips

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -466,11 +466,13 @@ App.controller("TimelineCtrl", function ($scope) {
       var start_second = parseFloat(progress[p]["start"]) / fps;
       var stop_second = parseFloat(progress[p]["end"]) / fps;
 
-      //figure out the actual pixel position
-      var start_pixel = start_second * $scope.pixelsPerSecond;
-      var stop_pixel = stop_second * $scope.pixelsPerSecond;
+      //figure out the actual pixel position, constrained by max width
+      var start_pixel = canvasMaxWidth(start_second * $scope.pixelsPerSecond);
+      var stop_pixel = canvasMaxWidth(stop_second * $scope.pixelsPerSecond);
       var rect_length = stop_pixel - start_pixel;
-
+      if (rect_length < 1) {
+        break;
+      }
       //get the element and draw the rects
       ctx.beginPath();
       ctx.rect(start_pixel, 0, rect_length, 5);

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -154,7 +154,8 @@ App.directive("tlRuler", function ($timeout) {
             var scale = scope.project.scale;
             var tick_pixels = scope.project.tick_pixels;
             var each_tick = tick_pixels / 2;
-            var pixel_length = scope.getTimelineWidth(1024);
+            // Don't go over the max supported canvas size
+            var pixel_length = Math.min(32767,scope.getTimelineWidth(1024));
 
             //draw the ruler
             var ctx = element[0].getContext("2d");

--- a/src/timeline/js/functions.js
+++ b/src/timeline/js/functions.js
@@ -103,9 +103,20 @@ function drawAudio(scope, clip_id) {
       max = 0.0,
       last_x = 0;
 
+    // Ensure that the waveform canvas doesn't exceed its max
+    // dimensions, even if it means we can't draw the full audio.
+    // (If we try to go over the max width, the whole canvas disappears)
+    var final_sample = end_sample;
+    var audio_width = (end_sample - start_sample) / sample_divisor;
+    var usable_width = canvasMaxWidth(audio_width);
+    if (audio_width > usable_width) {
+      // Just go as far as we can, then cut off the remaining waveform
+      final_sample = (usable_width * sample_divisor) - 1;
+    }
+
     // Go through all of the (reduced) samples
     // And whenever enough are "collected", draw a block
-    for (var i = start_sample; i < end_sample; i++) {
+    for (var i = start_sample; i < final_sample; i++) {
       // Flip negative values up
       sample = Math.abs(clip.audio_data[i]);
       // X-Position of *next* sample
@@ -115,7 +126,7 @@ function drawAudio(scope, clip_id) {
       avg_cnt++;
       max = Math.max(max, sample);
 
-      if (x >= last_x + block_width || i === end_sample - 1) {
+      if (x >= last_x + block_width || i === final_sample - 1) {
         // Block wide enough or last block -> draw it
 
         // Draw the slightly transparent max-bar
@@ -165,6 +176,11 @@ function secondsToTime(secs, fps_num, fps_den) {
     "milli": padNumber(milli, 2),
     "frame": padNumber(frame, 2)
   };
+}
+
+// Constrain canvas width values to under 32Kpixels
+function canvasMaxWidth(desired_width) {
+  return Math.min(32767, desired_width);
 }
 
 // Find the closest track number (based on a Y coordinate)

--- a/src/timeline/js/functions.js
+++ b/src/timeline/js/functions.js
@@ -108,7 +108,7 @@ function drawAudio(scope, clip_id) {
     // (If we try to go over the max width, the whole canvas disappears)
     var final_sample = end_sample;
     var audio_width = (end_sample - start_sample) / sample_divisor;
-    var usable_width = canvasMaxWidth(audio_width);
+    var usable_width = scope.canvasMaxWidth(audio_width);
     if (audio_width > usable_width) {
       // Just go as far as we can, then cut off the remaining waveform
       final_sample = (usable_width * sample_divisor) - 1;
@@ -176,11 +176,6 @@ function secondsToTime(secs, fps_num, fps_den) {
     "milli": padNumber(milli, 2),
     "frame": padNumber(frame, 2)
   };
-}
-
-// Constrain canvas width values to under 32Kpixels
-function canvasMaxWidth(desired_width) {
-  return Math.min(32767, desired_width);
 }
 
 // Find the closest track number (based on a Y coordinate)


### PR DESCRIPTION
While running some tests with the most recent AppImage Daily Build, I loaded a project file and noticed that the ruler _completely_ disappeared at 1-second zoom ­— it wasn't merely cut off, the whole thing was gone.

Turned out, the project had a duration of 644 seconds, which at 1-second zoom made the total timeline width `64450` pixels, well in excess of the 32Kpixel max supported width for HTML `<canvas>` elements. When I zoomed out to the 3-second level (21000-and-change pixels wide), the ruler reappeared.

It appears that the WebEngine layout engine, in contrast to WebKit, will _completely_ fail to render a canvas element that exceeds the max supported dimensions. With WebKit, the canvas was merely cut off at the maximum width, but WebEngine is clearly more fragile.

This PR adds a `canvasMaxWidth()` constraint function to the `$scope` in `controller.js`, which takes a single numerical argument (`desired_width`) and executes one statement: `return Math.min(32767, desired_width);` All code for computing canvas width in both the HTML and the JavaScript now wraps all of those computations in `canvasMaxWidth()` to ensure that none of the canvas elements exceed their maximum allowable dimensions.

The audio-waveform rendering appears a bit "off" in this code, placed oddly and sticking out onto the border of the Clip area slightly. But that's identical to how it renders with the current `develop` branch code _before_ this PR, so **#NOTMYFAULT**.

Might fix some open Issues, not sure. I haven't checked in a few days.