### PR TITLE
Change of name of library

### DIFF
--- a/src/presets/format_mp4_libsvtav1.xml
+++ b/src/presets/format_mp4_libsvtav1.xml
@@ -4,7 +4,7 @@
 	<type translatable="True">All Formats</type>
 	<title translatable="True">MP4 (AV1 svt)</title>
 	<videoformat>mp4</videoformat>
-	<videocodec>libsvt_av1</videocodec>
+	<videocodec>libsvtav1</videocodec>
 	<audiocodec>libvorbis</audiocodec>
 	<audiochannels>2</audiochannels>
 	<audiochannellayout>3</audiochannellayout>


### PR DESCRIPTION
With the official inclusion of SVT-AV1 the library changed from svt_av1 to svtav1. This takes this into account