### PR TITLE
Horizontal scroll of the timeline using SHIFT+scroll wheel

### DIFF
--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -284,6 +284,13 @@ App.controller("TimelineCtrl", function ($scope) {
     scrolling_tracks.scrollLeft(new_cursor_x);
   };
 
+  // Scroll the timeline horizontally of a certain amount (scrol_value)
+  $scope.scrollLeft = function (scroll_value) {
+    var scrolling_tracks = $("#scrolling_tracks");
+    var horz_scroll_offset = scrolling_tracks.scrollLeft();
+    scrolling_tracks.scrollLeft(horz_scroll_offset + scroll_value);
+  };
+
   // Center the timeline on a given time position
   $scope.centerOnTime = function (centerTime) {
     // Get the width of the timeline

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -284,13 +284,6 @@ App.controller("TimelineCtrl", function ($scope) {
     scrolling_tracks.scrollLeft(new_cursor_x);
   };
 
-  // Scroll the timeline horizontally of a certain amount (scrol_value)
-  $scope.scrollLeft = function (scroll_value) {
-    var scrolling_tracks = $("#scrolling_tracks");
-    var horz_scroll_offset = scrolling_tracks.scrollLeft();
-    scrolling_tracks.scrollLeft(horz_scroll_offset + scroll_value);
-  };
-
   // Center the timeline on a given time position
   $scope.centerOnTime = function (centerTime) {
     // Get the width of the timeline

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2703,6 +2703,12 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         # Execute JavaScript to center the timeline
         self.run_js(JS_SCOPE_SELECTOR + '.centerOnPlayhead();')
 
+    @pyqtSlot()
+    def scrollLeft(self, scroll_value):
+        """ --------------------------- """
+        # Execute JavaScript to -----------------
+        self.run_js(JS_SCOPE_SELECTOR + '.scrollLeft(%s);' % int(scroll_value))
+
     @pyqtSlot(int)
     def SetSnappingMode(self, enable_snapping):
         """ Enable / Disable snapping mode """
@@ -2781,13 +2787,18 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             get_app().updates.update(["scale"], newScale)
             get_app().updates.ignore_history = False
 
-    # Capture wheel event to alter zoom slider control
+    # Capture wheel event to alter zoom slider control or to use SHIFT+scroll for horizontal scroll
     def wheelEvent(self, event):
         if int(QCoreApplication.instance().keyboardModifiers() & Qt.ControlModifier) > 0:
             # For each 120 (standard scroll unit) adjust the zoom slider
             tick_scale = 120
             steps = int(event.angleDelta().y() / tick_scale)
             self.window.sliderZoom.setValue(self.window.sliderZoom.value() - self.window.sliderZoom.pageStep() * steps)
+        elif int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0:            
+            # For each 120 (standard scroll unit) scroll horizontally
+            tick_scale = 120
+            steps = int(event.angleDelta().y() / tick_scale)
+            self.scrollLeft(-steps*100)
         else:
             # Otherwise pass on to implement default functionality (scroll in QWebEngineView)
             super(type(self), self).wheelEvent(event)

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2705,8 +2705,8 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
     @pyqtSlot()
     def scrollLeft(self, scroll_value):
-        """ Horizontally scroll the timeline of scroll_value """
-        # Execute JavaScript to scroll the timeline
+        """ --------------------------- """
+        # Execute JavaScript to -----------------
         self.run_js(JS_SCOPE_SELECTOR + '.scrollLeft(%s);' % int(scroll_value))
 
     @pyqtSlot(int)

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2703,12 +2703,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         # Execute JavaScript to center the timeline
         self.run_js(JS_SCOPE_SELECTOR + '.centerOnPlayhead();')
 
-    @pyqtSlot()
-    def scrollLeft(self, scroll_value):
-        """ --------------------------- """
-        # Execute JavaScript to -----------------
-        self.run_js(JS_SCOPE_SELECTOR + '.scrollLeft(%s);' % int(scroll_value))
-
     @pyqtSlot(int)
     def SetSnappingMode(self, enable_snapping):
         """ Enable / Disable snapping mode """
@@ -2787,18 +2781,13 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             get_app().updates.update(["scale"], newScale)
             get_app().updates.ignore_history = False
 
-    # Capture wheel event to alter zoom slider control or to use SHIFT+scroll for horizontal scroll
+    # Capture wheel event to alter zoom slider control
     def wheelEvent(self, event):
         if int(QCoreApplication.instance().keyboardModifiers() & Qt.ControlModifier) > 0:
             # For each 120 (standard scroll unit) adjust the zoom slider
             tick_scale = 120
             steps = int(event.angleDelta().y() / tick_scale)
             self.window.sliderZoom.setValue(self.window.sliderZoom.value() - self.window.sliderZoom.pageStep() * steps)
-        elif int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0:            
-            # For each 120 (standard scroll unit) scroll horizontally
-            tick_scale = 120
-            steps = int(event.angleDelta().y() / tick_scale)
-            self.scrollLeft(-steps*100)
         else:
             # Otherwise pass on to implement default functionality (scroll in QWebEngineView)
             super(type(self), self).wheelEvent(event)

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2783,14 +2783,17 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
     # Capture wheel event to alter zoom slider control
     def wheelEvent(self, event):
-        if int(QCoreApplication.instance().keyboardModifiers() & Qt.ControlModifier) > 0:
+        if event.modifiers() & Qt.ControlModifier:
+            event.accept()
+            zoom = self.window.sliderZoom
             # For each 120 (standard scroll unit) adjust the zoom slider
             tick_scale = 120
             steps = int(event.angleDelta().y() / tick_scale)
-            self.window.sliderZoom.setValue(self.window.sliderZoom.value() - self.window.sliderZoom.pageStep() * steps)
+            delta = zoom.pageStep() * steps
+            log.debug("Zooming by %d steps", -steps)
+            zoom.setValue(zoom.value() - delta)
         else:
-            # Otherwise pass on to implement default functionality (scroll in QWebEngineView)
-            super(type(self), self).wheelEvent(event)
+            super().wheelEvent(event)
 
     # An item is being dragged onto the timeline (mouse is entering the timeline now)
     def dragEnterEvent(self, event):

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2705,8 +2705,8 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
     @pyqtSlot()
     def scrollLeft(self, scroll_value):
-        """ --------------------------- """
-        # Execute JavaScript to -----------------
+        """ Horizontally scroll the timeline of scroll_value """
+        # Execute JavaScript to scroll the timeline
         self.run_js(JS_SCOPE_SELECTOR + '.scrollLeft(%s);' % int(scroll_value))
 
     @pyqtSlot(int)

--- a/src/windows/views/webview_backend/webkit.py
+++ b/src/windows/views/webview_backend/webkit.py
@@ -123,3 +123,20 @@ class TimelineWebKitView(QWebView):
         else:
             # Ignore most keypresses
             event.ignore()
+
+    def wheelEvent(self, event):
+        """ Mousewheel scrolling """
+        if event.modifiers() & Qt.ShiftModifier:
+            event.accept()
+            frame = self.page().mainFrame()
+            # Compute scroll offset from wheel motion
+            tick_scale = 120
+            steps = int(event.angleDelta().y() / tick_scale)
+            delta = -(steps * 100)
+            log.debug("Scrolling horizontally by %d pixels", delta)
+            # Update the scroll position using AngularJS
+            js = f"$('body').scope().scrollLeft({delta});"
+            frame.evaluateJavaScript(js)
+        else:
+            super().wheelEvent(event)
+

--- a/src/windows/views/webview_backend/webkit.py
+++ b/src/windows/views/webview_backend/webkit.py
@@ -135,8 +135,7 @@ class TimelineWebKitView(QWebView):
             delta = -(steps * 100)
             log.debug("Scrolling horizontally by %d pixels", delta)
             # Update the scroll position using AngularJS
-            js = f"$('body').scope().scrollLeft({delta});"
+            js = "$('body').scope().scrollLeft({});".format(delta)
             frame.evaluateJavaScript(js)
         else:
             super().wheelEvent(event)
-


### PR DESCRIPTION
This PR adds a new functionality that allows the user to horizontally scroll the timeline using SHIFT+scroll. This is widely used in other programs, and particularly useful when using a mouse (indeed, horizontal scroll is already handled for trackpads). It allows not to have to manually click on the scroll bar to move horizontally. The same convention for the correspondence of scrolling down/up resulting in moving right/left was used to be consistent with other programs.

The scroll speed is proportional to the timeline window, which means that it doesn't scroll faster if the timeline is zoomed in or not (which honestly would be really annoying). The scroll speed was set arbitrarily based on my feeling of the most comfortable.