### PR TITLE
Blender: Add sunlight intensity parameter to earth.xml, enhance UI support

### DIFF
--- a/src/blender/earth.xml
+++ b/src/blender/earth.xml
@@ -12,130 +12,130 @@
 	</param>
 
 	<!-- DEPART COORDINATES -->
-	<param name="depart_title" type="text" title="Depart Title" description="">
+	<param name="depart_section_label" type="bold_label" title="Departure Location"/>
+	<param name="depart_title" type="text" title="Departure Title" description="">
 		<default>New York</default>
 	</param>
-	<param name="depart_lat_dir" type="dropdown" title="Depart Latitude (Equator)" description="">
+	<param name="depart_lat_label" type="label" title="Departure Coordinates, Latitude"/>
+	<param name="depart_lat_dir" type="dropdown" title="• Direction" description="">
 		<values>
 			<value name="North" num="N"/>
 			<value name="South" num="S"/>
 		</values>
 		<default>N</default>
 	</param>
-	<param name="depart_lat_deg" type="spinner" title="Depart Latitude (degrees)" description="">
+	<param name="depart_lat_deg" type="spinner" title="• Degrees" description="">
 		<min>0</min>
 		<max>90</max>
 		<default>40</default>
 	</param>
-	<param name="depart_lat_min" type="spinner" title="Depart Latitude (minutes)" description="">
+	<param name="depart_lat_min" type="spinner" title="• Minutes" description="">
 		<min>0</min>
 		<max>60</max>
 		<default>42</default>
 	</param>
-	<param name="depart_lat_sec" type="spinner" title="Depart Latitude (seconds)" description="">
+	<param name="depart_lat_sec" type="spinner" title="• Seconds" description="">
 		<min>0</min>
 		<max>60</max>
 		<default>51</default>
 	</param>
-	<param name="depart_lon_dir" type="dropdown" title="Depart Longitude (Prime Meridian)" description="">
+	<param name="depart_lon_label" type="label" title="Departure Coordinates, Longitude"/>
+	<param name="depart_lon_dir" type="dropdown" title="• Direction" description="">
 		<values>
 			<value name="East" num="E"/>
 			<value name="West" num="W"/>
 		</values>
 		<default>W</default>
 	</param>
-	<param name="depart_lon_deg" type="spinner" title="Depart Longitude (degrees)" description="">
+	<param name="depart_lon_deg" type="spinner" title="• Degrees" description="">
 		<min>0</min>
 		<max>180</max>
 		<default>74</default>
 	</param>
-	<param name="depart_lon_min" type="spinner" title="Depart Longitude (minutes)" description="">
+	<param name="depart_lon_min" type="spinner" title="• Minutes" description="">
 		<min>0</min>
 		<max>180</max>
 		<default>0</default>
 	</param>
-	<param name="depart_lon_sec" type="spinner" title="Depart Longitude (seconds)" description="">
+	<param name="depart_lon_sec" type="spinner" title="• Seconds" description="">
 		<min>0</min>
 		<max>180</max>
 		<default>23</default>
 	</param>
 
 	<!-- ARRIVAL COORDINATES -->
+	<param name="arrive_section_label" type="bold_label" title="Arrival Location"/>
 	<param name="arrive_title" type="text" title="Arrival Title" description="">
 		<default>Paris</default>
 	</param>
-	<param name="arrive_lat_dir" type="dropdown" title="Arrival Latitude (Equator)" description="">
+	<param name="arrive_lat_label" type="label" title="Arrival Coordinates, Latitude"/>
+	<param name="arrive_lat_dir" type="dropdown" title="• Direction" description="">
 		<values>
 			<value name="North" num="N"/>
 			<value name="South" num="S"/>
 		</values>
 		<default>N</default>
 	</param>
-	<param name="arrive_lat_deg" type="spinner" title="Arrival Latitude (degrees)" description="">
+	<param name="arrive_lat_deg" type="spinner" title="• Deegrees" description="">
 		<min>0</min>
 		<max>90</max>
 		<default>48</default>
 	</param>
