### PR TITLE
Fix the Qt gif dependency on the mac build server

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -112,19 +112,14 @@ if os.path.exists(os.path.join(PATH, "openshot_qt")):
     print("Loaded modules from openshot_qt directory: %s" % os.path.join(PATH, "openshot_qt"))
 
 # Append possible build server paths
-
 sys.path.insert(0, os.path.join(PATH, "build", "install-x86", "lib"))
 sys.path.insert(0, os.path.join(PATH, "build", "install-x86", "bin"))
-
 sys.path.insert(0, os.path.join(PATH, "build", "install-x64", "lib"))
 sys.path.insert(0, os.path.join(PATH, "build", "install-x64", "bin"))
 
-
 from classes import info
 from classes.logger import log
-
 log.info("Execution path: %s" % os.path.abspath(__file__))
-
 
 # Find files matching patterns
 def find_files(directory, patterns):
@@ -397,8 +392,7 @@ elif sys.platform == "darwin":
         src_files.append((filename, os.path.join("lib", os.path.relpath(filename, start=os.path.join(PATH, "openshot_qt")))))
 
     # Exclude gif library which crashes on Mac
-    build_exe_options["bin_excludes"] = ["/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib",
-                                         "/usr/local/opt/giflib/lib/libgif.dylib"]
+    build_exe_options["bin_excludes"] = ["/usr/local/opt/giflib/lib/libgif.dylib"]
 
 # Dependencies are automatically detected, but it might need fine tuning.
 build_exe_options["packages"] = python_packages


### PR DESCRIPTION
The build server has 2 competing libraries with different SO compatibility. The invalid gif library needs to be ignored.