### PR TITLE
Create new dummy webview backend, fix unit-test launching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
 
     - name: Test
       shell: bash
-      run: python3 ./src/tests/query_tests.py
+      run: python3 ./src/tests/query_tests.py -platform minimal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         sudo add-apt-repository ppa:openshot.developers/libopenshot-daily
         sudo apt update
         sudo apt install libopenshot-audio-dev libopenshot-dev python3-openshot
-        sudo apt install qttranslations5-l10n libssl-dev xvfb
+        sudo apt install qttranslations5-l10n libssl-dev
         sudo apt install python3-pyqt5 python3-pyqt5.qtsvg python3-pyqt5.qtwebengine python3-pyqt5.qtopengl python3-zmq python3-xdg
         pip3 install setuptools wheel
         pip3 install cx_Freeze==6.1 distro defusedxml requests certifi chardet urllib3
@@ -30,4 +30,4 @@ jobs:
 
     - name: Test
       shell: bash
-      run: xvfb-run --auto-servernum --server-num=1 --server-args "-screen 0 1920x1080x24" python3 ./src/tests/query_tests.py
+      run: python3 ./src/tests/query_tests.py

--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -82,6 +82,9 @@ JT = {"name": "Jonathan Thomas",
 # Desktop launcher ID, for Linux
 DESKTOP_ID = "org.openshot.OpenShot.desktop"
 
+# Mode of execution, will be adjusted to 'unittest' by test runner
+LAUNCH_MODE = 'gui'
+
 # Blender minimum version required (a string value)
 BLENDER_MIN_VERSION = "2.80"
 

--- a/src/classes/ui_util.py
+++ b/src/classes/ui_util.py
@@ -42,20 +42,17 @@ from PyQt5.QtWidgets import QApplication, QWidget, QTabWidget, QAction
 from PyQt5 import uic
 
 from classes.logger import log
-from classes import settings
 
 from . import openshot_rc  # noqa
 
 DEFAULT_THEME_NAME = "Humanity"
 
 
-def load_theme():
+def load_theme(settings):
     """ Load the current OS theme, or fallback to a default one """
 
-    s = settings.get_settings()
-
     # If theme not reported by OS
-    if QIcon.themeName() == '' and s.get("theme") != "No Theme":
+    if QIcon.themeName() == '' and settings.get("theme") != "No Theme":
 
         # Address known Ubuntu bug of not reporting configured theme name, use default ubuntu theme
         if os.getenv('DESKTOP_SESSION') == 'ubuntu':

--- a/src/launch.py
+++ b/src/launch.py
@@ -70,7 +70,7 @@ def main():
         help="Load Qt's QAbstractItemModelTester into data models "
         '(requires Qt 5.11+)')
     parser.add_argument('-b', '--web-backend', action='store',
-        choices=['auto', 'webkit', 'webengine'], default='auto',
+        choices=['auto', 'webkit', 'webengine', 'dummy'], default='auto',
         help="Web backend to use for Timeline")
     parser.add_argument('-d', '--debug', action='store_true',
         help='Enable debugging output')

--- a/src/launch.py
+++ b/src/launch.py
@@ -51,6 +51,26 @@ except ImportError:
     sys.path.append(openshot_qt.OPENSHOT_PATH)
     from classes import info
 
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QGuiApplication
+
+try:
+    # This apparently has to be done before loading QtQuick
+    # (via QtWebEgine) AND before creating the QApplication instance
+    QGuiApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
+    from OpenGL import GL  # noqa
+    # Enable High-DPI resolutions
+    QGuiApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
+except (ImportError, AttributeError):
+    pass
+
+try:
+    # QtWebEngineWidgets must be loaded prior to creating a QApplication
+    # But on systems with only WebKit, this will fail (and we ignore the failure)
+    from PyQt5.QtWebEngineWidgets import QWebEngineView  # noqa
+except ImportError:
+    pass
+
 
 def main():
     """"Initialize settings (not implemented) and create main window/application."""

--- a/src/tests/query_tests.py
+++ b/src/tests/query_tests.py
@@ -25,20 +25,28 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-import sys, os
-# Import parent folder (so it can find other imports)
-PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-if PATH not in sys.path:
-    sys.path.append(PATH)
-
-import random
+import sys
+import os
 import unittest
