### PR TITLE
Install a workflow to run Conflict Adviser on PRs

### DIFF
--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -1,0 +1,16 @@
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Marr11317/ConflictAdviser@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          conflict_label: "conflicts"
+          comment: 'Merge conflicts have been detected on this PR, please resolve.'

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -1,3 +1,4 @@
+name: Conflict Adviser
 on:
   push:
     branches:


### PR DESCRIPTION
[Conflict Adviser](https://github.com/Marr11317/ConflictAdviser) is a Github Actions tool that labels and comments on PRs with unresolved merge conflicts. Github very regrettably doesn't provide any visual indication of conflict status in a way that can be searched, filtered, or scanned for, the only way to discover merge conflicts is to open the individual PR page and scroll to the bottom.

With Conflict Adviser, every push to the `develop` branch will trigger a run that scans each PR, and if Github indicates that there are conflicts (based on the results of an async detection job that it runs, which are queryable using the Github API) then the designated label is applied. A comment is also left by the workflow. (The comment will generate an email notification for the submitter, something merely adding a label will not do).

If conflicts have been resolved, the label should eventually be removed automatically, though due to the async nature of the detection process and etc. there may be a delay. It's reasonable for submitters who have commit access to clear the label on their own if they choose to, once they've completed conflict resolution.