### PR TITLE
Input handling cleanup, new multi-file import feedback, context menu improvements

### DIFF
--- a/src/windows/add_to_timeline.py
+++ b/src/windows/add_to_timeline.py
@@ -49,7 +49,7 @@ class AddToTimeline(QDialog):
 
     ui_path = os.path.join(info.PATH, 'windows', 'ui', 'add-to-timeline.ui')
 
-    def btnMoveUpClicked(self, event):
+    def btnMoveUpClicked(self, checked):
         """Callback for move up button click"""
         log.info("btnMoveUpClicked")
 
@@ -78,7 +78,7 @@ class AddToTimeline(QDialog):
         idx = self.treeFiles.timeline_model.model.index(new_index, 0)
         self.treeFiles.setCurrentIndex(idx)
 
-    def btnMoveDownClicked(self, event):
+    def btnMoveDownClicked(self, checked):
         """Callback for move up button click"""
         log.info("btnMoveDownClicked")
 
@@ -107,7 +107,7 @@ class AddToTimeline(QDialog):
         idx = self.treeFiles.timeline_model.model.index(new_index, 0)
         self.treeFiles.setCurrentIndex(idx)
 
-    def btnShuffleClicked(self, event):
+    def btnShuffleClicked(self, checked):
         """Callback for move up button click"""
         log.info("btnShuffleClicked")
 
@@ -117,7 +117,7 @@ class AddToTimeline(QDialog):
         # Refresh tree
         self.treeFiles.refresh_view()
 
-    def btnRemoveClicked(self, event):
+    def btnRemoveClicked(self, checked):
         """Callback for move up button click"""
         log.info("btnRemoveClicked")
 

--- a/src/windows/cutting.py
+++ b/src/windows/cutting.py
@@ -355,7 +355,8 @@ class Cutting(QDialog):
         log.info('close')
 
     def closeEvent(self, event):
-        log.info('closeEvent')
+        log.debug('closeEvent')
+        event.accept()
 
         # Stop playback
         self.preview_parent.worker.Stop()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1051,17 +1051,17 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             self.actionPlay.trigger()
 
     def actionRewind_trigger(self, checked=True):
-
         # Get the video player object
         player = self.preview_thread.player
 
-        if player.Speed() - 1 != 0:
-            self.SpeedSignal.emit(player.Speed() - 1)
-        else:
-            self.SpeedSignal.emit(player.Speed() - 2)
+        new_speed = player.Speed() - 1
+        if new_speed == 0:
+            new_speed -= 1
+        log.debug("Setting speed to %s", new_speed)
 
         if player.Mode() == openshot.PLAYBACK_PAUSED:
             self.actionPlay.trigger()
+        self.SpeedSignal.emit(new_speed)
 
     def actionJumpStart_trigger(self, checked=True):
         log.info("actionJumpStart_trigger")

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -139,7 +139,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 QMessageBox.Cancel | QMessageBox.No | QMessageBox.Yes)
             if ret == QMessageBox.Yes:
                 # Save project
-                self.actionSave_trigger(event)
+                self.actionSave_trigger()
                 event.accept()
             elif ret == QMessageBox.Cancel:
                 # Show tutorial again, if any
@@ -355,7 +355,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 return lines[-to_read:offset and -offset or None]
             avg_line_length *= 2
 
-    def actionNew_trigger(self, event):
+    def actionNew_trigger(self):
 
         app = get_app()
         _ = app._tr  # Get translation function
@@ -369,7 +369,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 QMessageBox.Cancel | QMessageBox.No | QMessageBox.Yes)
             if ret == QMessageBox.Yes:
                 # Save project
-                self.actionSave_trigger(event)
+                self.actionSave_trigger()
             elif ret == QMessageBox.Cancel:
                 # User canceled prompt
                 return
@@ -395,7 +395,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Seek to frame 0
         self.SeekSignal.emit(1)
 
-    def actionAnimatedTitle_trigger(self, event):
+    def actionAnimatedTitle_trigger(self):
         # show dialog
         from windows.animated_title import AnimatedTitle
         win = AnimatedTitle()
@@ -406,7 +406,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         else:
             log.info('animated title add cancelled')
 
-    def actionAnimation_trigger(self, event):
+    def actionAnimation_trigger(self):
         # show dialog
         from windows.animation import Animation
         win = Animation()
@@ -417,7 +417,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         else:
             log.info('animation cancelled')
 
-    def actionTitle_trigger(self, event):
+    def actionTitle_trigger(self):
         # show dialog
         from windows.title_editor import TitleEditor
         win = TitleEditor()
@@ -428,7 +428,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         else:
             log.info('title editor add cancelled')
 
-    def actionEditTitle_trigger(self, event):
+    def actionEditTitle_trigger(self):
 
         # Loop through selected files (set 1 selected file if more than 1)
         for f in self.selected_files():
@@ -461,7 +461,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Update preview
         self.refreshFrameSignal.emit()
 
-    def actionDuplicateTitle_trigger(self, event):
+    def actionDuplicateTitle_trigger(self):
 
         file_path = None
 
@@ -480,7 +480,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Run the dialog event loop - blocking interaction on this window during that time
         return win.exec_()
 
-    def actionClearHistory_trigger(self, event):
+    def actionClearHistory_trigger(self):
         """Clear history for current project"""
         project = get_app().project
         project.has_unsaved_changes = True
@@ -623,7 +623,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         except Exception:
             log.info("Failed to clear %s", clear_path, exc_info=1)
 
-    def actionOpen_trigger(self, event):
+    def actionOpen_trigger(self):
         app = get_app()
         _ = app._tr
         recommended_path = app.project.current_filepath
@@ -639,7 +639,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 QMessageBox.Cancel | QMessageBox.No | QMessageBox.Yes)
             if ret == QMessageBox.Yes:
                 # Save project
-                self.actionSave_trigger(event)
+                self.actionSave_trigger()
             elif ret == QMessageBox.Cancel:
                 # User canceled prompt
                 return
@@ -654,7 +654,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Load project file
         self.OpenProjectSignal.emit(file_path)
 
-    def actionSave_trigger(self, event):
+    def actionSave_trigger(self):
         app = get_app()
         _ = app._tr
 
