### PR TITLE
Make use of new Timeline lookup APIs

### DIFF
--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -359,17 +359,7 @@ class Export(QDialog):
         self.delayed_fps_timer.start()
 
         # Determine max frame (based on clips)
-        timeline_length = 0.0
-        fps = self.timeline.info.fps.ToFloat()
-        clips = self.timeline.Clips()
-        for clip in clips:
-            clip_last_frame = clip.Position() + clip.Duration()
-            if clip_last_frame > timeline_length:
-                # Set max length of timeline
-                timeline_length = clip_last_frame
-
-        # Convert to int and round
-        self.timeline_length_int = round(timeline_length * fps) + 1
+        self.timeline_length_int = self.timeline.GetMaxFrame()
 
         # Set the min and max frame numbers for this project
         self.txtStartFrame.setValue(1)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -914,28 +914,16 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             log.error("Unable to open the download page: {}".format(str(ex)))
 
     def actionPlay_trigger(self, event, force=None):
-
-        # Determine max frame (based on clips)
-        timeline_length = 0.0
-        fps = get_app().window.timeline_sync.timeline.info.fps.ToFloat()
-        clips = get_app().window.timeline_sync.timeline.Clips()
-        for clip in clips:
-            clip_last_frame = clip.Position() + clip.Duration()
-            if clip_last_frame > timeline_length:
-                # Set max length of timeline
-                timeline_length = clip_last_frame
-
-        # Convert to int and round
-        timeline_length_int = round(timeline_length * fps) + 1
-
         if force == "pause":
             self.actionPlay.setChecked(False)
         elif force == "play":
             self.actionPlay.setChecked(True)
 
         if self.actionPlay.isChecked():
+            # Determine max frame (based on clips)
+            max_frame = get_app().window.timeline_sync.timeline.GetMaxFrame()
             ui_util.setup_icon(self, self.actionPlay, "actionPlay", "media-playback-pause")
-            self.PlaySignal.emit(timeline_length_int)
+            self.PlaySignal.emit(max_frame)
 
         else:
             ui_util.setup_icon(self, self.actionPlay, "actionPlay")  # to default
@@ -1014,21 +1002,9 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
     def actionJumpEnd_trigger(self, event):
         log.info("actionJumpEnd_trigger")
 
-        # Determine max frame (based on clips)
-        timeline_length = 0.0
-        fps = get_app().window.timeline_sync.timeline.info.fps.ToFloat()
-        clips = get_app().window.timeline_sync.timeline.Clips()
-        for clip in clips:
-            clip_last_frame = clip.Position() + clip.Duration()
-            if clip_last_frame > timeline_length:
-                # Set max length of timeline
-                timeline_length = clip_last_frame
-
-        # Convert to int and round
-        timeline_length_int = round(timeline_length * fps) + 1
-
-        # Seek to the 1st frame
-        self.SeekSignal.emit(timeline_length_int)
+        # Determine last frame (based on clips) & seek there
+        max_frame = get_app().window.timeline_sync.timeline.GetMaxFrame()
+        self.SeekSignal.emit(max_frame)
 
     def actionSaveFrame_trigger(self, event):
         log.info("actionSaveFrame_trigger")

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -91,42 +91,24 @@ class PropertiesModel(updates.UpdateInterface):
         log.info("Update item: %s" % item_type)
 
         if item_type == "clip":
-            c = None
-            clips = get_app().window.timeline_sync.timeline.Clips()
-            for clip in clips:
-                if clip.Id() == item_id:
-                    c = clip
-                    break
-
-            # Append to selected clips
-            self.selected.append((c, item_type))
+            c = get_app().window.timeline_sync.timeline.GetClip(item_id)
+            if c:
+                # Append to selected items
+                self.selected.append((c, item_type))
 
         if item_type == "transition":
-            t = None
-            trans = get_app().window.timeline_sync.timeline.Effects()
-            for tran in trans:
-                if tran.Id() == item_id:
-                    t = tran
-                    break
-
-            # Append to selected clips
-            self.selected.append((t, item_type))
+            t = get_app().window.timeline_sync.timeline.GetTimelineEffect(item_id)
+            if t:
+                # Append to selected items
+                self.selected.append((t, item_type))
 
         if item_type == "effect":
