### PR TITLE
Install a workflow to label PRs with merge conflicts

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,0 +1,30 @@
+
+name: Label merge conflicts
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the develop branch
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+    types: [opened, synchronize, reopened]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: eps1lon/actions-label-merge-conflict@v2.0.0
+        with:
+          # Token for the repository. Can be passed in using {{ secrets.GITHUB_TOKEN }}
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          # Name of the label which indicates that the branch is dirty
+          dirtyLabel: 'conflicts'
+          # Number of seconds after which the action runs again if the mergable state is unknown.
+          retryAfter: 300
+          # Number of times the action retries calculating the mergable state
+          retryMax: 2
+          # String. Comment to add when the pull request is conflicting. Supports markdown.
+          commentOnDirty: 'Merge conflicts have been detected on this PR, please resolve.'
+  


### PR DESCRIPTION
Let's try this again...

Label Merge Conflicts is a Github Actions tool that labels and comments on PRs with unresolved merge conflicts. Github very regrettably doesn't provide any visual indication of conflict status in a way that can be searched, filtered, or scanned for, the only way to discover merge conflicts is to open the individual PR page and scroll to the bottom.

Now, every push to the `develop` branch will trigger a workflow run that scans each PR, and if Github indicates that there are conflicts (based on the results of an async detection job that it runs, which are queryable using the Github API) then the designated label is applied. A comment is also left by the workflow. (The comment will generate an email notification for the submitter, something merely adding a label will not do).

If conflicts have been resolved, the label should eventually be removed automatically, though due to the async nature of the detection process and etc. there may be a delay. It's reasonable for submitters who have commit access to clear the label on their own if they choose to, once they've completed conflict resolution.