### PR TITLE
AppStream metadata: update content ratings

### DIFF
--- a/xdg/org.openshot.OpenShot.appdata.xml
+++ b/xdg/org.openshot.OpenShot.appdata.xml
@@ -47,26 +47,7 @@
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.0">
-    <content_attribute id="violence-cartoon">none</content_attribute>
-    <content_attribute id="violence-fantasy">none</content_attribute>
-    <content_attribute id="violence-realistic">none</content_attribute>
-    <content_attribute id="violence-bloodshed">none</content_attribute>
-    <content_attribute id="violence-sexual">none</content_attribute>
-    <content_attribute id="drugs-alcohol">none</content_attribute>
-    <content_attribute id="drugs-narcotics">none</content_attribute>
-    <content_attribute id="drugs-tobacco">none</content_attribute>
-    <content_attribute id="sex-nudity">none</content_attribute>
-    <content_attribute id="sex-themes">none</content_attribute>
-    <content_attribute id="language-profanity">none</content_attribute>
-    <content_attribute id="language-humor">none</content_attribute>
-    <content_attribute id="language-discrimination">none</content_attribute>
-    <content_attribute id="social-chat">none</content_attribute>
-    <content_attribute id="social-info">none</content_attribute>
-    <content_attribute id="social-audio">none</content_attribute>
-    <content_attribute id="social-location">none</content_attribute>
-    <content_attribute id="social-contacts">none</content_attribute>
-    <content_attribute id="money-purchasing">none</content_attribute>
-    <content_attribute id="money-gambling">none</content_attribute>
+    <content_attribute id="social-info">moderate</content_attribute>
   </content_rating>
   <provides>
     <binary>openshot-qt</binary>


### PR DESCRIPTION
So, I ran through the [OARS ratings tool](https://hughsie.github.io/oars/generate.html) for generating AppStream `<content_rating>` metadata blocks, and this is what it came up with. Two important changes:

1. Turns out we're _not_ supposed to include all of those tags marked `none` for content warnings that _don't_ apply; in fact, counter-intuitively, `none` is [documented as meaning](https://freedesktop.org/software/appstream/docs/chap-Metadata.html) "No rating given", whereas an _empty_ `<content_rating>` block means "the component was checked for age ratings and no age restrictions apply". So, the _absence_ of a rating category inside the `<content_rating>` block is the clearest way to indicate that the rating is not applicable to the software in question.
    
    (Also, this is what the official tool generated, so far be it from me to contradict it. Especially when its version is preferable to what we had before.)

1. Our diagnostic telemetry qualifies us for a "`moderate`" rating in the `social-info` category, though, according to the OARS scale:
    
    ![image](https://user-images.githubusercontent.com/538020/116040309-dca3c880-a639-11eb-9360-42e6e21404f6.png)
    
    (I'm basing this on our _intended_ use of the information, though I'm not 100% confident that the info provided by the metrics system **couldn't** be reversed to at least a partial identity for an individual user, if someone really wanted to.)
