### PR TITLE
Updating AppImage logic to support desktopintegration again

### DIFF
--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -354,22 +354,18 @@ try:
         with open(desk_in, "r") as inf, open(desk_out, "w") as outf:
             for line in inf:
                 if line.startswith("Exec="):
-                    outf.write("Exec=openshot-qt.wrapper %F\n")
+                    outf.write("Exec=openshot-qt-launch.wrapper %F\n")
                 else:
                     outf.write(line)
 
         # Copy desktop integration wrapper (prompts users to install shortcut)
         launcher_path = os.path.join(app_dir_path, "usr", "bin", "openshot-qt-launch")
         os.rename(os.path.join(app_dir_path, "usr", "bin", "launch-linux.sh"), launcher_path)
-        desktop_wrapper = os.path.join(app_dir_path, "usr", "bin", "openshot-qt.wrapper")
+        desktop_wrapper = os.path.join(app_dir_path, "usr", "bin", "openshot-qt-launch.wrapper")
         shutil.copyfile("/home/ubuntu/apps/AppImageKit/desktopintegration", desktop_wrapper)
 
-        # Create symlink for AppRun (our openshot-qt-launch script)
-        app_run_path = os.path.join(app_dir_path, "AppRun")
-        os.symlink(os.path.relpath(launcher_path, app_dir_path), app_run_path)
-
         # Create AppRun.64 file (the real one)
-        app_run_path = os.path.join(app_dir_path, "AppRun.64")
+        app_run_path = os.path.join(app_dir_path, "AppRun")
         shutil.copyfile("/home/ubuntu/apps/AppImageKit/AppRun", app_run_path)
 
         # Add execute bit to file mode for AppRun and scripts

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -350,7 +350,7 @@ try:
 
         # Copy .desktop file, replacing Exec= commandline
         desk_in = os.path.join(PATH, "xdg", "org.openshot.OpenShot.desktop")
-        desk_out = os.path.join(app_dir_path, "org.openshot.OpenShot.desktop")
+        desk_out = os.path.join(app_dir_path, "openshot-qt.desktop")
         with open(desk_in, "r") as inf, open(desk_out, "w") as outf:
             for line in inf:
                 if line.startswith("Exec="):
@@ -364,9 +364,9 @@ try:
         desktop_wrapper = os.path.join(app_dir_path, "usr", "bin", "openshot-qt.wrapper")
         shutil.copyfile("/home/ubuntu/apps/AppImageKit/desktopintegration", desktop_wrapper)
 
-        # Create symlink for AppRun
-        # app_run_path = os.path.join(app_dir_path, "AppRun")
-        # os.symlink(os.path.relpath(launcher_path, app_dir_path), app_run_path)
+        # Copy encodings folder
+        #shutil.copytree(os.path.join(app_dir_path, "usr", "bin", "lib", "encodings"),
+        #                os.path.join(app_dir_path, "usr", "bin", "encodings"))
 
         # Create AppRun file
         app_run_path = os.path.join(app_dir_path, "AppRun")

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -350,7 +350,7 @@ try:
 
         # Copy .desktop file, replacing Exec= commandline
         desk_in = os.path.join(PATH, "xdg", "org.openshot.OpenShot.desktop")
-        desk_out = os.path.join(app_dir_path, "openshot-qt.desktop")
+        desk_out = os.path.join(app_dir_path, "org.openshot.OpenShot.desktop")
         with open(desk_in, "r") as inf, open(desk_out, "w") as outf:
             for line in inf:
                 if line.startswith("Exec="):
@@ -364,12 +364,12 @@ try:
         desktop_wrapper = os.path.join(app_dir_path, "usr", "bin", "openshot-qt.wrapper")
         shutil.copyfile("/home/ubuntu/apps/AppImageKit/desktopintegration", desktop_wrapper)
 
