### PR TITLE
Fixing AppImage Icon for Chrome OS

### DIFF
--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -349,6 +349,9 @@ try:
         # See: https://docs.appimage.org/reference/appdir.html
         shutil.copyfile(icons[3][1], os.path.join(app_dir_path, ".DirIcon"))
 
+        # Install program icon
+        shutil.copyfile(icons[0][1], os.path.join(app_dir_path, "openshot-qt.svg"))
+
         dest = os.path.join(app_dir_path, "usr", "share", "pixmaps")
         os.makedirs(dest, exist_ok=True)
 

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -330,10 +330,10 @@ try:
 
         # XDG Freedesktop icon paths
         icons = [ ("scalable", os.path.join(PATH, "xdg", "openshot-qt.svg")),
-                  ("64x64", os.path.join(PATH, "icon", "64", "openshot-qt.png")),
-                  ("128x128", os.path.join(PATH, "icon", "128", "openshot-qt.png")),
-                  ("256x256", os.path.join(PATH, "icon", "256", "openshot-qt.png")),
-                  ("512x512", os.path.join(PATH, "icon", "512", "openshot-qt.png")),
+                  ("64x64", os.path.join(PATH, "xdg", "icon", "64", "openshot-qt.png")),
+                  ("128x128", os.path.join(PATH, "xdg", "icon", "128", "openshot-qt.png")),
+                  ("256x256", os.path.join(PATH, "xdg", "icon", "256", "openshot-qt.png")),
+                  ("512x512", os.path.join(PATH, "xdg", "icon", "512", "openshot-qt.png")),
                 ]
 
         # Copy desktop icons

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -326,7 +326,6 @@ try:
 
         # Recursively create AppDir /usr folder
         os.makedirs(os.path.join(app_dir_path, "usr"), exist_ok=True)