-	<param name="arrive_lat_min" type="spinner" title="Arrival Latitude (minutes)" description="">
+	<param name="arrive_lat_min" type="spinner" title="• Minutes" description="">
 		<min>0</min>
 		<max>60</max>
 		<default>51</default>
 	</param>
-	<param name="arrive_lat_sec" type="spinner" title="Arrival Latitude (seconds)" description="">
+	<param name="arrive_lat_sec" type="spinner" title="• Seconds" description="">
 		<min>0</min>
 		<max>60</max>
 		<default>24</default>
 	</param>
-	<param name="arrive_lon_dir" type="dropdown" title="Arrival Longitude (Prime Meridian)" description="">
+	<param name="arrive_lon_label" type="label" title="Arrival Coordinates, Longitude"/>
+	<param name="arrive_lon_dir" type="dropdown" title="• Direction" description="">
 		<values>
 			<value name="East" num="E"/>
 			<value name="West" num="W"/>
 		</values>
 		<default>E</default>
 	</param>
-	<param name="arrive_lon_deg" type="spinner" title="Arrival Longitude (degrees)" description="">
+	<param name="arrive_lon_deg" type="spinner" title="• Degrees" description="">
 		<min>0</min>
 		<max>180</max>
 		<default>2</default>
 	</param>
-	<param name="arrive_lon_min" type="spinner" title="Arrival Longitude (minutes)" description="">
+	<param name="arrive_lon_min" type="spinner" title="• Minutes" description="">
 		<min>0</min>
 		<max>180</max>
 		<default>21</default>
 	</param>
-	<param name="arrive_lon_sec" type="spinner" title="Arrival Longitude (seconds)" description="">
+	<param name="arrive_lon_sec" type="spinner" title="• Seconds" description="">
 		<min>0</min>
 		<max>180</max>
 		<default>7</default>
 	</param>
 	
-	
-	<!-- TEXTURE SETTINGS -->
-	<param name="map_texture" type="text" title="Custom Texture (Equirectangular)" description="">
-		<default></default>
-	</param>
-	
-	
 	<!-- FONT / MATERIAL SETTINGS -->
-	<param name="extrude" type="spinner" title="Extrude" description="">
+	<param name="font_section_label" type="bold_label" title="Text and Graphics"/>
+	<param name="extrude" type="spinner" title="• Extrusion depth" description="">
 		<min>0.0</min>
 		<max>1.0</max>
 		<default>0.1</default>
 	</param>
 
-	<param name="bevel_depth" type="spinner" title="Bevel Depth" description="">
+	<param name="bevel_depth" type="spinner" title="• Bevel depth" description="">
 		<min>0.0</min>
 		<max>1.0</max>
 		<default>0.02</default>
 	</param>
 
-	<param name="text_size" type="spinner" title="Text Size" description="">
+	<param name="text_size" type="spinner" title="• Text size" description="">
 		<min>0.0</min>
 		<max>10.0</max>
 		<default>1.0</default>
 	</param>
 	
-	<param name="fontname" type="dropdown" title="Font Name" description="">
+	<param name="fontname" type="dropdown" title="• Font Name" description="">
 		<values>
 			<value name="Bfont" num="Bfont"/>
 			<value name="WenQuanYiMicroHei (Unicode)" num="WenQuanYiMicroHei"/>
@@ -143,27 +143,50 @@
 		<default>Bfont</default>
 	</param>
 	
-	<param name="width" type="spinner" title="Text Width" description="">
+	<param name="width" type="spinner" title="• Text width" description="">
 		<min>0.0</min>
 		<max>10.0</max>
 		<default>1.0</default>
 	</param>
 
-	<param name="diffuse_color" type="color" title="Diffuse Color" description="">
+	<param name="diffuse_color" type="color" title="• Diffuse Color" description="">
 		<default>#FF0000</default>
 	</param>
 	
-	<param name="specular_color" type="color" title="Specular Color" description="">
+	<param name="specular_color" type="color" title="• Specular Color" description="">
 		<default>#ffffff</default>
 	</param>
 	
