### PR TITLE
Eliminate the Ubuntu Unity integration

### DIFF
--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -41,14 +41,15 @@ except ImportError:
 
 from xml.parsers.expat import ExpatError
 
-from PyQt5.QtCore import Qt, QCoreApplication, QTimer, QSize
+from PyQt5.QtCore import Qt, QCoreApplication, QTimer, QSize, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
     QMessageBox, QDialog, QFileDialog, QDialogButtonBox, QPushButton
 )
 from PyQt5.QtGui import QIcon
 
 from classes import info
-from classes import ui_util, openshot_rc
+from classes import ui_util
+from classes import openshot_rc  # noqa
 from classes import settings
 from classes.logger import log
 from classes.app import get_app
@@ -63,6 +64,10 @@ class Export(QDialog):
 
     # Path to ui file
     ui_path = os.path.join(info.PATH, 'windows', 'ui', 'export.ui')
+
+    ExportStarted = pyqtSignal(str, int, int)
+    ExportFrame = pyqtSignal(str, int, int, int, str)
+    ExportEnded = pyqtSignal(str)
 
     def __init__(self):
 
@@ -202,7 +207,7 @@ class Export(QDialog):
         self.cboSimpleQuality.currentIndexChanged.connect(
             functools.partial(self.cboSimpleQuality_index_changed, self.cboSimpleQuality))
         self.cboChannelLayout.currentIndexChanged.connect(self.updateChannels)
-        get_app().window.ExportFrame.connect(self.updateProgressBar)
+        self.ExportFrame.connect(self.updateProgressBar)
 
         # ********* Advanced Profile List **********
         # Loop through profiles
@@ -313,6 +318,7 @@ class Export(QDialog):
             if profile_path == path:
                 return profile
 
+    @pyqtSlot(str, int, int, int, str)
     def updateProgressBar(self, title_message, start_frame, end_frame, current_frame, format_of_progress_string):
         """Update progress bar during exporting"""
         if end_frame - start_frame > 0:
@@ -721,7 +727,6 @@ class Export(QDialog):
                 'fps': fps}
             return title_mes
 
-
         # get translations
         _ = get_app()._tr
 
@@ -905,7 +910,7 @@ class Export(QDialog):
 
             # Notify window of export started
             title_message = ""
-            get_app().window.ExportStarted.emit(export_file_path, video_settings.get("start_frame"), video_settings.get("end_frame"))
+            self.ExportStarted.emit(export_file_path, video_settings.get("start_frame"), video_settings.get("end_frame"))
 
             progressstep = max(1 , round(( video_settings.get("end_frame") - video_settings.get("start_frame") ) / 1000))
             start_time_export = time.time()
@@ -948,7 +953,13 @@ class Export(QDialog):
                             title_message = titlestring(seconds_left, fps_encode, "Remaining")
 
                     # Emit frame exported
-                    get_app().window.ExportFrame.emit(title_message, video_settings.get("start_frame"), video_settings.get("end_frame"), frame, format_of_progress_string)
+                    self.ExportFrame.emit(
+                        title_message,
+                        video_settings.get("start_frame"),
+                        video_settings.get("end_frame"),
+                        frame,
+                        format_of_progress_string
+                    )
 
                     # Process events (to show the progress bar moving)
                     QCoreApplication.processEvents()
@@ -967,8 +978,13 @@ class Export(QDialog):
             seconds_run = round((end_time_export - start_time_export))
             title_message = titlestring(seconds_run, fps_encode, "Elapsed")
 
-            get_app().window.ExportFrame.emit(title_message, video_settings.get("start_frame"),
-                                              video_settings.get("end_frame"), frame, format_of_progress_string)
+            self.ExportFrame.emit(
+                title_message,
+                video_settings.get("start_frame"),
+                video_settings.get("end_frame"),
+                frame,
+                format_of_progress_string
+            )
 
         except Exception as e:
             # TODO: Find a better way to catch the error. This is the only way I have found that
@@ -1006,7 +1022,7 @@ class Export(QDialog):
             msg.exec_()
 
         # Notify window of export started
-        get_app().window.ExportEnded.emit(export_file_path)
+        self.ExportEnded.emit(export_file_path)
 
         # Close timeline object
         self.timeline.Close()
