### PR TITLE
WIP: Properties: Rewrite keyframe processing

### DIFF
--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -159,7 +159,7 @@ class PropertiesModel(updates.UpdateInterface, QObject):
 
             if clip_frame != self.frame_number:
                 self.frame_number = clip_frame
-                log.info("Update frame to %s" % self.frame_number)
+                log.info("Update frame to %s", self.frame_number)
 
             # Update the model data
             if reload_model:

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -53,8 +53,7 @@ class ClipStandardItemModel(QStandardItemModel):
 
     def mimeData(self, indexes):
         # Create MimeData for drag operation
-        data = QMimeData(self)
-        data.setObjectName("properties.mimeData")
+        data = QMimeData()
 
         # Get list of all selected file ids
         property_names = []
@@ -157,7 +156,7 @@ class PropertiesModel(updates.UpdateInterface, QObject):
             # Update the model data
             if reload_model:
                 self.update_model(get_app().window.txtPropertyFilter.text())
-                
+
     @staticmethod
     def get_lib_object(i_id: str, i_type: str) -> object:
         """Find the openshot object for a timeline item, by ID"""
@@ -173,7 +172,7 @@ class PropertiesModel(updates.UpdateInterface, QObject):
         except Exception:
             log.warning("Exception in get_lib_object", exc_info=1)
             return None
-    
+
     @staticmethod
     def get_query_object(q_id: str, q_type: str) -> QueryObject:
         """Find the query object for a timeline item, by ID"""

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -29,15 +29,15 @@ import os
 from collections import OrderedDict
 from operator import itemgetter
 
-from PyQt5.QtCore import QMimeData, Qt, QLocale, QTimer
+from PyQt5.QtCore import Qt, pyqtSlot, QObject, QLocale, QTimer, QMimeData
 from PyQt5.QtGui import (
     QStandardItemModel, QStandardItem,
     QPixmap, QColor,
     )
 
-from classes import info, updates
+from classes import updates
 from classes import openshot_rc  # noqa
-from classes.query import Clip, Transition, Effect
+from classes.query import QueryObject, Clip, Transition, Effect
 from classes.logger import log
 from classes.app import get_app
 import openshot
@@ -46,12 +46,14 @@ import json
 
 
 class ClipStandardItemModel(QStandardItemModel):
-    def __init__(self, parent=None):
-        QStandardItemModel.__init__(self)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setObjectName("properties.ClipStandardItemModel")
 
     def mimeData(self, indexes):
         # Create MimeData for drag operation
-        data = QMimeData()
+        data = QMimeData(self)
+        data.setObjectName("properties.mimeData")
 
         # Get list of all selected file ids
         property_names = []
@@ -64,7 +66,7 @@ class ClipStandardItemModel(QStandardItemModel):
         return data
 
 
-class PropertiesModel(updates.UpdateInterface):
+class PropertiesModel(updates.UpdateInterface, QObject):
     # This method is invoked by the UpdateManager each time a change happens (i.e UpdateInterface)
     def changed(self, action):
 
@@ -93,7 +95,7 @@ class PropertiesModel(updates.UpdateInterface):
         self.selected = []
         self.filter_base_properties = []
 
-        log.debug("Update item: %s" % item_type)
+        log.debug("Update %s item %s", item_type, item_id)
 
         timeline = get_app().window.timeline_sync.timeline
         if item_type == "clip":
@@ -144,451 +146,322 @@ class PropertiesModel(updates.UpdateInterface):
             fps_float = float(fps["num"]) / float(fps["den"])
 
             # Requested time
-            requested_time = float(frame_number - 1) / fps_float
+            global_time = float(frame_number - 1) / fps_float
 
-            # Determine the frame needed for this clip (based on the position on the timeline)
-            time_diff = (requested_time - clip.Position()) + clip.Start()
-            self.frame_number = round(time_diff * fps_float) + 1
+            # Map to clip time (constrained within [Start:End])
+            clip_time = max(clip.Start(),
+                            min(clip.End(),
+                                (global_time - clip.Position())
+                                + clip.Start()
+                                ))
+            clip_frame = round(clip_time * fps_float) + 1
 
-            # Calculate biggest and smallest possible frames
-            min_frame_number = round((clip.Start() * fps_float)) + 1
-            max_frame_number = round((clip.End() * fps_float)) + 1
-
-            # Adjust frame number if out of range
-            if self.frame_number < min_frame_number:
-                self.frame_number = min_frame_number
-            if self.frame_number > max_frame_number:
-                self.frame_number = max_frame_number
-
-            log.info("Update frame to %s" % self.frame_number)
+            if clip_frame != self.frame_number:
+                self.frame_number = clip_frame
+                log.info("Update frame to %s" % self.frame_number)
 
             # Update the model data
             if reload_model:
                 self.update_model(get_app().window.txtPropertyFilter.text())
 
-    def remove_keyframe(self, item):
-        """Remove an existing keyframe (if any)"""
+    @staticmethod
+    def get_query_object(q_id: str, q_type: str) -> QueryObject:
+        """Find the query object for a timeline item, by ID"""
+        if q_type == "clip":
+            return Clip.get(id=q_id)
+        if q_type == "transition":
+            return Transition.get(id=q_id)
+        if q_type == "effect":
+            return Effect.get(id=q_id)
+        return None
 