-	<param name="specular_intensity" type="spinner" title="Specular Intensity" description="">
+	<param name="specular_intensity" type="spinner" title="• Specular Intensity" description="">
 		<min>0.0</min>
 		<max>1.0</max>
 		<default>0.5</default>
 	</param>
+
+	<param name="sun_intensity" type="spinner" title="Sunlight Intensity" description="">
+		<min>0.0</min>
+		<max>20.0</max>
+		<default>1.0</default>
+		<step>0.1</step>
+	</param>
+
+	<!-- TEXTURE SETTINGS - NOT NORMALLY USED -->
+	<param name="map_texture" type="text" title="Custom Texture File" description="">
+		<default></default>
+	</param>
 	
-	
+	<!-- SPEED -->
+	<param name="length_multiplier" type="dropdown" title="Animation Length" description="">
+		<values>
+			<value name="Default" num="1"/>
+			<value name="2X" num="2"/>
+			<value name="3X" num="3"/>
+			<value name="4X" num="4"/>
+			<value name="5X" num="5"/>
+		</values>
+		<default>1</default>
+	</param>
+
 	<param name="start_frame" type="spinner" title="Start Frame" description="">
 		<min>1</min>
 		<max>1</max>
@@ -176,15 +199,4 @@
 		<default>100</default>
 	</param>
 
-	<!-- SPEED -->
-	<param name="length_multiplier" type="dropdown" title="Animation Length" description="">
-		<values>
-			<value name="Default" num="1"/>
-			<value name="2X" num="2"/>
-			<value name="3X" num="3"/>
-			<value name="4X" num="4"/>
-			<value name="5X" num="5"/>
-		</values>
-		<default>1</default>
-	</param>
 </effect>

--- a/src/blender/scripts/earth.py.in
+++ b/src/blender/scripts/earth.py.in
@@ -20,8 +20,9 @@
 # Import Blender's python API.  This only works when the script is being
 # run from the context of Blender.  Blender contains it's own version of Python
 # with this library pre-installed.
-import math
 import bpy
+import os
+import math
 import json
 
 