-import uuid
-from PyQt5.QtGui import QGuiApplication
-from classes.app import OpenShotApp
-from classes import info
-import openshot  # Python module for libopenshot (required video editing module installed separately)
 import json
+import logging
+
+import openshot
+
+# Import parent folder (so it can find other imports)
+try:
+    from classes import info
+except ImportError:
+    PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+    if PATH not in sys.path:
+        sys.path.append(PATH)
+    from classes import info
+
+# Configure for unit testing, no Timeline web view and minimal log output
+info.LAUNCH_MODE = "unittest"
+info.WEB_BACKEND = "dummy"
+info.LOG_LEVEL_CONSOLE = logging.WARNING
+
 
 class TestQueryClass(unittest.TestCase):
     """ Unit test class for Query class """
@@ -46,8 +54,10 @@ class TestQueryClass(unittest.TestCase):
     @classmethod
     def setUpClass(TestQueryClass):
         """ Init unit test data """
+        from classes.app import OpenShotApp
+
         # Create Qt application
-        TestQueryClass.app = OpenShotApp([], mode="unittest")
+        TestQueryClass.app = OpenShotApp([])
         TestQueryClass.clip_ids = []
         TestQueryClass.file_ids = []
         TestQueryClass.transition_ids = []
@@ -319,5 +329,4 @@ class TestQueryClass(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    app = QGuiApplication(sys.argv)
     unittest.main()

--- a/src/tests/query_tests.py
+++ b/src/tests/query_tests.py
@@ -33,6 +33,8 @@ import logging
 
 import openshot
 
+from PyQt5.QtWidgets import QApplication
+
 # Import parent folder (so it can find other imports)
 try:
     from classes import info
@@ -47,7 +49,6 @@ info.LAUNCH_MODE = "unittest"
 info.WEB_BACKEND = "dummy"
 info.LOG_LEVEL_CONSOLE = logging.WARNING
 
-
 class TestQueryClass(unittest.TestCase):
     """ Unit test class for Query class """
 
@@ -57,7 +58,7 @@ class TestQueryClass(unittest.TestCase):
         from classes.app import OpenShotApp
 
         # Create Qt application
-        TestQueryClass.app = OpenShotApp([])
+        TestQueryClass.app = OpenShotApp(sys.argv)
         TestQueryClass.clip_ids = []
         TestQueryClass.file_ids = []
         TestQueryClass.transition_ids = []
@@ -329,4 +330,5 @@ class TestQueryClass(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    app = QApplication(sys.argv)
     unittest.main()

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -41,14 +41,15 @@ except ImportError:
 
 from xml.parsers.expat import ExpatError
 
-from PyQt5.QtCore import Qt, QCoreApplication, QTimer, QSize
+from PyQt5.QtCore import Qt, QCoreApplication, QTimer, QSize, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
     QMessageBox, QDialog, QFileDialog, QDialogButtonBox, QPushButton
 )
 from PyQt5.QtGui import QIcon
 
 from classes import info
-from classes import ui_util, openshot_rc
+from classes import ui_util
+from classes import openshot_rc  # noqa
 from classes import settings
 from classes.logger import log
 from classes.app import get_app
@@ -63,6 +64,10 @@ class Export(QDialog):
 
     # Path to ui file
     ui_path = os.path.join(info.PATH, 'windows', 'ui', 'export.ui')
+
+    ExportStarted = pyqtSignal(str, int, int)
+    ExportFrame = pyqtSignal(str, int, int, int, str)
+    ExportEnded = pyqtSignal(str)
 
     def __init__(self):
 
@@ -202,7 +207,7 @@ class Export(QDialog):
         self.cboSimpleQuality.currentIndexChanged.connect(
             functools.partial(self.cboSimpleQuality_index_changed, self.cboSimpleQuality))
         self.cboChannelLayout.currentIndexChanged.connect(self.updateChannels)
-        get_app().window.ExportFrame.connect(self.updateProgressBar)
+        self.ExportFrame.connect(self.updateProgressBar)
 
         # ********* Advanced Profile List **********
         # Loop through profiles
@@ -313,6 +318,7 @@ class Export(QDialog):
             if profile_path == path:
                 return profile
 
+    @pyqtSlot(str, int, int, int, str)
     def updateProgressBar(self, title_message, start_frame, end_frame, current_frame, format_of_progress_string):
         """Update progress bar during exporting"""
         if end_frame - start_frame > 0:
@@ -721,7 +727,6 @@ class Export(QDialog):
                 'fps': fps}
             return title_mes
 
