### PR TITLE
Differently work around PyQt5 bug with argument types

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -57,7 +57,7 @@ try:
     QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
     QApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
 except AttributeError:
-    pass # Quietly fail for older Qt5 versions
+    pass  # Quietly fail for older Qt5 versions
 
 
 def get_app():
@@ -84,7 +84,7 @@ class OpenShotApp(QApplication):
             log.info('Starting new session'.center(48))
 
             from classes import settings, project_data, updates, language, ui_util, logger_libopenshot
-            from . import openshot_rc
+            from . import openshot_rc  # noqa
             import openshot
 
             # Re-route stdout and stderr to logger
@@ -141,9 +141,12 @@ class OpenShotApp(QApplication):
         _ = self._tr
         libopenshot_version = openshot.OPENSHOT_VERSION_FULL
         if mode != "unittest" and libopenshot_version < info.MINIMUM_LIBOPENSHOT_VERSION:
-            QMessageBox.warning(None, _("Wrong Version of libopenshot Detected"),
-                                      _("<b>Version %(minimum_version)s is required</b>, but %(current_version)s was detected. Please update libopenshot or download our latest installer.") %
-                                {"minimum_version": info.MINIMUM_LIBOPENSHOT_VERSION, "current_version": libopenshot_version})
+            QMessageBox.warning(
+                None, _("Wrong Version of libopenshot Detected"),
+                _("<b>Version %(minimum_version)s is required</b>, but %(current_version)s was detected. Please update libopenshot or download our latest installer.") % {
+                    "minimum_version": info.MINIMUM_LIBOPENSHOT_VERSION,
+                    "current_version": libopenshot_version,
+                    })
             # Stop launching and exit
             sys.exit()
 
@@ -175,9 +178,13 @@ class OpenShotApp(QApplication):
             os.unlink(TEST_PATH_FILE)
             os.rmdir(TEST_PATH_DIR)
         except PermissionError as ex:
-            log.error('Failed to create PERMISSION/test.osp file (likely permissions error): %s' % TEST_PATH_FILE, exc_info=1)
-            QMessageBox.warning(None, _("Permission Error"),
-                                      _("%(error)s. Please delete <b>%(path)s</b> and launch OpenShot again." % {"error": str(ex), "path": info.USER_PATH}))
+            log.error('Failed to create file %s', TEST_PATH_FILE, exc_info=1)
+            QMessageBox.warning(
+                None, _("Permission Error"),
+                _("%(error)s. Please delete <b>%(path)s</b> and launch OpenShot again." % {
+                    "error": str(ex),
+                    "path": info.USER_PATH,
+                }))
             # Stop launching and exit
             raise
             sys.exit()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -37,7 +37,7 @@ from uuid import uuid4
 from copy import deepcopy
 
 from PyQt5.QtCore import (
-    Qt, pyqtSignal, QCoreApplication,
+    Qt, pyqtSignal, QCoreApplication, PYQT_VERSION_STR,
     QTimer, QDateTime, QFileInfo, QUrl,
     )
 from PyQt5.QtGui import QIcon, QCursor, QKeySequence
@@ -51,7 +51,8 @@ from PyQt5.QtWidgets import (
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 
 from windows.views.timeline_webview import TimelineWebView
-from classes import info, ui_util, openshot_rc, settings, qt_types, updates
+from classes import info, ui_util, settings, qt_types, updates
+from classes import openshot_rc  # noqa
 from classes.app import get_app
 from classes.logger import log
 from classes.timeline import TimelineSync
@@ -760,9 +761,20 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         if not recommended_path or not os.path.exists(recommended_path):
             recommended_path = os.path.join(info.HOME_PATH)
 
+        # PyQt through 5.13.0 had the 'directory' argument mis-typed as str
+        if PYQT_VERSION_STR < '5.13.1':
+            dir_type = "str"
+            start_location = str(recommended_path)
+        else:
+            dir_type = "QUrl"
+            start_location = QUrl.fromLocalFile(recommended_path)
+
+        log.debug("Calling getOpenFileURLs() with %s directory argument", dir_type)
         qurl_list = QFileDialog.getOpenFileUrls(
-            self, _("Import Files..."),
-            QUrl.fromLocalFile(recommended_path))[0]
+            self,
+            _("Import Files..."),
+            start_location,
+            )[0]
 
         # Set cursor to waiting
         app.setOverrideCursor(QCursor(Qt.WaitCursor))


### PR DESCRIPTION
Qt's getOpenFileUrls() and related Url-based functions are supposed to take a QUrl for the 'directory' argument (starting path), but until PyQt5 5.13.1 the argument was mis-typed as str.

The Windows builders refuse to freeze `distutils` for some reason, so rather than use `distutils.version.LooseVersion` for the comparison, we just resort to string compares on `PyQt5.QtCore.PYQT_VERSION_STR`. Python's string comparison operators typically do the right thing with `m.n.o`-style version numbers, so it should be fine.