-        # Determine what was changed
-        property = self.model.item(item.row(), 0).data()
-        property_type = property[1]["type"]
-        closest_point_x = property[1]["closest_point_x"]
-        property_type = property[1]["type"]
-        property_key = property[0]
-        object_id = property[1]["object_id"]
-        clip_id, item_type = item.data()
-
-        # Find this clip
-        c = None
-        clip_updated = False
-
-        if item_type == "clip":
-            # Get clip object
-            c = Clip.get(id=clip_id)
-        elif item_type == "transition":
-            # Get transition object
-            c = Transition.get(id=clip_id)
-        elif item_type == "effect":
-            # Get effect object
-            c = Effect.get(id=clip_id)
-
-        if not c:
-            return
-
-        # Create reference 
-        clip_data = c.data
-        if object_id:
-            clip_data = c.data.get('objects').get(object_id)
-    
-        if property_key in clip_data:  # Update clip attribute
-            log_id = "{}/{}".format(clip_id, object_id) if object_id else clip_id
-            log.debug("%s: remove %s keyframe. %s", log_id, property_key, clip_data.get(property_key))
-
-            # Determine type of keyframe (normal or color)
-            keyframe_list = []
-            if property_type == "color":
-                keyframe_list = [clip_data[property_key]["red"], clip_data[property_key]["blue"], clip_data[property_key]["green"]]
+    @staticmethod
+    def make_dataref(c, obj) -> dict:
+        try:
+            if obj:
+                return c.data.get('objects', {}).get(object_id)
             else:
-                keyframe_list = [clip_data[property_key]]
+                return c.data
+        except Exception:
+            log.error("Couldn't interpret query object", exc_info=1)
 
-            # Loop through each keyframe (red, blue, and green)
-            for keyframe in keyframe_list:
+    @staticmethod
+    def optimize_data(c, prop_key, prop_data, obj=None):
+        """Reduce a query object to just the updated part"""
+        try:
+            if obj:
+                c.data = {'objects': {obj: {prop_key: prop_data}}}
+            else:
+                c.data = {prop_key: prop_data}
+        except Exception:
+            log.error("Failed to update query object", exc_info=1)
 
-                # Keyframe
-                # Loop through points, find a matching points on this frame
-                closest_point = None
-                point_to_delete = None
-                for point in keyframe["Points"]:
-                    if point["co"]["X"] == self.frame_number:
-                        # Found point, Update value
-                        clip_updated = True
-                        point_to_delete = point
-                        break
-                    if point["co"]["X"] == closest_point_x:
-                        closest_point = point
+    @staticmethod
+    def interpret_as_type(prop_type: str, prop_value):
+        try:
+            if prop_type == "int":
+                return int(prop_value)
+            if prop_type == "float":
+                return float(prop_value)
+            if prop_type == "bool":
+                return bool(prop_value)
+            if prop_type in ["string", "font", "caption"]:
+                return str(prop_value)
+            if prop_type == "color":
+                return {
+                    "red": prop_value.red(),
+                    "green": prop_value.green(),
+                    "blue": prop_value.blue(),
+                }
+            if prop_type == "reader":
+                clip_object = openshot.Clip(prop_value)
+                clip_object.Open()
+                reader_json = json.loads(clip_object.Reader().Json())
+                clip_object.Close()
+                del clip_object
+                return reader_json
+        except Exception as ex:
+            log.warn(
+                'Invalid %s value %s passed to property: %s',
+                prop_type, prop_value, ex)
+            return None
 
-                # If no point found, use closest point x
-                if not point_to_delete:
-                    point_to_delete = closest_point
-
-                # Delete point (if needed)
-                if point_to_delete:
-                    clip_updated = True
-                    log.debug("Found point to delete at X=%s" % point_to_delete["co"]["X"])
-                    keyframe["Points"].remove(point_to_delete)
-
-            # Reduce # of clip properties we are saving (performance boost)
-            clip_data = {property_key: clip_data[property_key]}
-            if object_id:
-                clip_data = {'objects': {object_id: clip_data}}
-
-            # Save changes
-            if clip_updated:
-                # Save
-                c.save()
-
-                # Update the preview
-                get_app().window.refreshFrameSignal.emit()
-
-            # Clear selection
-            self.parent.clearSelection()
-
-    def color_update(self, item, new_color, interpolation=-1, interpolation_details=[]):
-        """Insert/Update a color keyframe for the selected row"""
-
+    def update_value(self, item, value):
+        """Insert/Update a keyframe point for the selected row"""
         # Determine what was changed
-        property = self.model.item(item.row(), 0).data()
-        property_type = property[1]["type"]
-        closest_point_x = property[1]["closest_point_x"]
-        previous_point_x = property[1]["previous_point_x"]
-        property_key = property[0]
-        object_id = property[1]["object_id"]
-        clip_id, item_type = item.data()
+        prop_key, prop_data = self.model.item(item.row(), 0).data()
+        prop_type = prop_data.get("type")
+        item_id, item_type = item.data()
+        object_id = prop_data.get("object_id")
+        c = PropertiesModel.get_query_object(item_id, item_type)
+        d = PropertiesModel.make_dataref(c, object_id)
+        # Convert the new value to the correct type for this property
+        new_value = PropertiesModel.interpret_as_type(prop_type, value)
+        # Sanity checks
+        if new_value is None or not c or prop_key not in d:
+            log.error(
+                "%s %s: can't update %s property %s to %s",
+                item_type, item_id, prop_type, prop_key, str(value))
+            return
+        # Are we updating a value with keyframes?
+        if (prop_type != "reader"
+           and isinstance(d[prop_key], dict)):
+            if prop_type == "color":
+                # Colors have three keyframe lists
+                points_to_update = [
+                   (d[prop_key].get(color, {}).get("Points", []), color_value)
+                   for color, color_value in new_value.items()
+                   ]
+            else:
+                points_to_update = [(d[prop_key].get("Points", []), new_value)]
+            # Will return True if any call produces True, else False
+            updated = any([
+                PropertiesModel.set_point(
+                    points, self.frame_number, point_value)
+                for points, point_value in points_to_update
+                ])
+            if not updated:
+                return
+        else:
+            # No keyframes, just set value directly (if changed)
+            if d[prop_key] == new_value:
+                return
+            d[prop_key] = new_value
+            obj_log = f" for object {object_id}" if object_id else ""
+            log.debug(
+                "%s %s: set %s property%s %s to %s",
+                item_type, item_id,
+                obj_log,
+                prop_type, prop_key,
+                str(value),
+                )
+        # Reduce # of clip properties we are saving (performance boost)
+        PropertiesModel.optimize_data(c, prop_key, d[prop_key], object_id)
+        c.save()
+        # Update the preview
+        get_app().window.refreshFrameSignal.emit()
+        self.parent().clearSelection()
 
