### PR TITLE
Adding optional version.json to /settings/ folder during build. 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ linux-builder:
     - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"
     - cd doc; make html SPHINXOPTS="-D html_theme_options.analytics_id=UA-4381101-5"; cd ..;
     - ~/auto-update-sphinx "$CI_PROJECT_DIR/build" "$CI_COMMIT_REF_NAME"
-    - python3 -u freeze.py build
+    - python3 -u freeze.py build --git-branch=$CI_COMMIT_REF_NAME
     - for dir in "build/*/"; do /bin/sh ./installer/mangle-hw-libs.sh $(realpath "${dir}"); done 
     - python3 -u installer/build-server.py "$SLACK_TOKEN" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "False" "$CI_COMMIT_REF_NAME"
   when: always
@@ -63,7 +63,7 @@ mac-builder:
     - export DYLD_LIBRARY_PATH=$CI_PROJECT_DIR/build/install-x64/lib:DYLD_LIBRARY_PATH
     - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID\nCI_PIPELINE_ID:$CI_PIPELINE_ID" > "build/install-x64/share/$CI_PROJECT_NAME"
     - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"
-    - python3 -u freeze.py bdist_mac --iconfile=installer/openshot.icns --custom-info-plist=installer/Info.plist --bundle-name="OpenShot Video Editor"
+    - python3 -u freeze.py bdist_mac --git-branch=$CI_COMMIT_REF_NAME --iconfile=installer/openshot.icns --custom-info-plist=installer/Info.plist --bundle-name="OpenShot Video Editor"
     - python3 -u installer/build-server.py "$SLACK_TOKEN" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "False" "$CI_COMMIT_REF_NAME"
   when: always
   except:
@@ -90,7 +90,7 @@ windows-builder-x64:
     - New-Item -path "build/install-x64/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID`nCI_PIPELINE_ID:$env:CI_PIPELINE_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0 '@^')
     - git log "$PREV_GIT_LABEL..@" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"
-    - python3 -u freeze.py build
+    - python3 -u freeze.py build --git-branch=$CI_COMMIT_REF_NAME
     - python3 -u installer/build-server.py "$SLACK_TOKEN" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "False" "$CI_COMMIT_REF_NAME"
   when: always
   except:
