### PR TITLE
CI: Ignore Ubuntu 20.04 failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,22 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allowed-to-fail }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        include:
+          - os: ubuntu-18.04
+            allowed-to-fail: false
+          - os: ubuntu-20.04
+            allowed-to-fail: true
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v2
 
     - name: Install dependencies
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
-      shell: bash
       run: |
         sudo add-apt-repository ppa:openshot.developers/libopenshot-daily
         sudo apt update
@@ -23,11 +29,7 @@ jobs:
         pip3 install cx_Freeze==6.1 distro defusedxml requests certifi chardet urllib3
 
     - name: Build Python package
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      shell: bash
       run: python3 freeze.py build
 
     - name: Test
-      shell: bash
       run: xvfb-run --auto-servernum --server-num=1 --server-args "-screen 0 1920x1080x24" python3 ./src/tests/query_tests.py


### PR DESCRIPTION
Until we can fix the unit tests runner, the CI job on `ubuntu-20.04` will often fail. Therefore, temporarily ignore those failures and don't allow them to cancel the `ubuntu-18.04` build.