### PR TITLE
Exclude a few more files from the mac build (tesseract and related)

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -392,7 +392,10 @@ elif sys.platform == "darwin":
         src_files.append((filename, os.path.join("lib", os.path.relpath(filename, start=os.path.join(PATH, "openshot_qt")))))
 
     # Exclude gif library which crashes on Mac
-    build_exe_options["bin_excludes"] = ["/usr/local/opt/giflib/lib/libgif.dylib"]
+    build_exe_options["bin_excludes"] = ["/System/Library/Frameworks/ImageIO.framework/Versions/A/Resources/libGIF.dylib",
+                                         "/usr/local/opt/giflib/lib/libgif.dylib",
+                                         "/usr/local/opt/tesseract/lib/libtesseract.4.dylib",
+                                         "/usr/local/opt/leptonica/lib/liblept.5.dylib"]
 
 # Dependencies are automatically detected, but it might need fine tuning.
 build_exe_options["packages"] = python_packages


### PR DESCRIPTION
Trying to avoid a crash related to tesseract and dependencies. libavdevice -> libtesseract -> liblept -> libgif. The libgif dylib conflicts with another similarly named system lib (in the ImageIO.framework). I'm hoping I can just prune out the libtesseract, and thus, all these conflicts.