### PR TITLE
Remove cache display from timeline

### DIFF
--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -58,9 +58,8 @@
 				<img ng-repeat="marker in project.markers" id="marker_{{marker.id}}_{{$index}}" ng-right-click="showMarkerMenu(marker.id)" style="position: absolute; bottom: 0px; left: {{(marker.position * pixelsPerSecond) - 6 }}px;" class="marker_icon" ng-src="media/images/markers/{{ marker.icon }}" draggable="false"/>
 			</span>
 			<br class="cleared">
-			
-			<!-- PROGRESS BAR -->
-			<canvas id="progress" width="{{canvasMaxWidth(project.duration * pixelsPerSecond)}}px" height="3px"></canvas>
+			<!-- former PROGRESS BAR -->
+			<div style="height: 3px;"></div>
  		</div>
  		<div class="cleared"></div>
 

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -51,7 +51,6 @@ App.controller("TimelineCtrl", function ($scope) {
       {id: "L4", number: 4, y: 0, label: "", lock: false}
     ],
     markers: [],
-    progress: {}
   };
 
   // Additional variables used to control the rendering of HTML
@@ -450,41 +449,6 @@ App.controller("TimelineCtrl", function ($scope) {
       // Push new clip onto stack
       $scope.project.clips.push(clip_json);
     });
-  };
-
-  // Update cache json
-  $scope.renderCache = function (cache_json) {
-    // Push new clip onto stack
-    $scope.project.progress = cache_json;
-
-    //clear the canvas first
-    var ruler = $("#progress");
-    var ctx = ruler[0].getContext("2d");
-    ctx.clearRect(0, 0, ruler.width(), ruler.height());
-
-    // Determine fps & and get cached ranges
-    var fps = $scope.project.fps.num / $scope.project.fps.den;
-    var progress = $scope.project.progress.ranges;
-
-    // Loop through each cached range of frames, and draw rect
-    for (var p = 0; p < progress.length; p++) {
-      //get the progress item details
-      var start_second = parseFloat(progress[p]["start"]) / fps;
-      var stop_second = parseFloat(progress[p]["end"]) / fps;
-
-      //figure out the actual pixel position, constrained by max width
-      var start_pixel = $scope.canvasMaxWidth(start_second * $scope.pixelsPerSecond);
-      var stop_pixel = $scope.canvasMaxWidth(stop_second * $scope.pixelsPerSecond);
-      var rect_length = stop_pixel - start_pixel;
-      if (rect_length < 1) {
-        break;
-      }
-      //get the element and draw the rects
-      ctx.beginPath();
-      ctx.rect(start_pixel, 0, rect_length, 5);
-      ctx.fillStyle = "#4B92AD";
-      ctx.fill();
-    }
   };
 
   // Clear all selections

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief Ruler directives (dragging playhead functionality, progress bars, tick marks, etc...)
+ * @brief Ruler directives (playhead functionality, markers, tick marks, etc...)
  * @author Jonathan Thomas <jonathan@openshot.org>
  * @author Cody Parker <cody@yourcodepro.com>
  *
@@ -52,7 +52,6 @@ App.directive("tlScrollableTracks", function () {
 
         $("#track_controls").scrollTop(element.scrollTop());
         $("#scrolling_ruler").scrollLeft(element.scrollLeft());
-        $("#progress_container").scrollLeft(element.scrollLeft());
       });
 
       // Initialize panning when middle mouse is clicked

--- a/src/timeline/media/css/main.css
+++ b/src/timeline/media/css/main.css
@@ -1,7 +1,7 @@
 html {
     height: 100%;
 }
