### PR TITLE
project_data: New keyframe scaler implementation

### DIFF
--- a/src/classes/keyframe_scaler.py
+++ b/src/classes/keyframe_scaler.py
@@ -1,9 +1,7 @@
 """
  @file
  @brief Process project data, scaling keyframe X coordinates by the given factor
- @author Noah Figg <eggmunkee@hotmail.com>
  @author Jonathan Thomas <jonathan@openshot.org>
- @author Olivier Girard <eolinwen@gmail.com>
  @author FeRD (Frank Dana) <ferdnyc@gmail.com>
 
  @section LICENSE
@@ -36,7 +34,7 @@ class KeyframeScaler:
     multiplied by the scaling factor, except X=1 (because the first
     frame never changes)"""
 
-    def _scale_value(self, value: float) -> int:
+    def _scale_x_value(self, value: float) -> int:
         """Scale value by some factor, except for 1 (leave that alone)"""
         if value == 1.0:
             return value
@@ -55,7 +53,7 @@ class KeyframeScaler:
         for k in keyframes:
             # Scale the X coordinate (frame #) by the stored factor
             [point["co"].update({
-                "X": self._scale_value(point["co"].get("X", 0.0))
+                "X": self._scale_x_value(point["co"].get("X", 0.0))
                 })
                 for point in k if "co" in point]
 

--- a/src/classes/keyframe_scaler.py
+++ b/src/classes/keyframe_scaler.py
@@ -1,0 +1,87 @@
+"""
+ @file
+ @brief Process project data, scaling keyframe X coordinates by the given factor
+ @author Noah Figg <eggmunkee@hotmail.com>
+ @author Jonathan Thomas <jonathan@openshot.org>
+ @author Olivier Girard <eolinwen@gmail.com>
+ @author FeRD (Frank Dana) <ferdnyc@gmail.com>
+
+ @section LICENSE
+
+ Copyright (c) 2008-2020 OpenShot Studios, LLC
+ (http://www.openshotstudios.com). This file is part of
+ OpenShot Video Editor (http://www.openshot.org), an open-source project
+ dedicated to delivering high quality video editing and animation solutions
+ to the world.
+
+ OpenShot Video Editor is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenShot Video Editor is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
+ """
+
+
+class KeyframeScaler:
+    """This factory class produces scaler objects which, when called,
+    will apply the assigned scaling factor to the keyframe points
+    in a project data dictionary. Keyframe X coordinate values are
+    multiplied by the scaling factor, except X=1 (because the first
+    frame never changes)"""
+
+    def _scale_value(self, value: float) -> int:
+        """Scale value by some factor, except for 1 (leave that alone)"""
+        if value == 1.0:
+            return value
+        # Round to nearest INT
+        return round(value * self._scale_factor)
+
+    def _update_prop(self, prop: dict):
+        """Find the keyframe points in a property and scale"""
+        # Create a list of lists of keyframe points for this prop
+        if "red" in prop:
+            # It's a color, one list of points for each channel
+            keyframes = [prop[color].get("Points", []) for color in prop]
+        else:
+            # Not a color, just a single list of points
+            keyframes = [prop.get("Points", [])]
+        for k in keyframes:
+            # Scale the X coordinate (frame #) by the stored factor
+            [point["co"].update({
+                "X": self._scale_value(point["co"].get("X", 0.0))
+                })
+                for point in k if "co" in point]
+
+    def _process_item(self, item: dict):
+        """Process all the dict sub-members of the current dict"""
+        dict_props = [
+            item[prop] for prop in item
+            if isinstance(item[prop], dict)
+            ]
+        for prop in dict_props:
+            self._update_prop(prop)
+
+    def __call__(self, data: dict) -> dict:
+        """Apply the stored scaling factor to a project data dict"""
+        # Look for keyframe objects in clips
+        for clip in data.get('clips', []):
+            self._process_item(clip)
+            # Also update any effects applied to the clip
+            for effect in clip.get("effects", []):
+                self._process_item(effect)
+        # Look for keyframe objects in project effects (transitions)
+        for effect in data.get('effects', []):
+            self._process_item(effect)
+        # return the scaled project data
+        return data
+
+    def __init__(self, factor: float):
+        """Store the scale factor assigned to this instance"""
+        self._scale_factor = factor

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -396,15 +396,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         from classes.app import get_app
         get_app().updates.load(self._data)
 
-    def scale_keyframe_value(self, original_value, scale_factor):
-        """Scale keyframe X coordinate by some factor, except for 1 (leave that alone)"""
-        if original_value == 1.0:
-            # This represents the first frame of a clip (so we want to maintain that)
-            return original_value
-        else:
-            # Round to nearest INT
-            return round(original_value * scale_factor)
-
     def rescale_keyframes(self, scale_factor):
         """Adjust all keyframe coordinates from previous FPS to new FPS (using a scale factor)
            and return scaled project data without modifing the current project."""

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -41,6 +41,8 @@ from classes.updates import UpdateInterface
 from classes.assets import get_assets_path
 from windows.views.find_file import find_missing_file
 
+from .keyframe_scaler import KeyframeScaler
+
 
 class ProjectDataStore(JsonDataStore, UpdateInterface):
     """ This class allows advanced searching of data structure, implements changes interface """
