### PR TITLE
Stable build dates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ linux-builder:
     - unzip artifacts.zip
     - cp -r "$CI_PROJECT_DIR/build/install-x64/python/." "$CI_PROJECT_DIR"
     - export LD_LIBRARY_PATH=$CI_PROJECT_DIR/build/install-x64/lib:$LD_LIBRARY_PATH
-    - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID" > "build/install-x64/share/$CI_PROJECT_NAME"
+    - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID\nCI_PIPELINE_ID:$CI_PIPELINE_ID" > "build/install-x64/share/$CI_PROJECT_NAME"
     - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"
     - cd doc; make html SPHINXOPTS="-D html_theme_options.analytics_id=UA-4381101-5"; cd ..;
     - ~/auto-update-sphinx "$CI_PROJECT_DIR/build" "$CI_COMMIT_REF_NAME"
@@ -61,7 +61,7 @@ mac-builder:
     - cp -r "$CI_PROJECT_DIR/build/install-x64/python/." "$CI_PROJECT_DIR"
     - export LD_LIBRARY_PATH=$CI_PROJECT_DIR/build/install-x64/lib:$LD_LIBRARY_PATH
     - export DYLD_LIBRARY_PATH=$CI_PROJECT_DIR/build/install-x64/lib:DYLD_LIBRARY_PATH
-    - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID" > "build/install-x64/share/$CI_PROJECT_NAME"
+    - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID\nCI_PIPELINE_ID:$CI_PIPELINE_ID" > "build/install-x64/share/$CI_PROJECT_NAME"
     - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"
     - /Library/Frameworks/Python.Framework/Versions/3.6/bin/python3.6 -u freeze.py bdist_mac --iconfile=installer/openshot.icns --custom-info-plist=installer/Info.plist --bundle-name="OpenShot Video Editor"
     - /Library/Frameworks/Python.Framework/Versions/3.6/bin/python3.6 -u installer/build-server.py "$SLACK_TOKEN" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "False" "$CI_COMMIT_REF_NAME"
@@ -87,7 +87,7 @@ windows-builder-x64:
     - Copy-Item "$CI_PROJECT_DIR/build/install-x64/python/*" -Destination "$CI_PROJECT_DIR"
     - $env:Path = "$CI_PROJECT_DIR\build\install-x64\lib;$CI_PROJECT_DIR\build\install-x64\python;C:\msys64\mingw64\bin;C:\msys64\mingw64\lib;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;C:\msys64\usr\lib\cmake\UnitTest++;C:\msys64\usr;C:\msys64\usr\lib;" + $env:Path;
     - $env:PYTHONPATH = "$CI_PROJECT_DIR\build\install-x64\python;C:\msys64\usr\lib;C:\msys64\usr\lib\site-packages\;C:\msys64\mingw64\lib\python3.7\;C:\msys64\mingw64\lib\python3.7\site-packages\;C:\msys64\mingw64\lib\python3.7\site-packages\PyQt5;";
-    - New-Item -path "build/install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
+    - New-Item -path "build/install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID`nCI_PIPELINE_ID:$env:CI_PIPELINE_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0 '@^')
     - git log "$PREV_GIT_LABEL..@" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"
     - python3 -u freeze.py build
@@ -114,7 +114,7 @@ windows-builder-x86:
     - Copy-Item "$CI_PROJECT_DIR/build/install-x86/python/*" -Destination "$CI_PROJECT_DIR"
     - $env:Path = "$CI_PROJECT_DIR\build\install-x86\lib;$CI_PROJECT_DIR\build\install-x86\python;C:\msys32\mingw32\bin;C:\msys32\mingw32\lib;C:\msys32\mingw32\lib\python3.7\;C:\msys32\mingw32\lib\python3.7\site-packages\;C:\msys32\mingw32\lib\python3.7\site-packages\PyQt5;C:\msys32\usr\lib\cmake\UnitTest++;C:\msys32\usr;C:\msys32\usr\lib;" + $env:Path;
     - $env:PYTHONPATH = "$CI_PROJECT_DIR\build\install-x86\python;C:\msys32\usr\lib;C:\msys32\usr\lib\site-packages\;C:\msys32\mingw32\lib\python3.7\;C:\msys32\mingw32\lib\python3.7\site-packages\;C:\msys32\mingw32\lib\python3.7\site-packages\PyQt5;";
-    - New-Item -path "build/install-x86/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID" -ItemType file -force
+    - New-Item -path "build/install-x86/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID`nCI_PIPELINE_ID:$env:CI_PIPELINE_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0 '@^')
     - git log "$PREV_GIT_LABEL..@" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x86/share/$CI_PROJECT_NAME.log"
     - python3 -u freeze.py build

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -35,7 +35,6 @@ import re
 import stat
 import subprocess
 import tinys3
