### PR TITLE
Profile: Seek to first frame on change

### DIFF
--- a/src/windows/profile.py
+++ b/src/windows/profile.py
@@ -83,7 +83,8 @@ class Profile(QDialog):
                     self.profile_paths[profile_name] = profile_path
 
                 except RuntimeError as e:
-                    # This exception occurs when there's a problem parsing the Profile file - display a message and continue
+                    # This exception occurs when there's a problem parsing
+                    # the Profile file - display a message and continue
                     log.error("Failed to parse file '%s' as a profile: %s" % (profile_path, e))
 
         # Sort list
@@ -119,51 +120,68 @@ class Profile(QDialog):
 
         # Set labels
         self.lblSize.setText("%sx%s" % (profile.info.width, profile.info.height))
-        self.lblFPS.setText("%0.2f" % (profile.info.fps.num / profile.info.fps.den))
-        self.lblOther.setText("DAR: %s/%s, SAR: %s/%s, Interlaced: %s" % (profile.info.display_ratio.num, profile.info.display_ratio.den, profile.info.pixel_ratio.num, profile.info.pixel_ratio.den, profile.info.interlaced_frame))
+        self.lblFPS.setText("%0.2f" % (profile.info.fps.ToFloat()))
+        # (Note: Takes advantage of openshot.Fraction's __string__ method
+        # which outputs the value with the format "{num}:{den}")
+        self.lblOther.setText("DAR: %s, SAR: %s, Interlaced: %s" % (
+            profile.info.display_ratio,
+            profile.info.pixel_ratio,
+            profile.info.interlaced_frame))
 
     def dropdown_activated(self, index):
         # Ignore if the selection wasn't changed
         if index == self.initial_index:
             return
 
-        # Get profile path
-        value = self.cboProfile.itemData(index)
+        win = get_app().window
+        proj = get_app().project
+        updates = get_app().updates
 
-        # Load profile
+        # Get profile path & load
+        value = self.cboProfile.itemData(index)
         profile = openshot.Profile(value)
 
         # Get current FPS (prior to changing)
-        current_fps = get_app().project.get("fps")
+        current_fps = proj.get("fps")
         current_fps_float = float(current_fps["num"]) / float(current_fps["den"])
-        new_fps_float = float(profile.info.fps.num) / float(profile.info.fps.den)
-        fps_factor = new_fps_float / current_fps_float
+        fps_factor = float(profile.info.fps.ToFloat() / current_fps_float)
 
         # Update timeline settings
-        get_app().updates.update(["profile"], profile.info.description)
-        get_app().updates.update(["width"], profile.info.width)
-        get_app().updates.update(["height"], profile.info.height)
-        get_app().updates.update(["fps"], {"num": profile.info.fps.num, "den": profile.info.fps.den})
-        get_app().updates.update(["display_ratio"], {"num": profile.info.display_ratio.num, "den": profile.info.display_ratio.den})
-        get_app().updates.update(["pixel_ratio"], {"num": profile.info.pixel_ratio.num, "den": profile.info.pixel_ratio.den})
+        updates.update(["profile"], profile.info.description)
+        updates.update(["width"], profile.info.width)
+        updates.update(["height"], profile.info.height)
+        updates.update(["fps"], {
+            "num": profile.info.fps.num,
+            "den": profile.info.fps.den,
+            })
+        updates.update(["display_ratio"], {
+            "num": profile.info.display_ratio.num,
+            "den": profile.info.display_ratio.den,
+            })
+        updates.update(["pixel_ratio"], {
+            "num": profile.info.pixel_ratio.num,
+            "den": profile.info.pixel_ratio.den,
+            })
 
         # Rescale all keyframes and reload project
         if fps_factor != 1.0:
             # Get a copy of rescaled project data (this does not modify the active project... yet)
-            rescaled_app_data = get_app().project.rescale_keyframes(fps_factor)
+            rescaled_app_data = proj.rescale_keyframes(fps_factor)
 
             # Apply rescaled data to active project
-            get_app().project._data = rescaled_app_data
+            proj._data = rescaled_app_data
 
             # Distribute all project data through update manager
-            get_app().updates.load(rescaled_app_data)
+            updates.load(rescaled_app_data)
 
         # Force ApplyMapperToClips to apply these changes
-        get_app().window.timeline_sync.timeline.ApplyMapperToClips()
+        win.timeline_sync.timeline.ApplyMapperToClips()
 
         # Update Window Title and stored index
-        get_app().window.SetWindowTitle(profile.info.description)
+        win.SetWindowTitle(profile.info.description)
         self.initial_index = index
 
+        # Reset the playhead position (visually it moves anyway)
+        win.SeekSignal.emit(1)
         # Refresh frame (since size of preview might have changed)
-        QTimer.singleShot(500, get_app().window.refreshFrameSignal.emit)
+        QTimer.singleShot(500, win.refreshFrameSignal.emit)


### PR DESCRIPTION
Visually, changing the project profile resets the playhead marker back to the start of the timeline. But the preview player was retaining the old position, causing subsequent operations to be performed in the wrong place. Now, we `Seek()` the player back to frame 1 as well.

Fixes #3119