-        if property_type == "color":
-            # Find this clip
-            c = None
-            clip_updated = False
+    @staticmethod
+    def set_point(points: list, x_pos: int, value: float) -> bool:
+        """Set a keyframe value in list 'points'"""
+        # Sanity check
+        if len(points) < 1 or "co" not in points[0]:
+            log.warning("Cannot interpret points list!")
+            return False
+        for point in sorted(points, key=lambda p: p["co"]["X"]):
+            log.debug("looping points: co.X = %d", point["co"]["X"])
+            if point["co"]["X"] < x_pos:
+                continue
+            if point["co"]["X"] == x_pos:
+                # Found point, Update value if changed
+                if point["co"]["Y"] == value:
+                    return False
+                log.debug(
+                    "updating point: co.X = %d to value: %.3f",
+                    point["co"]["X"], value)
+                point["co"]["Y"] = value
+                return True
+            if point["co"]["X"] > x_pos:
+                # We passed the point, stop looking
+                break
+        # If we haven't returned, no such point
+        log.debug(
+            "Adding new point at co.X = %d, value %0.3f",
+            x_pos, value)
+        points.append({
+            'co': {'X': x_pos, 'Y': value},
+            'interpolation': 1,
+            })
+        points.sort(key=lambda p: p["co"]["X"])
+        return True
 
-            if item_type == "clip":
-                # Get clip object
-                c = Clip.get(id=clip_id)
-            elif item_type == "transition":
-                # Get transition object
-                c = Transition.get(id=clip_id)
-            elif item_type == "effect":
-                # Get effect object
-                c = Effect.get(id=clip_id)
+    def update_interpolation(self, item, interpolation=-1, curves=[0, 0, 0, 0]):
+        """Change the interpolation type of the current curve segment"""
+        # Determine what will be changed
+        prop_key, prop_data = self.model.item(item.row(), 0).data()
+        item_id, item_type = item.data()
+        object_id = prop_data.get("object_id")
+        c = PropertiesModel.get_query_object(item_id, item_type)
+        d = PropertiesModel.make_dataref(c, object_id)
+        # Sanity checks
+        if not c or prop_key not in d:
+            log.error(
+                "Can't find property %s for %s %s",
+                prop_key, item_type, item_id)
+            # Can't find correct values to update
+            return
+        if item_type == "color":
+            # Colors have three keyframe lists
+            points_to_update = [
+                d[prop_key].get(color, {}).get("Points", [])
+                for color in ["red", "green", "blue"]
+                ]
+        else:
+            points_to_update = [d[prop_key].get("Points", [])]
+        # Will return True if any call produces True, else False
+        updated = any([
+            PropertiesModel.set_interpolation(
+                points,
+                prop_data.get("previous_point_x"),
+                prop_data.get("closest_point_x"),
+                interpolation,
+                curves,
+            ) for points in points_to_update])
+        if not updated:
+            return
+        # Reduce # of clip properties we are saving (performance boost)
+        PropertiesModel.optimize_data(c, prop_key, d[prop_key], object_id)
+        c.save()
+        # Update the preview
+        get_app().window.refreshFrameSignal.emit()
+        self.parent().clearSelection()
 
-            if c:
-                # Create reference 
-                clip_data = c.data
-                if object_id:
-                    clip_data = c.data.get('objects').get(object_id)
+    @staticmethod
+    def set_interpolation(points: list, prev_x: float, closest_x: float, interp: int, curves: list):
+        """Set the interpolation between two keyframe points"""
+        if len(points) < 1 or "co" not in points[0]:
+            log.warning("Cannot interpret points list!")
+            return False
+        for point in sorted(points, key=lambda p: p["co"]["X"]):
+            log.debug("Searching for segment endpoints, co.X = %s", point["co"]["X"])
+            if point["co"]["X"] < prev_x:
+                continue
+            if point["co"]["X"] == prev_x and interp == openshot.BEZIER:
+                log.debug(
+                    "Setting co.X = %s handle_right(X, Y): %s",
+                    point["co"]["X"], str(curves[0:2]))
+                point.update({
+                    "handle_right": {"X": curves[0], "Y": curves[1]},
+                    })
+                continue
+            if point["co"]["X"] == closest_x:
+                log.debug(
+                    "Setting co.X = %s interpolation %s",
+                    point["co"]["X"], interp)
+                point.update({"interpolation": interp})
+                if interp == openshot.BEZIER:
+                    log.debug(
+                        "Setting co.X = %s handle_left(X, Y): %s",
+                        point["co"]["X"], str(curves[2:4]))
+                    point.update({
+                        "handle_left": {"X": curves[2], "Y": curves[3]},
+                    })
+                break
+            if point["co"]["X"] > closest_x:
+                log.warning(
+                    "Could not find curve endpoint %s", closest_x)
+                return False
+        return True
 