-body { 
+body {
 	height: 100%;
     margin: 0;
     background-repeat: no-repeat;
@@ -48,7 +48,6 @@ img {
 #ruler_label { height: 39px; width: 140px; float: left; margin-bottom: 4px; }
 #ruler_ticks { background-color:#000; }
 #ruler_time { font-size: 13pt; color: #c8c8c8; padding-top: 14px; padding-left: 17px; }
-#progress_container {margin-left:140px; overflow: hidden; height: 13px;}
 .drag_cursor { cursor: move; }
 
 /* Tracks */
@@ -166,7 +165,7 @@ img {
 
 ::-webkit-scrollbar-track {
   background: #000000;
-  box-shadow: inset 0 0 0.6em rgba(75,196,233,1.0); 
+  box-shadow: inset 0 0 0.6em rgba(75,196,233,1.0);
   border-radius: 0.45em;
 }
 

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2828,9 +2828,15 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Create the timeline sync object (used for previewing timeline)
         self.timeline_sync = TimelineSync(self)
 
-        # Setup timeline
-        self.timeline = TimelineWebView(self)
+        # Setup timeline view
+        self.timeline = TimelineWebView(window=self)
+        self.timeline.setObjectName("main_window.timeline")
         self.frameWeb.layout().addWidget(self.timeline)
+
+        # Connect webview signals
+        self.sliderZoom.valueChanged.connect(self.timeline.update_zoom)
+        self.WaveformReady.connect(self.timeline.Waveform_Ready)
+        self.ThumbnailUpdated.connect(self.timeline.Thumbnail_Updated)
 
         # Configure the side docks to full-height
         self.setCorner(Qt.TopLeftCorner, Qt.LeftDockWidgetArea)

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2710,7 +2710,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
     @pyqtSlot()
     def centerOnPlayhead(self):
         """ Center the timeline on the current playhead position """
-        # Execute JavaScript to center the timeline
         self.run_js(JS_SCOPE_SELECTOR + '.centerOnPlayhead();')
 
     @pyqtSlot(int)
@@ -2834,8 +2833,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             # Track that a new item is being 'added'
             self.new_item = True
             self.item_type = "os_drop"
-
-            # accept event
             event.accept()
 
     # Add Clip
@@ -2854,10 +2851,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 # File not found, do nothing
                 return
 
-            # Get file name
             filename = os.path.basename(file.data["path"])
-
-            # Convert path to the correct relative path (based on this folder)
             file_path = file.absolute_path()
 
             # Create clip object for this file
@@ -3041,9 +3035,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
     # Without defining this method, the 'copy' action doesn't show with cursor
     def dragMoveEvent(self, event):
-        # Accept all move events
         event.accept()
-
         # Get cursor position
         pos = event.posF()
 
@@ -3055,9 +3047,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
     def dropEvent(self, event):
         log.info("Dropping item on timeline - item_id: %s, item_type: %s" % (self.item_id, self.item_type))
 
-        # Accept event
         event.accept()
-
         # Get position of cursor
         pos = event.posF()
 
@@ -3099,9 +3089,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         """A drag is in-progress and the user moves mouse outside of timeline"""
         log.debug('dragLeaveEvent - Undo drop')
 
-        # Accept event
         event.accept()
-
         # Clear selected clips
         self.window.removeSelection(self.item_id, self.item_type)
 
@@ -3125,25 +3113,19 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
     def redraw_audio_onTimeout(self):
         """Timer is ready to redraw audio (if any)"""
         log.debug('redraw_audio_onTimeout')
-
         # Pass to javascript timeline (and render)
         self.run_js(JS_SCOPE_SELECTOR + ".reDrawAllAudioData();")
 
     def ClearAllSelections(self):
         """Clear all selections in JavaScript"""
-
-        # Call javascript command
         self.run_js(JS_SCOPE_SELECTOR + ".clearAllSelections();")
 
     def SelectAll(self):
         """Select all clips and transitions in JavaScript"""
-
-        # Call javascript command
         self.run_js(JS_SCOPE_SELECTOR + ".selectAll();")
 
-    def __init__(self, window):
-        super().__init__()
-        self.setObjectName("TimelineWebView")
+    def __init__(self, *args, window=None, **kwargs):
+        super().__init__(*args, **kwargs)
 
         app = get_app()
         self.window = window
@@ -3156,17 +3138,8 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         # Add self as listener to project data updates (used to update the timeline)
         app.updates.add_listener(self)
 
-        # Connect zoom functionality
-        window.sliderZoom.valueChanged.connect(self.update_zoom)
-
-        # Connect waveform generation signal
-        window.WaveformReady.connect(self.Waveform_Ready)
-
         # Local audio waveform cache
         self.waveform_cache = {}
-
-        # Connect update thumbnail signal
-        window.ThumbnailUpdated.connect(self.Thumbnail_Updated)
 
         # Copy clipboard
         self.copy_clipboard = {}


### PR DESCRIPTION
Now that the preview player effectively has no cache, its status is trivial (it's always just a few frames around the playhead), making its display in the Timeline view a pointless waste of user attention and CPU cycles. So, this PR removes it entirely: From the timeline HTML, from the JS and CSS, and from the webview code (along with the `QTimer` that refreshed it).

To keep from messing up the interface layout (the playhead would be too tall), visually it's replaced by an empty `<div>` that's the same `3px` high.

In addition, the code that connects the webview to the signals from the main window is moved from `TimelineWebView.__init__()` to the calling function, so that it's done by the owner of the signals, and only after the object is fully created. Which is slightly "more correct".

A few offensively dumb comments are also removed. (This kind of thing...)
```python
# Accept event
event.accept()
```