-        # Copy encodings folder
-        #shutil.copytree(os.path.join(app_dir_path, "usr", "bin", "lib", "encodings"),
-        #                os.path.join(app_dir_path, "usr", "bin", "encodings"))
-
-        # Create AppRun file
+        # Create symlink for AppRun (our openshot-qt-launch script)
         app_run_path = os.path.join(app_dir_path, "AppRun")
+        os.symlink(os.path.relpath(launcher_path, app_dir_path), app_run_path)
+
+        # Create AppRun.64 file (the real one)
+        app_run_path = os.path.join(app_dir_path, "AppRun.64")
         shutil.copyfile("/home/ubuntu/apps/AppImageKit/AppRun", app_run_path)
 
         # Add execute bit to file mode for AppRun and scripts

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -365,8 +365,12 @@ try:
         shutil.copyfile("/home/ubuntu/apps/AppImageKit/desktopintegration", desktop_wrapper)
 
         # Create symlink for AppRun
+        # app_run_path = os.path.join(app_dir_path, "AppRun")
+        # os.symlink(os.path.relpath(launcher_path, app_dir_path), app_run_path)
+
+        # Create AppRun file
         app_run_path = os.path.join(app_dir_path, "AppRun")
-        os.symlink(os.path.relpath(launcher_path, app_dir_path), app_run_path)
+        shutil.copyfile("/home/ubuntu/apps/AppImageKit/AppRun", app_run_path)
 
         # Add execute bit to file mode for AppRun and scripts
         st = os.stat(app_run_path)

--- a/installer/launch-linux.sh
+++ b/installer/launch-linux.sh
@@ -13,4 +13,4 @@ export QT_PLUGIN_PATH="${HERE}"
 export OPENSSL_CONF="/dev/null"
 
 # Launch application
-exec "${HERE}"/AppRun.64 "$@"
+exec "${HERE}"/openshot-qt "$@"

--- a/installer/launch-linux.sh
+++ b/installer/launch-linux.sh
@@ -13,4 +13,4 @@ export QT_PLUGIN_PATH="${HERE}"
 export OPENSSL_CONF="/dev/null"
 
 # Launch application
-exec "${HERE}"/openshot-qt "$@"
+exec "${HERE}"/AppRun.64 "$@"

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -939,7 +939,7 @@
     "type": "text"
   },
   {
-    "value": false,
+    "value": true,
     "title": "Auto-Transform Selection",
     "type": "bool",
     "category": "General",


### PR DESCRIPTION
Fixing a regression which did not use the official AppRun executable... and thus our openshot-qt.wrapper was never called, which is what enables desktopintegration. I know this must still have some issues, since I'm having to do some of my own bootstrapping (which I should need to do, in order for libopenshot to be found at runtime). But this seems to work on all the distros I've tested on so far.

**The basic flow:**
1 - AppImage is mounted and executes `AppRun` in the root of our image. This is the official version of AppRun executable, and is a binary file.
2 - AppRun searches our `*.desktop file`, and locates the `openshot-qt-launch.wrapper` line, and then searches for that file, and executes it. This file is the `desktopintegration` file packaged along with AppImage code (renamed as openshot-qt-launch). It prompts the user to create a launcher, and then finally, removes the `.wrapper` and calls `openshot-qt-launch`. 
3 - `openshot-qt-launch` is a renamed version of `installer/launch-linux.sh`. This exports `LD_LIBRARY_PATH` and `QT_PLUGIN_PATH` to the current directory (i.e. the `usr/bin` folder in our AppImage), and then finally, executes `usr/bin/openshot-qt`, which is a binary created by cx_freeze (and is the official entry point to our source code). Without this script, libopenshot and Qt fail to be found inside the AppImage... which is strange and incorrect. But it's a simple work-around for now.

Finally, I also enabled auto-transform, which enables transform for any selected clip. To make it disappear, simple unselect all clips. I think it really improves visibility on transforming elements during video editing. It can be disabled in the Preferences.