@@ -73,6 +74,7 @@ params = {
     'start_frame': 1,
     'end_frame': 250,
     'length_multiplier': 1,
+    'sun_intensity': 1.0,
 
     'depart_title': 'Paris',
     'depart_lat_deg': 48,
@@ -282,8 +284,13 @@ update_curve(
     action.fcurves[2], math.radians(point_a.lon), math.radians(point_b.lon))
 
 # set world texture (i.e. the globe texture)
-if params["map_texture"]:
+if "map_texture" in params and os.path.exists(params["map_texture"]):
     bpy.data.textures["Texture.002"].image.filepath = params["map_texture"]
+
+# Configure light source (sunlight)
+bpy.data.lights["Lamp"].specular_factor = 0.0
+if "sun_intensity" in params:
+    bpy.data.lights["Lamp"].energy = float(params["sun_intensity"])
 
 # Get font object
 font = None

--- a/src/blender/scripts/explode.py.in
+++ b/src/blender/scripts/explode.py.in
@@ -104,7 +104,7 @@ def createExplodeTxt(title, particle_number, extrude, bevel_depth, spacemode,
     # emitfrom
     PSSettings.emit_from = 'VERT'
     # particle number
-    PSSettings.count = particle_number
+    PSSettings.count = int(particle_number)
     # particle lifetime
     PSSettings.lifetime = 200  # 200 + 48 > 150
     # start/end explosion

--- a/src/blender/scripts/magic_wand.py.in
+++ b/src/blender/scripts/magic_wand.py.in
@@ -119,8 +119,8 @@ bpy.data.scenes["Scene"].node_tree.nodes["Glare"].glare_type = params["glare_typ
 
 # Change particle settings
 psettings = bpy.data.particles["ParticleSettings"]
-psettings.count = params["particles_count"]
-psettings.lifetime = params["particles_lifetime"]
+psettings.count = int(params["particles_count"])
+psettings.lifetime = int(params["particles_lifetime"])
 psettings.effector_weights.gravity = params["particles_gravity"]
 psettings.object_align_factor = (
     params["velocity_x"], params["velocity_y"], params["velocity_z"])

--- a/src/blender/scripts/snow.py.in
+++ b/src/blender/scripts/snow.py.in
@@ -82,7 +82,7 @@ bpy.data.objects["Wand"].particle_systems[0].settings.particle_size = params["si
 
 # Change particle settings
 particle_object = bpy.data.particles[0]
-particle_object.count = params["particles_count"]
+particle_object.count = int(params["particles_count"])
 
 # Change Scene settings
 scene_object = bpy.data.scenes[0]

--- a/src/classes/ui_util.py
+++ b/src/classes/ui_util.py
@@ -36,8 +36,8 @@ try:
 except ImportError:
     from xml.etree import ElementTree
 
-from PyQt5.QtCore import QDir, QLocale
-from PyQt5.QtGui import QIcon
+from PyQt5.QtCore import Qt, QDir, QLocale
+from PyQt5.QtGui import QIcon, QColor
 from PyQt5.QtWidgets import QApplication, QWidget, QTabWidget, QAction
 from PyQt5 import uic
 
@@ -250,6 +250,16 @@ def init_ui(window):
     except Exception:
         log.info(
             'Failed to initialize an element on %s', window.objectName())
+
+
+def best_contrast(background: QColor) -> QColor:
+    """Choose text color for best contrast against a background color"""
+    colrgb = background.getRgbF()
+    # Compute perceptive luminance of background color
+    lum = (0.299 * colrgb[0] + 0.587 * colrgb[1] + 0.114 * colrgb[2])
+    if (lum < 0.5):
+        return QColor(Qt.white)
+    return QColor(Qt.black)
 
 
 def center(window):

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -378,16 +378,6 @@ class TitleEditor(QDialog):
         refresh_fn()
         self.save_and_reload()
 
-    @staticmethod
-    def best_contrast(bg: QtGui.QColor) -> QtGui.QColor:
-        """Choose text color for best contrast against a background"""
-        colrgb = bg.getRgbF()
-        # Compute perceptive luminance of background color
-        lum = (0.299 * colrgb[0] + 0.587 * colrgb[1] + 0.114 * colrgb[2])
-        if (lum < 0.5):
-            return QtGui.QColor(Qt.white)
-        return QtGui.QColor(Qt.black)
-
     def btnFontColor_clicked(self):
         app = get_app()
         _ = app._tr
@@ -463,7 +453,7 @@ class TitleEditor(QDialog):
             opacity = float(ard.get("opacity", 1.0))
 
             color = QtGui.QColor(color)
-            text_color = self.best_contrast(color)
+            text_color = ui_util.best_contrast(color)
             # Set the color of the button, ignoring alpha
             self.btnFontColor.setStyleSheet(
                 "background-color: %s; opacity: %s; color: %s;"
@@ -510,7 +500,7 @@ class TitleEditor(QDialog):
             opacity = float(ard.get("opacity", 1.0))
 
             color = QtGui.QColor(color)
-            text_color = self.best_contrast(color)
+            text_color = ui_util.best_contrast(color)
 
             # Set the colors of the button, ignoring opacity
             self.btnBackgroundColor.setStyleSheet(

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -111,12 +111,14 @@ class BlenderListView(QListView):
                 self.params[param["name"]] = float(param["default"])
 
                 widget = QDoubleSpinBox()
-                widget.setMinimum(float(param["min"]))
-                widget.setMaximum(float(param["max"]))
+                widget.setRange(float(param["min"]), float(param["max"]))
                 widget.setValue(float(param["default"]))
-                widget.setSingleStep(0.01)
+                step = param.get("step", 0.01)
+                widget.setSingleStep(float(step))
+                digits = param.get("digits", 2)
+                widget.setDecimals(int(digits))
                 widget.setToolTip(param["title"])
-                widget.valueChanged.connect(functools.partial(self.spinner_value_changed, param))
+                widget.valueChanged.connect(functools.partial(self.spinner_value_changed, widget, param))
 
             elif param["type"] == "text":
                 # add value to dictionary
@@ -199,9 +201,9 @@ class BlenderListView(QListView):
         self.end_processing()
         self.init_slider_values()
 
-    def spinner_value_changed(self, param, value):
+    def spinner_value_changed(self, widget, param, value):
         self.params[param["name"]] = value
-        log.info('Animation param %s set to %s' % (param["name"], value))
+        log.info('Animation param %s set to %0.2f' % (param["name"], value))
 
     def text_value_changed(self, widget, param, value=None):
         try:

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -103,6 +103,9 @@ class BlenderListView(QListView):
             label.setText(_(param["title"]))
             label.setToolTip(_(param["title"]))
 
+            if "bold_label" in param["type"]:
+                label.setStyleSheet(r"* { font-weight: bold; font-size: 120%; }")
+
             if param["type"] == "spinner":
                 # add value to dictionary
                 self.params[param["name"]] = float(param["default"])


### PR DESCRIPTION
This PR grew out of https://github.com/OpenShot/openshot-qt/issues/4047#issuecomment-801169343, where @Mikrotherion noted that the rendering of the World Globe animated title was a bit dark. I agreed, and determined that it was a lighting issue.

Rather than impose a new lighting scheme on everyone, I decided to add a `sun_intensity` parameter that allows the user to adjust the intensity of the light source from the default `1.0`. It can go down to `0.0`, or up to `20.0` which is _extremely_ bright and cartoonish.

Along the way I also enhanced the form builder a bit, so that there are some new features the XML files can take advantage of (and `earth.xml` already does, now):

* `<param>` tags are no longer required to include an empty `description=""` attribute
* The existing support for unknown-type `<param>` tags creating labels is now taken advantage of to format the parameters for `earth.xml` more hierarchically (details below)
* In addition, a new `<param type="bold_label" title="Some text/>` tag can be used to create, well, **bold** labels
* Support for the existing `<param type="spinner">` child tags `<step>` and `<digits>` is now implemented. The defaults for both are the previously-hardcoded `0.01` and `2` (which signifies two digits **_after_ the decimal point**, not two total digits), respectively.
    So, for example, the following will display values to 2 decimal places, and raise or lower in increments of `0.10`:
    ```xml
    <param name="sun_intensity" type="spinner" title="Sunlight intensity">
      <min>0.0</min>
      <max>10.0</max>
      <default>1.0</default>
      <step>0.1</step>
      <digits>2</digits>
    </param>
    ```

With the new label support, I relabeled a lot of parameters in `earth.xml` to show as a hierarchy, and shortened the labels on the values considerably because the wide labels weren't really fitting in the window. So, now, the settings will load like this:

![image](https://user-images.githubusercontent.com/538020/111876314-ae650600-8974-11eb-86d2-4856742a027a.png)

I'm not 100% happy with it (I'd like a bit _more_ of a true hierarchy, at the bold-labeled levels, and perhaps even the ability to collapse those sections on their bold headings), but it's a start.

Oh, yes, I also migrated my `best_contrast()` function from the Title Editor into `classes.ui`, and it's now used by the Animated Titles interface for the same purpose: To show text labels on color buttons:

![image](https://user-images.githubusercontent.com/538020/111876430-17e51480-8975-11eb-809f-8146172dd7ec.png)

The color labels are enabled on all color buttons for all of the titles, that's not specific to `earth.xml`. The `<step>`, `<digits>`, `<param type="bold_label" .../>`, etc. XML features are also enabled everywhere, but `earth.xml` is currently the only file which makes use of them.

#### Sunlight Intensity

We should probably pick a new default that's higher than `1.0`, as well. Here's the current (non-adjustable) lighting level at `1.0` intensity:
![Screenshot from 2021-03-24 11-51-16](https://user-images.githubusercontent.com/538020/112342902-082d3f00-8c99-11eb-9829-5ff8d495e5f0.png)

Raising it to `3.0`:
![Screenshot from 2021-03-24 11-51-35](https://user-images.githubusercontent.com/538020/112342935-0fece380-8c99-11eb-84bb-3db72bf1975a.png)

And, maxed out at `20.0`:
![Screenshot from 2021-03-24 11-52-06](https://user-images.githubusercontent.com/538020/112342982-18451e80-8c99-11eb-87bf-6f262a5eed81.png)
