### PR TITLE
"Copy Keyframes > All" includes "Crop *" settings

### DIFF
--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1462,6 +1462,10 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 self.copy_clipboard[clip_id] = clip.data
             elif action == MENU_COPY_KEYFRAMES_ALL:
                 self.copy_clipboard[clip_id]['alpha'] = clip.data['alpha']
+                self.copy_clipboard[clip_id]['crop_height'] = clip.data['crop_height']
+                self.copy_clipboard[clip_id]['crop_width'] = clip.data['crop_width']
+                self.copy_clipboard[clip_id]['crop_x'] = clip.data['crop_x']
+                self.copy_clipboard[clip_id]['crop_y'] = clip.data['crop_y']
                 self.copy_clipboard[clip_id]['gravity'] = clip.data['gravity']
                 self.copy_clipboard[clip_id]['scale_x'] = clip.data['scale_x']
                 self.copy_clipboard[clip_id]['scale_y'] = clip.data['scale_y']


### PR DESCRIPTION
(Feel free to ignore / reject this PR or tell me i'm out of my mind)

But this may help someone who maybe expecting the Copy Keyframes > All feature to include the Crop keyframes (which work together with scaling X/Y and location X/Y to "frame" a video nicely).

Added data elements during copy in my proposal:
-`crop_x`
-`crop_y`
-`crop_height`
-`crop_width`

Tested it locally and seems to work. Not sure if there is a catch. Again, please just tell me if there is.

Hope this helps