### PR TITLE
Add minimum os version to Info.plist

### DIFF
--- a/installer/Info.plist
+++ b/installer/Info.plist
@@ -16,6 +16,8 @@
 	<string>icon.icns</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.video</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.15.0</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 </dict>


### PR DESCRIPTION
… so we don't attempt to install on an older system which will fail. Some of our binaries require 10.15 (such as Python3), and thus, hopefully this attribute will fail more gently when trying to install our app on an older system.