### PR TITLE
WIP: [added a replace_file button]

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -678,6 +678,19 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             # Restore cursor
             app.restoreOverrideCursor()
 
+    def actionReplace_File_trigger(self):
+        log.debug("actionRemove_from_Project_trigger")
+        #TODO: make hide this option until a file is selected
+        #Using the technique from Remove_from_Project
+
+        f = self.files_model.current_file()
+        f.delete()
+
+        # if not f:
+        #     log.warn("Replace File Failed")
+        #     return #TODO: default to import_file
+        self.actionImportFiles_trigger()
+
     def invalidImage(self, filename=None):
         """ Show a popup when an image file can't be loaded """
         if not filename:

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -1409,6 +1409,18 @@
     <string>File Properties</string>
    </property>
   </action>
+  <action name="actionReplace_File">
+   <property name="icon">
+    <iconset theme="video-x-generic" resource="../../../images/openshot.qrc">
+     <normaloff>:/icons/Humanity/actions/16/edit-copy.svg</normaloff>:/icons/Humanity/actions/16/edit-copy.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Replace File</string>
+   </property>
+   <property name="toolTip">
+    <string>Replace File</string>
+   </property>
+  </action>
   <action name="actionPropertyFilterClear">
    <property name="icon">
     <iconset theme="edit-clear" resource="../../../images/openshot.qrc">

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -72,6 +72,7 @@ class FilesListView(QListView):
                 menu.addAction(self.win.actionDuplicateTitle)
                 menu.addSeparator()
 
+            menu.addAction(self.win.actionReplace_File)
             menu.addAction(self.win.actionPreview_File)
             menu.addAction(self.win.actionSplitClip)
             menu.addAction(self.win.actionAdd_to_Timeline)

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -75,6 +75,7 @@ class FilesTreeView(QTreeView):
                 menu.addAction(self.win.actionDuplicateTitle)
                 menu.addSeparator()
 
+            menu.addAction(self.win.actionReplace_File)
             menu.addAction(self.win.actionPreview_File)
             menu.addAction(self.win.actionSplitClip)
             menu.addAction(self.win.actionAdd_to_Timeline)


### PR DESCRIPTION
Test Problem 2
===
## Goal: 
    Add a new 'replace file' item to the right click file menu

1. Checked file.rst
** Verified that menu when you right click on a file is called the 'file menu'
just so I know what to look for.

1. Searched "DetailsView" as it's going to be a sibling of the button I'm adding.

1. Looked up pyqt documentation on rightclick menus
** Found that they're called context menus, and created with 
    `def contextMenuEvent(...`

1. Searched the repo for that function definition, in .py files related to the file menu.

1. Found files_listview.py and files_treeview.py

1. Each of the actions in files_listview and files_treeview appear in main_window.py and main-window.ui
** Realize this is how the functions are associated to names, Icons and Tooltips.

1. Add an action for replace file to the main-window.ui, and added it to the context
menu in listview and treeview. ReplaceFile now shows up in rightclick menu.

1. Implemented replacement (incompletely) by deleting the selected files, and calling the importFiles function.

Remaining Issues
===
1. A way of keeping the clipping the same between a file and it's replacement
2. Making the correct icon display