-import time
 import traceback
 from github3 import login
 from requests.auth import HTTPBasicAuth
@@ -193,13 +192,13 @@ def upload(file_path, github_release):
 def parse_version_info(version_path):
     """Parse version info from gitlab artifacts"""
     # Get name of version file
-    version_name = os.path.split(version_path)[1]
+    version_name = os.path.basename(version_path)
     version_info[version_name] = {
         "CI_PROJECT_NAME": None,
         "CI_COMMIT_REF_NAME": None,
         "CI_COMMIT_SHA": None,
         "CI_JOB_ID": None,
-        "COMMIT_DATE_UNIX": None,
+        "CI_PIPELINE_ID": None,
         }
 
     if os.path.exists(version_path):
@@ -261,22 +260,12 @@ try:
     openshot_qt_git_desc = ""
     needs_upload = True
 
-    # Add num of commits from libopenshot and libopenshot-audio (for naming purposes)
-    # If not an official release
-    if git_branch_name == "develop":
-        # Make filename more descriptive for daily builds (add time epoch)
-        build_date = int(
-            version_info.get('openshot-qt').get('COMMIT_DATE_UNIX', 0))
-        if not build_date:
-            log.error("Could not find commit date! %s", version_info)
-            build_date = int(time.time())
-        openshot_qt_git_desc = "OpenShot-v%s-%d" % (info.VERSION, build_date)
-        openshot_qt_git_desc = "%s-%s-%s" % (openshot_qt_git_desc, version_info.get('libopenshot').get('CI_COMMIT_SHA')[:8], version_info.get('libopenshot-audio').get('CI_COMMIT_SHA')[:8])
+    pipeline_id = version_info.get('openshot-qt').get('CI_PIPELINE_ID')
+    if git_branch_name.startswith("release"):
+        # Name release candidates with pipeline ID for uniqueness
+        openshot_qt_git_desc = "OpenShot-v%s-release-candidate-%s" % (
+            info.VERSION, pipeline_id)
         # Get daily git_release object
-        github_release = get_release(repo, "daily")
-    elif git_branch_name.startswith("release"):
-        # Get daily git_release object
-        openshot_qt_git_desc = "OpenShot-v%s-release-candidate-%d" % (info.VERSION, int(time.time()))
         github_release = get_release(repo, "daily")
     elif git_branch_name == "master":
         # Get official version release (i.e. v2.1.0, v2.x.x)
@@ -289,12 +278,18 @@ try:
             # Create a new release if one if missing
             github_release = repo.create_release(github_release_name, target_commitish="master", prerelease=True)
     else:
-        # Make filename more descriptive for daily builds
-        openshot_qt_git_desc = "OpenShot-v%s-%d" % (info.VERSION, int(time.time()))
-        openshot_qt_git_desc = "%s-%s-%s" % (openshot_qt_git_desc, version_info.get('libopenshot').get('CI_COMMIT_SHA')[:8], version_info.get('libopenshot-audio').get('CI_COMMIT_SHA')[:8])
+        # Generate unique name using library commit SHAs and pipeline ID
+        openshot_qt_git_desc = "OpenShot-v%s-%s-%s-%s" % (
+            info.VERSION,
+            pipeline_id,
+            version_info.get('libopenshot').get('CI_COMMIT_SHA')[:8],
+            version_info.get('libopenshot-audio').get('CI_COMMIT_SHA')[:8],
+            )
         # Get daily git_release object
         github_release = get_release(repo, "daily")
-        needs_upload = False
+        if git_branch_name != "develop":
+            # Only upload develop-branch pipelines as Daily Builds
+            needs_upload = False
 
     # Output git description
     output("git description of openshot-qt-git: %s" % openshot_qt_git_desc)

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -198,7 +198,9 @@ def parse_version_info(version_path):
         "CI_PROJECT_NAME": None,
         "CI_COMMIT_REF_NAME": None,
         "CI_COMMIT_SHA": None,
-        "CI_JOB_ID": None}
+        "CI_JOB_ID": None,
+        "COMMIT_DATE_UNIX": None,
+        }
 
     if os.path.exists(version_path):
         with open(version_path, "r") as f:
@@ -263,7 +265,10 @@ try:
     # If not an official release
     if git_branch_name == "develop":
         # Make filename more descriptive for daily builds (add time epoch)
