### PR TITLE
freeze.py: Exclude remaining glib2 libs

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -317,7 +317,13 @@ elif sys.platform == "linux":
                     "libICE.so.6",
                     "libp11-kit.so.0",
                     "libSM.so.6",
+                    # Next 5 are all part of glib2
+                    "libglib-2.0.so.0",
                     "libgobject-2.0.so.0",
+                    "libgio-2.0.so.0",
+                    "libgmodule-2.0.so.0",
+                    "libgthread-2.0.so.0",
+
                     "libdrm.so.2",
                     "libfreetype.so.6",
                     "libfontconfig.so.1",


### PR DESCRIPTION
Users are reporting that our AppImages won't run on their system, with error messages pointing to a missing symbol `g_uri_ref` in `libgobject-2.0.so.0`. We don't bundle `libgobject` and we're [not supposed to](https://github.com/AppImage/pkg2appimage/blob/master/excludelist), but we do bundle `libgio-2.0.so.0` which is also a part of glib2.

This PR adds exclusions for all five `glib2` libraries, on the basis that we probably shouldn't exclude some parts and bundle other parts. If this causes problems we may have to start including `libgobject-2.0.so.0` along with the others.

(hopefully...) fixes #3807, fixes #3821 