### PR TITLE
Label merge conflicts: lower retry delay, raise retry count

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -15,7 +15,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: eps1lon/actions-label-merge-conflict@v2.0.0
+      - uses: eps1lon/actions-label-merge-conflict@v2.0.1
         with:
           # Token for the repository. Can be passed in using {{ secrets.GITHUB_TOKEN }}
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,0 +1,30 @@
+
+name: Label merge conflicts
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the develop branch
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+    types: [opened, synchronize, reopened]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: eps1lon/actions-label-merge-conflict@v2.0.0
+        with:
+          # Token for the repository. Can be passed in using {{ secrets.GITHUB_TOKEN }}
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          # Name of the label which indicates that the branch is dirty
+          dirtyLabel: 'conflicts'
+          # Number of seconds after which the action runs again if the mergable state is unknown.
+          retryAfter: 300
+          # Number of times the action retries calculating the mergable state
+          retryMax: 2
+          # String. Comment to add when the pull request is conflicting. Supports markdown.
+          commentOnDirty: 'Merge conflicts have been detected on this PR, please resolve.'
+  

--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -22,9 +22,9 @@ jobs:
           # Name of the label which indicates that the branch is dirty
           dirtyLabel: 'conflicts'
           # Number of seconds after which the action runs again if the mergable state is unknown.
-          retryAfter: 300
+          retryAfter: 60
           # Number of times the action retries calculating the mergable state
-          retryMax: 2
+          retryMax: 5
           # String. Comment to add when the pull request is conflicting. Supports markdown.
           commentOnDirty: 'Merge conflicts have been detected on this PR, please resolve.'
   


### PR DESCRIPTION
The retry delay I set was way, waaay too high (`300` seconds), and the max retries was too low (`2`). Tweaking them to `60` seconds and `5`, respectively.