### PR TITLE
Revert "Test bumping the version (for gitlab-ci deployment testing)"

### DIFF
--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -28,8 +28,9 @@
 import os
 from time import strftime
 
-VERSION = "2.5.2"
-MINIMUM_LIBOPENSHOT_VERSION = "0.2.6"
+VERSION = "2.5.1-dev2"
+MINIMUM_LIBOPENSHOT_VERSION = "0.2.5"
+DATE = "20200228000000"
 NAME = "openshot-qt"
 PRODUCT_NAME = "OpenShot Video Editor"
 GPL_VERSION = "3"


### PR DESCRIPTION
This reverts commit ac6e07f7b86fe74bed0ab540a5c9fa4158be2639.

Pretty sure OpenShot 2.5.2 wasn't intended to be released yet, especially since it depends on a version of libopenshot that doesn't _exist_.