### PR TITLE
WIP: Reversed Track Gradient

### DIFF
--- a/src/timeline/media/css/main.css
+++ b/src/timeline/media/css/main.css
@@ -60,7 +60,7 @@ img {
 .track_label { padding-top: 2px; padding-left: 2px; padding-left: 4px; text-shadow: 0 0 10px #ffffff; }
 .track_name { width: 140px; height: 64px; color: #fff; font-size: 9pt; margin-left: 5px; margin-bottom: 8px; background-color: #000; border: 1px solid #4B92AD; border-top-left-radius: 8px; border-bottom-left-radius: 8px; box-shadow: 0px 0px 10px #000; }
 .track_disabled { background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(20,20,20,1)), color-stop(100%,rgba(6,6,6,1))) !important; }
-.track { height: 64px; background-color: #000; margin-bottom: 8px; background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(50,50,50,1)), color-stop(100%,rgba(6,6,6,1))); border-top: 1px solid #4b92ad; border-bottom: 1px solid #4b92ad; border-right: 1px solid #4B92AD; border-top-right-radius: 8px; border-bottom-right-radius: 8px; box-shadow: 0px 0px 10px #000; }
+.track { height: 64px; background-color: #000; margin-bottom: 8px; background: -webkit-gradient(linear, left bottom, left top, color-stop(0%,rgba(50,50,50,1)), color-stop(100%,rgba(6,6,6,1))); border-top: 1px solid #4b92ad; border-bottom: 1px solid #4b92ad; border-right: 1px solid #4B92AD; border-top-right-radius: 8px; border-bottom-right-radius: 8px; box-shadow: 0px 0px 10px #000; }
 
 /* Playhead */
 .playhead-line { z-index: 9998; position: absolute; height:316px; top:0px; width:1px; background-color:#ff0024; opacity:1;}


### PR DESCRIPTION
Test Part 1: Gradient Problem
===
## Goal: Vertically invert the color gradient for tracks
1. Spent a while looking for visual settings in .py files. Which I now see don't control the visual styling.
1. Searched the project for the word gradient.
1. Found more results than I could make use of.
1. Looked at documentation for the name of the UI element I was looking for
** Tutorial indicated I'm looking in the timeline
** Also saw that 'clips' are media segments and are put on 'tracks'
1. Checked commit history for commits referencing 'timeline'
1. Found 'ee9365028fe6e4e2c08f15e5d9338a03d4ee1383': Timeline CSS: More visible keyframe marks
** Sounds like a visual change... Getting warmer.
1. Glanced up and down main.css found "Tracks" next to "Clips"
1. Started changing colors to #00FF00 to narrow down which style statements control what.
1. This looks right:

   ```.track { height: 64px; background-color: #000; margin-bottom: 8px; background: -webkit-gradient(linear, left bottom, left top, color-stop(0%,rgba(50,50,50,1)), color-stop(100%,rgba(6,6,6,1))); border-top: 1px solid #4b92ad; border-bottom: 1px solid #4b92ad; border-right: 1px solid #4B92AD; border-top-right-radius: 8px; border-bottom-right-radius: 8px; box-shadow: 0px 0px 10px #000; }```

    * Switched this:

        `background: -webkit-gradient(linear, left top, left bottom,...`

    * To This:

        `background: -webkit-gradient(linear, left bottom, left top,`

1. Ran the program to check