@@ -732,7 +732,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 app.project.current_filepath = None
                 app.project.has_unsaved_changes = True
 
-    def actionSaveAs_trigger(self, event):
+    def actionSaveAs_trigger(self):
         app = get_app()
         _ = app._tr
 
@@ -753,7 +753,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             # Save new project
             self.save_project(file_path)
 
-    def actionImportFiles_trigger(self, event):
+    def actionImportFiles_trigger(self):
         app = get_app()
         _ = app._tr
 
@@ -1554,7 +1554,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Basic shortcuts i.e just a letter
         if key.matches(self.getShortcutByName("seekPreviousFrame")) == QKeySequence.ExactMatch:
             # Pause video
-            self.actionPlay_trigger(event, force="pause")
+            self.actionPlay_trigger(force="pause")
             # Set speed to 0
             if player.Speed() != 0:
                 self.SpeedSignal.emit(0)
@@ -1566,7 +1566,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         elif key.matches(self.getShortcutByName("seekNextFrame")) == QKeySequence.ExactMatch:
             # Pause video
-            self.actionPlay_trigger(event, force="pause")
+            self.actionPlay_trigger(force="pause")
             # Set speed to 0
             if player.Speed() != 0:
                 self.SpeedSignal.emit(0)
@@ -1752,7 +1752,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         else:
             super(MainWindow, self).keyPressEvent(event)
 
-    def actionProfile_trigger(self, event):
+    def actionProfile_trigger(self):
         # Show dialog
         from windows.profile import Profile
         win = Profile()
@@ -1761,7 +1761,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         if result == QDialog.Accepted:
             log.info('Profile add confirmed')
 
-    def actionSplitClip_trigger(self, event):
+    def actionSplitClip_trigger(self):
         log.info("actionSplitClip_trigger")
 
         # Loop through selected files (set 1 selected file if more than 1)
@@ -1782,7 +1782,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         else:
             log.info('Cutting Cancelled')
 
-    def actionRemove_from_Project_trigger(self, event):
+    def actionRemove_from_Project_trigger(self):
         log.info("actionRemove_from_Project_trigger")
 
         # Loop through selected files
@@ -1803,7 +1803,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Refresh preview
         get_app().window.refreshFrameSignal.emit()
 
-    def actionRemoveClip_trigger(self, event):
+    def actionRemoveClip_trigger(self):
         log.info('actionRemoveClip_trigger')
 
         # Loop through selected clips
@@ -1820,14 +1820,14 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Refresh preview
         get_app().window.refreshFrameSignal.emit()
 
-    def actionProperties_trigger(self, event):
+    def actionProperties_trigger(self):
         log.info('actionProperties_trigger')
 
         # Show properties dock
         if not self.dockProperties.isVisible():
             self.dockProperties.show()
 
-    def actionRemoveEffect_trigger(self, event):
+    def actionRemoveEffect_trigger(self):
         log.info('actionRemoveEffect_trigger')
 
         # Loop through selected clips
@@ -1862,7 +1862,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Refresh preview
         get_app().window.refreshFrameSignal.emit()
 
-    def actionRemoveTransition_trigger(self, event):
+    def actionRemoveTransition_trigger(self):
         log.info('actionRemoveTransition_trigger')
 
         # Loop through selected clips
@@ -1879,7 +1879,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Refresh preview
         get_app().window.refreshFrameSignal.emit()
 
-    def actionRemoveTrack_trigger(self, event):
+    def actionRemoveTrack_trigger(self):
         log.info('actionRemoveTrack_trigger')
 
         # Get translation function
@@ -1915,7 +1915,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         # Refresh preview
         get_app().window.refreshFrameSignal.emit()
 
-    def actionLockTrack_trigger(self, event):
+    def actionLockTrack_trigger(self):
         """Callback for locking a track"""
         log.info('actionLockTrack_trigger')
 
@@ -1927,7 +1927,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         selected_track.data['lock'] = True
         selected_track.save()
 
-    def actionUnlockTrack_trigger(self, event):
+    def actionUnlockTrack_trigger(self):
         """Callback for unlocking a track"""
         log.info('actionUnlockTrack_trigger')
 
@@ -1939,7 +1939,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         selected_track.data['lock'] = False
         selected_track.save()
 
-    def actionRenameTrack_trigger(self, event):
+    def actionRenameTrack_trigger(self):
         """Callback for renaming track"""
         log.info('actionRenameTrack_trigger')
 
@@ -1966,7 +1966,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             selected_track.data["label"] = text
             selected_track.save()
 
-    def actionRemoveMarker_trigger(self, event):
+    def actionRemoveMarker_trigger(self):
         log.info('actionRemoveMarker_trigger')
 
         for marker_id in self.selected_markers:
@@ -1975,17 +1975,17 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 # Remove track
                 m.delete()
 
-    def actionTimelineZoomIn_trigger(self, event):
+    def actionTimelineZoomIn_trigger(self):
         self.sliderZoom.setValue(self.sliderZoom.value() - self.sliderZoom.singleStep())
 
-    def actionTimelineZoomOut_trigger(self, event):
+    def actionTimelineZoomOut_trigger(self):
         self.sliderZoom.setValue(self.sliderZoom.value() + self.sliderZoom.singleStep())
 
-    def actionFullscreen_trigger(self, event):
+    def actionFullscreen_trigger(self):
         # Toggle fullscreen state (current state mask XOR WindowFullScreen)
         self.setWindowState(self.windowState() ^ Qt.WindowFullScreen)
 
-    def actionFile_Properties_trigger(self, event):
+    def actionFile_Properties_trigger(self):
         log.info("Show file properties")
 
         # Get current selected file (corresponding to menu, if possible)
@@ -2012,7 +2012,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         else:
             log.info('File Properties Cancelled')
 
-    def actionDetailsView_trigger(self, event):
+    def actionDetailsView_trigger(self):
         log.info("Switch to Details View")
 
         # Get settings
@@ -2040,7 +2040,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             self.effectsView = self.effectsTreeView
             self.effectsView.show()
 
-    def actionThumbnailView_trigger(self, event):
+    def actionThumbnailView_trigger(self):
         log.info("Switch to Thumbnail View")
 
         # Get settings
