### PR TITLE
Blender: Use JSON serialization to pass parameters

### DIFF
--- a/src/blender/scripts/blinds.py
+++ b/src/blender/scripts/blinds.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 
 def load_font(font_path):
@@ -80,6 +81,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Modify Text / Curve settings
 text_object = bpy.data.curves["Title"]

--- a/src/blender/scripts/blur.py
+++ b/src/blender/scripts/blur.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 
 def load_font(font_path):
@@ -82,6 +83,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Modify Text / Curve settings
 text_object = bpy.data.curves["Text"]

--- a/src/blender/scripts/colors.py
+++ b/src/blender/scripts/colors.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 
 def load_font(font_path):
@@ -80,6 +81,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Get font object
 font = None

--- a/src/blender/scripts/dissolve.py
+++ b/src/blender/scripts/dissolve.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains its own version of Python
 # with this library pre-installed.
 import bpy
+import json
 from math import pi
 
 
@@ -254,6 +255,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Get font object
 font = None

--- a/src/blender/scripts/earth.py
+++ b/src/blender/scripts/earth.py
@@ -22,6 +22,7 @@
 # with this library pre-installed.
 import math
 import bpy
+import json
 
 
 def load_font(font_path):
@@ -101,6 +102,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 depart = {
     "lat_deg": params["depart_lat_deg"],

--- a/src/blender/scripts/explode.py
+++ b/src/blender/scripts/explode.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains its own version of Python
 # with this library pre-installed.
 import bpy
+import json
 from math import pi
 
 
@@ -188,6 +189,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Get font object
 font = None

--- a/src/blender/scripts/fly_by_1.py
+++ b/src/blender/scripts/fly_by_1.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 
 def load_font(font_path):
@@ -80,6 +81,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())

--- a/src/blender/scripts/fly_by_two_titles.py
+++ b/src/blender/scripts/fly_by_two_titles.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 
 def load_font(font_path):
@@ -80,6 +81,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())

--- a/src/blender/scripts/glare.py
+++ b/src/blender/scripts/glare.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 
 def load_font(font_path):
@@ -80,6 +81,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())

--- a/src/blender/scripts/glass_slider.py
+++ b/src/blender/scripts/glass_slider.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 
 def load_font(font_path):
@@ -80,6 +81,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # TITLE 1 - Modify Text / Curve settings
 text_object1 = bpy.data.curves["Title1"]

--- a/src/blender/scripts/lens_flare.py
+++ b/src/blender/scripts/lens_flare.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
@@ -62,6 +63,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Modify the Location of the Wand
 sphere_object = bpy.data.objects["Sphere"]

--- a/src/blender/scripts/magic_wand.py
+++ b/src/blender/scripts/magic_wand.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
@@ -71,6 +72,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 
 def update_curve(curve, start, end):

--- a/src/blender/scripts/neon_curves.py
+++ b/src/blender/scripts/neon_curves.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 
 def load_font(font_path):
@@ -85,6 +86,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Modify Text / Curve settings
 text_object = bpy.data.curves["Text.001"]

--- a/src/blender/scripts/picture_frames_4.py
+++ b/src/blender/scripts/picture_frames_4.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
@@ -73,6 +74,13 @@ def get_scale_values(height, width):
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Split the picture information
 picture1 = params["project_files1"].split("|")

--- a/src/blender/scripts/rotate_360.py
+++ b/src/blender/scripts/rotate_360.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 
 def load_font(font_path):
@@ -80,6 +81,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())

--- a/src/blender/scripts/slide_left_to_right.py
+++ b/src/blender/scripts/slide_left_to_right.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 
 def load_font(font_path):
@@ -80,6 +81,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())

--- a/src/blender/scripts/snow.py
+++ b/src/blender/scripts/snow.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 # Debug Info:
 # ./blender -b test.blend -P demo.py
@@ -62,6 +63,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Modify the Location of the Wand
 wand_object = bpy.data.objects["Wand"]

--- a/src/blender/scripts/spacemovie_intro.py
+++ b/src/blender/scripts/spacemovie_intro.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 
 def load_font(font_path):
@@ -86,6 +87,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())

--- a/src/blender/scripts/wireframe_text.py
+++ b/src/blender/scripts/wireframe_text.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 
 def load_font(font_path):
@@ -81,6 +82,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+   injected_params = json.loads(params_json)
+   params.update(injected_params)
+except NameError:
+   pass
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())

--- a/src/blender/scripts/zoom_clapboard.py
+++ b/src/blender/scripts/zoom_clapboard.py
@@ -21,6 +21,7 @@
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
 import bpy
+import json
 
 
 def load_font(font_path):
@@ -80,6 +81,13 @@ params = {
 # file, and adjust the settings.  The .blend file is specified in the XML file
 # that defines this template in OpenShot.
 # ----------------------------------------------------------------------------
+
+# Process parameters supplied as JSON serialization
+try:
+    injected_params = json.loads(params_json)
+    params.update(injected_params)
+except NameError:
+    pass
 
 # Modify Text / Curve settings
 #print (bpy.data.curves.keys())

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -32,6 +32,7 @@ import sys
 import re
 import functools
 import shlex
+import json
 
 # Try to get the security-patched XML functions from defusedxml
 try:
@@ -527,20 +528,15 @@ Blender Path: {}
 
         # prepare string to inject
         user_params = "\n#BEGIN INJECTING PARAMS\n"
+
         param_data = copy.deepcopy(self.params)
         param_data.update(self.get_project_params(is_preview))
-        for k, v in param_data.items():
-            if isinstance(v, (int, float, list, bool)):
-                user_params += "params['{}'] = {}\n".format(k, v)
-            if isinstance(v, str):
-                user_params += "params['{}'] = '{}'\n".format(k, v.replace("'", r"\'").replace("\\", "\\\\"))
-        user_params += "#END INJECTING PARAMS\n"
 
-        # Insert the single frame number to render for preview
-        if frame:
-            user_params += "\n#RENDER FRAME FOR PREVIEW\n"
-            user_params += "params['{}'] = {}\n".format("preview_frame", frame)
-            user_params += "#END RENDER FRAME FOR PREVIEW\n"
+        param_serialization = json.dumps(param_data)
+        user_params += r'params_json = """{}"""'.format(
+            param_serialization)
+
+        user_params += "\n#END INJECTING PARAMS\n"
 
         # If GPU rendering is selected, see if GPU enable code is available
         s = settings.get_settings()


### PR DESCRIPTION
This should be more robust against corruption due to bad escaping and the like. All of the Blender script templates have been updated to `import json` and use `json.dumps()` to deserialize the injected string. Then they `params.update()` the existing parameter dictionary.

Fixes #3759