### PR TITLE
TimelineWebView: Log WebKit import fail reason

### DIFF
--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -169,7 +169,7 @@ else:
             from .webview_backend.webkit import TimelineWebKitView as WebViewClass
             WEBVIEW_LOADED = True
         except ImportError:
-            pass
+            log.error("Import failure loading WebKit backend", exc_info=1)
         finally:
             if not WEBVIEW_LOADED:
                 raise RuntimeError(


### PR DESCRIPTION
If we only raise an exception from the WebEngine import failure, when **both** backends fail to import, then we lose any visibility into the reason WHY the WebKit backend failed to load. (Important if the failure reason is a code error, not a missing PyQtWebKit module.)

In #3857 we discovered that bugs in the `TimelineWebKitView` code could lead to confusing unit test failures, due to the backend class silently failing to import. This PR will make it not-so-silent.