@@ -117,7 +117,7 @@ windows-builder-x86:
     - New-Item -path "build/install-x86/share/" -Name "$CI_PROJECT_NAME" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID`nCI_PIPELINE_ID:$env:CI_PIPELINE_ID" -ItemType file -force
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0 '@^')
     - git log "$PREV_GIT_LABEL..@" --oneline --pretty=format:"%C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x86/share/$CI_PROJECT_NAME.log"
-    - python3 -u freeze.py build
+    - python3 -u freeze.py build --git-branch=$CI_COMMIT_REF_NAME
     - editbin /LARGEADDRESSAWARE "$CI_PROJECT_DIR\build\exe.mingw-3.7\openshot-qt.exe"
     - python3 -u installer/build-server.py "$SLACK_TOKEN" "$S3_ACCESS_KEY" "$S3_SECRET_KEY" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "True" "$CI_COMMIT_REF_NAME"
   when: always

--- a/installer/build-mac-dmg.sh
+++ b/installer/build-mac-dmg.sh
@@ -28,7 +28,7 @@ mv "$OS_PATH/MacOS/lib/presets" "$OS_PATH/Resources/presets"; ln -s "../../Resou
 mv "$OS_PATH/MacOS/lib/profiles" "$OS_PATH/Resources/profiles"; ln -s "../../Resources/profiles" "$OS_PATH/MacOS/lib/profiles";
 mv "$OS_PATH/MacOS/lib/resources" "$OS_PATH/Resources/resources"; ln -s "../../Resources/resources" "$OS_PATH/MacOS/lib/resources";
 mv "$OS_PATH/MacOS/lib/settings" "$OS_PATH/Resources/settings"; ln -s "../../Resources/settings" "$OS_PATH/MacOS/lib/settings";
-cp "$OS_PATH/MacOS/settings/"*.log "$OS_PATH/Resources/settings/"; # Copy *.log files into settings
+cp "$OS_PATH/MacOS/settings/"* "$OS_PATH/Resources/settings/"; # Copy *.log files into settings
 rm -r "$OS_PATH/MacOS/settings/" # remove old settings folder
 mv "$OS_PATH/MacOS/lib/tests" "$OS_PATH/Resources/tests"; ln -s "../../Resources/tests" "$OS_PATH/MacOS/lib/tests";
 mv "$OS_PATH/MacOS/lib/timeline" "$OS_PATH/Resources/timeline"; ln -s "../../Resources/timeline" "$OS_PATH/MacOS/lib/timeline";

--- a/installer/version_parser.py
+++ b/installer/version_parser.py
@@ -26,9 +26,13 @@
  """
 
 import os
+import sys
 import json
 import datetime
-from classes import info
+
+PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))  # Primary openshot folder
+sys.path.append(os.path.join(PATH, 'src', 'classes'))
+import info
 
 
 def parse_version_info(version_path):

--- a/installer/version_parser.py
+++ b/installer/version_parser.py
@@ -1,0 +1,111 @@
+"""
+ @file
+ @brief Parse version info files for libopenshot-audio, libopenshot, and openshot-qt (created on gitlab-ci.yml)
+ @author Jonathan Thomas <jonathan@openshot.org>
+
+ @section LICENSE
+
+ Copyright (c) 2008-2016 OpenShot Studios, LLC
+ (http://www.openshotstudios.com). This file is part of
+ OpenShot Video Editor (http://www.openshot.org), an open-source project
+ dedicated to delivering high quality video editing and animation solutions
+ to the world.
+
+ OpenShot Video Editor is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenShot Video Editor is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
+ """
+
+import os
+import json
+import datetime
+from classes import info
+
+
+def parse_version_info(version_path):
+    """Parse version info from gitlab artifacts"""
+    version_info = { "date": f'{datetime.datetime.now():%Y-%m-%d %H:%M}' }
+
+    # Get name of version file
+    version_name = os.path.basename(version_path)
+    version_info[version_name] = {
+        "CI_PROJECT_NAME": None,
+        "CI_COMMIT_REF_NAME": None,
+        "CI_COMMIT_SHA": None,
+        "CI_JOB_ID": None,
+        "CI_PIPELINE_ID": None,
+        }
+
+    if os.path.exists(version_path):
+        with open(version_path, "r") as f:
+            # Parse each line in f as a 'key:value' string
+            version_info[version_name].update((l.strip().split(':') for l in f.readlines()))
+
+    return version_info
+
+def parse_build_name(version_info, git_branch_name=""):
+    """Calculate the build name used in URLs and Installers from the version_info dict"""
+    # Check for all version info needed to construct the build URL
+    build_name = ""
+    release_label = ""
+
+    # Determine release type string to inject
+    if git_branch_name.startswith("release"):
+        # Release candidate
+        release_label = "release-candidate"
+    elif git_branch_name == "master":
+        # Release
+        release_label = ""
+    else:
+        # Daily
+        release_label = "daily"
+
+    if all(key in version_info for key in ("libopenshot", "libopenshot-audio", "openshot-qt")):
+        # Construct base build URL pattern
+        if release_label:
+            # Daily and Release Candidates
+            build_name = "OpenShot-v%s-%s-%s-%s-%s" % (
+                info.VERSION,
+                release_label,
+                version_info.get('openshot-qt', {}).get('CI_PIPELINE_ID', 'NA'),
+                version_info.get('libopenshot', {}).get('CI_COMMIT_SHA', 'NA')[:8],
+                version_info.get('libopenshot-audio', {}).get('CI_COMMIT_SHA', 'NA')[:8],
+            )
+        else:
+            # Official releases
+            build_name = "OpenShot-v%s" % info.VERSION
+
+    return build_name
+
+
+if __name__ == "__main__":
+    """Run these methods manually for testing"""
+    # Determine absolute PATH of OpenShot folder
+    PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))  # Primary openshot folder
+
+    version_info = {}
+    settings_path = os.path.join(PATH, "src", "settings")
+
+    # Parse all version info (if found)
+    for git_log_filename in os.listdir(settings_path):
+        git_log_filepath = os.path.join(settings_path, git_log_filename)
+        if os.path.splitext(git_log_filepath)[1] == "":
+            # No extension, parse version info
+            version_info.update(parse_version_info(git_log_filepath))
+
+    # Calculate build name from version info
+    version_info["build_name"] = parse_build_name(version_info, "daily")
+    version_info["build_name"] = parse_build_name(version_info, "release-123-abc")
+    version_info["build_name"] = parse_build_name(version_info, "master")
+
+    # Dump version info to json string
+    print(json.dumps(version_info, indent=4, sort_keys=True))

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -124,7 +124,8 @@ class OpenShotApp(QApplication):
             if os.path.exists(version_path):
                 with open(version_path, "r", encoding="UTF-8") as f:
                     version_info = json.loads(f.read())
-                    log.info("Frozen version info from build server:\n%s" % json.dumps(version_info, indent=4, sort_keys=True))
+                    log.info("Frozen version info from build server:\n%s" %
+                             json.dumps(version_info, indent=4, sort_keys=True))
 
         except Exception:
             log.debug("Error displaying dependency/system details", exc_info=1)

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -32,6 +32,7 @@ import os
 import platform
 import sys
 import traceback
+import json
 
 from PyQt5.QtCore import PYQT_VERSION_STR
 from PyQt5.QtCore import QT_VERSION_STR
@@ -117,6 +118,14 @@ class OpenShotApp(QApplication):
             log.info("python version: %s" % platform.python_version())
             log.info("qt5 version: %s" % QT_VERSION_STR)
             log.info("pyqt5 version: %s" % PYQT_VERSION_STR)
+
+            # Look for frozen version info
+            version_path = os.path.join(info.PATH, "settings", "version.json")
+            if os.path.exists(version_path):
+                with open(version_path, "r", encoding="UTF-8") as f:
+                    version_info = json.loads(f.read())
+                    log.info("Frozen version info from build server:\n%s" % json.dumps(version_info, indent=4, sort_keys=True))
+
         except Exception:
             log.debug("Error displaying dependency/system details", exc_info=1)
 

--- a/src/windows/about.py
+++ b/src/windows/about.py
@@ -179,11 +179,21 @@ class About(QDialog):
         self.btnlicense.clicked.connect(self.load_license)
         self.btnchangelog.clicked.connect(self.load_changelog)
 
+        # Look for frozen version info
+        frozen_version_label = ""
+        version_path = os.path.join(info.PATH, "settings", "version.json")
+        if os.path.exists(version_path):
+            with open(version_path, "r", encoding="UTF-8") as f:
+                version_info = json.loads(f.read())
+                if version_info:
+                    frozen_version_label = "<br/><br/><b>%s</b><br/>Build Date: %s" % \
+                        (version_info.get('build_name'), version_info.get('date'))
+
         # Init some variables
         openshot_qt_version = _("Version: %s") % info.VERSION
         libopenshot_version = "libopenshot: %s" % openshot.OPENSHOT_VERSION_FULL
         self.txtversion.setText(
-            "<b>%s</b><br/>%s" % (openshot_qt_version, libopenshot_version))
+            "<b>%s</b><br/>%s%s" % (openshot_qt_version, libopenshot_version, frozen_version_label))
         self.txtversion.setAlignment(Qt.AlignCenter)
 
         # Track metrics


### PR DESCRIPTION
This is a dump of all 3 repos version info used in this build, including the current date/time. Also, some refactoring of build url naming and version parsing (used by both freeze and build-server.py now. The idea is to include an easy to consume dump of version data, which can be output on launch in the openshot-qt log file (if the version.json is included in the source). This will only exist for frozen copies of OpenShot (from freeze.py). 

The goal of this info (printed on launch if available), will definitively answer the question, when did a user's build get created, what versions and pipeline ids were used on GitLab, and what was the build file name. There should be no more ambiguity. 👍 