### PR TITLE
Add a Dependabot configuration to automatically check for outdated Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Github's [Dependabot](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-dependencies-updated-automatically) is a tool that scans for version updates of supported dependencies, and will automatically open pull requests to update when new versions are discovered.

This PR enables Dependabot scanning for our Github Actions, as we now make use of enough of them that it's worth making sure we keep up to date with new releases.