-            e = None
-            clips = get_app().window.timeline_sync.timeline.Clips()
-            for clip in clips:
-                for effect in clip.Effects():
-                    if effect.Id() == item_id:
-                        e = effect
-                        break
-
-            # Filter out basic properties, since this is an effect on a clip
-            self.filter_base_properties = ["position", "layer", "start", "end", "duration"]
-
-            # Append to selected items
-            self.selected.append((e, item_type))
-
+            e = get_app().window.timeline_sync.timeline.GetClipEffect(item_id)
+            if e:
+                # Filter out basic properties, since this is an effect on a clip
+                self.filter_base_properties = ["position", "layer", "start", "end", "duration"]
+                # Append to selected items
+                self.selected.append((e, item_type))
 
         # Update frame # from timeline
         self.update_frame(get_app().window.preview_thread.player.Position(), reload_model=False)
@@ -159,12 +141,10 @@ class PropertiesModel(updates.UpdateInterface):
                 parent_clip_id = effect.parent["id"]
 
                 # Find this clip object
-                clips = get_app().window.timeline_sync.timeline.Clips()
-                for c in clips:
-                    if c.Id() == parent_clip_id:
-                        # Override the selected clip object (so the effect gets the correct starting position)
-                        clip = c
-                        break
+                c = get_app().window.timeline_sync.timeline.GetClip(parent_clip_id)
+                if c:
+                    # Override the selected clip object (so the effect gets the correct starting position)
+                    clip = c
 
             # Get FPS from project
             fps = get_app().project.get("fps")

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -351,9 +351,6 @@ class VideoWidget(QWidget, updates.UpdateInterface):
             fps = get_app().project.get("fps")
             fps_float = float(fps["num"]) / float(fps["den"])
 
-            # Corner size
-            cs = 14.0
-
             # Determine frame # of clip
             start_of_clip_frame = round(float(self.transforming_clip.data["start"]) * fps_float) + 1
             position_of_clip_frame = (float(self.transforming_clip.data["position"]) * fps_float) + 1
@@ -634,12 +631,12 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
         self.mutex.unlock()
 
-    def updateProperty(self, id, frame_number, property_key, new_value, refresh=True):
+    def updateProperty(self, clip_id, frame_number, property_key, new_value, refresh=True):
         """Update a keyframe property to a new value, adding or updating keyframes as needed"""
         found_point = False
         clip_updated = False
 
-        c = Clip.get(id=id)
+        c = Clip.get(id=clip_id)
         if not c:
             # No clip found
             return
@@ -661,11 +658,8 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         # Reduce # of clip properties we are saving (performance boost)
         c.data = {property_key: c.data.get(property_key)}
 
-        # Save changes
         if clip_updated:
-            # Save
             c.save()
-
             # Update the preview
             if refresh:
                 get_app().window.refreshFrameSignal.emit()
@@ -695,8 +689,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
             self.transforming_clip = Clip.get(id=clip_id)
             self.transforming_clip_object = win.timeline_sync.timeline.GetClip(clip_id)
             if self.transforming_clip and self.transforming_clip_object:
-                needs_refresh = True
-
+                need_refresh = True
 
         # Update the preview and reselct current frame in properties
         if need_refresh:
@@ -765,12 +758,8 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         _ = get_app()._tr
 
         # Init aspect ratio settings (default values)
-        self.aspect_ratio = openshot.Fraction()
-        self.pixel_ratio = openshot.Fraction()
-        self.aspect_ratio.num = 16
-        self.aspect_ratio.den = 9
-        self.pixel_ratio.num = 1
-        self.pixel_ratio.den = 1
+        self.aspect_ratio = openshot.Fraction(16, 9)
+        self.pixel_ratio = openshot.Fraction(1, 1)
         self.transforming_clip = None
         self.transforming_clip_object = None
         self.transform = None

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -679,7 +679,9 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
     def transformTriggered(self, clip_id):
         """Handle the transform signal when it's emitted"""
