### PR TITLE
New Zoom Slider Widget - Modernizing and simplifying timeline scrolling, panning, and zooming :partying_face: 

### DIFF
--- a/src/classes/query.py
+++ b/src/classes/query.py
@@ -311,6 +311,11 @@ class Track(QueryObject):
         """ Take any arguments given as filters, and find the first matching object """
         return QueryObject.get(Track, **kwargs)
 
+    def __lt__(self, other):
+        return self.data.get('number', 0) < other.data.get('number', 0)
+
+    def __gt__(self, other):
+        return self.data.get('number', 0) > other.data.get('number', 0)
 
 class Effect(QueryObject):
     """ This class allows Effects to be queried, updated, and deleted from the project data. """

--- a/src/launch.py
+++ b/src/launch.py
@@ -52,7 +52,7 @@ except ImportError:
     from classes import info
 
 
-def main():
+if __name__ == "__main__":
     """"Initialize settings (not implemented) and create main window/application."""
 
     parser = argparse.ArgumentParser(description = 'OpenShot version ' + info.SETUP['version'])
@@ -141,7 +141,3 @@ def main():
 
     # Run and return result
     sys.exit(app.run())
-
-
-if __name__ == "__main__":
-    main()

--- a/src/launch.py
+++ b/src/launch.py
@@ -52,7 +52,7 @@ except ImportError:
     from classes import info
 
 
-if __name__ == "__main__":
+def main():
     """"Initialize settings (not implemented) and create main window/application."""
 
     parser = argparse.ArgumentParser(description = 'OpenShot version ' + info.SETUP['version'])