-
         # get translations
         _ = get_app()._tr
 
@@ -905,7 +910,7 @@ class Export(QDialog):
 
             # Notify window of export started
             title_message = ""
-            get_app().window.ExportStarted.emit(export_file_path, video_settings.get("start_frame"), video_settings.get("end_frame"))
+            self.ExportStarted.emit(export_file_path, video_settings.get("start_frame"), video_settings.get("end_frame"))
 
             progressstep = max(1 , round(( video_settings.get("end_frame") - video_settings.get("start_frame") ) / 1000))
             start_time_export = time.time()
@@ -948,7 +953,13 @@ class Export(QDialog):
                             title_message = titlestring(seconds_left, fps_encode, "Remaining")
 
                     # Emit frame exported
-                    get_app().window.ExportFrame.emit(title_message, video_settings.get("start_frame"), video_settings.get("end_frame"), frame, format_of_progress_string)
+                    self.ExportFrame.emit(
+                        title_message,
+                        video_settings.get("start_frame"),
+                        video_settings.get("end_frame"),
+                        frame,
+                        format_of_progress_string
+                    )
 
                     # Process events (to show the progress bar moving)
                     QCoreApplication.processEvents()
@@ -967,8 +978,13 @@ class Export(QDialog):
             seconds_run = round((end_time_export - start_time_export))
             title_message = titlestring(seconds_run, fps_encode, "Elapsed")
 
-            get_app().window.ExportFrame.emit(title_message, video_settings.get("start_frame"),
-                                              video_settings.get("end_frame"), frame, format_of_progress_string)
+            self.ExportFrame.emit(
+                title_message,
+                video_settings.get("start_frame"),
+                video_settings.get("end_frame"),
+                frame,
+                format_of_progress_string
+            )
 
         except Exception as e:
             # TODO: Find a better way to catch the error. This is the only way I have found that
@@ -1006,7 +1022,7 @@ class Export(QDialog):
             msg.exec_()
 
         # Notify window of export started
-        get_app().window.ExportEnded.emit(export_file_path)
+        self.ExportEnded.emit(export_file_path)
 
         # Close timeline object
         self.timeline.Close()
@@ -1035,8 +1051,13 @@ class Export(QDialog):
             # Restore windows title to show elapsed time
             title_message = titlestring(seconds_run, fps_encode, "Elapsed")
 
-            get_app().window.ExportFrame.emit(title_message, video_settings.get("start_frame"),
-                                              video_settings.get("end_frame"), frame, format_of_progress_string)
+            self.ExportFrame.emit(
+                title_message,
+                video_settings.get("start_frame"),
+                video_settings.get("end_frame"),
+                frame,
+                format_of_progress_string
+            )
 
             # Make progress bar green (to indicate we are done)
             from PyQt5.QtGui import QPalette
@@ -1054,7 +1075,8 @@ class Export(QDialog):
         if self.exporting and not self.close_button.isVisible():
             # Show confirmation dialog
             _ = get_app()._tr