-                # Update clip attribute
-                if property_key in clip_data:
-                    log_id = "{}/{}".format(clip_id, object_id) if object_id else clip_id
-                    log.debug("%s: update color property %s. %s", log_id, property_key, clip_data.get(property_key))
+    def remove_keyframe(self, item):
+        """Remove an existing keyframe point (if any)"""
+        # Determine what will be changed
+        prop_key, prop_data = self.model.item(item.row(), 0).data()
+        prop_type = prop_data.get("type")
+        closest_x = prop_data.get("closest_point_x")
+        object_id = prop_data.get("object_id", None)
+        item_id, item_type = item.data()
+        c = PropertiesModel.get_query_object(item_id, item_type)
+        d = PropertiesModel.make_dataref(c, object_id)
 
-                    # Loop through each keyframe (red, blue, and green)
-                    for color, new_value in [
-                            ("red", new_color.red()),
-                            ("blue", new_color.blue()),
-                            ("green", new_color.green()),
-                            ]:
+        # Sanity checks
+        if not c or prop_key not in d:
+            log.error(
+                "%s %s: can't find %s property %s",
+                item_type, item_id, prop_type, prop_key)
+            return
+        log.debug(
+            "%s %s: Removing point %d",
+            item_type, item_id, closest_x)
+        if prop_type == "color":
+            # Colors have three keyframe lists
+            points_to_remove = [
+                d[prop_key].get(color, {}).get("Points", [])
+                for color in ["red", "green", "blue"]
+                ]
+        else:
+            points_to_remove = [d[prop_key].get("Points", [])]
+        for points in points_to_remove:
+            for point in sorted(points, key=lambda p: p["co"]["X"]):
+                if point["co"]["X"] == closest_x:
+                    points.remove(point)
+                    break
+            else:
+                log.warning("Can't find point to remove at %d", closest_x)
+                return
+        # Reduce # of clip properties we are saving (performance boost)
+        PropertiesModel.optimize_data(c, prop_key, d[prop_key], object_id)
+        c.save()
+        # Update the preview
+        get_app().window.refreshFrameSignal.emit()
+        self.parent().clearSelection()
 
-                        # Keyframe
-                        # Loop through points, find a matching points on this frame
-                        found_point = False
-                        for point in clip_data[property_key][color]["Points"]:
-                            log.debug("looping points: co.X = %s" % point["co"]["X"])
-                            if interpolation == -1 and point["co"]["X"] == self.frame_number:
-                                # Found point, Update value
-                                found_point = True
-                                clip_updated = True
-                                # Update point
-                                point["co"]["Y"] = new_value
-                                log.debug(
-                                    "updating point: co.X = %d to value: %.3f",
-                                    point["co"]["X"], float(new_value))
-                                break
-
-                            elif interpolation > -1 and point["co"]["X"] == previous_point_x:
-                                # Only update interpolation type (and the LEFT side of the curve)
-                                found_point = True
-                                clip_updated = True
-                                point["interpolation"] = interpolation
-                                if interpolation == 0:
-                                    point["handle_right"] = point.get("handle_right") or {"Y": 0.0, "X": 0.0}
-                                    point["handle_right"]["X"] = interpolation_details[0]
-                                    point["handle_right"]["Y"] = interpolation_details[1]
-
-                                log.debug(
-                                    "updating interpolation mode point: co.X = %d to %d",
-                                    point["co"]["X"], interpolation)
-                                log.debug("use interpolation preset: %s", str(interpolation_details))
-
-                            elif interpolation > -1 and point["co"]["X"] == closest_point_x:
-                                # Only update interpolation type (and the RIGHT side of the curve)
-                                found_point = True
-                                clip_updated = True
-                                point["interpolation"] = interpolation
-                                if interpolation == 0:
-                                    point["handle_left"] = point.get("handle_left") or {"Y": 0.0, "X": 0.0}
-                                    point["handle_left"]["X"] = interpolation_details[2]
-                                    point["handle_left"]["Y"] = interpolation_details[3]
-
-                                log.debug(
-                                    "updating interpolation mode point: co.X = %d to %d",
-                                    point["co"]["X"], interpolation)
-                                log.debug("use interpolation preset: %s", str(interpolation_details))
-
-                        # Create new point (if needed)
-                        if not found_point:
-                            clip_updated = True
-                            log.debug("Created new point at X=%d", self.frame_number)
-                            clip_data[property_key][color]["Points"].append({
-                                'co': {'X': self.frame_number, 'Y': new_value},
-                                'interpolation': 1,
-                                })
-
-                # Reduce # of clip properties we are saving (performance boost)
-                clip_data = {property_key: clip_data[property_key]}
-                if object_id:
-                    clip_data = {'objects': {object_id: clip_data}}
-                
-                # Save changes
-                if clip_updated:
-                    # Save
-                    c.save()
-
-                    # Update the preview
-                    get_app().window.refreshFrameSignal.emit()
-
-                # Clear selection
-                self.parent.clearSelection()
-
-    def value_updated(self, item, interpolation=-1, value=None, interpolation_details=[]):
-        """ Table cell change event - also handles context menu to update interpolation value """
-
+    @pyqtSlot('QStandardItem*')
+    def item_changed(self, item: QStandardItem):
+        """Handle itemChanged signals from underlying model"""
         if self.ignore_update_signal:
             return
+        new_value = item.data(Qt.EditRole)
+        log.debug("item value changed to %s", new_value)
+        self.update_value(item, new_value)
 