+        win = get_app().window
         need_refresh = False
+
         # Disable Transform UI
         if self and self.transforming_clip:
             # Is this the same clip_id already being transformed?
@@ -691,20 +693,15 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         # Get new clip for transform
         if clip_id:
             self.transforming_clip = Clip.get(id=clip_id)
+            self.transforming_clip_object = win.timeline_sync.timeline.GetClip(clip_id)
+            if self.transforming_clip and self.transforming_clip_object:
+                needs_refresh = True
 
-            if self.transforming_clip:
-                self.transforming_clip_object = None
-                clips = get_app().window.timeline_sync.timeline.Clips()
-                for clip in clips:
-                    if clip.Id() == self.transforming_clip.id:
-                        self.transforming_clip_object = clip
-                        need_refresh = True
-                        break
 
         # Update the preview and reselct current frame in properties
         if need_refresh:
-            get_app().window.refreshFrameSignal.emit()
-            get_app().window.propertyTableView.select_frame(get_app().window.preview_thread.player.Position())
+            win.refreshFrameSignal.emit()
+            win.propertyTableView.select_frame(win.preview_thread.player.Position())
 
     def resizeEvent(self, event):
         """Widget resize event"""

--- a/src/windows/views/timeline_webview.py
+++ b/src/windows/views/timeline_webview.py
@@ -942,12 +942,7 @@ class TimelineWebView(TimelineMixin, updates.UpdateInterface):
             file_path = clip.data["reader"]["path"]
 
             # Find actual clip object from libopenshot
-            c = None
-            clips = get_app().window.timeline_sync.timeline.Clips()
-            for clip_object in clips:
-                if clip_object.Id() == clip_id:
-                    c = clip_object
-
+            c = get_app().window.timeline_sync.timeline.GetClip(clip_id)
             if c and c.Reader() and not c.Reader().info.has_single_image:
                 # Find frame 1 channel_filter property
                 channel_filter = c.channel_filter.GetInt(1)
@@ -2209,7 +2204,7 @@ class TimelineWebView(TimelineMixin, updates.UpdateInterface):
                     original_duration = clip.data["original_data"]["duration"]
 
                 log.info('Updating timing for clip ID {}, original duration: {}'
-                    .format(clip.id, original_duration))
+                         .format(clip.id, original_duration))
                 log.debug(clip.data)
 
                 # Extend end & duration (due to freeze)
@@ -2237,12 +2232,7 @@ class TimelineWebView(TimelineMixin, updates.UpdateInterface):
                     del clip.data["time"]["Points"][-1]
 
                     # Find actual clip object from libopenshot
-                    c = None
-                    clips = get_app().window.timeline_sync.timeline.Clips()
-                    for clip_object in clips:
-                        if clip_object.Id() == clip_id:
-                            c = clip_object
-                            break
+                    c = get_app().window.timeline_sync.timeline.GetClip(clip_id)
                     if c:
                         # Look up correct position from time curve
                         start_animation_frames_value = c.time.GetLong(start_animation_frames)
@@ -2250,12 +2240,7 @@ class TimelineWebView(TimelineMixin, updates.UpdateInterface):
                 # Do we already have a volume curve? Look up intersecting frame # from volume curve
                 if len(clip.data["volume"]["Points"]) > 1:
                     # Find actual clip object from libopenshot
-                    c = None
-                    clips = get_app().window.timeline_sync.timeline.Clips()
-                    for clip_object in clips:
-                        if clip_object.Id() == clip_id:
-                            c = clip_object
-                            break
+                    c = get_app().window.timeline_sync.timeline.GetClip(clip_id)
                     if c:
                         # Look up correct volume from time curve
                         start_volume_value = c.volume.GetValue(start_animation_frames)


### PR DESCRIPTION
This follows on from OpenShot/libopenshot#563, by actually making use of the more efficient new APIs in OpenShot.

(This means that the `devel` branch requires a recent development version of libopenshot, built within the past two weeks since 563 merged. The `develop` branch is now completely incompatible with libopenshot 0.2.5. Fair warning.)