-            result = QMessageBox.question(self,
+            result = QMessageBox.question(
+                self,
                 _("Export Video"),
                 _("Are you sure you want to cancel the export?"),
                 QMessageBox.No | QMessageBox.Yes)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -125,7 +125,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.tutorial_manager.hide_dialog()
 
         # Prompt user to save (if needed)
-        if app.project.needs_save() and self.mode != "unittest":
+        if app.project.needs_save() and info.LAUNCH_MODE != "unittest":
             log.info('Prompt user to save project')
             # Translate object
             _ = app._tr
@@ -2868,11 +2868,11 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.emojiListView = EmojisListView(self.emojis_model)
         self.tabEmojis.layout().addWidget(self.emojiListView)
 
-    def __init__(self, *args, mode=None):
+    def __init__(self, *args, **kwargs):
 
         # Create main window base class
-        super().__init__(*args)
-        self.mode = mode    # None or unittest (None is normal usage)
+        super().__init__(*args, **kwargs)
+        self.setObjectName("main_window")
         self.initialized = False
 
         # set window on app for reference during initialization of children
@@ -2920,7 +2920,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         get_current_Version()
 
         # Connect signals
-        if self.mode != "unittest":
+        if info.LAUNCH_MODE != "unittest":
             self.RecoverBackup.connect(self.recover_backup)
 
         # Initialize and start the thumbnail HTTP server
@@ -3065,7 +3065,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.OpenProjectSignal.connect(self.open_project)
 
         # Show window
-        if self.mode != "unittest":
+        if info.LAUNCH_MODE != "unittest":
             self.show()
         else:
             log.info('Hiding UI for unittests')

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -105,9 +105,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     FoundVersionSignal = pyqtSignal(str)
     WaveformReady = pyqtSignal(str, list)
     TransformSignal = pyqtSignal(str)
-    ExportStarted = pyqtSignal(str, int, int)
-    ExportFrame = pyqtSignal(str, int, int, int, str)
-    ExportEnded = pyqtSignal(str)
     MaxSizeChanged = pyqtSignal(object)
     InsertKeyframe = pyqtSignal(object)
     OpenProjectSignal = pyqtSignal(str)
@@ -2810,24 +2807,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Update cache reference, so it doesn't go out of scope
         self.cache_object = new_cache_object
 
-    def FrameExported(self, title_message, start_frame, end_frame, current_frame):
-        """Update progress in Unity Launcher (if connected)"""
-        try:
-            # Set progress and show progress bar
-            self.unity_launcher.set_property("progress", current_frame / (end_frame - start_frame))
-            self.unity_launcher.set_property("progress_visible", True)
-        except Exception:
-            log.debug('Failed to notify unity launcher of export progress. Frame: %s' % current_frame)
-
-    def ExportFinished(self, path):
-        """Show completion in Unity Launcher (if connected)"""
-        try:
-            # Set progress on Unity launcher and hide progress bar
-            self.unity_launcher.set_property("progress", 0.0)
-            self.unity_launcher.set_property("progress_visible", False)
-        except Exception:
-            log.debug('Failed to notify unity launcher of export progress. Completed.')
-
     def initModels(self):
         """Set up model/view classes for MainWindow"""
         s = settings.get_settings()
@@ -3093,21 +3072,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Create tutorial manager
         self.tutorial_manager = TutorialManager(self)
-
-        # Connect to Unity DBus signal (if linux)
-        self.unity_launcher = None
-        if "linux" in sys.platform:
-            try:
-                # Get connection to Unity Launcher
-                import gi
-                gi.require_version('Unity', '7.0')
-                from gi.repository import Unity
-                self.unity_launcher = Unity.LauncherEntry.get_for_desktop_id(info.DESKTOP_ID)
-            except Exception:
-                log.debug('Failed to connect to Unity launcher (Linux only) for updating export progress.')
-            else:
-                self.ExportFrame.connect(self.FrameExported)
-                self.ExportEnded.connect(self.ExportFinished)
 
         # Save settings
         s.save()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2943,7 +2943,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Connect signals
         if self.mode != "unittest":
             self.RecoverBackup.connect(self.recover_backup)
-        app.aboutToQuit.connect(self.close)
 
         # Initialize and start the thumbnail HTTP server
         self.http_server_thread = httpThumbnailServerThread()

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -69,7 +69,7 @@ class PreviewParent(QObject):
         _ = get_app()._tr
 
         # Only JUCE audio errors bubble up here now
-        if get_app().window.mode != "unittest":
+        if info.LAUNCH_MODE != "unittest":
             QMessageBox.warning(self.parent, _("Audio Error"), _("Please fix the following error and restart OpenShot\n%s") % error)
 
     @pyqtSlot(object, object)

--- a/src/windows/views/emojis_listview.py
+++ b/src/windows/views/emojis_listview.py
@@ -30,6 +30,7 @@ from PyQt5.QtGui import QDrag
 from PyQt5.QtWidgets import QListView
 
 import openshot  # Python module for libopenshot (required video editing module installed separately)
+from classes import info
 from classes.query import File
 from classes.app import get_app
 from classes.settings import get_settings
@@ -182,6 +183,6 @@ class EmojisListView(QListView):
                 # Off by one, due to 'show all' choice above
                 dropdown_index = index + 1
 
-        if self.win.mode != "unittest":
+        if info.LAUNCH_MODE != "unittest":
             self.win.emojiFilterGroup.currentIndexChanged.connect(self.group_changed)
         self.win.emojiFilterGroup.setCurrentIndex(dropdown_index)

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -152,7 +152,11 @@ MENU_SPLIT_AUDIO_MULTIPLE = 1
 # Import shenanigans
 WEBVIEW_LOADED = None
 
-if info.WEB_BACKEND and info.WEB_BACKEND == "webkit":
+if info.WEB_BACKEND and info.WEB_BACKEND == "dummy":
+    from .webview_backend.dummy import DummyWebView
+    WebViewClass = DummyWebView
+    WEBVIEW_LOADED = True
+elif info.WEB_BACKEND and info.WEB_BACKEND == "webkit":
     from .webview_backend.webkit import TimelineWebKitView
     WebViewClass = TimelineWebKitView
     WEBVIEW_LOADED = True

--- a/src/windows/views/webview_backend/dummy.py
+++ b/src/windows/views/webview_backend/dummy.py
@@ -1,0 +1,47 @@
+"""
+ @file
+ @brief Dummy backend for TimelineWebView
+ @author Jonathan Thomas <jonathan@openshot.org>
+ @author FeRD (Frank Dana) <ferdnyc@gmail.com>
+
+ @section LICENSE
+
+ Copyright (c) 2008-2020 OpenShot Studios, LLC
+ (http://www.openshotstudios.com). This file is part of
+ OpenShot Video Editor (http://www.openshot.org), an open-source project
+ dedicated to delivering high quality video editing and animation solutions
+ to the world.
+
+ OpenShot Video Editor is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenShot Video Editor is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
+ """
+
+from classes.logger import log
+
+from PyQt5.QtWidgets import QWidget
+
+
+class DummyWebView(QWidget):
+    """A QWidget-derived class which provides the methods necessary for
+    TimelineWebView to function, but does not display anything. Intended
+    primarily for unit test runs and other simulated environments."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def run_js(self, code, callback=None):
+        log.debug("run_js request received: %s", code)
+        if callback:
+            callback("{}")
+        else:
+            return None


### PR DESCRIPTION
This PR changes the application startup substantially to make it more resilient. Specifically, it:

1. Creates a new `webview_backend.dummy`, containing a `DummyWebView` class derived from `QWidget` and providing a stub `run_js` method. This webview can be used in place of the existing WebKit and WebEngine options in situations where the webview is not expected to display anything.
2. Replaces the old `mode="unittest"` argument to `OpenShotApp` and `MainWindow` with an info variable, `info.LAUNCH_MODE`. The default value is `"gui"`, and many more things in the startup are made dependent on the value of `info.LAUNCH_MODE`.
3. Removes the `QApplication` configuration previously being done at the top of `classes.app`, and instead does it at the top of `launch.py`. This ensures that the necessary settings/imports will be completed _**before**_ instantiating the `QApplication`-derived `OpenShotApp` object.
4. Updates `query_tests.py` to set `info.LAUNCH_MODE="unittest"` and `info.WEB_BACKEND="dummy"`, as well as `info.LOG_LEVEL_CONSOLE="WARNING"`, so that startup will be constrained and logging output will be kept to a minimum during the unit test runs. This prevents crashing due to unnecessarily loaded GUI elements (especially the QML-based QWebEngineView) and keeps the unit test runs streamlined for CI use.
5. Enhances `query_tests.py` to process Qt standard command line arguments, and adds `-platform minimal` to the arguments when the unit tests are run in the Github Actions CI. This is necessary when executing the code in an environment without an X server, and is a lighter alternative to the `xvfb` virtual-server environment that was previously used.

This PR also incorporates the change from #3937, eliminating the attempts to communicate with Ubuntu Unity.