-        # Get translation method
-        _ = get_app()._tr
-
-        # Determine what was changed
-        property = self.model.item(item.row(), 0).data()
-        closest_point_x = property[1]["closest_point_x"]
-        previous_point_x = property[1]["previous_point_x"]
-        property_type = property[1]["type"]
-        property_key = property[0]
-        object_id = property[1]["object_id"]
-        clip_id, item_type = item.data()
-
-        # Get value (if any)
-        if item.text():
-            # Set and format value based on property type
-            if value is not None:
-                # Override value
-                new_value = value
-            elif property_type == "string":
-                # Use string value
-                new_value = item.text()
-            elif property_type == "bool":
-                # Use boolean value
-                if item.text() == _("False"):
-                    new_value = False
-                else:
-                    new_value = True
-            elif property_type == "int":
-                # Use int value
-                new_value = QLocale().system().toInt(item.text())[0]
-            else:
-                # Use decimal value
-                new_value = QLocale().system().toFloat(item.text())[0]
-        else:
-            new_value = None
-
-        log.info(
-            "%s for %s changed to %s at frame %s with interpolation: %s at closest x: %s"
-            % (property_key, clip_id, new_value, self.frame_number, interpolation, closest_point_x))
-
-        # Find this clip
-        c = None
-        clip_updated = False
-
-        if item_type == "clip":
-            # Get clip object
-            c = Clip.get(id=clip_id)
-        elif item_type == "transition":
-            # Get transition object
-            c = Transition.get(id=clip_id)
-        elif item_type == "effect":
-            # Get effect object
-            c = Effect.get(id=clip_id)
-
-        if c:
-            
-            # Create reference 
-            clip_data = c.data
-            if object_id:
-                clip_data = c.data.get('objects').get(object_id)
-
-            # Update clip attribute
-            if property_key in clip_data:
-                log_id = "{}/{}".format(clip_id, object_id) if object_id else clip_id
-                log.debug("%s: update property %s. %s", log_id, property_key, clip_data.get(property_key))
-
-                # Check the type of property (some are keyframe, and some are not)
-                if property_type != "reader" and type(clip_data[property_key]) == dict:
-                    # Keyframe
-                    # Loop through points, find a matching points on this frame
-                    found_point = False
-                    point_to_delete = None
-                    for point in clip_data[property_key]["Points"]:
-                        log.debug("looping points: co.X = %s" % point["co"]["X"])
-                        if interpolation == -1 and point["co"]["X"] == self.frame_number:
-                            # Found point, Update value
-                            found_point = True
-                            clip_updated = True
-                            # Update or delete point
-                            if new_value is not None:
-                                point["co"]["Y"] = float(new_value)
-                                log.debug(
-                                    "updating point: co.X = %d to value: %.3f",
-                                    point["co"]["X"], float(new_value))
-                            else:
-                                point_to_delete = point
-                            break
-
-                        elif interpolation > -1 and point["co"]["X"] == previous_point_x:
-                            # Only update interpolation type (and the LEFT side of the curve)
-                            found_point = True
-                            clip_updated = True
-                            point["interpolation"] = interpolation
-                            if interpolation == 0:
-                                point["handle_right"] = point.get("handle_right") or {"Y": 0.0, "X": 0.0}
-                                point["handle_right"]["X"] = interpolation_details[0]
-                                point["handle_right"]["Y"] = interpolation_details[1]
-
-                            log.debug(
-                                "updating interpolation mode point: co.X = %d to %d",
-                                point["co"]["X"], interpolation)
-                            log.debug("use interpolation preset: %s", str(interpolation_details))
-
-                        elif interpolation > -1 and point["co"]["X"] == closest_point_x:
-                            # Only update interpolation type (and the RIGHT side of the curve)
-                            found_point = True
-                            clip_updated = True
-                            point["interpolation"] = interpolation
-                            if interpolation == 0:
-                                point["handle_left"] = point.get("handle_left") or {"Y": 0.0, "X": 0.0}
-                                point["handle_left"]["X"] = interpolation_details[2]
-                                point["handle_left"]["Y"] = interpolation_details[3]
-
-                            log.debug(
-                                "updating interpolation mode point: co.X = %d to %d",
-                                point["co"]["X"], interpolation)
-                            log.debug("use interpolation preset: %s", str(interpolation_details))
-
-                    # Delete point (if needed)
-                    if point_to_delete:
-                        clip_updated = True
-                        log.debug("Found point to delete at X=%s" % point_to_delete["co"]["X"])
-                        clip_data[property_key]["Points"].remove(point_to_delete)
-
-                    # Create new point (if needed)
-                    elif not found_point and new_value is not None:
-                        clip_updated = True
-                        log.debug("Created new point at X=%d", self.frame_number)
-                        clip_data[property_key]["Points"].append({
-                            'co': {'X': self.frame_number, 'Y': new_value},
-                            'interpolation': 1})
-
-            if not clip_updated:
-                # If no keyframe was found, set a basic property
-                if property_type == "int":
-                    clip_updated = True
-                    try:
-                        clip_data[property_key] = int(new_value)
-                    except Exception as ex:
-                        log.warn('Invalid Integer value passed to property: %s' % ex)
-
-                elif property_type == "float":
-                    clip_updated = True
-                    try:
-                        clip_data[property_key] = float(new_value)
-                    except Exception as ex:
-                        log.warn('Invalid Float value passed to property: %s' % ex)
-
-                elif property_type == "bool":
-                    clip_updated = True
-                    try:
-                        clip_data[property_key] = bool(new_value)
-                    except Exception as ex:
-                        log.warn('Invalid Boolean value passed to property: %s' % ex)
-
-                elif property_type == "string":
-                    clip_updated = True
-                    try:
-                        clip_data[property_key] = str(new_value)
-                    except Exception as ex:
-                        log.warn('Invalid String value passed to property: %s' % ex)
-
-                elif property_type in ["font", "caption"]:
-                    clip_updated = True
-                    try:
-                        clip_data[property_key] = str(new_value)
-                    except Exception as ex:
-                        log.warn('Invalid Font/Caption value passed to property: %s' % ex)
-
-                elif property_type == "reader":
-                    # Transition
-                    clip_updated = True
-                    try:
-                        clip_object = openshot.Clip(value)
-                        clip_object.Open()
-                        clip_data[property_key] = json.loads(clip_object.Reader().Json())
-                        clip_object.Close()
-                        clip_object = None
-                    except Exception as ex:
-                        log.warn('Invalid Reader value passed to property: %s (%s)' % (value, ex))
-
-            # Reduce # of clip properties we are saving (performance boost)
-            clip_data = {property_key: clip_data.get(property_key)}
-            if object_id:
-                clip_data = {'objects': {object_id: clip_data}}
-
-            # Save changes
-            if clip_updated:
-                # Save
-                c.save()
-
-                # Update the preview
-                get_app().window.refreshFrameSignal.emit()
-
-                log.info("Item %s: changed %s to %s at frame %s (x: %s)" % (clip_id, property_key, new_value, self.frame_number, closest_point_x))
-
-            # Clear selection
-            self.parent.clearSelection()
-
-    def set_property(self, property, filter, c, item_type, object_id=None):
+    def set_property(self, prop, filt, c, item_type, object_id=None):
         app = get_app()
         _ = app._tr
