### PR TITLE
Use new effect.ParentClip() for more efficient property lookup, fix cutting closeEvent()

### DIFF
--- a/src/windows/cutting.py
+++ b/src/windows/cutting.py
@@ -356,7 +356,6 @@ class Cutting(QDialog):
 
     def closeEvent(self, event):
         log.debug('closeEvent')
-        event.accept()
 
         # Stop playback
         self.preview_parent.worker.Stop()


### PR DESCRIPTION
When getting properties for an _effect_, we also need its parent clip's parameters for positioning.
I realized I'd left a hole in the libopenshot Timeline lookup APIs by not providing a way to easily look that up. Fortunately, @jonoomph was nice enough to fill that hole with recent libopenshot changes. 

So, this PR uses `effect.ParentClip()` to grab the corresponding clip data at the same time it looks up the effect data, preventing us having to chase it down later.

It also fixes a bug that #3784 created with the cutting module ("Split Clip..." window). It seems that calling `event.accept()` in a `closeEvent()` handler, then going on to do more cleanup work on your local data, is a bad idea and leaves you with a window that won't close. Removing the `event.accept()` fixed it, though possibly just calling `super().close()` would have as well. I haven't explored that possibility.