@@ -1035,8 +1051,13 @@ class Export(QDialog):
             # Restore windows title to show elapsed time
             title_message = titlestring(seconds_run, fps_encode, "Elapsed")
 
-            get_app().window.ExportFrame.emit(title_message, video_settings.get("start_frame"),
-                                              video_settings.get("end_frame"), frame, format_of_progress_string)
+            self.ExportFrame.emit(
+                title_message,
+                video_settings.get("start_frame"),
+                video_settings.get("end_frame"),
+                frame,
+                format_of_progress_string
+            )
 
             # Make progress bar green (to indicate we are done)
             from PyQt5.QtGui import QPalette
@@ -1054,7 +1075,8 @@ class Export(QDialog):
         if self.exporting and not self.close_button.isVisible():
             # Show confirmation dialog
             _ = get_app()._tr
-            result = QMessageBox.question(self,
+            result = QMessageBox.question(
+                self,
                 _("Export Video"),
                 _("Are you sure you want to cancel the export?"),
                 QMessageBox.No | QMessageBox.Yes)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -105,9 +105,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     FoundVersionSignal = pyqtSignal(str)
     WaveformReady = pyqtSignal(str, list)
     TransformSignal = pyqtSignal(str)
-    ExportStarted = pyqtSignal(str, int, int)
-    ExportFrame = pyqtSignal(str, int, int, int, str)
-    ExportEnded = pyqtSignal(str)
     MaxSizeChanged = pyqtSignal(object)
     InsertKeyframe = pyqtSignal(object)
     OpenProjectSignal = pyqtSignal(str)
@@ -2810,24 +2807,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Update cache reference, so it doesn't go out of scope
         self.cache_object = new_cache_object
 
-    def FrameExported(self, title_message, start_frame, end_frame, current_frame):
-        """Update progress in Unity Launcher (if connected)"""
-        try:
-            # Set progress and show progress bar
-            self.unity_launcher.set_property("progress", current_frame / (end_frame - start_frame))
-            self.unity_launcher.set_property("progress_visible", True)
-        except Exception:
-            log.debug('Failed to notify unity launcher of export progress. Frame: %s' % current_frame)
-
-    def ExportFinished(self, path):
-        """Show completion in Unity Launcher (if connected)"""
-        try:
-            # Set progress on Unity launcher and hide progress bar
-            self.unity_launcher.set_property("progress", 0.0)
-            self.unity_launcher.set_property("progress_visible", False)
-        except Exception:
-            log.debug('Failed to notify unity launcher of export progress. Completed.')
-
     def initModels(self):
         """Set up model/view classes for MainWindow"""
         s = settings.get_settings()
@@ -3093,21 +3072,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Create tutorial manager
         self.tutorial_manager = TutorialManager(self)
-
-        # Connect to Unity DBus signal (if linux)
-        self.unity_launcher = None
-        if "linux" in sys.platform:
-            try:
-                # Get connection to Unity Launcher
-                import gi
-                gi.require_version('Unity', '7.0')
-                from gi.repository import Unity
-                self.unity_launcher = Unity.LauncherEntry.get_for_desktop_id(info.DESKTOP_ID)
-            except Exception:
-                log.debug('Failed to connect to Unity launcher (Linux only) for updating export progress.')
-            else:
-                self.ExportFrame.connect(self.FrameExported)
-                self.ExportEnded.connect(self.ExportFinished)
 
         # Save settings
         s.save()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2943,7 +2943,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Connect signals
         if self.mode != "unittest":
             self.RecoverBackup.connect(self.recover_backup)
-        app.aboutToQuit.connect(self.close)
 
         # Initialize and start the thumbnail HTTP server
         self.http_server_thread = httpThumbnailServerThread()


### PR DESCRIPTION
I honestly don't think the Unity progress-bar integration was working even on Ubuntu anymore, but turns out now it's also causing crashes on Fedora 33 when Python tries to `import gi`.

This PR rips out the Unity integration, and moves the export-progress signals from `main_window` to `export` as they're now only used locally.

It also removes an `aboutToQuit` signal connection I had added, which is causing double unsaved-project prompts on exit if you say "No" to the first one.