-        openshot_qt_git_desc = "OpenShot-v%s-%d" % (info.VERSION, int(time.time()))
+        build_date = int(
+            version_info.get('openshot-qt').get('COMMIT_DATE_UNIX', 0)
+            ) or int(time.time())
+        openshot_qt_git_desc = "OpenShot-v%s-%d" % (info.VERSION, build_date)
         openshot_qt_git_desc = "%s-%s-%s" % (openshot_qt_git_desc, version_info.get('libopenshot').get('CI_COMMIT_SHA')[:8], version_info.get('libopenshot-audio').get('CI_COMMIT_SHA')[:8])
         # Get daily git_release object
         github_release = get_release(repo, "daily")

--- a/installer/build-server.py
+++ b/installer/build-server.py
@@ -204,9 +204,9 @@ def parse_version_info(version_path):
 
     if os.path.exists(version_path):
         with open(version_path, "r") as f:
-            for line in f.readlines():
-                line_details = line.split(":")
-                version_info[version_name][line_details[0]] = line_details[1].strip()
+            # Parse each line in f as a 'key:value' string
+            version_info[version_name].update(
+                (l.strip().split(':') for l in f.readlines()))
     else:
         # Fail
         raise Exception("Missing version artifacts: %s (%s)" % (version_path, str(version_info)))
@@ -266,8 +266,10 @@ try:
     if git_branch_name == "develop":
         # Make filename more descriptive for daily builds (add time epoch)
         build_date = int(
-            version_info.get('openshot-qt').get('COMMIT_DATE_UNIX', 0)
-            ) or int(time.time())
+            version_info.get('openshot-qt').get('COMMIT_DATE_UNIX', 0))
+        if not build_date:
+            log.error("Could not find commit date! %s", version_info)
+            build_date = int(time.time())
         openshot_qt_git_desc = "OpenShot-v%s-%d" % (info.VERSION, build_date)
         openshot_qt_git_desc = "%s-%s-%s" % (openshot_qt_git_desc, version_info.get('libopenshot').get('CI_COMMIT_SHA')[:8], version_info.get('libopenshot-audio').get('CI_COMMIT_SHA')[:8])
         # Get daily git_release object


### PR DESCRIPTION
This PR, along with OpenShot/libopenshot-audio#107 and OpenShot/libopenshot#588, implements an idea I had while discussing Daily Build versions with @rexdk in OpenShot/openshot-qt#3825:

By using the UNIX epoch date of the _openshot-qt **commit**_ that the build is generated from, instead of the value of `time.time()`, we can ensure that the set of Daily Build files generated for a given build run all have the _same_ version identifiers in their filename, and differ only by the specifics of the format/architecture targeted.

Before, due to the use of `int(time.time())` to set the first part of the build identifier, each of the builders' files was named slightly differently. 

Now, instead of e.g. (from the most recent Daily Build run):
```
OpenShot-v2.5.1-dev2-1604704263-b910d2f6-2cb4eeff-x86_64.AppImage
OpenShot-v2.5.1-dev2-1604704263-b910d2f6-2cb4eeff-x86_64.AppImage.torrent
OpenShot-v2.5.1-dev2-1604704807-b910d2f6-2cb4eeff-x86.exe
OpenShot-v2.5.1-dev2-1604704813-b910d2f6-2cb4eeff-x86_64.exe
OpenShot-v2.5.1-dev2-1604704807-b910d2f6-2cb4eeff-x86.exe.torrent
OpenShot-v2.5.1-dev2-1604704813-b910d2f6-2cb4eeff-x86_64.exe.torrent
OpenShot-v2.5.1-dev2-1604707336-b910d2f6-2cb4eeff-x86_64.dmg
OpenShot-v2.5.1-dev2-1604707336-b910d2f6-2cb4eeff-x86_64.dmg.torrent
```
We'd instead have (based on the timestamp of the triggering commit):
```
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86_64.AppImage
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86_64.AppImage.torrent
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86.exe
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86_64.exe
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86.exe.torrent
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86_64.exe.torrent
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86_64.dmg
OpenShot-v2.5.1-dev2-1604699062-b910d2f6-2cb4eeff-x86_64.dmg.torrent
```
Much nicer, IMHO.

This PR adds capture of the openshot-qt commit timestamp (as a UNIX epoch time), and storage in the `share/openshot-qt` metadata file.

It also updates `build-server.py` to:
1. Expect a new field `COMMIT_DATE_UNIX`, when reading the metadata files for all three architectures
1. Prefer `int(version_info['openshot-qt']['COMMIT_DATE_UNIX'])` as the source of the timestamp component of the build filename, although it will fall back to `int(time.time())` if for some reason the commit date isn't available.

This change may conceivably cause the Daily Build timestamps to initially go _backwards_ slightly in time, if the most recent commit ends up being timestamped _before_ the wall-clock timestamps of the previous set of builds. But even if that happens, it should hopefully be a one-time thing.