@@ -2138,7 +2138,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 continue
             self.docks_menu.addAction(dock.toggleViewAction())
 
-    def actionSimple_View_trigger(self, event):
+    def actionSimple_View_trigger(self):
         """ Switch to the default / simple view  """
         self.removeDocks()
 
@@ -2183,7 +2183,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.restoreState(qt_types.str_to_bytes(simple_state))
         QCoreApplication.processEvents()
 
-    def actionAdvanced_View_trigger(self, event):
+    def actionAdvanced_View_trigger(self):
         """ Switch to an alternative view """
         self.removeDocks()
 
@@ -2228,25 +2228,25 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.restoreState(qt_types.str_to_bytes(advanced_state))
         QCoreApplication.processEvents()
 
-    def actionFreeze_View_trigger(self, event):
+    def actionFreeze_View_trigger(self):
         """ Freeze all dockable widgets on the main screen """
         self.freezeDocks()
         self.actionFreeze_View.setVisible(False)
         self.actionUn_Freeze_View.setVisible(True)
         self.docks_frozen = True
 
-    def actionUn_Freeze_View_trigger(self, event):
+    def actionUn_Freeze_View_trigger(self):
         """ Un-Freeze all dockable widgets on the main screen """
         self.unFreezeDocks()
         self.actionFreeze_View.setVisible(True)
         self.actionUn_Freeze_View.setVisible(False)
         self.docks_frozen = False
 
-    def actionShow_All_trigger(self, event):
+    def actionShow_All_trigger(self):
         """ Show all dockable widgets """
         self.showDocks(self.getDocks())
 
-    def actionTutorial_trigger(self, event):
+    def actionTutorial_trigger(self):
         """ Show tutorial again """
         s = settings.get_settings()
 

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -811,9 +811,13 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             return False
 
         # Get translations
-        _ = get_app()._tr
+        app = get_app()
+        _ = app._tr
 