-        os.makedirs(os.path.join(app_dir_path, "usr", "share", "icons", "hicolor", "scalable", "apps", "xdg"), exist_ok=True)
 
         # XDG Freedesktop icon paths
         icons = [ ("scalable", os.path.join(PATH, "xdg", "openshot-qt.svg")),

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -328,19 +328,19 @@ try:
         os.makedirs(os.path.join(app_dir_path, "usr"), exist_ok=True)
 
         # Install program icon
-        shutil.copyfile(os.path.join(PATH, "xdg", "openshot-qt.svg"),
-                        os.path.join(app_dir_path, "openshot-qt.svg"))
+        icon_256_png = os.path.join(PATH, "xdg", "icon", "256", "openshot-qt.png")
+        shutil.copyfile(icon_256_png, os.path.join(app_dir_path, "openshot-qt.png"))
 
-        # Install .DirIcon AppImage icon (used on some distros such as Chrome OS)
+        # Install .DirIcon AppImage icon
         # See: https://docs.appimage.org/reference/appdir.html
-        shutil.copyfile(os.path.join(PATH, "xdg", "icon", "256", "openshot-qt.png"),
-                        os.path.join(app_dir_path, ".DirIcon"))
+        # SVG icon not supported on Chrome OS (with AppImage desktop integration)
+        # PNG is assumed with desktop integration
+        shutil.copyfile(icon_256_png, os.path.join(app_dir_path, ".DirIcon"))
 
         dest = os.path.join(app_dir_path, "usr", "share", "pixmaps")
         os.makedirs(dest, exist_ok=True)
 
-        shutil.copyfile(os.path.join(PATH, "xdg", "openshot-qt.svg"),
-                        os.path.join(dest, "openshot-qt.svg"))
+        shutil.copyfile(icon_256_png, os.path.join(dest, "openshot-qt.png"))
 
         # Install MIME handler
         dest = os.path.join(app_dir_path, "usr", "share", "mime", "packages")

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -327,20 +327,24 @@ try:
         # Recursively create AppDir /usr folder
         os.makedirs(os.path.join(app_dir_path, "usr"), exist_ok=True)
 
-        # Install program icon
-        icon_256_png = os.path.join(PATH, "xdg", "icon", "256", "openshot-qt.png")
-        shutil.copyfile(icon_256_png, os.path.join(app_dir_path, "openshot-qt.png"))
+        # Install program icon (as a 128x128 PNG & SVG)
+        icon_svg = os.path.join(PATH, "xdg", "openshot-qt.svg")
+        icon_128_png = os.path.join(PATH, "xdg", "icon", "128", "openshot-qt.png")
+        shutil.copyfile(icon_128_png, os.path.join(app_dir_path, "openshot-qt.png"))
+        shutil.copyfile(icon_svg, os.path.join(app_dir_path, "openshot-qt.svg"))
 
         # Install .DirIcon AppImage icon
         # See: https://docs.appimage.org/reference/appdir.html
         # SVG icon not supported on Chrome OS (with AppImage desktop integration)
         # PNG is assumed with desktop integration
-        shutil.copyfile(icon_256_png, os.path.join(app_dir_path, ".DirIcon"))
+        shutil.copyfile(icon_128_png, os.path.join(app_dir_path, ".DirIcon"))
 
         dest = os.path.join(app_dir_path, "usr", "share", "pixmaps")
         os.makedirs(dest, exist_ok=True)
 
-        shutil.copyfile(icon_256_png, os.path.join(dest, "openshot-qt.png"))
+        # Copy pixmaps (as a 128x128 PNG & SVG)
+        shutil.copyfile(icon_128_png, os.path.join(dest, "openshot-qt.png"))
+        shutil.copyfile(icon_svg, os.path.join(dest, "openshot-qt.svg"))
 
         # Install MIME handler
         dest = os.path.join(app_dir_path, "usr", "share", "mime", "packages")

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -363,7 +363,7 @@ try:
         os.makedirs(dest, exist_ok=True)
 
         shutil.copyfile(os.path.join(PATH, "xdg", "org.openshot.OpenShot.xml"),
-                        os.path.join(dest, "org.openshot.OpenShot.xml"))
+                        os.path.join(dest, "openshot-qt.xml"))
 
         # Copy the entire frozen app
         shutil.copytree(os.path.join(PATH, "build", exe_dir),
@@ -371,7 +371,7 @@ try:
 
         # Copy .desktop file, replacing Exec= commandline
         desk_in = os.path.join(PATH, "xdg", "org.openshot.OpenShot.desktop")
-        desk_out = os.path.join(app_dir_path, "org.openshot.OpenShot.desktop")
+        desk_out = os.path.join(app_dir_path, "openshot-qt.desktop")
         with open(desk_in, "r") as inf, open(desk_out, "w") as outf:
             for line in inf:
                 if line.startswith("Exec="):

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -326,25 +326,35 @@ try:
 
         # Recursively create AppDir /usr folder
         os.makedirs(os.path.join(app_dir_path, "usr"), exist_ok=True)
+        os.makedirs(os.path.join(app_dir_path, "usr", "share", "icons", "hicolor", "scalable", "apps", "xdg"), exist_ok=True)
 
-        # Install program icon (as a 128x128 PNG & SVG)
-        icon_svg = os.path.join(PATH, "xdg", "openshot-qt.svg")
-        icon_128_png = os.path.join(PATH, "xdg", "icon", "128", "openshot-qt.png")
-        shutil.copyfile(icon_128_png, os.path.join(app_dir_path, "openshot-qt.png"))
-        shutil.copyfile(icon_svg, os.path.join(app_dir_path, "openshot-qt.svg"))
+        # XDG Freedesktop icon paths
+        icons = [ ("scalable", os.path.join(PATH, "xdg", "openshot-qt.svg")),
+                  ("64x64", os.path.join(PATH, "icon", "64", "openshot-qt.png")),
+                  ("128x128", os.path.join(PATH, "icon", "128", "openshot-qt.png")),
+                  ("256x256", os.path.join(PATH, "icon", "256", "openshot-qt.png")),
+                  ("512x512", os.path.join(PATH, "icon", "512", "openshot-qt.png")),
+                ]
 
-        # Install .DirIcon AppImage icon
+        # Copy desktop icons
+        icon_theme_path = os.path.join(app_dir_path, "usr", "share", "icons", "hicolor")
+
+        # Copy each icon
+        for icon_size, icon_path in icons:
+            dest_icon_path = os.path.join(icon_theme_path, icon_size, "apps", os.path.split(icon_path)[-1])
+            os.makedirs(os.path.split(dest_icon_path)[0], exist_ok=True)
+            shutil.copyfile(icon_path, dest_icon_path)
+
+        # Install .DirIcon AppImage icon (256x256)
         # See: https://docs.appimage.org/reference/appdir.html
-        # SVG icon not supported on Chrome OS (with AppImage desktop integration)
-        # PNG is assumed with desktop integration
-        shutil.copyfile(icon_128_png, os.path.join(app_dir_path, ".DirIcon"))
+        shutil.copyfile(icons[3][1], os.path.join(app_dir_path, ".DirIcon"))
 
         dest = os.path.join(app_dir_path, "usr", "share", "pixmaps")
         os.makedirs(dest, exist_ok=True)
 
-        # Copy pixmaps (as a 128x128 PNG & SVG)
-        shutil.copyfile(icon_128_png, os.path.join(dest, "openshot-qt.png"))
-        shutil.copyfile(icon_svg, os.path.join(dest, "openshot-qt.svg"))
+        # Copy pixmaps (as a 64x64 PNG & SVG)
+        shutil.copyfile(icons[0][1], os.path.join(dest, "openshot-qt.svg"))
+        shutil.copyfile(icons[1][1], os.path.join(dest, "openshot-qt.png"))
 
         # Install MIME handler
         dest = os.path.join(app_dir_path, "usr", "share", "mime", "packages")


### PR DESCRIPTION
I've done a few new things to resolve the AppImage icon
- During the launch script in the AppImage, we now manually copy a 'normal' and 'large' thumbnail into ~/.cache/thumbnails/
- I fixed the internal AppImage location of all icons: `usr/share/icons/hicolor/128x128/apps/openshot-qt.png` (for example)
- We no longer use an SVG for our desktop icon, since that does not seem to be supported with .cache (as far as I can tell)
- I've tested this on Ubuntu 20.04 and the newest version of Chrome OS, but work, and include desktop launchers with an icon

I'm happy to take further PRs to improve our AppImage support, especially with respect to icons and launchers, but for now, this seems much better than before.