-        label = property[1]["name"]
-        name = property[0]
-        value = property[1]["value"]
-        type = property[1]["type"]
-        memo = property[1]["memo"]
-        readonly = property[1]["readonly"]
-        keyframe = property[1]["keyframe"]
-        points = property[1]["points"]
-        interpolation = property[1]["interpolation"]
-        choices = property[1]["choices"]
+        name = prop[0]
+        prop_data = prop[1]
+        label = prop_data["name"]
+        value = prop_data["value"]
+        prop_type = prop_data["type"]
+        memo = prop_data["memo"]
+        readonly = prop_data["readonly"]
+        keyframe = prop_data["keyframe"]
+        points = prop_data["points"]
+        interpolation = prop_data["interpolation"]
+        choices = prop_data["choices"]
         # Add object id reference to QStandardItem
-        property[1]["object_id"] = object_id
+        prop_data["object_id"] = object_id
 
         # Adding Transparency to translation file
         transparency_label = _("Transparency")  # noqa
@@ -598,7 +471,7 @@ class PropertiesModel(updates.UpdateInterface):
             selected_choice = [c for c in choices if c["selected"] is True][0]["name"]
 
         # Hide filtered out properties
-        if filter and filter.lower() not in _(label).lower():
+        if filt and filt.lower() not in _(label).lower():
             return
 
         # Hide unused base properties (if any)
@@ -612,12 +485,12 @@ class PropertiesModel(updates.UpdateInterface):
             # Append Property Name
             col = QStandardItem("Property")
             col.setText(_(label))
-            col.setData(property)
+            col.setData(prop)
             if keyframe and points > 1:
                 col.setBackground(QColor("green"))  # Highlight keyframe background
             elif points > 1:
                 col.setBackground(QColor(42, 130, 218))  # Highlight interpolated value background
-            if readonly or type in ["color", "font", "caption"] or choices or label == "Track":
+            if readonly or prop_type in ["color", "font", "caption"] or choices or label == "Track":
                 col.setFlags(Qt.ItemIsEnabled)
             else:
                 col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)
@@ -627,24 +500,24 @@ class PropertiesModel(updates.UpdateInterface):
             col = QStandardItem("Value")
             if selected_choice:
                 col.setText(_(selected_choice))
-            elif type == "string":
+            elif prop_type == "string":
                 # Use string value
                 col.setText(memo)
-            elif type == "font":
+            elif prop_type == "font":
                 # Use font value
                 col.setText(memo)
-            elif type == "caption":
+            elif prop_type == "caption":
                 # Use caption value
                 col.setText(memo)
                 # Load caption editor also
                 get_app().window.CaptionTextLoaded.emit(memo, row)
-            elif type == "bool":
+            elif prop_type == "bool":
                 # Use boolean value
                 if value:
                     col.setText(_("True"))
                 else:
                     col.setText(_("False"))
-            elif type == "color":
+            elif prop_type == "color":
                 # Don't output a value for colors
                 col.setText("")
             elif type == "reader":
@@ -652,7 +525,7 @@ class PropertiesModel(updates.UpdateInterface):
                 reader_path = reader_json.get("path", "/")
                 fileName = os.path.basename(reader_path)
                 col.setText(fileName)
-            elif type == "int" and label == "Track":
+            elif prop_type == "int" and label == "Track":
                 # Find track display name
                 all_tracks = get_app().project.get("layers")
                 display_count = len(all_tracks)
@@ -665,7 +538,7 @@ class PropertiesModel(updates.UpdateInterface):
                 track_name = display_label or _("Track %s") % display_count
                 col.setText(track_name)
 
-            elif type == "int":
+            elif prop_type == "int":
                 col.setText("%d" % value)
             else:
                 # Use numeric value
@@ -682,14 +555,14 @@ class PropertiesModel(updates.UpdateInterface):
                 else:
                     col.setBackground(QColor(42, 130, 218))  # Highlight interpolated value background
 
-            if type == "color":
+            if prop_type == "color":
                 # Color needs to be handled special
