### PR TITLE
Preferences: Don't filter file dialog when selecting helper executables

### DIFF
--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -437,7 +437,10 @@ class Preferences(QDialog):
             if prev_val and os.path.exists(prev_val):
                 startpath = prev_val
 
-        fileName = QFileDialog.getOpenFileName(self, _("Select executable file"), startpath, _("All Files (*)"))[0]
+        fileName = QFileDialog.getOpenFileName(
+            self,
+            _("Select executable file"),
+            startpath)[0]
         if fileName:
             if platform.system() == "Darwin":
                 # Check for Mac specific app-bundle executable file (if any)


### PR DESCRIPTION
`getOpenFileName()` defaults to "`All Files (*)`" if we just leave the filter argument blank, so we should do that instead of specifying it explicitly and having to deal with translations.

Fixes #3943