### PR TITLE
Fix MainWindow inheritance

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -85,7 +85,7 @@ from windows.views.transitions_treeview import TransitionsTreeView
 from windows.views.tutorial import TutorialManager
 
 
-class MainWindow(QMainWindow, updates.UpdateWatcher):
+class MainWindow(updates.UpdateWatcher, QMainWindow):
     """ This class contains the logic for the main window widget """
 
     # Path to ui file


### PR DESCRIPTION
A change I left out of #3684 — MainWindow (and really all Qt-based classes) needs to have its Qt parent listed _last_ in its parent class list, so that it will be the first lookup for all inherited members.

IOW,
```python
class MainWindow(QMainWindow, UpdateListener):
```

Doesn't guarantee that `super()` calls will always go to the corresponding `QMainWindow` class members (if they're present). But,
```python
class MainWindow(UpdateListener, QMainWindow):
```

does.

This especially matters for things like `__init__` that lots of classes share, but it's also a good idea in general, apparently. Python's multiple-inheritance implementation received _two_ massive overhauls back in the Python 3.2 - 3.4 dev cycles, before reaching its current form, and it can still be a bit shaky at times apparently.