-                red = property[1]["red"]["value"]
-                green = property[1]["green"]["value"]
-                blue = property[1]["blue"]["value"]
+                red = prop_data["red"]["value"]
+                green = prop_data["green"]["value"]
+                blue = prop_data["blue"]["value"]
                 col.setBackground(QColor(red, green, blue))
 
-            if readonly or type in ["color", "font", "caption"] or choices or label == "Track":
+            if readonly or prop_type in ["color", "font", "caption"] or choices or label == "Track":
                 col.setFlags(Qt.ItemIsEnabled)
             else:
                 col.setFlags(
@@ -706,7 +579,7 @@ class PropertiesModel(updates.UpdateInterface):
             # Update the value of the existing model
             # Get 1st Column
             col = self.items[name]["row"][0]
-            col.setData(property)
+            col.setData(prop)
 
             # For non-color types, update the background color
             if keyframe and points > 1:
@@ -723,25 +596,25 @@ class PropertiesModel(updates.UpdateInterface):
             col = self.items[name]["row"][1]
             if selected_choice:
                 col.setText(_(selected_choice))
-            elif type == "string":
+            elif prop_type == "string":
                 # Use string value
                 col.setText(memo)
-            elif type == "font":
+            elif prop_type == "font":
                 # Use font value
                 col.setText(memo)
-            elif type == "caption":
+            elif prop_type == "caption":
                 # Use caption value
                 col.setText(memo)
-            elif type == "bool":
+            elif prop_type == "bool":
                 # Use boolean value
                 if value:
                     col.setText(_("True"))
                 else:
                     col.setText(_("False"))
-            elif type == "color":
+            elif prop_type == "color":
                 # Don't output a value for colors
                 col.setText("")
-            elif type == "int" and label == "Track":
+            elif prop_type == "int" and label == "Track":
                 # Find track display name
                 all_tracks = get_app().project.get("layers")
                 display_count = len(all_tracks)
@@ -753,10 +626,10 @@ class PropertiesModel(updates.UpdateInterface):
                     display_count -= 1
                 track_name = display_label or _("Track %s") % display_count
                 col.setText(track_name)
-            elif type == "int":
+            elif prop_type == "int":
                 col.setText("%d" % value)
-            elif type == "reader":
-                reader_json = json.loads(property[1].get("memo", "{}"))
+            elif prop_type == "reader":
+                reader_json = json.loads(prop_data.get("memo", "{}"))
                 reader_path = reader_json.get("path", "/")
                 fileName = os.path.basename(reader_path)
                 col.setText("%s" % fileName)
@@ -783,21 +656,20 @@ class PropertiesModel(updates.UpdateInterface):
                 my_icon = QPixmap()
                 col.setData(my_icon, Qt.DecorationRole)
 
-            if type == "color":
+            if prop_type == "color":
                 # Update the color based on the color curves
-                red = property[1]["red"]["value"]
-                green = property[1]["green"]["value"]
-                blue = property[1]["blue"]["value"]
+                red = prop_data["red"]["value"]
+                green = prop_data["green"]["value"]
+                blue = prop_data["blue"]["value"]
                 col.setBackground(QColor(red, green, blue))
 
             # Update helper dictionary
             row.append(col)
 
         # Keep track of items in a dictionary (for quick look up)
-        self.items[name] = {"row": row, "property": property}
+        self.items[name] = {"row": row, "property": prop}
 
-    def update_model(self, filter=""):
-        log.debug("updating clip properties model.")
+    def update_model(self, filt=""):
         app = get_app()
         _ = app._tr
 
@@ -817,9 +689,9 @@ class PropertiesModel(updates.UpdateInterface):
             all_properties = OrderedDict(sorted(raw_properties.items(), key=lambda x: x[1]['name']))
 
             # Check if filter was changed (if so, wipe previous model data)
-            if self.previous_filter != filter:
-                self.previous_filter = filter
-                self.new_item = True  # filter changed, so we need to regenerate the entire model
+            if self.previous_filter != filt:
+                self.previous_filter = filt
+                self.new_item = True
 
             # Ignore any events from this method
             self.ignore_update_signal = True
@@ -837,15 +709,15 @@ class PropertiesModel(updates.UpdateInterface):
                 get_app().window.CaptionTextLoaded.emit("", None)
 
             # Loop through properties, and build a model
-            for property in all_properties.items():
-                self.set_property(property, filter, c, item_type)
+            for prop in all_properties.items():
+                self.set_property(prop, filt, c, item_type)
 
             # Insert objects properties from custom effects
             if objects_raw_properties:
                 for obj_id in objects_raw_properties:
                     objects_all_properties = OrderedDict(sorted(objects_raw_properties[obj_id].items(), key=lambda x: x[1]['name']))
-                    for property in objects_all_properties.items():
-                        self.set_property(property, filter, c, item_type, object_id=obj_id)
+                    for prop in objects_all_properties.items():
+                        self.set_property(prop, filt, c, item_type, object_id=obj_id)
 
             # Update the values on the next call to this method (instead of adding rows)
             self.new_item = False
@@ -863,7 +735,8 @@ class PropertiesModel(updates.UpdateInterface):
         # Done updating model
         self.ignore_update_signal = False
 
-    def __init__(self, parent, *args):
+    def __init__(self, parent=None, *args, **kwargs):
+        super().__init__(parent, *args, **kwargs)
 
         # Keep track of the selected items (clips, transitions, etc...)
         self.selected = []
@@ -873,25 +746,25 @@ class PropertiesModel(updates.UpdateInterface):
         self.new_item = True
         self.items = {}
         self.ignore_update_signal = False
-        self.parent = parent
         self.previous_filter = None
         self.filter_base_properties = []
 
         # Create standard model
-        self.model = ClipStandardItemModel()
+        self.model = ClipStandardItemModel(self)
         self.model.setColumnCount(2)
 
         # Timer to use a delay before showing properties (to prevent a mass selection from trying
         # to update the property model hundreds of times)
-        self.update_timer = QTimer(parent)
+        self.update_timer = QTimer(self)
+        self.update_timer.setObjectName("properties.update_timer")
         self.update_timer.setInterval(100)
         self.update_timer.setSingleShot(True)
         self.update_timer.timeout.connect(self.update_item_timeout)
         self.next_item_id = None
         self.next_item_type = None
 
-        # Connect data changed signal
-        self.model.itemChanged.connect(self.value_updated)
+        # Connect data changed signal for underlying model
+        self.model.itemChanged.connect(self.item_changed)
 
         # Add self as listener to project data updates (used to update the timeline)
         get_app().updates.add_listener(self)

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -27,6 +27,7 @@
 
 import os
 from collections import OrderedDict
+from typing import Sequence
 from operator import itemgetter
 
 from PyQt5.QtCore import Qt, pyqtSlot, QObject, QLocale, QTimer, QMimeData
@@ -316,7 +317,8 @@ class PropertiesModel(updates.UpdateInterface, QObject):
         points.sort(key=lambda p: p["co"]["X"])
         return True
 
-    def update_interpolation(self, item, interpolation=-1, handles=[0, 0, 0, 0]):
+    def update_interpolation(
+            self, item, interpolation=-1, handles=(0.0, 0.0, 0.0, 0.0)):
         """Change the interpolation type of the current curve segment"""
         # Determine what will be changed
         prop_key, prop_data = self.model.item(item.row(), 0).data()
@@ -358,7 +360,9 @@ class PropertiesModel(updates.UpdateInterface, QObject):
         self.parent().clearSelection()
 
     @staticmethod
-    def set_interpolation(points: list, prev_x: float, closest_x: float, interp: int, handles: list):
+    def set_interpolation(
+            points: list, prev_x: float, closest_x: float,
+            interp: int, handles: Sequence[float]):
         """Set the interpolation between two keyframe points"""
         if len(points) < 1 or "co" not in points[0]:
             log.warning("Cannot interpret points list!")
@@ -745,8 +749,8 @@ class PropertiesModel(updates.UpdateInterface, QObject):
         # Done updating model
         self.ignore_update_signal = False
 
-    def __init__(self, parent=None, *args, **kwargs):
-        super().__init__(parent, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         # Keep track of the selected items (clips, transitions, etc...)
         self.selected = []

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -416,9 +416,6 @@ class PropertiesModel(updates.UpdateInterface, QObject):
                 "%s %s: can't find %s property %s",
                 item_type, item_id, prop_type, prop_key)
             return
-        log.debug(
-            "%s %s: Removing point %d",
-            item_type, item_id, closest_x)
         if prop_type == "color":
             # Colors have three keyframe lists
             points_to_remove = [
@@ -428,8 +425,16 @@ class PropertiesModel(updates.UpdateInterface, QObject):
         else:
             points_to_remove = [d[prop_key].get("Points", [])]
         for points in points_to_remove:
+            if len(points) <= 1:
+                log.warning(
+                    "%s %s: Can't delete last point for %s!",
+                    item_type, item_id, prop_key)
+                return False
             for point in sorted(points, key=lambda p: p["co"]["X"]):
                 if point["co"]["X"] == closest_x:
+                    log.debug(
+                        "%s %s: Removing point %d",
+                        item_type, item_id, closest_x)
                     points.remove(point)
                     break
             else:


### PR DESCRIPTION
- `PropertiesModel.value_updated()` was an overworked method that performed all of the following functions:
  * Inserting new keyframe points
  * Updating existing keyframe points
  * Updating NON-keyframe property values
  * Changing interpolation types for existing keyframes
  * Handling `itemChange` signals from the properties table (which are emitted when the user edits a property value by double-clicking and typing, as opposed to dragging the sliders or using the context menus)
  * Converting values produced by the properties model to the proper data type / format for insertion into the project data store.

  As a result, it was a confusing ramble of conditional logic.

- Yet, color properties (specifically, and only) were handled by a separate (but largely cut-and-paste identical) `color_updated()` method.

So, with this PR, I have:
- Broken all of the `value_updated()` logic apart into separate, purpose-focused methods:
  * `update_value()` to set/modify properties
  * `set_point()`, a staticmethod that creates/modifies points in a single keyframe point list (called by `update_value()` one or multiple times to adjust individual property curves)
  * `update_interpolation()` to apply keyframe interpolation parameters
  * `set_interpolation()`, a staticmethod that adjusts interpolation values for a single keyframe point list (called by `update_interpolation()` one or multiple times to adjust individual property curves)
  * `item_changed()`, the slot that processes the itemChanged signal from the properties view (by calling `update_value()` with the necessary parameters)
  * `interpret_as_type()`, a staticmethod used to convert model data values into project data values before applying them to the project dict.
- Generalized all of the above to handle color and non-color properties, both keyframe and non-keyframe, supporting all implemented data types. (The `TODO` about adding `QFont`/`QFontInfo` support to the old `value_updated()` method has been redirected to `interpret_as_type()`, where that support would now be implemented... but has not yet been.)
- Rewritten `remove_keyframe()` to supplement and complement the new methods listed above

WIP because I have about 100 corner cases to test, to ensure that this is fully compatible with the old code (except where it fixes bugs in the old code). And also because there's a lot of ongoing conversation in #3823 that's worth incorporating into these changes. But I wanted to get it out there early.

Ultimately, hopefully: Fixes #3823