-        # Handle exception
+        # Process the event queue first, since we've been ignoring input
+        app.processEvents()
+
+        # Display prompt dialog
         ret = QMessageBox.question(
             self,
             _("Import Image Sequence"),
@@ -1541,6 +1545,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             return
 
         # A valid keysequence was detected
+        event.accept()
         key = QKeySequence(modifiers + key_value)
 
         # Get the video player object
@@ -1646,7 +1651,6 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         elif key.matches(self.getShortcutByName("actionAnimatedTitle")) == QKeySequence.ExactMatch:
             self.actionAnimatedTitle.trigger()
         elif key.matches(self.getShortcutByName("actionDuplicateTitle")) == QKeySequence.ExactMatch:
-            log.info("Duplicating title, %s", event)
             self.actionDuplicateTitle.trigger()
         elif key.matches(self.getShortcutByName("actionEditTitle")) == QKeySequence.ExactMatch:
             self.actionEditTitle.trigger()
@@ -1750,7 +1754,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         # If we didn't act on the event, forward it to the base class
         else:
-            super(MainWindow, self).keyPressEvent(event)
+            QMainWindow.keyPressEvent(self, event)
 
     def actionProfile_trigger(self):
         # Show dialog

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -983,7 +983,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             QMessageBox.information(self, "Error !", "Unable to open the Download web page")
             log.error("Unable to open the download page", exc_info=1)
 
-    def actionPlay_trigger(self, checked, force=None):
+    def actionPlay_trigger(self, checked=True, force=None):
         if force == "pause":
             self.actionPlay.setChecked(False)
         elif force == "play":
@@ -1114,7 +1114,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         log.info("Saving frame to %s", framePath)
 
         # Pause playback (to prevent crash since we are fixing to change the timeline's max size)
-        app.window.actionPlay_trigger(None, force="pause")
+        self.actionPlay_trigger(force="pause")
 
         # Save current cache object and create a new CacheMemory object (ignore quality and scale prefs)
         old_cache_object = self.cache_object
@@ -1759,14 +1759,14 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
     def actionProfile_trigger(self):
         # Show dialog
         from windows.profile import Profile
+        log.debug("Showing preferences dialog")
         win = Profile()
         # Run the dialog event loop - blocking interaction on this window during this time
         result = win.exec_()
-        if result == QDialog.Accepted:
-            log.info('Profile add confirmed')
+        log.debug("Preferences dialog closed")
 
     def actionSplitClip_trigger(self):
-        log.info("actionSplitClip_trigger")
+        log.debug("actionSplitClip_trigger")
 
         # Loop through selected files (set 1 selected file if more than 1)
         f = self.files_model.current_file()
@@ -1787,7 +1787,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
             log.info('Cutting Cancelled')
 
     def actionRemove_from_Project_trigger(self):
-        log.info("actionRemove_from_Project_trigger")
+        log.debug("actionRemove_from_Project_trigger")
 
         # Loop through selected files
         for f in self.selected_files():
@@ -1808,7 +1808,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         get_app().window.refreshFrameSignal.emit()
 
     def actionRemoveClip_trigger(self):
-        log.info('actionRemoveClip_trigger')
+        log.debug('actionRemoveClip_trigger')
 
         # Loop through selected clips
         for clip_id in deepcopy(self.selected_clips):
@@ -1825,14 +1825,14 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         get_app().window.refreshFrameSignal.emit()
 
     def actionProperties_trigger(self):
-        log.info('actionProperties_trigger')
+        log.debug('actionProperties_trigger')
 
         # Show properties dock
         if not self.dockProperties.isVisible():
             self.dockProperties.show()
 
     def actionRemoveEffect_trigger(self):
-        log.info('actionRemoveEffect_trigger')
+        log.debug('actionRemoveEffect_trigger')
 
         # Loop through selected clips
         for effect_id in deepcopy(self.selected_effects):
@@ -1864,10 +1864,10 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                     self.removeSelection(effect_id, "effect")
 
         # Refresh preview
-        get_app().window.refreshFrameSignal.emit()
+        self.refreshFrameSignal.emit()
 
     def actionRemoveTransition_trigger(self):
-        log.info('actionRemoveTransition_trigger')
+        log.debug('actionRemoveTransition_trigger')
 
         # Loop through selected clips
         for tran_id in deepcopy(self.selected_transitions):
@@ -1881,10 +1881,10 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
                 t.delete()
 
         # Refresh preview
-        get_app().window.refreshFrameSignal.emit()
+        self.refreshFrameSignal.emit()
 
     def actionRemoveTrack_trigger(self):
-        log.info('actionRemoveTrack_trigger')
+        log.debug('actionRemoveTrack_trigger')
 
         # Get translation function
         _ = get_app()._tr
@@ -1917,11 +1917,11 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
         self.selected_tracks = []
 
         # Refresh preview
-        get_app().window.refreshFrameSignal.emit()
+        self.refreshFrameSignal.emit()
 
     def actionLockTrack_trigger(self):
         """Callback for locking a track"""
-        log.info('actionLockTrack_trigger')
+        log.debug('actionLockTrack_trigger')
 
         # Get details of track
         track_id = self.selected_tracks[0]
@@ -2100,7 +2100,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
     def showDocks(self, docks):
         """ Show all dockable widgets on the main screen """
         for dock in docks:
-            if get_app().window.dockWidgetArea(dock) != Qt.NoDockWidgetArea:
+            if self.dockWidgetArea(dock) != Qt.NoDockWidgetArea:
                 # Only show correctly docked widgets
                 dock.show()
 
@@ -2361,7 +2361,7 @@ class MainWindow(QMainWindow, updates.UpdateWatcher):
 
         if not self.selected_clips:
             # Clear transform (if no other clips are selected)
-            get_app().window.TransformSignal.emit("")
+            self.TransformSignal.emit("")
 
         # Move selection to next selected clip (if any)
         self.show_property_id = ""

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -443,14 +443,12 @@ class FilesModel(QObject, updates.UpdateInterface):
                     log.warning("Directory recursion failed", exc_info=1)
             elif os.path.isfile(filepath):
                 media_paths.append(filepath)
-
+        if not media_paths:
+            return
         # Import all new media files
-        if media_paths:
-            media_paths.sort()
-            log.debug("Importing file list: {}".format(media_paths))
-            return self.add_files(media_paths, quiet=import_quietly)
-        else:
-            return False
+        media_paths.sort()
+        log.debug("Importing file list: {}".format(media_paths))
+        self.add_files(media_paths, quiet=import_quietly)
 
     def get_thumb_path(
             self, file_id, thumbnail_frame, clear_cache=False):

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -51,7 +51,7 @@ class PreviewParent(QObject):
 
     # Signal when the playback mode changes in the preview player (i.e PLAY, PAUSE, STOP)
     def onModeChanged(self, current_mode):
-        log.info('onModeChanged')
+        log.debug('Playback mode changed to %s', current_mode)
         try:
             if current_mode is openshot.PLAYBACK_PLAY:
                 self.parent.SetPlayheadFollow(False)
@@ -63,7 +63,7 @@ class PreviewParent(QObject):
 
     # Signal when the playback encounters an error
     def onError(self, error):
-        log.info('onError: %s' % error)
+        log.warning('Player error: %s', error)
 
         # Get translation object
         _ = get_app()._tr
@@ -178,11 +178,11 @@ class PlayerWorker(QObject):
             QCoreApplication.processEvents()
 
         self.finished.emit()
-        log.info('exiting thread')
+        log.debug('exiting playback thread')
 
     @pyqtSlot()
     def initPlayer(self):
-        log.info("initPlayer")
+        log.debug("initPlayer")
 
         # Get the address of the player's renderer (a QObject that emits signals when frames are ready)
         self.renderer_address = self.player.GetRendererQObject()
@@ -196,16 +196,16 @@ class PlayerWorker(QObject):
 
     def previewFrame(self, number):
         """ Preview a certain frame """
-        log.info("previewFrame: %s" % number)
-
         # Mark frame number for processing
         self.Seek(number)
 
-        log.info("self.player.Position(): %s" % self.player.Position())
+        log.info(
+            "previewFrame: %s, player Position(): %s",
+            number, self.player.Position())
 
     def refreshFrame(self):
         """ Refresh a certain frame """
-        log.info("refreshFrame")
+        log.debug("refreshFrame")
 
         # Always load back in the timeline reader
         self.parent.LoadFileSignal.emit('')
@@ -213,7 +213,7 @@ class PlayerWorker(QObject):
         # Mark frame number for processing (if parent is done initializing)
         self.Seek(self.player.Position())
 
-        log.info("self.player.Position(): %s" % self.player.Position())
+        log.info("player Position(): %s", self.player.Position())
 
     def LoadFile(self, path=None):
         """ Load a media file into the video player """
@@ -233,7 +233,7 @@ class PlayerWorker(QObject):
         # If blank path, switch back to self.timeline reader
         if not path:
             # Return to self.timeline reader
-            log.info("Set timeline reader again in player: %s" % self.timeline)
+            log.debug("Set timeline reader again in player: %s" % self.timeline)
             self.player.Reader(self.timeline)
 
             # Clear clip reader reference
@@ -285,7 +285,7 @@ class PlayerWorker(QObject):
 
         # Close and destroy old clip readers (leaving the 3 most recent)
         while len(self.previous_clip_readers) > 3:
-            log.info('Removing old clips from preview: %s' % self.previous_clip_readers[0])
+            log.debug('Removing old clips from preview: %s' % self.previous_clip_readers[0])
             previous_clip = self.previous_clips.pop(0)
             previous_clip.Close()
             previous_reader = self.previous_clip_readers.pop(0)

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -701,7 +701,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.delayed_resize_timer.start()
 
         # Pause playback (to prevent crash since we are fixing to change the timeline's max size)
-        self.win.actionPlay_trigger(event, force="pause")
+        self.win.actionPlay_trigger(force="pause")
 
     def delayed_resize_callback(self):
         """Callback for resize event timer (to delay the resize event, and prevent lots of similar resize events)"""

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -73,6 +73,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
     def paintEvent(self, event, *args):
         """ Custom paint event """
+        event.accept()
         self.mutex.lock()
 
         # Paint custom frame image on QWidget
@@ -309,6 +310,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
     def mousePressEvent(self, event):
         """Capture mouse press event on video preview window"""
+        event.accept()
         self.mouse_pressed = True
         self.mouse_dragging = False
         self.mouse_position = event.pos()
@@ -318,6 +320,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         get_app().updates.ignore_history = True
 
     def mouseReleaseEvent(self, event):
+        event.accept()
         """Capture mouse release event on video preview window"""
         self.mouse_pressed = False
         self.mouse_dragging = False
@@ -342,6 +345,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
     def mouseMoveEvent(self, event):
         """Capture mouse events on video preview window """
         self.mutex.lock()
+        event.accept()
 
         if self.mouse_pressed:
             self.mouse_dragging = True
@@ -697,6 +701,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
     def resizeEvent(self, event):
         """Widget resize event"""
+        event.accept()
         self.delayed_size = self.size()
         self.delayed_resize_timer.start()
 
@@ -722,6 +727,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
     # Capture wheel event to alter zoom/scale of widget
     def wheelEvent(self, event):
+        event.accept()
         # For each 120 (standard scroll unit) adjust the zoom slider
         tick_scale = 1024
         self.zoom += event.angleDelta().y() / tick_scale

--- a/src/windows/views/effects_listview.py
+++ b/src/windows/views/effects_listview.py
@@ -44,7 +44,7 @@ class EffectsListView(QListView):
 
         menu = QMenu(self)
         menu.addAction(self.win.actionDetailsView)
-        menu.exec_(event.globalPos())
+        menu.popup(event.globalPos())
 
     def startDrag(self, event):
         """ Override startDrag method to display custom icon """

--- a/src/windows/views/effects_treeview.py
+++ b/src/windows/views/effects_treeview.py
@@ -39,14 +39,15 @@ class EffectsTreeView(QTreeView):
 
     def contextMenuEvent(self, event):
         # Set context menu mode
+        event.accept()
         app = get_app()
         app.context_menu_object = "effects"
 
         menu = QMenu(self)
         menu.addAction(self.win.actionThumbnailView)
-        menu.exec_(event.globalPos())
+        menu.popup(event.globalPos())
 
-    def startDrag(self, event):
+    def startDrag(self, supportedActions):
         """ Override startDrag method to display custom icon """
 
         # Get first column indexes for all selected rows

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -40,6 +40,7 @@ class FilesListView(QListView):
     drag_item_size = 48
 
     def contextMenuEvent(self, event):
+        event.accept()
 
         # Set context menu mode
         app = get_app()
@@ -80,13 +81,15 @@ class FilesListView(QListView):
             menu.addSeparator()
 
         # Show menu
-        menu.exec_(event.globalPos())
+        menu.popup(event.globalPos())
 
     def dragEnterEvent(self, event):
         # If dragging urls onto widget, accept
-        if event.mimeData().hasUrls():
-            event.setDropAction(Qt.CopyAction)
-            event.accept()
+        if not event.mimeData().hasUrls():
+            event.ignore()
+            return
+        event.accept()
+        event.setDropAction(Qt.CopyAction)
 
     def startDrag(self, supportedActions):
         """ Override startDrag method to display custom icon """
@@ -115,7 +118,7 @@ class FilesListView(QListView):
 
     # Without defining this method, the 'copy' action doesn't show with cursor
     def dragMoveEvent(self, event):
-        pass
+        event.accept()
 
     # Handle a drag and drop being dropped on widget
     def dropEvent(self, event):

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -119,19 +119,19 @@ class FilesListView(QListView):
 
     # Handle a drag and drop being dropped on widget
     def dropEvent(self, event):
+        if not event.mimeData().hasUrls():
+            # Nothing we're interested in
+            event.reject()
+            return
+        event.accept()
         # Use try/finally so we always reset the cursor
         try:
             # Set cursor to waiting
             get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
 
-            if not event.mimeData().hasUrls():
-                return
-
             qurl_list = event.mimeData().urls()
             log.info("Processing drop event for {} urls".format(len(qurl_list)))
-            result = self.files_model.process_urls(qurl_list)
-            if result:
-                event.accept()
+            self.files_model.process_urls(qurl_list)
         finally:
             # Restore cursor
             get_app().restoreOverrideCursor()

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -122,19 +122,19 @@ class FilesTreeView(QTreeView):
 
     # Handle a drag and drop being dropped on widget
     def dropEvent(self, event):
+        if not event.mimeData().hasUrls():
+            # Nothing we're interested in
+            event.reject()
+            return
+        event.accept()
         # Use try/finally so we always reset the cursor
         try:
             # Set cursor to waiting
             get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
 
-            if not event.mimeData().hasUrls():
-                return
-
             qurl_list = event.mimeData().urls()
             log.info("Processing drop event for {} urls".format(len(qurl_list)))
-            result = self.files_model.process_urls(qurl_list)
-            if result:
-                event.accept()
+            self.files_model.process_urls(qurl_list)
         finally:
             # Restore cursor
             get_app().restoreOverrideCursor()

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -48,6 +48,7 @@ class FilesTreeView(QTreeView):
         app = get_app()
         app.context_menu_object = "files"
 
+        event.accept()
         index = self.indexAt(event.pos())
 
         # Build menu
@@ -83,7 +84,7 @@ class FilesTreeView(QTreeView):
             menu.addSeparator()
 
         # Show menu
-        menu.exec_(event.globalPos())
+        menu.popup(event.globalPos())
 
     def dragEnterEvent(self, event):
         # If dragging urls onto widget, accept
@@ -118,13 +119,13 @@ class FilesTreeView(QTreeView):
 
     # Without defining this method, the 'copy' action doesn't show with cursor
     def dragMoveEvent(self, event):
-        pass
+        event.accept()
 
     # Handle a drag and drop being dropped on widget
     def dropEvent(self, event):
         if not event.mimeData().hasUrls():
             # Nothing we're interested in
-            event.reject()
+            event.ignore()
             return
         event.accept()
         # Use try/finally so we always reset the cursor

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -549,7 +549,7 @@ class PropertiesTableView(QTableView):
             # Update colors interpolation mode
             self.clip_properties_model.color_update(self.selected_item, QColor("#000"), interpolation=0, interpolation_details=preset)
 
-    def Linear_Action_Triggered(self, event):
+    def Linear_Action_Triggered(self):
         log.info("Linear_Action_Triggered")
         if self.property_type != "color":
             # Update keyframe interpolation mode
@@ -558,7 +558,7 @@ class PropertiesTableView(QTableView):
             # Update colors interpolation mode
             self.clip_properties_model.color_update(self.selected_item, QColor("#000"), interpolation=1, interpolation_details=[])
 
-    def Constant_Action_Triggered(self, event):
+    def Constant_Action_Triggered(self):
         log.info("Constant_Action_Triggered")
         if self.property_type != "color":
             # Update keyframe interpolation mode
@@ -567,17 +567,17 @@ class PropertiesTableView(QTableView):
             # Update colors interpolation mode
             self.clip_properties_model.color_update(self.selected_item, QColor("#000"), interpolation=2, interpolation_details=[])
 
-    def Insert_Action_Triggered(self, event):
+    def Insert_Action_Triggered(self):
         log.info("Insert_Action_Triggered")
         if self.selected_item:
             current_value = QLocale().system().toDouble(self.selected_item.text())[0]
             self.clip_properties_model.value_updated(self.selected_item, value=current_value)
 
-    def Remove_Action_Triggered(self, event):
+    def Remove_Action_Triggered(self):
         log.info("Remove_Action_Triggered")
         self.clip_properties_model.remove_keyframe(self.selected_item)
 
-    def Choice_Action_Triggered(self, event):
+    def Choice_Action_Triggered(self):
         log.info("Choice_Action_Triggered")
         choice_value = self.sender().data()
 
@@ -585,7 +585,7 @@ class PropertiesTableView(QTableView):
         self.clip_properties_model.value_updated(self.selected_item, value=choice_value)
 
     def refresh_menu(self):
-        """ Ensure we update the meun when our source models change """
+        """ Ensure we update the menu when our source models change """
         self.menu_reset = True
 
     def __init__(self, *args):
@@ -725,7 +725,7 @@ class SelectionLabel(QFrame):
         # Return the menu object
         return menu
 
-    def Action_Triggered(self, event):
+    def Action_Triggered(self):
         # Switch selection
         item_id = self.sender().data()['item_id']
         item_type = self.sender().data()['item_type']

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -342,27 +342,19 @@ class PropertiesTableView(QTableView):
         # Update model
         self.clip_properties_model.update_model(value)
 
-    def contextMenuEvent(self, event=None, release=False):
+    def contextMenuEvent(self, event):
         """ Display context menu, or release lock when menu displays """
-        if release:
-            # Just clear the menu lock and exit
-            self.menu_lock = False
+        # Get property being acted on
+        index = self.indexAt(event.pos())
+        if not index.isValid():
+            event.ignore()
             return
-
-        if self.menu_lock or not event:
-            # If we're locked, ignore this menu request
-            # But set a 100ms timer to release the lock, just in case
-            QTimer.singleShot(100, partial(self.contextMenuEvent, release=True))
-            return
-
-        # Lock against repeated calls until we've displayed the menu
-        self.menu_lock = True
 
         # Get data model and selection
-        model = self.clip_properties_model.model
-        row = self.indexAt(event.pos()).row()
-        selected_label = model.item(row, 0)
-        selected_value = model.item(row, 1)
+        idx = self.indexAt(event.pos())
+        row = idx.row()
+        selected_label = idx.model().item(row, 0)
+        selected_value = idx.model().item(row, 1)
         self.selected_item = selected_value
         frame_number = self.clip_properties_model.frame_number
 
@@ -389,7 +381,6 @@ class PropertiesTableView(QTableView):
 
             # Handle reader type values
             if self.property_type == "reader" and not self.choices:
-
                 # Add all files
                 file_choices = []
                 for i in range(self.files_model.rowCount()):
@@ -397,8 +388,8 @@ class PropertiesTableView(QTableView):
                     if not idx.isValid():
                         continue
                     icon = idx.data(Qt.DecorationRole)
-                    name = idx.sibling(idx.row(), 1).data()
-                    path = os.path.join(idx.sibling(idx.row(), 4).data(), name)
+                    name = idx.sibling(i, 1).data()
+                    path = os.path.join(idx.sibling(i, 4).data(), name)
 
                     # Append file choice
                     file_choices.append({"name": name,
@@ -408,7 +399,7 @@ class PropertiesTableView(QTableView):
                                          })
 
                 # Add root file choice
-                self.choices.append({"name": _("Files"), "value": file_choices, "selected": False})
+                self.choices.append({"name": _("Files"), "value": file_choices, "selected": False, icon: None})
 
                 # Add all transitions
                 trans_choices = []
@@ -417,8 +408,8 @@ class PropertiesTableView(QTableView):
                     if not idx.isValid():
                         continue
                     icon = idx.data(Qt.DecorationRole)
-                    name = idx.sibling(idx.row(), 1).data()
-                    path = idx.sibling(idx.row(), 3).data()
+                    name = idx.sibling(i, 1).data()
+                    path = idx.sibling(i, 3).data()
 
                     # Append transition choice
                     trans_choices.append({"name": name,
@@ -438,7 +429,7 @@ class PropertiesTableView(QTableView):
                 for track in reversed(sorted(all_tracks, key=itemgetter('number'))):
                     # Append track choice
                     track_name = track.get("label") or _("Track %s") % display_count
-                    self.choices.append({"name": track_name, "value": track.get("number"), "selected": False})
+                    self.choices.append({"name": track_name, "value": track.get("number"), "selected": False, "icon": None})
                     display_count -= 1
 
             # Define bezier presets
@@ -476,25 +467,17 @@ class PropertiesTableView(QTableView):
                 (0.680, -0.550, 0.265, 1.550, _("Ease In/Out (Back)"))
             ]
 
-            bezier_icon = QIcon(QPixmap(os.path.join(info.IMAGES_PATH, "keyframe-%s.png" % openshot.BEZIER)))
-            linear_icon = QIcon(QPixmap(os.path.join(info.IMAGES_PATH, "keyframe-%s.png" % openshot.LINEAR)))
-            constant_icon = QIcon(QPixmap(os.path.join(info.IMAGES_PATH, "keyframe-%s.png" % openshot.CONSTANT)))
-
             # Add menu options for keyframes
             menu = QMenu(self)
             if points > 1:
                 # Menu items only for multiple points
-                Bezier_Menu = QMenu(_("Bezier"), self)
-                Bezier_Menu.setIcon(bezier_icon)
+                Bezier_Menu = menu.AddMenu(self.bezier_icon, _("Bezier"))
                 for bezier_preset in bezier_presets:
                     preset_action = Bezier_Menu.addAction(bezier_preset[4])
                     preset_action.triggered.connect(partial(self.Bezier_Action_Triggered, bezier_preset))
-                menu.addMenu(Bezier_Menu)
-                Linear_Action = menu.addAction(_("Linear"))
-                Linear_Action.setIcon(linear_icon)
+                Linear_Action = menu.addAction(self.linear_icon, _("Linear"))
                 Linear_Action.triggered.connect(self.Linear_Action_Triggered)
-                Constant_Action = menu.addAction(_("Constant"))
-                Constant_Action.setIcon(constant_icon)
+                Constant_Action = menu.addAction(self.constant_icon, _("Constant"))
                 Constant_Action.triggered.connect(self.Constant_Action_Triggered)
                 menu.addSeparator()
             if points >= 1:
@@ -520,28 +503,24 @@ class PropertiesTableView(QTableView):
                 # Divide into smaller QMenus (since large lists cover the entire screen)
                 # For example: Transitions -> 1 -> sub items
                 SubMenu = None
-                SubMenuRoot = QMenu(_(choice["name"]), self)
-                SubMenuSize = 24
+                SubMenuRoot = menu.addMenu(_(choice["name"]))
+                SubMenuSize = 25
                 SubMenuNumber = 0
-                for sub_choice in choice["value"]:
-                    if len(choice["value"]) > SubMenuSize:
-                        if not SubMenu or len(SubMenu.children()) == SubMenuSize or sub_choice == choice["value"][-1]:
-                            SubMenuNumber += 1
-                            if SubMenu:
-                                SubMenuRoot.addMenu(SubMenu)
-                            SubMenu = QMenu(str(SubMenuNumber), self)
-                        Choice_Action = SubMenu.addAction(_(sub_choice["name"]))
-                    else:
-                        Choice_Action = SubMenuRoot.addAction(_(sub_choice["name"]))
+                if len(choice["value"]) > SubMenuSize:
+                    SubMenu = SubMenuRoot.addMenu(str(SubMenuNumber))
+                else:
+                    SubMenu = SubMenuRoot
+                for i, sub_choice in enumerate(choice["value"], 1):
+                    if i % SubMenuSize == 0:
+                        SubMenuNumber += 1
+                        SubMenu = SubMenuRoot.addMenu(str(SubMenuNumber))
+                    Choice_Action = SubMenu.addAction(
+                        sub_choice["icon"], _(sub_choice["name"]))
                     Choice_Action.setData(sub_choice["value"])
-                    if "icon" in sub_choice:
-                        Choice_Action.setIcon(sub_choice["icon"])
                     Choice_Action.triggered.connect(self.Choice_Action_Triggered)
-                menu.addMenu(SubMenuRoot)
 
-            # Show choice menu and release lock
-            menu.popup(QCursor.pos())
-            self.contextMenuEvent(event, release=True)
+            # Show choice menuk
+            menu.popup(event.globalPos())
 
     def Bezier_Action_Triggered(self, preset=[]):
         log.info("Bezier_Action_Triggered: %s" % str(preset))
@@ -619,8 +598,10 @@ class PropertiesTableView(QTableView):
         self.lock_selection = False
         self.prev_row = None
 
-        # Context menu concurrency lock
-        self.menu_lock = False
+        # Context menu icons
+        self.bezier_icon = QIcon(QPixmap(os.path.join(info.IMAGES_PATH, "keyframe-%s.png" % openshot.BEZIER)))
+        self.linear_icon = QIcon(QPixmap(os.path.join(info.IMAGES_PATH, "keyframe-%s.png" % openshot.LINEAR)))
+        self.constant_icon = QIcon(QPixmap(os.path.join(info.IMAGES_PATH, "keyframe-%s.png" % openshot.CONSTANT)))
 
         # Setup header columns
         self.setModel(self.clip_properties_model.model)
@@ -687,8 +668,7 @@ class SelectionLabel(QFrame):
             if clip:
                 item_name = clip.title()
                 item_icon = QIcon(QPixmap(clip.data.get('image')))
-                action = menu.addAction(item_name)
-                action.setIcon(item_icon)
+                action = menu.addAction(item_icon, item_name)
                 action.setData({'item_id': item_id, 'item_type': 'clip'})
                 action.triggered.connect(self.Action_Triggered)
 
@@ -698,8 +678,7 @@ class SelectionLabel(QFrame):
                     if effect:
                         item_name = effect.title()
                         item_icon = QIcon(QPixmap(os.path.join(info.PATH, "effects", "icons", "%s.png" % effect.data.get('class_name').lower())))
-                        action = menu.addAction('  >  %s' % _(item_name))
-                        action.setIcon(item_icon)
+                        action = menu.addAction(item_icon, '  >  %s' % _(item_name))
                         action.setData({'item_id': effect.id, 'item_type': 'effect'})
                         action.triggered.connect(self.Action_Triggered)
 
@@ -709,8 +688,7 @@ class SelectionLabel(QFrame):
             if trans:
                 item_name = _(trans.title())
                 item_icon = QIcon(QPixmap(trans.data.get('reader', {}).get('path')))
-                action = menu.addAction(_(item_name))
-                action.setIcon(item_icon)
+                action = menu.addAction(item_icon, _(item_name))
                 action.setData({'item_id': item_id, 'item_type': 'transition'})
                 action.triggered.connect(self.Action_Triggered)
 
@@ -720,8 +698,7 @@ class SelectionLabel(QFrame):
             if effect:
                 item_name = _(effect.title())
                 item_icon = QIcon(QPixmap(os.path.join(info.PATH, "effects", "icons", "%s.png" % effect.data.get('class_name').lower())))
-                action = menu.addAction(_(item_name))
-                action.setIcon(item_icon)
+                action = menu.addAction(item_icon, _(item_name))
                 action.setData({'item_id': item_id, 'item_type': 'effect'})
                 action.triggered.connect(self.Action_Triggered)
 
@@ -784,7 +761,7 @@ class SelectionLabel(QFrame):
 
     def __init__(self, *args):
         # Invoke parent init
-        QFrame.__init__(self, *args)
+        super().__init__(*args)
         self.item_id = None
         self.item_type = None
 

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -166,6 +166,8 @@ class PropertiesTableView(QTableView):
         if row is None:
             return
 
+        event.accept()
+
         if model.item(row, 0):
             self.selected_label = model.item(row, 0)
             self.selected_item = model.item(row, 1)
@@ -268,6 +270,7 @@ class PropertiesTableView(QTableView):
 
     def mouseReleaseEvent(self, event):
         # Inform UpdateManager to accept updates, and only store our final update
+        event.accept()
         get_app().updates.ignore_history = False
 
         # Add final update to undo/redo history
@@ -500,7 +503,7 @@ class PropertiesTableView(QTableView):
                 Insert_Action.triggered.connect(self.Insert_Action_Triggered)
                 Remove_Action = menu.addAction(_("Remove Keyframe"))
                 Remove_Action.triggered.connect(self.Remove_Action_Triggered)
-                menu.popup(QCursor.pos())
+                menu.popup(event.globalPos())
 
             # Menu for choices
             if not self.choices:

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -28,9 +28,16 @@
 import os
 from functools import partial
 from operator import itemgetter
-from PyQt5.QtCore import Qt, QRectF, QLocale, pyqtSignal, QObject, QTimer
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import QTableView, QAbstractItemView, QMenu, QSizePolicy, QHeaderView, QColorDialog, QItemDelegate, QStyle, QLabel, QPushButton, QHBoxLayout, QFrame
+from PyQt5.QtCore import Qt, QRectF, QLocale, pyqtSignal, QTimer
+from PyQt5.QtGui import (
+    QCursor, QIcon, QColor, QBrush, QPen, QPalette, QPixmap,
+    QPainter, QPainterPath, QLinearGradient,
+)
+from PyQt5.QtWidgets import (
+    QTableView, QAbstractItemView, QMenu, QSizePolicy,
+    QHeaderView, QColorDialog, QItemDelegate, QStyle, QLabel,
+    QPushButton, QHBoxLayout, QFrame,
+)
 
 from classes.logger import log
 from classes.app import get_app

--- a/src/windows/views/transitions_listview.py
+++ b/src/windows/views/transitions_listview.py
@@ -49,7 +49,7 @@ class TransitionsListView(QListView):
         # Ignore event, propagate to parent
         event.ignore()
 
-    def startDrag(self, event):
+    def startDrag(self, supportedActions):
         """ Override startDrag method to display custom icon """
 
         # Get first column indexes for all selected rows

--- a/src/windows/views/transitions_listview.py
+++ b/src/windows/views/transitions_listview.py
@@ -38,16 +38,15 @@ class TransitionsListView(QListView):
     drag_item_size = 48
 
     def contextMenuEvent(self, event):
+        event.accept()
+
         # Set context menu mode
         app = get_app()
         app.context_menu_object = "transitions"
 
         menu = QMenu(self)
         menu.addAction(self.win.actionDetailsView)
-        menu.exec_(event.globalPos())
-
-        # Ignore event, propagate to parent
-        event.ignore()
+        menu.popup(event.globalPos())
 
     def startDrag(self, supportedActions):
         """ Override startDrag method to display custom icon """

--- a/src/windows/views/transitions_treeview.py
+++ b/src/windows/views/transitions_treeview.py
@@ -44,7 +44,7 @@ class TransitionsTreeView(QTreeView):
 
         menu = QMenu(self)
         menu.addAction(self.win.actionThumbnailView)
-        menu.exec_(event.globalPos())
+        menu.popup(event.globalPos())
 
     def startDrag(self, event):
         """ Override startDrag method to display custom icon """


### PR DESCRIPTION
#### Update

OK, this grew into quite a few things. This PR includes the following changes:

- A lot (hopefully all?) of the event handlers now `accept()` their input early in the process, to make sure the system stops propagating it and frees up the GUI for other tasks
- A lot of the callback functions that _aren't_ even handlers have had their `event` parameter removed, because they never accepted `event`s as arguments. (The only standard argument an action's `triggered()` callback takes is `checked`, a boolean that's passed with checkable actions to indicate their current status.)
- Drag-and-drop file processing (actually, all `add_files` processing) now regularly triggers event loop processing, to avoid UI freezes
- Imports of more than 15 files at once will now show a localized "Imported M / N" counter in the status bar of the main window as they're running through the imports. The total count may adjust itself downward, if image sequence redundancies are removed from the list during the middle of the run.
- Context menus now use `menu.popup()` instead of `menu.exec()`, as `popup()` runs asynchronously and keeps the menu from freezing the rest of the UI while it's displayed. (You can even right-click things while OpenShot's preview is playing, though it's rarely very useful to do so.)

#### Unrelated or only loosely-related
- I removed the locking mechanism from the Properties context menu and cleaned up that menu code a bit, to address #3783
- I fixed a longstanding bug where hitting the Reverse/Rewind button while the player is Paused would make it start playing _forward_ instead of backwards
- I improved the console/logfile output from the preview player, to make it more useful and less noisy

Fixes #3782, fixes #3783, fixes #909

##### Original summary

The code for the drop events in the two file view classes never sat right with me, as it was only calling `event.accept()` _after_ processing all of the dropped URLs. (The idea being that it would only accept on a successful import. But that's not how Qt events work. An accept just means you're _handling_ the event, which we are.)

@USATechDude reported input-handling issues on MacOS that I think are likely caused by the event not being accepted, so this PR is an attempt to correct that.

I tested this on Linux and it works fine, but then again the old code seemed to work fine on Linux. Still, even if it doesn't fix the issue, I'm pretty sure the code's more correct this way.