@@ -406,53 +408,13 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
     def rescale_keyframes(self, scale_factor):
         """Adjust all keyframe coordinates from previous FPS to new FPS (using a scale factor)
            and return scaled project data without modifing the current project."""
-        log.info('Scale all keyframes by a factor of %s' % scale_factor)
-
-        # Create copy of active project data
-        data = copy.deepcopy(self._data)
-
-        # Rescale the the copied project data
-        # Loop through all clips (and look for Keyframe objects)
-        # Scale the X coordinate by factor (which represents the frame #)
-        for clip in data.get('clips', []):
-            for attribute in clip:
-                if type(clip.get(attribute)) == dict and "Points" in clip.get(attribute):
-                    for point in clip.get(attribute).get("Points"):
-                        if "co" in point:
-                            point["co"]["X"] = self.scale_keyframe_value(point["co"].get("X", 0.0), scale_factor)
-                if type(clip.get(attribute)) == dict and "red" in clip.get(attribute):
-                    for color in clip.get(attribute):
-                        for point in clip.get(attribute).get(color).get("Points"):
-                            if "co" in point:
-                                point["co"]["X"] = self.scale_keyframe_value(point["co"].get("X", 0.0), scale_factor)
-            for effect in clip.get("effects", []):
-                for attribute in effect:
-                    if type(effect.get(attribute)) == dict and "Points" in effect.get(attribute):
-                        for point in effect.get(attribute).get("Points"):
-                            if "co" in point:
-                                point["co"]["X"] = self.scale_keyframe_value(point["co"].get("X", 0.0), scale_factor)
-                    if type(effect.get(attribute)) == dict and "red" in effect.get(attribute):
-                        for color in effect.get(attribute):
-                            for point in effect.get(attribute).get(color).get("Points"):
-                                if "co" in point:
-                                    point["co"]["X"] = self.scale_keyframe_value(point["co"].get("X", 0.0), scale_factor)
-
-        # Loop through all effects/transitions (and look for Keyframe objects)
-        # Scale the X coordinate by factor (which represents the frame #)
-        for effect in data.get('effects', []):
-            for attribute in effect:
-                if type(effect.get(attribute)) == dict and "Points" in effect.get(attribute):
-                    for point in effect.get(attribute).get("Points"):
-                        if "co" in point:
-                            point["co"]["X"] = self.scale_keyframe_value(point["co"].get("X", 0.0), scale_factor)
-                if type(effect.get(attribute)) == dict and "red" in effect.get(attribute):
-                    for color in effect.get(attribute):
-                        for point in effect.get(attribute).get(color).get("Points"):
-                            if "co" in point:
-                                point["co"]["X"] = self.scale_keyframe_value(point["co"].get("X", 0.0), scale_factor)
-
-        # return the copied and scaled project data
-        return data
+        #
+        log.info('Scale all keyframes by a factor of %s', scale_factor)
+        # Create a scaler instance
+        scaler = KeyframeScaler(factor=scale_factor)
+        # Create copy of active project data and scale
+        scaled = scaler(copy.deepcopy(self._data))
+        return scaled
 
     def read_legacy_project_file(self, file_path):
         """Attempt to read a legacy version 1.x openshot project file"""


### PR DESCRIPTION
This PR replaces the `rescale_keyframes` method of `project_data.py` with a new implementation:
- Move the bulk of `rescale_keyframes` to a separate file, and implement it as a factory class `KeyframeScaler`. Instances of the class are callables which have been assigned a scaling factor. Calling the scaler instance on a project data dict will apply the factor.
- Break up the scaling code into multiple private methods, optimized to be as DRY as possible. Avoid deep nesting and repetition.

The previous code was a diagonal cascade of tests and loops, and repeated the exact same code three times for each of the lists it acted on.

The new code breaks the algorithm up into four methods, each one representing the algorithm for one level of that cascade, and each outer method repeatedly calls the next innermost one as they process all of the objects, keyframe properties, points lists, and individual points.

Beyond the unspooling of the algorithms, the new methods use a couple of somewhat daunting list comprehensions to efficiently process the contents of the various lists and dicts being modified. All I can say is, I've run a bunch of project data structures through it, and so far it's always done the right thing — even when I've added non-standard data that was specifically _trying_ to trick it.

(For example, placing a `"Points"` key directly on a `"clips"` list member, or placing a `"co"` or `"X"` key in something that's not a `"Points"` list, won't fool it. It also won't touch the keyframe-related contents of `"history"` objects, or any of the other structures aside from a specific type of key found inside an object from the list stored in either `"clips"` or `"effects"`.)

But you, too, can easily test the algorithm, because it's all self-contained in `src/classes/keyframe_scaler.py` and has no `PyQt` or `openshot` dependencies.

Running a project file through it is as easy as:

```python3
import copy
import json
from keyframe_scaler import KeyframeScaler
# Load the file in to a Python dict
with open("myfile.osp", "r") as f:
    project_data = json.load(f)
# Create a callable scaler instance which doubles all X coordinates > 1
double_scaler = KeyframeScaler(factor=2)
# Apply the scaling factor to a copy of a project data dictioary
new_dict = double_scaler(copy.deepcopy(project_data))
# And if you want to see what it did...
from pprint import pprint
pprint(new_dict)
```

(The KeyframeScaler class won't copy the dict, so unless it's passed a structure that's been run through `copy.deepcopy()` it will modify the source data in place. Perhaps I should change that, and move the `deepcopy()` into the class?)
