### PR TITLE
Upgrade label-merge-conflicts action to version 2.0.1

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -15,7 +15,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: eps1lon/actions-label-merge-conflict@v2.0.0
+      - uses: eps1lon/actions-label-merge-conflict@v2.0.1
         with:
           # Token for the repository. Can be passed in using {{ secrets.GITHUB_TOKEN }}
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,0 +1,30 @@
+
+name: Label merge conflicts
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the develop branch
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+    types: [opened, synchronize, reopened]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: eps1lon/actions-label-merge-conflict@v2.0.0
+        with:
+          # Token for the repository. Can be passed in using {{ secrets.GITHUB_TOKEN }}
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          # Name of the label which indicates that the branch is dirty
+          dirtyLabel: 'conflicts'
+          # Number of seconds after which the action runs again if the mergable state is unknown.
+          retryAfter: 300
+          # Number of times the action retries calculating the mergable state
+          retryMax: 2
+          # String. Comment to add when the pull request is conflicting. Supports markdown.
+          commentOnDirty: 'Merge conflicts have been detected on this PR, please resolve.'
+  


### PR DESCRIPTION
Version 2.0.0 (the first one installed) had a retry timeout bug that hit us on the very first attempted run (which I had to abort after 30 minutes of spinning). That bug should be fixed by eps1lon/actions-label-merge-conflict#31, included in v2.0.1.