### PR TITLE
Timeline CSS: More visible keyframe marks

### DIFF
--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -1424,7 +1424,10 @@ App.controller("TimelineCtrl", function ($scope) {
         images: {start: 3, end: 7},
         show_audio: false,
         alpha: {Points: []},
-        location_x: {Points: []},
+        location_x: {Points: [
+				  {co: {X: 1.0, Y: -0.5}},
+          {co: {X: 30.0, Y: -0.4}}
+        ]},
         location_y: {Points: []},
         scale_x: {Points: []},
         scale_y: {Points: []},

--- a/src/timeline/media/css/main.css
+++ b/src/timeline/media/css/main.css
@@ -116,13 +116,13 @@ img {
     bottom: 0px;
     height: 8px;
     width: 10px;
-    margin-left: -7px;
+    margin-left: -5px;
 }
 .point_icon {
-    width: 1px;
+    width: 2px;
     height: 6px;
-    margin: 0 4px;
     background: -webkit-gradient(linear, left top, left bottom, color-stop(40%,rgba(0,255,0,1)), color-stop(100%,rgba(0,255,0,0)));
+    margin: 0 3px;
 }
 
 /* Transitions */

--- a/src/timeline/media/css/main.css
+++ b/src/timeline/media/css/main.css
@@ -114,14 +114,16 @@ img {
 .point_region {
     position: absolute;
     bottom: 0px;
-    height: 8px;
+    height: 10px;
     width: 10px;
     margin-left: -5px;
+    margin-bottom: -6px;
+    overflow: visible;
 }
 .point_icon {
     width: 2px;
-    height: 6px;
-    background: -webkit-gradient(linear, left top, left bottom, color-stop(40%,rgba(0,255,0,1)), color-stop(100%,rgba(0,255,0,0)));
+    height: 10px;
+    background: linear-gradient(180deg, #0f08, #0f0);
     margin: 0 3px;
 }
 


### PR DESCRIPTION
This PR makes a small tweak to the Timeline CSS, with the goal of making the keyframe position markings (the small green ticks along the lower edge of the clip/transition) slightly more visible.

1. It shifts the marks slightly to the right (by `2px`, since I noticed marks at the first frame had slid slightly beyond the edge of the canvas for clips positioned at the far left of the Timeline)
1. It widens each mark from `1px` wide to `2px` wide, ensuring that a mark can't disappear completely behind the playhead line when they're both positioned at the same frame.

Before:

![Screenshot from 2020-11-17 01-12-57](https://user-images.githubusercontent.com/538020/99353395-6ae97680-2872-11eb-8a4d-fdb4a03f4687.png)

(Granted, the point where a mark could disappear behind the playhead line entirely wasn't actually the same position _as_ the keyframe, indicating that the positioning issues went even deeper:)

![Screenshot from 2020-11-17 01-12-40](https://user-images.githubusercontent.com/538020/99353486-99675180-2872-11eb-9723-fb746cf8dddf.png)

Nevertheless, both problems are solved in the After:

![Screenshot from 2020-11-17 01-08-38](https://user-images.githubusercontent.com/538020/99353510-ac7a2180-2872-11eb-908e-a499b6346e32.png)

![Screenshot from 2020-11-17 01-08-48](https://user-images.githubusercontent.com/538020/99353515-b00da880-2872-11eb-806a-c0b479480e67.png)