@@ -141,3 +141,7 @@ if __name__ == "__main__":
 
     # Run and return result
     sys.exit(app.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -51,7 +51,7 @@
 				<div class="playhead-line-small"></div>
 			</div>
 			<!-- Ruler extends beyond tracks area at least for a width of vertical scroll bar (or more, like 50px here) -->
-			<canvas tl-ruler id="ruler" width="{{canvasMaxWidth(getTimelineWidth(1024) + 50)}}px" height="39"></canvas>
+			<canvas tl-ruler id="ruler" width="{{canvasMaxWidth(getTimelineWidth(0) + 6)}}px" height="39"></canvas>
 
 			<!-- MARKERS --> 
 			<span class="ruler_marker" id="marker_for_{{marker.id}}">
@@ -76,9 +76,9 @@
 		</div>
 		<!-- TRACKS CONTAINER (right of screen) -->
 		<div tl-scrollable-tracks id="scrolling_tracks">
-			<div id="track-container" tl-track tl-multi-selectable style="width: {{getTimelineWidth(1024)}}px; padding-bottom: 2px;">
+			<div id="track-container" tl-track tl-multi-selectable style="width: {{getTimelineWidth(0) - 6}}px; padding-bottom: 2px;">
 				<!-- TRACKS -->
-				<div ng-repeat="layer in project.layers.slice().reverse()" id="track_{{layer.number}}" ng-right-click="showTimelineMenu($event, layer.number)"  class="{{getTrackStyle(layer.lock)}}" style="width:{{getTimelineWidth(1024)}}px;">
+				<div ng-repeat="layer in project.layers.slice().reverse()" id="track_{{layer.number}}" ng-right-click="showTimelineMenu($event, layer.number)"  class="{{getTrackStyle(layer.lock)}}" style="width:{{getTimelineWidth(0) - 6}}px;">
 				</div>
 				
 				<!-- CLIPS -->

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -270,7 +270,7 @@ App.controller("TimelineCtrl", function ($scope) {
     }
 
     // Compare to previous scale (and ignore tiny differences)
-    if (Math.abs(parseFloat(scaleVal) - $scope.project.scale) < 0.00001) {
+    if (Math.abs(parseFloat(scaleVal) - $scope.project.scale) < 1.0e-5) {
       // Do not change scale if the value is this tiny
       // This can cause the Ruler $watch to fail, and will leave the Ruler blank
       return;

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -108,11 +108,6 @@ App.controller("TimelineCtrl", function ($scope) {
     var frames_per_second = $scope.project.fps.num / $scope.project.fps.den;
     var position_seconds = ((position_frames - 1) / frames_per_second);
 
-    // Center on the playhead if it has moved out of view and the timeline should follow it
-    if ($scope.enable_playhead_follow && !$scope.isTimeVisible(position_seconds)) {
-      $scope.centerOnTime(position_seconds);
-    }
-
     // Update internal scope (in seconds)
     $scope.movePlayhead(position_seconds);
   };
@@ -274,6 +269,13 @@ App.controller("TimelineCtrl", function ($scope) {
       cursor_time = parseFloat(horz_scroll_offset) / $scope.pixelsPerSecond;
     }
 
+    // Compare to previous scale (and ignore tiny differences)
+    if (Math.abs(parseFloat(scaleVal) - $scope.project.scale) < 0.00001) {
+      // Do not change scale if the value is this tiny
+      // This can cause the Ruler $watch to fail, and will leave the Ruler blank
+      return;
+    }
+
     $scope.$apply(function () {
       $scope.project.scale = parseFloat(scaleVal);
       $scope.pixelsPerSecond = parseFloat($scope.project.tick_pixels) / parseFloat($scope.project.scale);
@@ -282,6 +284,14 @@ App.controller("TimelineCtrl", function ($scope) {
     // Scroll back to correct cursor time (minus the difference of the cursor location)
     var new_cursor_x = Math.round((cursor_time * $scope.pixelsPerSecond) - center_x);
     scrolling_tracks.scrollLeft(new_cursor_x);
+  };
+
+  // Change the scale and apply to scope
+  $scope.setScroll = function (normalizedScrollValue) {
+    var timeline_length = Math.min(32767, $scope.getTimelineWidth(0));
+    var scrolling_tracks = $("#scrolling_tracks");
+    var horz_scroll_offset = normalizedScrollValue * timeline_length;
+    scrolling_tracks.scrollLeft(horz_scroll_offset);
   };
 
   // Scroll the timeline horizontally of a certain amount (scrol_value)
@@ -949,22 +959,20 @@ App.controller("TimelineCtrl", function ($scope) {
     var scrolling_tracks = $("#scrolling_tracks");
     var vert_scroll_offset = scrolling_tracks.scrollTop();
 
-    $scope.$apply(function () {
-      // Loop through each layer
-      for (var layer_index = 0; layer_index < $scope.project.layers.length; layer_index++) {
-        var layer = $scope.project.layers[layer_index];
+    // Loop through each layer
+    for (var layer_index = 0; layer_index < $scope.project.layers.length; layer_index++) {
+      var layer = $scope.project.layers[layer_index];
 
-        // Find element on screen (bound to this layer)
-        var layer_elem = $("#track_" + layer.number);
-        if (layer_elem.offset()) {
-          // Update the top offset
-          layer.y = layer_elem.offset().top + vert_scroll_offset;
-        }
+      // Find element on screen (bound to this layer)
+      var layer_elem = $("#track_" + layer.number);
+      if (layer_elem.offset()) {
+        // Update the top offset
+        layer.y = layer_elem.offset().top + vert_scroll_offset;
       }
-      // Update playhead height
-      $scope.playhead_height = $("#track-container").height();
-      $(".playhead-line").height($scope.playhead_height);
-    });
+    }
+    // Update playhead height
+    $scope.playhead_height = $("#track-container").height();
+    $(".playhead-line").height($scope.playhead_height);
   };
 
   // Sort clips and transitions by position
@@ -1389,6 +1397,9 @@ App.controller("TimelineCtrl", function ($scope) {
 
     // Re-index Layer Y values
     $scope.updateLayerIndex();
+
+    // Force a scroll event (from 1 to 0, to send the geometry to zoom slider)
+    $("#scrolling_tracks").scrollLeft(1);
 
     // Scroll to top/left when loading a project
     $("#scrolling_tracks").animate({

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -269,20 +269,14 @@ App.controller("TimelineCtrl", function ($scope) {
       cursor_time = parseFloat(horz_scroll_offset) / $scope.pixelsPerSecond;
     }
 
-    // Compare to previous scale (and ignore tiny differences)
-    if (Math.abs(parseFloat(scaleVal) - $scope.project.scale) < 1.0e-5) {
-      // Do not change scale if the value is this tiny
-      // This can cause the Ruler $watch to fail, and will leave the Ruler blank
-      return;
-    }
-
     $scope.$apply(function () {
       $scope.project.scale = parseFloat(scaleVal);
       $scope.pixelsPerSecond = parseFloat($scope.project.tick_pixels) / parseFloat($scope.project.scale);
     });
 
     // Scroll back to correct cursor time (minus the difference of the cursor location)
-    var new_cursor_x = Math.round((cursor_time * $scope.pixelsPerSecond) - center_x);
+    var new_cursor_x = Math.max(0, Math.round((cursor_time * $scope.pixelsPerSecond) - center_x));
+    scrolling_tracks.scrollLeft(new_cursor_x + 1); // force scroll event
     scrolling_tracks.scrollLeft(new_cursor_x);
   };
 

--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -146,12 +146,13 @@ App.directive("tlClip", function ($timeout) {
             }
             // Resize timeline if it's too small to contain all clips
             scope.resizeTimeline();
-
-            // update clip in Qt (very important =)
-            if (scope.Qt) {
-              timeline.update_clip_data(JSON.stringify(scope.clip), true, true, false);
-            }
           });
+
+          // update clip in Qt (very important =)
+          if (scope.Qt) {
+            timeline.update_clip_data(JSON.stringify(scope.clip), true, true, false);
+          }
+
           //resize the audio canvas to match the new clip width
           if (scope.clip.show_audio) {
             //redraw audio as the resize cleared the canvas

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -53,6 +53,18 @@ App.directive("tlScrollableTracks", function () {
         $("#track_controls").scrollTop(element.scrollTop());
         $("#scrolling_ruler").scrollLeft(element.scrollLeft());
         $("#progress_container").scrollLeft(element.scrollLeft());
+
+        // Send scrollbar position to Qt
+        if (scope.Qt) {
+           // Calculate scrollbar positions (left and right edge of scrollbar)
+           var timeline_length = Math.min(32767, scope.getTimelineWidth(0));
+           var left_scrollbar_edge = scroll_left_pixels / timeline_length;
+           var right_scrollbar_edge = (scroll_left_pixels + element.width()) / timeline_length;
+
+           // Send normalized scrollbar positions to Qt
+           timeline.ScrollbarChanged([left_scrollbar_edge, right_scrollbar_edge, timeline_length, element.width()]);
+        }
+
       });
 
       // Initialize panning when middle mouse is clicked

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -217,33 +217,3 @@ App.directive("tlRuler", function ($timeout) {
 
   };
 });
-
-
-// The HTML5 canvas ruler
-App.directive("tlRulertime", function () {
-  return {
-    restrict: "A",
-    link: function (scope, element, attrs) {
-      //on click of the ruler canvas, jump playhead to the clicked spot
-      element.on("mousedown", function () {
-        var playhead_seconds = 0.0;
-        // Update playhead
-        scope.movePlayhead(playhead_seconds);
-        scope.previewFrame(playhead_seconds);
-
-      });
-
-      // Move playhead to new position (if it's not currently being animated)
-      element.on("mousemove", function (e) {
-        if (e.which === 1 && !scope.playhead_animating) { // left button
-          var playhead_seconds = 0.0;
-          // Update playhead
-          scope.movePlayhead(playhead_seconds);
-          scope.previewFrame(playhead_seconds);
-        }
-      });
-
-
-    }
-  };
-});

--- a/src/timeline/js/directives/transition.js
+++ b/src/timeline/js/directives/transition.js
@@ -121,13 +121,12 @@ App.directive("tlTransition", function () {
               scope.transition.position = new_left;
               scope.transition.end -= delta_time;
             }
-
-            // update transition in Qt (very important =)
-            if (scope.Qt) {
-              timeline.update_transition_data(JSON.stringify(scope.transition), true, false);
-            }
-
           });
+
+          // update transition in Qt (very important =)
+          if (scope.Qt) {
+            timeline.update_transition_data(JSON.stringify(scope.transition), true, false);
+          }
 
           dragLoc = null;
 

--- a/src/timeline/media/css/main.css
+++ b/src/timeline/media/css/main.css
@@ -1,7 +1,7 @@
 html {
     height: 100%;
 }
-body { 
+body {
 	height: 100%;
     margin: 0;
     background-repeat: no-repeat;
@@ -161,12 +161,12 @@ img {
 .snapping-line.ng-hide-add.ng-hide-add-active { opacity:0.0; }
 
 /* Scrollbar style */
-::-webkit-scrollbar { width: 0.9em; height: 0.9em; }
+::-webkit-scrollbar { width: 6px; height: 6px; }
 ::-webkit-scrollbar-thumb { background-color: #4b92ad; border-radius: 0.45em; }
 
 ::-webkit-scrollbar-track {
   background: #000000;
-  box-shadow: inset 0 0 0.6em rgba(75,196,233,1.0); 
+  box-shadow: inset 0 0 0.6em rgba(75,196,233,1.0);
   border-radius: 0.45em;
 }
 

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2293,7 +2293,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             self.show_property_timer.start()
 
         # Notify UI that selection has been potentially changed
-        self.SelectionChanged.emit()
+        self.selection_timer.start()
 
     # Remove from the selected items
     def removeSelection(self, item_id, item_type):
@@ -2326,9 +2326,12 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             self.show_property_id = self.selected_effects[0]
             self.show_property_type = item_type
 
-        # Change selected item in properties view
+        # Change selected item
         self.show_property_timer.start()
+        self.selection_timer.start()
 
+    def emit_selection_signal(self):
+        """Emit a signal for selection changed. Callback for selection timer."""
         # Notify UI that selection has been potentially changed
         self.SelectionChanged.emit()
 
@@ -2870,6 +2873,14 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.show_property_timer.setInterval(100)
         self.show_property_timer.setSingleShot(True)
         self.show_property_timer.timeout.connect(self.show_property_timeout)
+
+        # Selection timer
+        # Timer to use a delay before emitting selection signal (to prevent a mass selection from trying
+        # to update the zoom slider widget hundreds of times)
+        self.selection_timer = QTimer()
+        self.selection_timer.setInterval(100)
+        self.selection_timer.setSingleShot(True)
+        self.selection_timer.timeout.connect(self.emit_selection_signal)
 
         # Setup video preview QWidget
         self.videoPreview = VideoWidget()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2564,7 +2564,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Hook up caption editor signal
         self.captionTextEdit.textChanged.connect(self.captionTextEdit_TextChanged)
-        self.caption_save_timer = QTimer()
+        self.caption_save_timer = QTimer(self)
         self.caption_save_timer.setInterval(100)
         self.caption_save_timer.setSingleShot(True)
         self.caption_save_timer.timeout.connect(self.caption_editor_save)
@@ -2869,7 +2869,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # to update the property model hundreds of times)
         self.show_property_id = None
         self.show_property_type = None
-        self.show_property_timer = QTimer()
+        self.show_property_timer = QTimer(self)
         self.show_property_timer.setInterval(100)
         self.show_property_timer.setSingleShot(True)
         self.show_property_timer.timeout.connect(self.show_property_timeout)
@@ -2877,7 +2877,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Selection timer
         # Timer to use a delay before emitting selection signal (to prevent a mass selection from trying
         # to update the zoom slider widget hundreds of times)
-        self.selection_timer = QTimer()
+        self.selection_timer = QTimer(self)
         self.selection_timer.setInterval(100)
         self.selection_timer.setSingleShot(True)
         self.selection_timer.timeout.connect(self.emit_selection_signal)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -29,7 +29,6 @@
 
 import os
 import shutil
-import sys
 import webbrowser
 from copy import deepcopy
 from time import sleep
@@ -46,12 +45,11 @@ from PyQt5.QtWidgets import (
     QMessageBox, QDialog, QFileDialog, QInputDialog,
     QAction, QActionGroup, QSizePolicy,
     QStatusBar, QToolBar, QToolButton,
-    QLineEdit, QSlider, QLabel, QComboBox, QTextEdit
+    QLineEdit, QComboBox, QTextEdit
 )
 
 from classes import exceptions, info, settings, qt_types, ui_util, updates
 from classes.app import get_app
-from classes.conversion import zoomToSeconds, secondsToZoom
 from classes.exporters.edl import export_edl
 from classes.exporters.final_cut_pro import export_xml
 from classes.importers.edl import import_edl

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -97,22 +97,23 @@ class PropertiesModel(updates.UpdateInterface):
 
         timeline = get_app().window.timeline_sync.timeline
         if item_type == "clip":
-            item = timeline.GetClip(item_id)
-        elif item_type == "transition":
-            item = timeline.GetEffect(item_id)
-        elif item_type == "effect":
-            item = timeline.GetClipEffect(item_id)
-            # Filter out basic properties, since this is an effect on a clip
-            self.filter_base_properties = ["position", "layer", "start", "end", "duration"]
-            if item:
-                # We also need the parent
-                self.selected_parent = item.ParentClip()
-        else:
-            item = None
-
-        if not item:
-            return
-        self.selected.append((item, item_type))
+            c = timeline.GetClip(item_id)
+            if c:
+                # Append to selected items
+                self.selected.append((c, item_type))
+        if item_type == "transition":
+            t = timeline.GetEffect(item_id)
+            if t:
+                # Append to selected items
+                self.selected.append((t, item_type))
+        if item_type == "effect":
+            e = timeline.GetClipEffect(item_id)
+            if e:
+                # Filter out basic properties, since this is an effect on a clip
+                self.filter_base_properties = ["position", "layer", "start", "end", "duration"]
+                # Append to selected items
+                self.selected.append((e, item_type))
+                self.selected_parent = e.ParentClip()
 
         # Update frame # from timeline
         self.update_frame(get_app().window.preview_thread.player.Position(), reload_model=False)
@@ -835,7 +836,7 @@ class PropertiesModel(updates.UpdateInterface):
 
         # Timer to use a delay before showing properties (to prevent a mass selection from trying
         # to update the property model hundreds of times)
-        self.update_timer = QTimer()
+        self.update_timer = QTimer(parent)
         self.update_timer.setInterval(100)
         self.update_timer.setSingleShot(True)
         self.update_timer.timeout.connect(self.update_item_timeout)

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -1113,7 +1113,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         # Show Property timer
         # Timer to use a delay before sending MaxSizeChanged signals (so we don't spam libopenshot)
         self.delayed_size = None
-        self.delayed_resize_timer = QTimer()
+        self.delayed_resize_timer = QTimer(self)
         self.delayed_resize_timer.setInterval(200)
         self.delayed_resize_timer.setSingleShot(True)
         self.delayed_resize_timer.timeout.connect(self.delayed_resize_callback)

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -3145,20 +3145,21 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
         # Get final cache object from timeline
         try:
-            cache_object = self.window.timeline_sync.timeline.GetCache()
-            if not cache_object or cache_object.Count() <= 0:
-                return
-            # Get the JSON from the cache object (i.e. which frames are cached)
-            cache_json = self.window.timeline_sync.timeline.GetCache().Json()
-            cache_dict = json.loads(cache_json)
-            cache_version = cache_dict["version"]
+            if self.window.timeline_sync and self.window.timeline_sync.timeline:
+                cache_object = self.window.timeline_sync.timeline.GetCache()
+                if not cache_object or cache_object.Count() <= 0:
+                    return
+                # Get the JSON from the cache object (i.e. which frames are cached)
+                cache_json = self.window.timeline_sync.timeline.GetCache().Json()
+                cache_dict = json.loads(cache_json)
+                cache_version = cache_dict["version"]
 
-            if self.cache_renderer_version == cache_version:
-                # Nothing has changed, ignore
-                return
-            # Cache has changed, re-render it
-            self.cache_renderer_version = cache_version
-            self.run_js(JS_SCOPE_SELECTOR + ".renderCache({});".format(cache_json))
+                if self.cache_renderer_version == cache_version:
+                    # Nothing has changed, ignore
+                    return
+                # Cache has changed, re-render it
+                self.cache_renderer_version = cache_version
+                self.run_js(JS_SCOPE_SELECTOR + ".renderCache({});".format(cache_json))
         except Exception as ex:
             # Log the exception and ignore
             log.warning("Exception processing timeline cache: %s", ex)

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -227,14 +227,10 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             initial_scale = get_app().project.get("scale") or 15.0
             self.window.sliderZoomWidget.setZoomFactor(initial_scale)
 
-            # The setValue() above doesn't trigger update_zoom when a project file is
-            # loaded on the command line (too early?), so also call the JS directly
-            self.run_js(JS_SCOPE_SELECTOR + ".setScale(" + str(initial_scale) + ", 0);")
-
-    # Javascript callable function to update the project data when a clip changes
     @pyqtSlot(str, bool, bool, bool)
     def update_clip_data(self, clip_json, only_basic_props=True, ignore_reader=False, ignore_refresh=False):
-        """ Create an updateAction and send it to the update manager """
+        """ Javascript callable function to update the project data when a clip changes.
+        Create an updateAction and send it to the update manager """
 
         # read clip json
         try:

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -3150,7 +3150,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 if not cache_object or cache_object.Count() <= 0:
                     return
                 # Get the JSON from the cache object (i.e. which frames are cached)
-                cache_json = self.window.timeline_sync.timeline.GetCache().Json()
+                cache_json = cache_object.Json()
                 cache_dict = json.loads(cache_json)
                 cache_version = cache_dict["version"]
 

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -47,7 +47,6 @@ from classes.app import get_app
 from classes.logger import log
 from classes.query import File, Clip, Transition, Track
 from classes.waveform import get_audio_data
-from classes.conversion import zoomToSeconds, secondsToZoom
 from classes.effect_init import effect_options
 
 # Constants used by this file

--- a/src/windows/views/zoom_slider.py
+++ b/src/windows/views/zoom_slider.py
@@ -31,7 +31,7 @@ from PyQt5.QtCore import (
 from PyQt5.QtGui import (
     QPainter, QPixmap, QColor, QPen, QBrush, QCursor, QPainterPath
 )
-from PyQt5.QtWidgets import QSizePolicy, QWidget, QPushButton
+from PyQt5.QtWidgets import QSizePolicy, QWidget
 
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 

--- a/src/windows/views/zoom_slider.py
+++ b/src/windows/views/zoom_slider.py
@@ -526,7 +526,7 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
         # Show Property timer
         # Timer to use a delay before sending MaxSizeChanged signals (so we don't spam libopenshot)
         self.delayed_size = None
-        self.delayed_resize_timer = QTimer()
+        self.delayed_resize_timer = QTimer(self)
         self.delayed_resize_timer.setInterval(200)
         self.delayed_resize_timer.setSingleShot(True)
         self.delayed_resize_timer.timeout.connect(self.delayed_resize_callback)

--- a/src/windows/views/zoom_slider.py
+++ b/src/windows/views/zoom_slider.py
@@ -119,28 +119,23 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
         clip_pen.setCosmetic(True)
         painter.setPen(clip_pen)
 
-        clip_pen = QPen(QBrush(QColor("#53a0ed")), 1.5)
-        clip_pen.setCosmetic(True)
         selected_clip_pen = QPen(QBrush(QColor("Red")), 1.5)
         selected_clip_pen.setCosmetic(True)
 
-        scroll_color = QColor("#53a0ed")
-        scroll_color.setAlphaF(0.25)
+        scroll_color = QColor("#4053a0ed")
         scroll_pen = QPen(QBrush(scroll_color), 2.0)
         scroll_pen.setCosmetic(True)
 
-        marker_color = QColor("#53a0ed")
-        marker_color.setAlphaF(0.25)
+        marker_color = QColor("#4053a0ed")
         marker_pen = QPen(QBrush(marker_color), 1.0)
         marker_pen.setCosmetic(True)
 
-        playhead_color = QColor("Red")
+        playhead_color = QColor(Qt.red)
         playhead_color.setAlphaF(0.5)
         playhead_pen = QPen(QBrush(playhead_color), 1.0)
         playhead_pen.setCosmetic(True)
 
-        handle_color = QColor("#53a0ed")
-        handle_color.setAlphaF(0.65)
+        handle_color = QColor("#a653a0ed")
         handle_pen = QPen(QBrush(handle_color), 1.5)
         handle_pen.setCosmetic(True)
 
@@ -365,7 +360,7 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
         scroll_width_seconds = normalized_scroll_width * project_duration
         tick_pixels = 100
         if self.scrollbar_position[3] > 0.0:
-            # Calculate the new zoom factor, based on 100 pixels per tick
+            # Calculate the new zoom factor, based on pixels per tick
             zoom_factor = scroll_width_seconds / (self.scrollbar_position[3] / tick_pixels)
 
             # Set scroll width (and send signal)

--- a/src/windows/views/zoom_slider.py
+++ b/src/windows/views/zoom_slider.py
@@ -36,7 +36,6 @@ from PyQt5.QtWidgets import QSizePolicy, QWidget, QPushButton
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 
 from classes import updates
-from classes import openshot_rc  # noqa
 from classes.app import get_app
 from classes.query import Clip, Track, Transition, Marker
 
@@ -154,7 +153,6 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
             project_duration = get_app().project.get("duration")
             pixels_per_second = event.rect().width() / project_duration
             project_pixel_width = max(0, project_duration * pixels_per_second)
-            timeline_max_width = self.scrollbar_position[2]
             scroll_width = (self.scrollbar_position[1] - self.scrollbar_position[0]) * event.rect().width()
 
             # Get FPS info

--- a/src/windows/views/zoom_slider.py
+++ b/src/windows/views/zoom_slider.py
@@ -1,0 +1,510 @@
+"""
+ @file
+ @brief This file contains the zoom slider QWidget (for interactive zooming/panning on the timeline)
+ @author Jonathan Thomas <jonathan@openshot.org>
+
+ @section LICENSE
+
+ Copyright (c) 2008-2018 OpenShot Studios, LLC
+ (http://www.openshotstudios.com). This file is part of
+ OpenShot Video Editor (http://www.openshot.org), an open-source project
+ dedicated to delivering high quality video editing and animation solutions
+ to the world.
+
+ OpenShot Video Editor is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenShot Video Editor is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
+ """
+
+from PyQt5.QtCore import (
+    Qt, QCoreApplication, QRectF, QTimer
+)
+from PyQt5.QtGui import (
+    QPainter, QPixmap, QColor, QPen, QBrush, QCursor, QPainterPath
+)
+from PyQt5.QtWidgets import QSizePolicy, QWidget, QPushButton
+
+import openshot  # Python module for libopenshot (required video editing module installed separately)
+
+from classes import updates
+from classes import openshot_rc  # noqa
+from classes.app import get_app
+from classes.query import Clip, Track, Transition, Marker
+
+
+class ZoomSlider(QWidget, updates.UpdateInterface):
+    """ A QWidget used to zoom and pan around a Timeline"""
+
+    # This method is invoked by the UpdateManager each time a change happens (i.e UpdateInterface)
+    def changed(self, action):
+        # Clear previous rects
+        self.clip_rects.clear()
+        self.clip_rects_selected.clear()
+        self.marker_rects.clear()
+
+        # Get layer lookup
+        layers = {}
+        for count, layer in enumerate(reversed(sorted(Track.filter()))):
+            layers[layer.data.get('number')] = count
+
+        # Wait for timeline object and valid scrollbar positions
+        if get_app().window.timeline and self.scrollbar_position[2] != 0.0:
+            # Get max width of timeline
+            project_duration = get_app().project.get("duration")
+            pixels_per_second = self.width() / project_duration
+            project_pixel_width = max(0, project_duration * pixels_per_second)
+
+            # Determine scale factor
+            horizontal_factor = self.width() / project_pixel_width
+            vertical_factor = self.height() / len(layers.keys())
+
+            for clip in Clip.filter():
+                # Calculate clip geometry (and cache it)
+                clip_x = (clip.data.get('position', 0.0) * pixels_per_second) * horizontal_factor
+                clip_y = layers.get(clip.data.get('layer', 0), 0) * vertical_factor
+                clip_width = ((clip.data.get('end', 0.0) - clip.data.get('start',0.0))
+                              * pixels_per_second) * horizontal_factor
+                clip_rect = QRectF(clip_x, clip_y, clip_width, 1.0 * vertical_factor)
+                if clip.id in get_app().window.selected_clips:
+                    # selected clip
+                    self.clip_rects_selected.append(clip_rect)
+                else:
+                    # un-selected clip
+                    self.clip_rects.append(clip_rect)
+
+            for clip in Transition.filter():
+                # Calculate clip geometry (and cache it)
+                clip_x = (clip.data.get('position', 0.0) * pixels_per_second) * horizontal_factor
+                clip_y = layers.get(clip.data.get('layer', 0), 0) * vertical_factor
+                clip_width = ((clip.data.get('end', 0.0) - clip.data.get('start',0.0))
+                              * pixels_per_second) * horizontal_factor
+                clip_rect = QRectF(clip_x, clip_y, clip_width, 1.0 * vertical_factor)
+                if clip.id in get_app().window.selected_transitions:
+                    # selected clip
+                    self.clip_rects_selected.append(clip_rect)
+                else:
+                    # un-selected clip
+                    self.clip_rects.append(clip_rect)
+
+            for marker in Marker.filter():
+                # Calculate clip geometry (and cache it)
+                marker_x = (marker.data.get('position', 0.0) * pixels_per_second) * horizontal_factor
+                marker_rect = QRectF(marker_x, 0, 0.5, len(layers) * vertical_factor)
+                self.marker_rects.append(marker_rect)
+
+        # Force re-paint
+        self.update()
+
+    def paintEvent(self, event, *args):
+        """ Custom paint event """
+        event.accept()
+
+        # Paint timeline preview on QWidget
+        painter = QPainter(self)
+        painter.setRenderHints(QPainter.Antialiasing | QPainter.SmoothPixmapTransform | QPainter.TextAntialiasing, True)
+
+        # Fill the whole widget with the solid color (background solid color)
+        painter.fillRect(event.rect(), QColor("#191919"))
+
+        # Create pens / colors
+        clip_pen = QPen(QBrush(QColor("#53a0ed")), 1.5)
+        clip_pen.setCosmetic(True)
+        painter.setPen(clip_pen)
+
+        clip_pen = QPen(QBrush(QColor("#53a0ed")), 1.5)
+        clip_pen.setCosmetic(True)
+        selected_clip_pen = QPen(QBrush(QColor("Red")), 1.5)
+        selected_clip_pen.setCosmetic(True)
+
+        scroll_color = QColor("#53a0ed")
+        scroll_color.setAlphaF(0.25)
+        scroll_pen = QPen(QBrush(scroll_color), 2.0)
+        scroll_pen.setCosmetic(True)
+
+        marker_color = QColor("#53a0ed")
+        marker_color.setAlphaF(0.25)
+        marker_pen = QPen(QBrush(marker_color), 1.0)
+        marker_pen.setCosmetic(True)
+
+        playhead_color = QColor("Red")
+        playhead_color.setAlphaF(0.5)
+        playhead_pen = QPen(QBrush(playhead_color), 1.0)
+        playhead_pen.setCosmetic(True)
+
+        handle_color = QColor("#53a0ed")
+        handle_color.setAlphaF(0.65)
+        handle_pen = QPen(QBrush(handle_color), 1.5)
+        handle_pen.setCosmetic(True)
+
+        # Get layer lookup
+        layers = Track.filter()
+
+        # Wait for timeline object and valid scrollbar positions
+        if get_app().window.timeline and self.scrollbar_position[2] != 0.0:
+            # Get max width of timeline
+            project_duration = get_app().project.get("duration")
+            pixels_per_second = event.rect().width() / project_duration
+            project_pixel_width = max(0, project_duration * pixels_per_second)
+            timeline_max_width = self.scrollbar_position[2]
+            scroll_width = (self.scrollbar_position[1] - self.scrollbar_position[0]) * event.rect().width()
+
+            # Get FPS info
+            fps_num = get_app().project.get("fps").get("num", 24)
+            fps_den = get_app().project.get("fps").get("den", 1)
+            fps_float = float(fps_num / fps_den)
+
+            # Determine scale factor
+            horizontal_factor = event.rect().width() / project_pixel_width
+            vertical_factor = event.rect().height() / len(layers)
+
+            # Loop through each clip
+            painter.setPen(clip_pen)
+            for clip_rect in self.clip_rects:
+                painter.drawRect(clip_rect)
+
+            painter.setPen(selected_clip_pen)
+            for clip_rect in self.clip_rects_selected:
+                painter.drawRect(clip_rect)
+
+            painter.setPen(marker_pen)
+            for marker_rect in self.marker_rects:
+                painter.drawRect(marker_rect)
+
+            painter.setPen(playhead_pen)
+            playhead_x = ((self.current_frame / fps_float) * pixels_per_second) * horizontal_factor
+            playhead_rect = QRectF(playhead_x, 0, 0.5, len(layers) * vertical_factor)
+            painter.drawRect(playhead_rect)
+
+            # Draw scroll bars (if available)
+            if self.scrollbar_position:
+                painter.setPen(scroll_pen)
+
+                # scroll bar path
+                scroll_x = self.scrollbar_position[0] * event.rect().width()
+                self.scroll_bar_rect = QRectF(scroll_x, 0.0, scroll_width, event.rect().height())
+                scroll_path = QPainterPath()
+                scroll_path.addRoundedRect(self.scroll_bar_rect, 6, 6)
+
+                # draw scroll bar rect
+                painter.fillPath(scroll_path, scroll_color)
+                painter.drawPath(scroll_path)
+
+                # draw handles
+                painter.setPen(handle_pen)
+                handle_width = 12.0
+
+                # left handle
+                left_handle_x = (self.scrollbar_position[0] * event.rect().width()) - (handle_width/2.0)
+                self.left_handle_rect = QRectF(left_handle_x, event.rect().height() / 4.0, handle_width, event.rect().height() / 2.0)
+                left_handle_path = QPainterPath()
+                left_handle_path.addRoundedRect(self.left_handle_rect, handle_width, handle_width)
+                painter.fillPath(left_handle_path, handle_color)
+
+                # right handle
+                right_handle_x = (self.scrollbar_position[1] * event.rect().width()) - (handle_width/2.0)
+                self.right_handle_rect = QRectF(right_handle_x, event.rect().height() / 4.0, handle_width, event.rect().height() / 2.0)
+                right_handle_path = QPainterPath()
+                right_handle_path.addRoundedRect(self.right_handle_rect, handle_width, handle_width)
+                painter.fillPath(right_handle_path, handle_color)
+
+            # Determine if play-head is inside scroll area
+            if get_app().window.preview_thread.player.Mode() == openshot.PLAYBACK_PLAY and self.is_auto_center:
+                if not self.scroll_bar_rect.contains(playhead_rect):
+                    get_app().window.TimelineCenter.emit()
+
+        # End painter
+        painter.end()
+
+    def mousePressEvent(self, event):
+        """Capture mouse press event"""
+        event.accept()
+        self.mouse_pressed = True
+        self.mouse_dragging = False
+        self.mouse_position = event.pos().x()
+
+        # Ignore undo/redo history temporarily (to avoid a huge pile of undo/redo history)
+        get_app().updates.ignore_history = True
+
+    def mouseReleaseEvent(self, event):
+        """Capture mouse release event"""
+        event.accept()
+
+        self.mouse_pressed = False
+        self.mouse_dragging = False
+        self.left_handle_dragging = False
+        self.right_handle_dragging = False
+        self.scroll_bar_dragging = False
+
+    def mouseMoveEvent(self, event):
+        """Capture mouse events"""
+        event.accept()
+
+        # Get current mouse position
+        mouse_pos = event.pos().x()
+        if mouse_pos < 0:
+            mouse_pos = 0
+        elif mouse_pos > self.width():
+            mouse_pos = self.width()
+
+        # Set cursor
+        if not self.mouse_dragging:
+            if self.left_handle_rect.contains(event.pos()):
+                self.setCursor(self.cursors.get('resize_x'))
+            elif self.right_handle_rect.contains(event.pos()):
+                self.setCursor(self.cursors.get('resize_x'))
+            elif self.scroll_bar_rect.contains(event.pos()):
+                self.setCursor(self.cursors.get('move'))
+            else:
+                self.setCursor(Qt.ArrowCursor)
+
+        # Detect dragging
+        if self.mouse_pressed and not self.mouse_dragging:
+            self.mouse_dragging = True
+
+            if self.left_handle_rect.contains(event.pos()):
+                self.left_handle_dragging = True
+            elif self.right_handle_rect.contains(event.pos()):
+                self.right_handle_dragging = True
+            elif self.scroll_bar_rect.contains(event.pos()):
+                self.scroll_bar_dragging = True
+            else:
+                self.setCursor(Qt.ArrowCursor)
+
+        # Dragging handle
+        if self.mouse_dragging:
+            if self.left_handle_dragging:
+                # Update scrollbar position
+                delta = (self.mouse_position - mouse_pos) / self.width()
+                new_left_pos = self.scrollbar_position[0] - delta
+                if int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0:
+                    # SHIFT key pressed (move both handles)
+                    new_right_pos = self.scrollbar_position[1] + delta
+                else:
+                    new_right_pos = self.scrollbar_position[1]
+
+                if new_left_pos < 0.0:
+                    new_left_pos = 0.0
+                    new_right_pos = self.scroll_bar_rect.width() / self.width()
+                elif new_right_pos > 1.0:
+                    new_left_pos = 1.0 - (self.scroll_bar_rect.width() / self.width())
+                    new_right_pos = 1.0
+
+                self.scrollbar_position = [new_left_pos,
+                                           new_right_pos,
+                                           self.scrollbar_position[2],
+                                           self.scrollbar_position[3]]
+                self.delayed_resize_timer.start()
+
+            elif self.right_handle_dragging:
+                delta = (self.mouse_position - mouse_pos) / self.width()
+                if int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0:
+                    # SHIFT key pressed (move both handles)
+                    new_left_pos = self.scrollbar_position[0] + delta
+                else:
+                    new_left_pos = self.scrollbar_position[0]
+                new_right_pos = self.scrollbar_position[1] - delta
+
+                if new_left_pos < 0.0:
+                    new_left_pos = 0.0
+                    new_right_pos = self.scroll_bar_rect.width() / self.width()
+                elif new_right_pos > 1.0:
+                    new_left_pos = 1.0 - (self.scroll_bar_rect.width() / self.width())
+                    new_right_pos = 1.0
+
+                self.scrollbar_position = [new_left_pos,
+                                           new_right_pos,
+                                           self.scrollbar_position[2],
+                                           self.scrollbar_position[3]]
+                self.delayed_resize_timer.start()
+
+            elif self.scroll_bar_dragging:
+                # Update scrollbar position
+                delta = (self.mouse_position - mouse_pos) / self.width()
+                new_left_pos = self.scrollbar_position[0] - delta
+                new_right_pos = self.scrollbar_position[1] - delta
+
+                if new_left_pos < 0.0:
+                    new_left_pos = 0.0
+                    new_right_pos = self.scroll_bar_rect.width() / self.width()
+                elif new_right_pos > 1.0:
+                    new_left_pos = 1.0 - (self.scroll_bar_rect.width() / self.width())
+                    new_right_pos = 1.0
+
+                self.scrollbar_position = [new_left_pos,
+                                           new_right_pos,
+                                           self.scrollbar_position[2],
+                                           self.scrollbar_position[3]]
+
+                # Emit signal to scroll Timeline
+                get_app().window.TimelineScroll.emit(self.scrollbar_position[0])
+
+            # Force re-paint
+            self.update()
+
+        # Update mouse position
+        self.mouse_position = mouse_pos
+
+    def resizeEvent(self, event):
+        """Widget resize event"""
+        event.accept()
+        self.delayed_size = self.size()
+        self.delayed_resize_timer.start()
+
+    def delayed_resize_callback(self):
+        """Callback for resize event timer (to delay the resize event, and prevent lots of similar resize events)"""
+        # Get max width of timeline
+        project_duration = get_app().project.get("duration")
+        normalized_scroll_width = self.scrollbar_position[1] - self.scrollbar_position[0]
+        scroll_width_seconds = normalized_scroll_width * project_duration
+        tick_pixels = 100
+        if self.scrollbar_position[3] > 0.0:
+            # Calculate the new zoom factor, based on 100 pixels per tick
+            zoom_factor = scroll_width_seconds / (self.scrollbar_position[3] / tick_pixels)
+
+            # Set scroll width (and send signal)
+            if zoom_factor > 0.0:
+                self.setZoomFactor(zoom_factor)
+
+                # Emit signal to scroll Timeline
+                get_app().window.TimelineScroll.emit(self.scrollbar_position[0])
+
+    # Capture wheel event to alter zoom/scale of widget
+    def wheelEvent(self, event):
+        event.accept()
+
+        # Repaint widget on zoom
+        self.repaint()
+
+    def setZoomFactor(self, zoom_factor):
+        """Set the current zoom factor"""
+        # Force recalculation of clips
+        self.zoom_factor = zoom_factor
+
+        # Emit zoom signal
+        get_app().window.TimelineZoom.emit(self.zoom_factor)
+        get_app().window.TimelineCenter.emit()
+
+        # Force re-paint
+        self.repaint()
+
+    def zoomIn(self):
+        """Zoom into timeline"""
+        new_factor = self.zoom_factor - 10.0
+        if new_factor < 1:
+            new_factor = 1
+
+        # Emit zoom signal
+        self.setZoomFactor(new_factor)
+
+    def zoomOut(self):
+        """Zoom out of timeline"""
+        new_factor = self.zoom_factor + 10.0
+
+        # Emit zoom signal
+        self.setZoomFactor(new_factor)
+
+    def update_scrollbars(self, new_positions):
+        """Consume the current scroll bar positions from the webview timeline"""
+        self.scrollbar_position = new_positions
+
+        # Check for empty clips rects
+        if not self.clip_rects:
+            self.changed(None)
+
+        # Disable auto center
+        self.is_auto_center = False
+
+        # Force re-paint
+        self.repaint()
+
+    def handle_selection(self):
+        # Force recalculation of clips and repaint
+        self.changed(None)
+        self.repaint()
+
+    def update_playhead_pos(self, currentFrame):
+        """Callback when position is changed"""
+        self.current_frame = currentFrame
+
+        # Force re-paint
+        self.repaint()
+
+    def handle_play(self):
+        """Callback when play button is clicked"""
+        self.is_auto_center = True
+
+    def connect_playback(self):
+        """Connect playback signals"""
+        self.win.preview_thread.position_changed.connect(self.update_playhead_pos)
+        self.win.PlaySignal.connect(self.handle_play)
+
+    def __init__(self, *args):
+        # Invoke parent init
+        QWidget.__init__(self, *args)
+
+        # Translate object
+        _ = get_app()._tr
+
+        # Init default values
+        self.leftHandle = None
+        self.rightHandle = None
+        self.centerHandle = None
+        self.mouse_pressed = False
+        self.mouse_dragging = False
+        self.mouse_position = None
+        self.zoom_factor = 15.0
+        self.scrollbar_position = [0.0, 0.0, 0.0, 0.0]
+        self.left_handle_rect = QRectF()
+        self.left_handle_dragging = False
+        self.right_handle_rect = QRectF()
+        self.right_handle_dragging = False
+        self.scroll_bar_rect = QRectF()
+        self.scroll_bar_dragging = False
+        self.clip_rects = []
+        self.clip_rects_selected = []
+        self.marker_rects = []
+        self.current_frame = 0
+        self.is_auto_center = True
+
+        # Initialize cursors
+        self.cursors = {
+            "move": QCursor(QPixmap(":/cursors/cursor_move.png")),
+            "resize_x": QCursor(QPixmap(":/cursors/cursor_resize_x.png")),
+            "hand": QCursor(QPixmap(":/cursors/cursor_hand.png")),
+            }
+
+        # Init Qt widget's properties (background repainting, etc...)
+        super().setAttribute(Qt.WA_OpaquePaintEvent)
+        super().setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+        # Add self as listener to project data updates (used to update the timeline)
+        get_app().updates.add_listener(self)
+
+        # Set mouse tracking
+        self.setMouseTracking(True)
+
+        # Get a reference to the window object
+        self.win = get_app().window
+
+        # Connect zoom functionality
+        self.win.TimelineScrolled.connect(self.update_scrollbars)
+
+        # Connect Selection signals
+        self.win.SelectionChanged.connect(self.handle_selection)
+
+        # Show Property timer
+        # Timer to use a delay before sending MaxSizeChanged signals (so we don't spam libopenshot)
+        self.delayed_size = None
+        self.delayed_resize_timer = QTimer()
+        self.delayed_resize_timer.setInterval(200)
+        self.delayed_resize_timer.setSingleShot(True)
+        self.delayed_resize_timer.timeout.connect(self.delayed_resize_callback)


### PR DESCRIPTION
New zoom slider widget replaces the old +/- buttons and simple zoom slider from previous versions of OpenShot. This new widget draws a mini timeline preview, allows the user to select any portion of the timeline, and also pan/scroll around the timeline with great accuracy. The playhead is also previewed, to give a better context of "where" you are on the timeline.

![Zoom-Slider](https://user-images.githubusercontent.com/5551883/116649024-129bc200-a944-11eb-8f53-c622feb1c321.png)

https://user-images.githubusercontent.com/5551883/116649037-1deeed80-a944-11eb-9977-18aba7e1d669.mp4


