### PR TITLE
Integrate Stale GitHub Plugin for openshot-qt repo

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,30 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 180
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 10
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - enhancement
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  Thank you so much for submitting an issue to help improve OpenShot Video Editor. We are sorry about this, but this particular issue has gone unnoticed for quite some time. To help keep the OpenShot GitHub Issue Tracker organized and focused, we must ensure that every issue is correctly labelled and triaged, to get the proper attention.
+
+  This issue will be closed, as it meets the following criteria:
+  - No activity in the past 180 days
+  - No one is assigned to this issue
+
+  We'd like to ask you to help us out and determine whether this issue should be reopened.
+  - If this issue is reporting a bug, please can you attempt to reproduce on the [latest daily build](https://www.openshot.org/download/#daily) to help us to understand whether the bug still needs our attention.
+  - If this issue is proposing a new feature, please can you verify whether the feature proposal is still relevant.
+
+  Thanks again for your help!
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+# Only close issues
+only: issues
+# Don't close issues which are assigned to somebody
+exemptAssignees: true


### PR DESCRIPTION
I give full credit to the GitLab-CE project for some of this wording. It was so artfully said, I adapted a version for OpenShot. Not sure how to give proper credit, so hopefully this works. 

We have been using the stale plugin for a while on our libopenshot, and libopenshot-audio repos. This PR adds the same functionality to the openshot-qt repo. Essentially, I understand the arguments for and against the use of this GitHub plugin, but I feel that if an issues goes unnoticed, uncommented, and unassigned for 180 days, it is marked with the 'Stale' label, and 10 days later it is auto-closed. I think if an issue has gone unnoticed for that long, it should be closed (and either improved, reworded, verified, etc... before reopening). This also gives 10 days for someone to respond and keep the issue open. 

OpenShot is only a few volunteers, but we have millions of users. In other words, we are understaffed and we tend to get a lot of unhelpful issues reported (bad tickets, unclear, no logs, no steps, etc...). We don't have the resources to go close each and every bad ticket. So, I hope this will really help the good quality tickets stand out more (and the bad tickets to disappear).