### PR TITLE
Overhaul app launching, unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,5 @@ jobs:
 
     - name: Test
       shell: bash
-      run: xvfb-run --auto-servernum --server-num=1 --server-args "-screen 0 1920x1080x24" python3 ./src/tests/query_tests.py
+      run: python3 ./src/tests/query_tests.py -platform offscreen
+

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -36,8 +36,7 @@ import json
 
 from PyQt5.QtCore import PYQT_VERSION_STR
 from PyQt5.QtCore import QT_VERSION_STR
-from PyQt5.QtCore import Qt, pyqtSlot
-from PyQt5.QtGui import QPalette, QColor, QFontDatabase, QFont
+from PyQt5.QtCore import pyqtSlot
 from PyQt5.QtWidgets import QApplication, QStyleFactory, QMessageBox
 
 
@@ -191,6 +190,7 @@ class OpenShotApp(QApplication):
 
     def gui(self):
         from classes import language, ui_util, logger_libopenshot
+        from PyQt5.QtGui import QFont, QFontDatabase as QFD
 
         _ = self._tr
         info = self.info
@@ -240,49 +240,23 @@ class OpenShotApp(QApplication):
         log.debug("Loading UI theme")
         if self.settings.get("theme") != "No Theme":
             # Load embedded font
-            try:
-                log.info("Setting font to %s" % os.path.join(info.IMAGES_PATH, "fonts", "Ubuntu-R.ttf"))
-                font_id = QFontDatabase.addApplicationFont(os.path.join(info.IMAGES_PATH, "fonts", "Ubuntu-R.ttf"))
-                font_family = QFontDatabase.applicationFontFamilies(font_id)[0]
-                font = QFont(font_family)
-                font.setPointSizeF(10.5)
-                QApplication.setFont(font)
-            except Exception:
-                log.debug("Error setting Ubuntu-R.ttf QFont", exc_info=1)
+            font_path = os.path.join(info.IMAGES_PATH, "fonts", "Ubuntu-R.ttf")
+            if os.path.exists(font_path):
+                log.info("Setting font to %s", font_path)
+                try:
+                    font_id = QFD.addApplicationFont(font_path)
+                    font_family = QFD.applicationFontFamilies(font_id)[0]
+                    font = QFont(font_family)
+                    font.setPointSizeF(10.5)
+                    QApplication.setFont(font)
+                except Exception:
+                    log.warning("Error setting Ubuntu-R.ttf QFont", exc_info=1)
 
-        # Set Experimental Dark Theme
+        # Set Dark Theme, if selected
         if self.settings.get("theme") == "Humanity: Dark":
-            # Only set if dark theme selected
             log.info("Setting custom dark theme")
             self.setStyle(QStyleFactory.create("Fusion"))
-
-            darkPalette = self.palette()
-
-            darkPalette.setColor(QPalette.Window, QColor(53, 53, 53))
-            darkPalette.setColor(QPalette.WindowText, Qt.white)
-            darkPalette.setColor(QPalette.Base, QColor(25, 25, 25))
-            darkPalette.setColor(QPalette.AlternateBase, QColor(53, 53, 53))
-            darkPalette.setColor(QPalette.Light, QColor(68, 68, 68))
-            darkPalette.setColor(QPalette.Text, Qt.white)
-            darkPalette.setColor(QPalette.Button, QColor(53, 53, 53))
-            darkPalette.setColor(QPalette.ButtonText, Qt.white)
-            darkPalette.setColor(QPalette.Highlight, QColor(42, 130, 218, 192))
-            darkPalette.setColor(QPalette.HighlightedText, Qt.black)
-            #
-            # Disabled palette
-            #
-            darkPalette.setColor(QPalette.Disabled, QPalette.WindowText, QColor(255, 255, 255, 128))
-            darkPalette.setColor(QPalette.Disabled, QPalette.Base, QColor(68, 68, 68))
-            darkPalette.setColor(QPalette.Disabled, QPalette.Text, QColor(255, 255, 255, 128))
-            darkPalette.setColor(QPalette.Disabled, QPalette.Button, QColor(53, 53, 53, 128))
-            darkPalette.setColor(QPalette.Disabled, QPalette.ButtonText, QColor(255, 255, 255, 128))
-            darkPalette.setColor(QPalette.Disabled, QPalette.Highlight, QColor(151, 151, 151, 192))
-            darkPalette.setColor(QPalette.Disabled, QPalette.HighlightedText, Qt.black)
-
-            # Tooltips
-            darkPalette.setColor(QPalette.ToolTipBase, QColor(42, 130, 218))
-            darkPalette.setColor(QPalette.ToolTipText, Qt.white)
-
+            darkPalette = ui_util.make_dark_palette(self.palette())
             self.setPalette(darkPalette)
             self.setStyleSheet("QToolTip { color: #ffffff; background-color: #2a82da; border: 0px solid white; }")
 

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -335,7 +335,8 @@ class OpenShotApp(QApplication):
         count = len(self.errors)
         if count > 0:
             self.log.warning("Displaying {} startup messages".format(count))
-        for error in self.errors:
+        while self.errors:
+            error = self.errors.pop(0)
             error.show()
 
     def _tr(self, message):

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -55,16 +55,21 @@ try:
 except ImportError:
     pass
 
+def get_app():
+    """ Get the current QApplication instance of OpenShot """
+    return QApplication.instance()
+
+
+def get_settings():
+    """Get a reference to the app's settings object"""
+    return get_app().get_settings()
+
 try:
     # Enable High-DPI resolutions
     QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
 except AttributeError:
     pass  # Quietly fail for older Qt5 versions
 
-
-def get_app():
-    """ Returns the current QApplication instance of OpenShot """
-    return QApplication.instance()
 
 
 class OpenShotApp(QApplication):
@@ -296,6 +301,11 @@ class OpenShotApp(QApplication):
             _("Error loading settings file: %(file_path)s. Settings will be reset.")
             % {"file_path": filepath}
             )
+
+    def get_settings(self):
+        if not hasattr(self, "settings"):
+            return None
+        return self.settings
 
     def _tr(self, message):
         return self.translate("", message)

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -360,5 +360,6 @@ def onLogTheEnd():
         log.info(time.asctime().center(48))
         log.info("=" * 48)
     except Exception:
-        from logging import log
-        log.debug('Failed to write session ended log')
+        import logging
+        log = logging.getLogger(".")
+        log.debug('Failed to write session ended log', exc_info=1)

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -79,7 +79,7 @@ class OpenShotApp(QApplication):
     def __init__(self, *args, mode=None):
         QApplication.__init__(self, *args)
         self.mode = mode or "normal"
-        self.args = list(*args)
+        self.args = super().arguments()
         self.errors = []
 
         try:

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -28,9 +28,9 @@
  """
 
 import atexit
+import sys
 import os
 import platform
-import sys
 import traceback
 import json
 
@@ -40,20 +40,6 @@ from PyQt5.QtCore import Qt, pyqtSlot
 from PyQt5.QtGui import QPalette, QColor, QFontDatabase, QFont
 from PyQt5.QtWidgets import QApplication, QStyleFactory, QMessageBox
 
-try:
-    # This apparently has to be done before loading QtQuick
-    # (via QtWebEgine) AND before creating the QApplication instance
-    QApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
-    from OpenGL import GL  # noqa
-except (ImportError, AttributeError):
-    pass
-
-try:
-    # QtWebEngineWidgets must be loaded prior to creating a QApplication
-    # But on systems with only WebKit, this will fail (and we ignore the failure)
-    from PyQt5.QtWebEngineWidgets import QWebEngineView
-except ImportError:
-    pass
 
 def get_app():
     """ Get the current QApplication instance of OpenShot """
@@ -64,12 +50,26 @@ def get_settings():
     """Get a reference to the app's settings object"""
     return get_app().get_settings()
 
-try:
-    # Enable High-DPI resolutions
-    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
-except AttributeError:
-    pass  # Quietly fail for older Qt5 versions
 
+class StartupError:
+    """ Store and later display an error encountered during setup"""
+    levels = {
+        "warning": QMessageBox.warning,
+        "error": QMessageBox.critical,
+    }
+
+    def __init__(self, title="", message="", level="warning"):
+        """Create an error message object, populated with details"""
+        self.title = title
+        self.message = message
+        self.level = level
+
+    def show(self):
+        """Display the stored error message"""
+        box_call = self.levels[self.level]
+        box_call(None, self.title, self.message)
+        if self.level == "error":
+            sys.exit()
 
 
 class OpenShotApp(QApplication):
@@ -78,6 +78,9 @@ class OpenShotApp(QApplication):
 
     def __init__(self, *args, mode=None):
         QApplication.__init__(self, *args)
+        self.mode = mode or "normal"
+        self.args = list(*args)
+        self.errors = []
 
         try:
             # Import modules
@@ -85,35 +88,61 @@ class OpenShotApp(QApplication):
             from classes.logger import log, reroute_output
 
             # Log the session's start
-            import time
-            log.info("------------------------------------------------")
-            log.info(time.asctime().center(48))
-            log.info('Starting new session'.center(48))
+            if mode != "unittest":
+                import time
+                log.info("-" * 48)
+                log.info(time.asctime().center(48))
+                log.info('Starting new session'.center(48))
 
-            from classes import (
-                settings, project_data, updates, language, ui_util,
-                logger_libopenshot
-                )
+            log.debug("Starting up in {} mode".format(self.mode))
+            log.debug("Command line: {}".format(self.args))
+
+            from classes import settings, project_data, updates
             import openshot
 
             # Re-route stdout and stderr to logger
-            reroute_output()
+            if mode != "unittest":
+                reroute_output()
+
         except ImportError as ex:
             tb = traceback.format_exc()
             log.error('OpenShotApp::Import Error', exc_info=1)
-            QMessageBox.warning(None, "Import Error",
-                                "Module: %(name)s\n\n%(tb)s" % {"name": ex.name, "tb": tb})
-            # Stop launching and exit
+            self.errors.append(StartupError(
+                "Import Error",
+                "Module: %(name)s\n\n%(tb)s" % {"name": ex.name, "tb": tb},
+                level="error"))
+            # Stop launching
             raise
         except Exception:
             log.error('OpenShotApp::Init Error', exc_info=1)
             sys.exit()
 
+        self.info = info
+
         # Log some basic system info
+        self.log = log
+        self.show_environment(info, openshot)
+        if self.mode != "unittest":
+            self.check_libopenshot_version(info, openshot)
+
+        # Init data objects
+        self.settings = settings.SettingStore(parent=self)
+        self.settings.load()
+        self.project = project_data.ProjectDataStore()
+        self.updates = updates.UpdateManager()
+        # It is important that the project is the first listener if the key gets update
+        self.updates.add_listener(self.project)
+        self.updates.reset()
+
+        # Set location of OpenShot program (for libopenshot)
+        openshot.Settings.Instance().PATH_OPENSHOT_INSTALL = info.PATH
+
+    def show_environment(self, info, openshot):
+        log = self.log
         try:
-            log.info("------------------------------------------------")
+            log.info("-" * 48)
             log.info(("OpenShot (version %s)" % info.SETUP['version']).center(48))
-            log.info("------------------------------------------------")
+            log.info("-" * 48)
 
             log.info("openshot-qt version: %s" % info.VERSION)
             log.info("libopenshot version: %s" % openshot.OPENSHOT_VERSION_FULL)
@@ -135,60 +164,47 @@ class OpenShotApp(QApplication):
         except Exception:
             log.debug("Error displaying dependency/system details", exc_info=1)
 
-        # Setup application
-        self.setApplicationName('openshot')
-        self.setApplicationVersion(info.SETUP['version'])
-        try:
-            # Qt 5.7+ only
-            self.setDesktopFile("org.openshot.OpenShot")
-        except AttributeError:
-            pass
-
-        # Init settings
-        self.settings = settings.SettingStore(parent=self)
-        self.settings.load()
-
         # Init and attach exception handler
         from classes import exceptions
         sys.excepthook = exceptions.ExceptionHandler
 
+    def check_libopenshot_version(self, info, openshot):
+        """Detect minimum libopenshot version"""
+        _ = self._tr
+        ver = openshot.OPENSHOT_VERSION_FULL
+        min = info.MINIMUM_LIBOPENSHOT_VERSION
+        if ver >= min:
+            return True
+
+        self.errors.append(StartupError(
+            _("Wrong Version of libopenshot Detected"),
+            _("<b>Version %(minimum_version)s is required</b>, "
+              "but %(current_version)s was detected. "
+              "Please update libopenshot or download our latest installer.") % {
+                "minimum_version": min,
+                "current_version": ver,
+                },
+            level="error",
+        ))
+        raise RuntimeError(
+            "libopenshot version {} found, minimum is {}".format(ver, min))
+
+    def gui(self):
+        from classes import language, ui_util, logger_libopenshot
+
+        _ = self._tr
+        info = self.info
+        log = self.log
+
         # Init translation system
         language.init_language()
-
-        # Detect minimum libopenshot version
-        _ = self._tr
-        libopenshot_version = openshot.OPENSHOT_VERSION_FULL
-        if mode != "unittest" and libopenshot_version < info.MINIMUM_LIBOPENSHOT_VERSION:
-            QMessageBox.warning(
-                None,
-                _("Wrong Version of libopenshot Detected"),
-                _("<b>Version %(minimum_version)s is required</b>, "
-                  "but %(current_version)s was detected. "
-                  "Please update libopenshot or download our latest installer.")
-                % {
-                    "minimum_version": info.MINIMUM_LIBOPENSHOT_VERSION,
-                    "current_version": libopenshot_version,
-                    })
-            # Stop launching and exit
-            sys.exit()
-
-        # Set location of OpenShot program (for libopenshot)
-        openshot.Settings.Instance().PATH_OPENSHOT_INSTALL = info.PATH
-
-        # Tests of project data loading/saving
-        self.project = project_data.ProjectDataStore()
-
-        # Init Update Manager
-        self.updates = updates.UpdateManager()
-
-        # It is important that the project is the first listener if the key gets update
-        self.updates.add_listener(self.project)
 
         # Load ui theme if not set by OS
         ui_util.load_theme()
 
         # Test for permission issues (and display message if needed)
         try:
+            log.debug("Testing write access to user directory")
             # Create test paths
             TEST_PATH_DIR = os.path.join(info.USER_PATH, 'PERMISSION')
             TEST_PATH_FILE = os.path.join(TEST_PATH_DIR, 'test.osp')
@@ -201,15 +217,17 @@ class OpenShotApp(QApplication):
             os.rmdir(TEST_PATH_DIR)
         except PermissionError as ex:
             log.error('Failed to create file %s', TEST_PATH_FILE, exc_info=1)
-            QMessageBox.warning(
-                None, _("Permission Error"),
-                _("%(error)s. Please delete <b>%(path)s</b> and launch OpenShot again." % {
+            self.errors.append(StartupError(
+                _("Permission Error"),
+                _("%(error)s. Please delete <b>%(path)s</b> and launch OpenShot again.") % {
                     "error": str(ex),
                     "path": info.USER_PATH,
-                }))
-            # Stop launching and exit
-            raise
-            sys.exit()
+                    },
+                level="error",
+            ))
+
+        # Display any outstanding startup messages
+        self.show_errors()
 
         # Start libopenshot logging thread
         self.logger_libopenshot = logger_libopenshot.LoggerLibOpenShot()
@@ -219,6 +237,7 @@ class OpenShotApp(QApplication):
         self.context_menu_object = None
 
         # Set Font for any theme
+        log.debug("Loading UI theme")
         if self.settings.get("theme") != "No Theme":
             # Load embedded font
             try:
@@ -269,72 +288,77 @@ class OpenShotApp(QApplication):
 
         # Create main window
         from windows.main_window import MainWindow
-        self.window = MainWindow(mode=mode)
+        log.debug("Creating main interface window")
+        self.window = MainWindow(mode=self.mode)
 
-        # Reset undo/redo history
-        self.updates.reset()
+        # Clear undo/redo history
         self.window.updateStatusChanged(False, False)
 
         # Connect our exit signals
         self.aboutToQuit.connect(self.cleanup)
 
-        log.info('Process command-line arguments: %s' % args)
-        if len(args[0]) == 2:
-            path = args[0][1]
-            if ".osp" in path:
-                # Auto load project passed as argument
-                self.window.OpenProjectSignal.emit(path)
-            else:
-                # Apply the default settings and Auto import media file
-                self.project.load("")
-                self.window.filesView.add_file(path)
-        else:
+        args = self.args
+        if len(args) < 2:
             # Recover backup file (this can't happen until after the Main Window has completely loaded)
             self.window.RecoverBackup.emit()
+            return
+
+        log.info('Process command-line arguments: %s' % args)
+
+        # Auto load project if passed as argument
+        if args[1].endswith(".osp"):
+            self.window.OpenProjectSignal.emit(args[1])
+            return
+
+        # Start a new project and auto import any media files
+        self.project.load("")
+        for arg in args[1:]:
+            self.window.filesView.add_file(arg)
 
     def settings_load_error(self, filepath=None):
         """Use QMessageBox to warn the user of a settings load issue"""
         _ = self._tr
-        QMessageBox.warning(
-            None,
+        self.errors.append(StartupError(
             _("Settings Error"),
-            _("Error loading settings file: %(file_path)s. Settings will be reset.")
-            % {"file_path": filepath}
-            )
+            _("Error loading settings file: %(file_path)s. Settings will be reset.") % {
+                "file_path": filepath
+                },
+            level="warning",
+        ))
 
     def get_settings(self):
         if not hasattr(self, "settings"):
             return None
         return self.settings
 
+    def show_errors(self):
+        count = len(self.errors)
+        if count > 0:
+            self.log.warning("Displaying {} startup messages".format(count))
+        for error in self.errors:
+            error.show()
+
     def _tr(self, message):
         return self.translate("", message)
-
-    # Start event loop
-    def run(self):
-        """ Start the primary Qt event loop for the interface """
-        return self.exec_()
 
     @pyqtSlot()
     def cleanup(self):
         """aboutToQuit signal handler for application exit"""
         try:
-            from classes.logger import log
             self.settings.save()
         except Exception:
-            log.error("Couldn't save user settings on exit.", exc_info=1)
+            self.log.error("Couldn't save user settings on exit.", exc_info=1)
 
 
-# Log the session's end
 @atexit.register
 def onLogTheEnd():
     """ Log when the primary Qt event loop ends """
     try:
         from classes.logger import log
         import time
-        log.info('OpenShot\'s session ended'.center(48))
+        log.info("OpenShot's session ended".center(48))
         log.info(time.asctime().center(48))
-        log.info("================================================")
+        log.info("=" * 48)
     except Exception:
-        from classes.logger import log
+        from logging import log
         log.debug('Failed to write session ended log')

--- a/src/classes/exceptions.py
+++ b/src/classes/exceptions.py
@@ -31,11 +31,12 @@ import platform
 
 from classes import info
 from classes.logger import log
-from classes.metrics import track_exception_stacktrace, track_metric_error
 
 
 def ExceptionHandler(exeception_type, exeception_value, exeception_traceback):
     """Callback for any unhandled exceptions"""
+    from classes.metrics import track_exception_stacktrace
+
     log.error(
         'Unhandled Exception',
         exc_info=(exeception_type, exeception_value, exeception_traceback))
@@ -71,6 +72,8 @@ def tail_file(f, n, offset=None):
 
 def libopenshot_crash_recovery():
     """Walk libopenshot.log for the last line before this launch"""
+    from classes.metrics import track_exception_stacktrace, track_metric_error
+
     log_path = os.path.join(info.USER_PATH, "libopenshot.log")
     last_log_line = ""
     last_stack_trace = ""

--- a/src/classes/language.py
+++ b/src/classes/language.py
@@ -33,7 +33,6 @@ from PyQt5.QtCore import QLocale, QLibraryInfo, QTranslator, QCoreApplication
 
 from classes.logger import log
 from classes import info
-from classes import settings
 
 
 try:
@@ -75,7 +74,11 @@ def init_language():
                     ]
 
     # Get the user's configured language preference
-    preference_lang = settings.get_settings().get('default-language')
+    settings = app.get_settings()
+    if settings:
+        preference_lang = settings.get('default-language')
+    else:
+        preference_lang = "Default"
 
     # Output all languages detected from various sources
     log.info("Qt Detected Languages: {}".format(QLocale().system().uiLanguages()))

--- a/src/classes/logger_libopenshot.py
+++ b/src/classes/logger_libopenshot.py
@@ -26,8 +26,9 @@
  """
 
 from threading import Thread
-from classes import settings, info
+from classes import info
 from classes.logger import log
+from classes.app import get_app
 import openshot
 import os
 import zmq
@@ -46,7 +47,7 @@ class LoggerLibOpenShot(Thread):
         self.running = True
 
         # Get settings
-        s = settings.get_settings()
+        s = get_app().get_settings()
 
         # Get port from settings
         port = s.get("debug-port")

--- a/src/classes/metrics.py
+++ b/src/classes/metrics.py
@@ -91,6 +91,7 @@ params = {
 # incase the user enables metrics later
 metric_queue = []
 
+
 def track_metric_screen(screen_name):
     """Track a GUI screen being shown"""
     metric_params = deepcopy(params)

--- a/src/classes/metrics.py
+++ b/src/classes/metrics.py
@@ -35,15 +35,15 @@ import urllib.parse
 from copy import deepcopy
 from classes import info
 from classes import language
+from classes.app import get_app
 from classes.logger import log
-from classes import settings
 import openshot
 
 from PyQt5.QtCore import QT_VERSION_STR
 from PyQt5.QtCore import PYQT_VERSION_STR
 
 # Get settings
-s = settings.get_settings()
+s = get_app().get_settings()
 
 # Determine OS version
 os_version = "X11; Linux %s" % platform.machine()

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -33,7 +33,8 @@ import os
 import random
 import shutil
 
-from classes import info, settings
+from classes import info
+from classes.app import get_app
 from classes.image_types import is_image
 from classes.json_data import JsonDataStore
 from classes.logger import log
@@ -276,7 +277,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         info.BLENDER_PATH = os.path.join(info.USER_PATH, "blender")
 
         # Get default profile
-        s = settings.get_settings()
+        s = get_app().get_settings()
         default_profile = s.get("default-profile")
 
         # Loop through profiles
@@ -853,7 +854,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             # Ignore backup recovery project
             return
 
-        s = settings.get_settings()
+        s = get_app().get_settings()
         recent_projects = s.get("recent_projects")
 
         # Make sure file_path is absolute

--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -35,30 +35,14 @@ from classes.logger import log
 from classes.json_data import JsonDataStore
 
 
-def get_settings():
-    """ Get the current application's settings instance """
-    return SettingStore.get_app().get_settings()
-
-
 class SettingStore(JsonDataStore):
     """ This class only allows setting pre-existing keys taken from default settings file, and merges user settings
     on load, assumes default OS dir."""
 
-    @classmethod
-    def save_app(cls, app_reference):
-        cls._app = app_reference
-
-    @classmethod
-    def get_app(cls):
-        if hasattr(cls, "_app"):
-            return cls._app
-        return None
-
     def __init__(self, parent=None):
         super().__init__()
         # Also keep track of our parent, if defined
-        if parent:
-            SettingStore.save_app(parent)
+        self.app = parent
         # Set the data type name for logging clarity (base class functions use this variable)
         self.data_type = "user settings"
         self.settings_filename = "openshot.settings"
@@ -111,10 +95,9 @@ class SettingStore(JsonDataStore):
             except Exception as ex:
                 log.error("Error loading settings file: %s", ex)
                 user_settings = {}
-                app = SettingStore.get_app()
-                if app:
+                if self.app:
                     # We have a parent, ask to show a message box
-                    app.settings_load_error(file_path)
+                    self.app.settings_load_error(file_path)
 
         # Merge default and user settings, excluding settings not in default, Save settings
         self._data = self.merge_settings(default_settings, user_settings)

--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -37,7 +37,7 @@ from classes.json_data import JsonDataStore
 
 def get_settings():
     """ Get the current application's settings instance """
-    return SettingStore.get_app().settings
+    return SettingStore.get_app().get_settings()
 
 
 class SettingStore(JsonDataStore):
@@ -72,20 +72,22 @@ class SettingStore(JsonDataStore):
         """ Store setting, but adding isn't allowed. All possible settings must be in default settings file. """
         key = key.lower()
 
-        # Load user setting's values (for easy merging)
-        user_values = {}
-        for item in self._data:
-            if "setting" in item and "value" in item:
-                user_values[item["setting"].lower()] = item
+        # Index settings values (for easy updates)
+        user_values = {
+            item["setting"].lower(): item
+            for item in self._data
+            if all(["setting" in item, "value" in item])
+        }
 
         # Save setting
         if key in user_values:
-            user_values[key]["value"] = value
+            user_values[key].update({"value": value})
         else:
             log.warn(
                 "{} key '{}' not valid. The following are valid: {}".format(
-                self.data_type, key,
-                list(self._data.keys()),
+                    self.data_type,
+                    key,
+                    list(self._data.keys()),
                 ))
 
     def load(self):

--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -31,7 +31,6 @@ import openshot  # Python module for libopenshot (required video editing module 
 from classes.updates import UpdateInterface
 from classes.logger import log
 from classes.app import get_app
-from classes import settings
 
 
 class TimelineSync(UpdateInterface):
@@ -41,7 +40,7 @@ class TimelineSync(UpdateInterface):
         self.app = get_app()
         self.window = window
         project = self.app.project
-        s = settings.get_settings()
+        s = self.app.get_settings()
 
         # Get some settings from the project
         fps = project.get("fps")

--- a/src/classes/ui_util.py
+++ b/src/classes/ui_util.py
@@ -36,13 +36,14 @@ try:
 except ImportError:
     from xml.etree import ElementTree
 
-from PyQt5.QtCore import QDir, QLocale
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QApplication, QWidget, QTabWidget, QAction
+from PyQt5.QtCore import Qt, QDir, QLocale
+from PyQt5.QtGui import QIcon, QPalette, QColor
+from PyQt5.QtWidgets import (
+    QApplication, QWidget, QStyleFactory, QTabWidget, QAction)
 from PyQt5 import uic
 
+from classes.app import get_app
 from classes.logger import log
-from classes import settings
 
 from . import openshot_rc  # noqa
 
@@ -52,7 +53,7 @@ DEFAULT_THEME_NAME = "Humanity"
 def load_theme():
     """ Load the current OS theme, or fallback to a default one """
 
-    s = settings.get_settings()
+    s = get_app().get_settings()
 
     # If theme not reported by OS
     if QIcon.themeName() == '' and s.get("theme") != "No Theme":
@@ -102,6 +103,35 @@ def get_default_icon(theme_name):
     start_path = ":/icons/" + DEFAULT_THEME_NAME + "/"
     icon_path = search_dir(start_path, theme_name)
     return QIcon(icon_path), icon_path
+
+
+def make_dark_palette(darkPalette: QPalette) -> QPalette:
+    darkPalette.setColor(QPalette.Window, QColor(53, 53, 53))
+    darkPalette.setColor(QPalette.WindowText, Qt.white)
+    darkPalette.setColor(QPalette.Base, QColor(25, 25, 25))
+    darkPalette.setColor(QPalette.AlternateBase, QColor(53, 53, 53))
+    darkPalette.setColor(QPalette.Light, QColor(68, 68, 68))
+    darkPalette.setColor(QPalette.Text, Qt.white)
+    darkPalette.setColor(QPalette.Button, QColor(53, 53, 53))
+    darkPalette.setColor(QPalette.ButtonText, Qt.white)
+    darkPalette.setColor(QPalette.Highlight, QColor(42, 130, 218, 192))
+    darkPalette.setColor(QPalette.HighlightedText, Qt.black)
+    #
+    # Disabled palette
+    #
+    darkPalette.setColor(QPalette.Disabled, QPalette.WindowText, QColor(255, 255, 255, 128))
+    darkPalette.setColor(QPalette.Disabled, QPalette.Base, QColor(68, 68, 68))
+    darkPalette.setColor(QPalette.Disabled, QPalette.Text, QColor(255, 255, 255, 128))
+    darkPalette.setColor(QPalette.Disabled, QPalette.Button, QColor(53, 53, 53, 128))
+    darkPalette.setColor(QPalette.Disabled, QPalette.ButtonText, QColor(255, 255, 255, 128))
+    darkPalette.setColor(QPalette.Disabled, QPalette.Highlight, QColor(151, 151, 151, 192))
+    darkPalette.setColor(QPalette.Disabled, QPalette.HighlightedText, Qt.black)
+
+    # Tooltips
+    darkPalette.setColor(QPalette.ToolTipBase, QColor(42, 130, 218))
+    darkPalette.setColor(QPalette.ToolTipText, Qt.white)
+
+    return darkPalette
 
 
 def search_dir(base_path, theme_name):

--- a/src/classes/waveform.py
+++ b/src/classes/waveform.py
@@ -31,12 +31,11 @@ from copy import deepcopy
 from classes import info
 from classes.app import get_app
 from classes.logger import log
-from classes import settings
 import openshot
 
 
 # Get settings
-s = settings.get_settings()
+s = get_app().get_settings()
 
 
 def get_audio_data(clip_id, file_path, channel_filter, volume_keyframe):

--- a/src/launch.py
+++ b/src/launch.py
@@ -121,7 +121,7 @@ def main():
     parser.add_argument(
         'remain', nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
 
-    args = parser.parse_args()
+    args, extra_args = parser.parse_known_args()
 
     # Display version and exit (if requested)
     if args.version:
@@ -174,6 +174,7 @@ def main():
     from classes.app import OpenShotApp
 
     argv = [sys.argv[0]]
+    argv.extend(extra_args)
     argv.extend(args.remain)
     try:
         app = OpenShotApp(argv)

--- a/src/launch.py
+++ b/src/launch.py
@@ -44,6 +44,31 @@ import sys
 import os.path
 import argparse
 
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QApplication
+
+try:
+    # This apparently has to be done before loading QtQuick
+    # (via QtWebEgine) AND before creating the QApplication instance
+    QApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
+    from OpenGL import GL  # noqa
+except (ImportError, AttributeError):
+    pass
+
+try:
+    # QtWebEngineWidgets must be loaded prior to creating a QApplication
+    # But on systems with only WebKit, this will fail (and we ignore the failure)
+    from PyQt5 import QtWebEngineWidgets
+    WebEngineView = QtWebEngineWidgets.QWebEngineView
+except ImportError:
+    pass
+
+try:
+    # Enable High-DPI resolutions
+    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
+except AttributeError:
+    pass  # Quietly fail for older Qt5 versions
+
 try:
     from classes import info
 except ImportError:
@@ -51,36 +76,50 @@ except ImportError:
     sys.path.append(openshot_qt.OPENSHOT_PATH)
     from classes import info
 
+# Global holder for QApplication instance
+app = None
+
 
 def main():
     """"Initialize settings (not implemented) and create main window/application."""
 
-    parser = argparse.ArgumentParser(description = 'OpenShot version ' + info.SETUP['version'])
-    parser.add_argument('-l', '--lang', action='store',
+    global app
+
+    # Configure argument handling for commandline launches
+    parser = argparse.ArgumentParser(description='OpenShot version ' + info.SETUP['version'])
+    parser.add_argument(
+        '-l', '--lang', action='store',
         help='language code for interface (overrides '
              'preferences and system environment)')
-    parser.add_argument('--list-languages', dest='list_languages',
+    parser.add_argument(
+        '--list-languages', dest='list_languages',
         action='store_true',
         help='List all language codes supported by OpenShot')
-    parser.add_argument('--path', dest='py_path', action='append',
+    parser.add_argument(
+        '--path', dest='py_path', action='append',
         help='Additional locations to search for modules '
-              '(PYTHONPATH). Can be used multiple times.')
-    parser.add_argument('--test-models', dest='modeltest',
+             '(PYTHONPATH). Can be used multiple times.')
+    parser.add_argument(
+        '--test-models', dest='modeltest',
         action='store_true',
         help="Load Qt's QAbstractItemModelTester into data models "
         '(requires Qt 5.11+)')
-    parser.add_argument('-b', '--web-backend', action='store',
+    parser.add_argument(
+        '-b', '--web-backend', action='store',
         choices=['auto', 'webkit', 'webengine'], default='auto',
         help="Web backend to use for Timeline")
-    parser.add_argument('-d', '--debug', action='store_true',
+    parser.add_argument(
+        '-d', '--debug', action='store_true',
         help='Enable debugging output')
-    parser.add_argument('--debug-file', action='store_true',
+    parser.add_argument(
+        '--debug-file', action='store_true',
         help='Debugging output (logfile only)')
-    parser.add_argument('--debug-console', action='store_true',
+    parser.add_argument(
+        '--debug-console', action='store_true',
         help='Debugging output (console only)')
     parser.add_argument('-V', '--version', action='store_true')
-    parser.add_argument('remain', nargs=argparse.REMAINDER,
-       help=argparse.SUPPRESS)
+    parser.add_argument(
+        'remain', nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
 
     args = parser.parse_args()
 
@@ -91,15 +130,15 @@ def main():
 
     # Set up debugging log level to requested streams
     if args.debug or args.debug_file:
-            info.LOG_LEVEL_FILE = 'DEBUG'
+        info.LOG_LEVEL_FILE = 'DEBUG'
     if args.debug or args.debug_console:
-            info.LOG_LEVEL_CONSOLE = 'DEBUG'
+        info.LOG_LEVEL_CONSOLE = 'DEBUG'
 
     if args.list_languages:
         from classes.language import get_all_languages
         print("Supported Languages:")
-        for lang in get_all_languages():
-            print("  {:>12}  {}".format(lang[0],lang[1]))
+        for code, lang in get_all_languages():
+            print("  {:>12}  {}".format(code, lang))
         sys.exit()
 
     if args.py_path:
@@ -111,8 +150,8 @@ def main():
                 else:
                     print("{} does not exist".format(os.path.realpath(p)))
             except TypeError as ex:
-                    print("Bad path {}: {}".format(p, ex))
-                    continue
+                print("Bad path {}: {}".format(p, ex))
+                continue
 
     if args.modeltest:
         info.MODEL_TEST = True
@@ -135,12 +174,24 @@ def main():
     from classes.app import OpenShotApp
 
     argv = [sys.argv[0]]
-    for arg in args.remain:
-        argv.append(arg)
-    app = OpenShotApp(argv)
+    argv.extend(args.remain)
+    try:
+        app = OpenShotApp(argv)
+    except Exception:
+        app.show_errors()
 
-    # Run and return result
-    sys.exit(app.run())
+    # Setup Qt application details
+    app.setApplicationName('openshot')
+    app.setApplicationVersion(info.SETUP['version'])
+    try:
+        # Qt 5.7+ only
+        app.setDesktopFile("org.openshot.OpenShot")
+    except AttributeError:
+        pass
+
+    # Launch GUI and start event loop
+    app.gui()
+    sys.exit(app.exec_())
 
 
 if __name__ == "__main__":

--- a/src/tests/query_tests.py
+++ b/src/tests/query_tests.py
@@ -25,20 +25,33 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-import sys, os
+import sys
+import os
+import random
+import unittest
+import uuid
+import json
+
+import openshot
+
+from PyQt5.QtGui import QGuiApplication
+try:
+    # QtWebEngineWidgets must be loaded prior to creating a QApplication
+    # But on systems with only WebKit, this will fail (and we ignore the failure)
+    from PyQt5.QtWebEngineWidgets import QWebEngineView
+except ImportError:
+    pass
+
 # Import parent folder (so it can find other imports)
 PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 if PATH not in sys.path:
     sys.path.append(PATH)
 
-import random
-import unittest
-import uuid
-from PyQt5.QtGui import QGuiApplication
 from classes.app import OpenShotApp
 from classes import info
-import openshot  # Python module for libopenshot (required video editing module installed separately)
-import json
+
+
+app = None
 
 class TestQueryClass(unittest.TestCase):
     """ Unit test class for Query class """
@@ -47,7 +60,7 @@ class TestQueryClass(unittest.TestCase):
     def setUpClass(TestQueryClass):
         """ Init unit test data """
         # Create Qt application
-        TestQueryClass.app = OpenShotApp([], mode="unittest")
+        TestQueryClass.app = QGuiApplication.instance()
         TestQueryClass.clip_ids = []
         TestQueryClass.file_ids = []
         TestQueryClass.transition_ids = []
@@ -106,8 +119,7 @@ class TestQueryClass(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         "Hook method for deconstructing the class fixture after running all tests in the class."
-        print ('Exiting Unittests: Quitting QApplication')
-        TestQueryClass.app.window.actionQuit.trigger()
+        TestQueryClass.app.quit()
 
     def test_add_clip(self):
         """ Test the Clip.save method by adding multiple clips """
@@ -318,6 +330,19 @@ class TestQueryClass(unittest.TestCase):
         self.assertEqual(len(File.filter()), num_files + 1)
 
 
-if __name__ == '__main__':
-    app = QGuiApplication(sys.argv)
+def main():
+    global app
+    info.LOG_LEVEL_CONSOLE = "ERROR"
+    try:
+        app = OpenShotApp(sys.argv, mode="unittest")
+    except Exception:
+        from logging import logger
+        log = logger.getlog(".")
+        log.error("Failed to instantiate OpenShotApp", exc_info=1)
+        sys.exit()
     unittest.main()
+    app.exec_()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/tests/query_tests.py
+++ b/src/tests/query_tests.py
@@ -336,8 +336,8 @@ def main():
     try:
         app = OpenShotApp(sys.argv, mode="unittest")
     except Exception:
-        from logging import logger
-        log = logger.getlog(".")
+        import logging
+        log = logging.getLogger(".")
         log.error("Failed to instantiate OpenShotApp", exc_info=1)
         sys.exit()
     unittest.main()

--- a/src/windows/add_to_timeline.py
+++ b/src/windows/add_to_timeline.py
@@ -33,7 +33,6 @@ from random import shuffle, randint, uniform
 from PyQt5.QtWidgets import QDialog
 from PyQt5.QtGui import QIcon
 
-from classes import settings
 from classes import info, ui_util, time_parts
 from classes.logger import log
 from classes.query import Clip, Transition
@@ -437,12 +436,12 @@ class AddToTimeline(QDialog):
         # Init UI
         ui_util.init_ui(self)
 
-        # Get settings
-        self.settings = settings.get_settings()
-
         # Get translation object
         self.app = get_app()
         _ = self.app._tr
+
+        # Get settings
+        self.settings = self.app.get_settings()
 
         # Track metrics
         track_metric_screen("add-to-timeline-screen")

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -50,7 +50,6 @@ from PyQt5.QtGui import QIcon
 from classes import info
 from classes import ui_util
 from classes import openshot_rc  # noqa
-from classes import settings
 from classes.logger import log
 from classes.app import get_app
 from classes.metrics import track_metric_screen, track_metric_error
@@ -78,12 +77,12 @@ class Export(QDialog):
 
         # get translations & settings
         _ = get_app()._tr
-        self.s = settings.get_settings()
+        self.s = get_app().get_settings()
 
         track_metric_screen("export-screen")
 
         # Dynamically load tabs from settings data
-        self.settings_data = settings.get_settings().get_all_settings()
+        self.settings_data = self.s.get_all_settings()
 
         # Add buttons to interface
         self.cancel_button = QPushButton(_('Cancel'))

--- a/src/windows/file_properties.py
+++ b/src/windows/file_properties.py
@@ -35,7 +35,7 @@ from PyQt5.QtWidgets import (
 # Python module for libopenshot (required video editing module installed separately)
 import openshot
 
-from classes import info, ui_util, settings
+from classes import info, ui_util
 from classes.app import get_app
 from classes.logger import log
 from classes.metrics import track_metric_screen
@@ -64,7 +64,7 @@ class FileProperties(QDialog):
         _ = app._tr
 
         # Get settings
-        self.s = settings.get_settings()
+        self.s = app.get_settings()
 
         # Track metrics
         track_metric_screen("file-properties-screen")
@@ -75,7 +75,7 @@ class FileProperties(QDialog):
         self.buttonBox.addButton(QPushButton(_('Cancel')), QDialogButtonBox.RejectRole)
 
         # Dynamically load tabs from settings data
-        self.settings_data = settings.get_settings().get_all_settings()
+        self.settings_data = self.s.get_all_settings()
 
         # Get file properties
         filename = os.path.basename(self.file.data["path"])

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -49,7 +49,7 @@ from PyQt5.QtWidgets import (
     QLineEdit, QSlider, QLabel, QComboBox, QTextEdit
 )
 
-from classes import exceptions, info, settings, qt_types, ui_util, updates
+from classes import exceptions, info, qt_types, ui_util, updates
 from classes.app import get_app
 from classes.conversion import zoomToSeconds, secondsToZoom
 from classes.exporters.edl import export_edl
@@ -383,7 +383,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         try:
             # Update history in project data
-            s = settings.get_settings()
+            s = app.get_settings()
             app.updates.save_history(app.project, s.get("history-limit"))
 
             # Save project to file
@@ -570,7 +570,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         import time
 
         app = get_app()
-        s = settings.get_settings()
+        s = app.get_settings()
 
         # Get current filepath (if any)
         file_path = app.project.current_filepath
@@ -799,7 +799,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             log.info('Preferences add cancelled')
 
         # Save settings
-        s = settings.get_settings()
+        s = get_app().get_settings()
         s.save()
 
         # Restore normal cursor
@@ -1007,7 +1007,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Save current cache object and create a new CacheMemory object (ignore quality and scale prefs)
         old_cache_object = self.cache_object
-        new_cache_object = openshot.CacheMemory(settings.get_settings().get("cache-limit-mb") * 1024 * 1024)
+        new_cache_object = openshot.CacheMemory(app.get_settings().get("cache-limit-mb") * 1024 * 1024)
         self.timeline_sync.timeline.SetCache(new_cache_object)
 
         # Set MaxSize to full project resolution and clear preview cache so we get a full resolution frame
@@ -1409,14 +1409,14 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def getShortcutByName(self, setting_name):
         """ Get a key sequence back from the setting name """
-        s = settings.get_settings()
+        s = get_app().get_settings()
         shortcut = QKeySequence(s.get(setting_name))
         return shortcut
 
     def getAllKeyboardShortcuts(self):
         """ Get a key sequence back from the setting name """
         keyboard_shortcuts = []
-        all_settings = settings.get_settings()._data
+        all_settings = get_app().get_settings()._data
         for setting in all_settings:
             if setting.get('category') == 'Keyboard':
                 keyboard_shortcuts.append(setting)
@@ -1910,7 +1910,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Get settings
         app = get_app()
-        s = settings.get_settings()
+        s = app.get_settings()
 
         # Files
         if app.context_menu_object == "files":
@@ -1938,7 +1938,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Get settings
         app = get_app()
-        s = settings.get_settings()
+        s = app.get_settings()
 
         # Files
         if app.context_menu_object == "files":
@@ -2137,7 +2137,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def actionTutorial_trigger(self):
         """ Show tutorial again """
-        s = settings.get_settings()
+        s = get_app().get_settings()
 
         # Clear tutorial settings
         s.set("tutorial_enabled", True)
@@ -2256,7 +2256,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             log.info('addSelection: item_id: {}, item_type: {}, clear_existing: {}'.format(
                 item_id, item_type, clear_existing))
 
-        s = settings.get_settings()
+        s = get_app().get_settings()
 
         # Clear existing selection (if needed)
         if clear_existing:
@@ -2339,7 +2339,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     # Update window settings in setting store
     def save_settings(self):
-        s = settings.get_settings()
+        s = get_app().get_settings()
 
         # Save window state and geometry (saves toolbar and dock locations)
         s.set('window_state_v2', qt_types.bytes_to_str(self.saveState()))
@@ -2348,7 +2348,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     # Get window settings from setting store
     def load_settings(self):
-        s = settings.get_settings()
+        s = get_app().get_settings()
 
         # Window state and geometry (also toolbar, dock locations and frozen UI state)
         if s.get('window_state_v2'):
@@ -2371,7 +2371,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def load_recent_menu(self):
         """ Clear and load the list of recent menu items """
-        s = settings.get_settings()
+        s = get_app().get_settings()
         _ = get_app()._tr  # Get translation function
 
         # Get list of recent projects
@@ -2407,7 +2407,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def remove_recent_project(self, file_path):
         """Remove a project from the Recent menu if OpenShot can't find it"""
-        s = settings.get_settings()
+        s = get_app().get_settings()
         recent_projects = s.get("recent_projects")
         if file_path in recent_projects:
             recent_projects.remove(file_path)
@@ -2420,7 +2420,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def clear_recents_clicked(self):
         """Clear all recent projects"""
-        s = settings.get_settings()
+        s = get_app().get_settings()
         s.set("recent_projects", [])
 
         # Reload recent project list
@@ -2667,7 +2667,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def InitCacheSettings(self):
         """Set the correct cache settings for the timeline"""
         # Load user settings
-        s = settings.get_settings()
+        s = get_app().get_settings()
         log.info("InitCacheSettings")
         log.info("cache-mode: %s" % s.get("cache-mode"))
         log.info("cache-limit-mb: %s" % s.get("cache-limit-mb"))
@@ -2707,7 +2707,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def initModels(self):
         """Set up model/view classes for MainWindow"""
-        s = settings.get_settings()
+        s = get_app().get_settings()
 
         # Setup files tree and list view (both share a model)
         self.files_model = FilesModel()
@@ -2779,7 +2779,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         _ = app._tr
 
         # Load user settings for window
-        s = settings.get_settings()
+        s = app.get_settings()
         self.recent_menu = None
 
         # Track metrics

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -40,7 +40,7 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtGui import QKeySequence, QIcon
 
-from classes import info, ui_util, settings
+from classes import info, ui_util
 from classes import openshot_rc  # noqa
 from classes.app import get_app
 from classes.language import get_all_languages
@@ -68,10 +68,10 @@ class Preferences(QDialog):
         ui_util.init_ui(self)
 
         # Get settings
-        self.s = settings.get_settings()
+        self.s = get_app().get_settings()
 
         # Dynamically load tabs from settings data
-        self.settings_data = settings.get_settings().get_all_settings()
+        self.settings_data = self.s.get_all_settings()
 
         # Track metrics
         track_metric_screen("preferences-screen")

--- a/src/windows/process_effect.py
+++ b/src/windows/process_effect.py
@@ -35,7 +35,7 @@ from PyQt5.QtGui import QBrush
 from PyQt5.QtWidgets import *
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 
-from classes import info, ui_util, settings, qt_types, updates
+from classes import info, ui_util, qt_types, updates
 from classes.app import get_app
 from classes.logger import log
 from classes.metrics import *

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -34,7 +34,7 @@ from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 
-from classes import info, ui_util, time_parts, settings, qt_types, updates
+from classes import info, ui_util, time_parts, qt_types, updates
 from classes.app import get_app
 from classes.logger import log
 from classes.metrics import *

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -47,7 +47,7 @@ from PyQt5.QtWidgets import (
 
 import openshot
 
-from classes import info, ui_util, settings
+from classes import info, ui_util
 from classes.logger import log
 from classes.app import get_app
 from classes.metrics import track_metric_screen
@@ -611,7 +611,7 @@ class TitleEditor(QDialog):
     def btnAdvanced_clicked(self):
         """Use an external editor to edit the image"""
         # Get editor executable from settings
-        s = settings.get_settings()
+        s = get_app().get_settings()
         prog = s.get("title_editor")
         # Store filename field to display on reload
         filename_text = self.txtFileName.toPlainText().strip()

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -51,7 +51,6 @@ from PyQt5.QtGui import QColor, QImage, QPixmap
 
 from classes import info
 from classes.logger import log
-from classes import settings
 from classes.query import File
 from classes.app import get_app
 
@@ -498,7 +497,7 @@ class BlenderListView(QListView):
     def error_with_blender(self, version=None, worker_message=None):
         """ Show a friendly error message regarding the blender executable or version. """
         _ = self.app._tr
-        s = settings.get_settings()
+        s = self.app.get_settings()
 
         error_message = ""
         if version:
@@ -546,7 +545,7 @@ Blender Path: {}
         user_params += "\n#END INJECTING PARAMS\n"
 
         # If GPU rendering is selected, see if GPU enable code is available
-        s = settings.get_settings()
+        s = self.app.get_settings()
         gpu_code_body = None
         if s.get("blender_gpu_enabled"):
             gpu_enable_py = os.path.join(info.PATH, "blender", "scripts", "gpu_enable.py.in")
@@ -724,7 +723,7 @@ class Worker(QObject):
         self.target_script = target_script
         self.preview_frame = preview_frame
 
-        s = settings.get_settings()
+        s = get_app().get_settings()
         self.blender_exec_path = s.get("blender_command")
 
         # Init regex expression used to determine blender's render progress

--- a/src/windows/views/emojis_listview.py
+++ b/src/windows/views/emojis_listview.py
@@ -32,7 +32,6 @@ from PyQt5.QtWidgets import QListView
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 from classes.query import File
 from classes.app import get_app
-from classes.settings import get_settings
 from classes.logger import log
 import json
 
@@ -116,7 +115,7 @@ class EmojisListView(QListView):
         self.group_model.setFilterKeyColumn(1)
 
         # Save current emoji filter to settings
-        s = get_settings()
+        s = get_app().get_settings()
         setting_emoji_group = s.get('emoji_group_filter') or 'smileys-emotion'
         if setting_emoji_group != item:
             s.set('emoji_group_filter', item)
@@ -165,7 +164,7 @@ class EmojisListView(QListView):
         self.setStyleSheet('QListView::item { padding-top: 2px; }')
 
         # Get default emoji filter group
-        s = get_settings()
+        s = get_app().get_settings()
         default_type = s.get('emoji_group_filter') or 'smileys-emotion'
 
         # setup filter events

--- a/src/windows/views/tutorial.py
+++ b/src/windows/views/tutorial.py
@@ -36,7 +36,6 @@ from PyQt5.QtWidgets import (
     QPushButton, QToolButton, QCheckBox,
 )
 from classes.logger import log
-from classes.settings import get_settings
 from classes.app import get_app
 from classes.metrics import track_metric_screen
 
@@ -67,7 +66,7 @@ class TutorialDialog(QWidget):
 
     def checkbox_metrics_callback(self, state):
         """ Callback for error and anonymous usage checkbox"""
-        s = get_settings()
+        s = get_app().get_settings()
         if state == Qt.Checked:
             # Enabling metrics sending
             s.set("send_metrics", True)
@@ -118,7 +117,7 @@ class TutorialDialog(QWidget):
         # probably okay for now.
         if self.widget_id == "0":
             # Get settings
-            s = get_settings()
+            s = get_app().get_settings()
 
             # create spinner
             checkbox_metrics = QCheckBox()
@@ -260,7 +259,7 @@ class TutorialManager(object):
 
     def hide_tips(self, tid, user_clicked=False):
         """ Hide the current tip, and don't show anymore """
-        s = get_settings()
+        s = get_app().get_settings()
 
         # Loop through and find current tid
         for tutorial_object in self.tutorial_objects:
@@ -348,7 +347,7 @@ class TutorialManager(object):
         _ = app._tr
 
         # get settings
-        s = get_settings()
+        s = app.get_settings()
         self.tutorial_enabled = s.get("tutorial_enabled")
         self.tutorial_ids = s.get("tutorial_ids").split(",")
 

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -42,7 +42,6 @@ from PyQt5.QtGui import QCursor, QKeySequence, QColor
 from PyQt5.QtWidgets import QMenu, QDialog
 
 from classes import info, updates
-from classes import settings
 from classes.app import get_app
 from classes.logger import log
 from classes.query import File, Clip, Transition, Track
@@ -2885,7 +2884,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             # Adjust clip duration, start, and end
             new_clip["duration"] = new_clip["reader"]["duration"]
             if file.data["media_type"] == "image":
-                new_clip["end"] = settings.get_settings().get("default-image-length")  # default to 8 seconds
+                new_clip["end"] = get_app().get_settings().get("default-image-length")  # default to 8 seconds
 
             # Overwrite frame rate (incase the user changed it in the File Properties)
             file_properties_fps = float(file.data["fps"]["num"]) / float(file.data["fps"]["den"])


### PR DESCRIPTION
This PR, tested on both Linux and Windows, completely revamps the initial creation of the `QApplication` instance and the `MainWindow` class, as OpenShot is being started by `launch.py` (also significantly rewritten), all in the service of one central goal: completely divorce the application setup (which is done in `OpenShotApp's __init__`, same as always) from the interface startup, which now lives in a new `OpenShotApp.gui()` method. Calling that is optional, and the unit tests simply... don't.

When launching the unit tests (from `tests/query_tests.py`), the interface is never even started, and therefore (by implication) neither is the web backend. Which alleviates the problems caused by `QtWebEngine` not shutting down properly because it hasn't even had a chance to start yet before the unit tests are completed.

I've also moved all of that OpenGL setup stuff and other housekeeping out of the top of classes.app and put it in `launch.py` instead, so that it's truly done BEFORE creating the `QApplication` (or, `OpenShotApp`) instance. I've always been wary of the fact that we were effectively doing it "while" the instance was being created, not technically "before".

And having it in `launch.py` means the unit tests can also skip that stuff. It's now possible, in fact, to run the unit tests in a headless environment without needing `xrdb`, just by adding a `-platform minimal` or `-platform offscreen` on the command line for `query_tests.py`. (The platform plugin has to be changed because Qt's default on Linux is xcb, which still expects an X display even if nothing makes use of it.)

There were some other changes involved, like deferring any `QMessageBox` calls that previously occurred during `OpenShotApp.__init__()`. Now they're placed on a queue, and not shown until requested by `launch.py` (or automatically, if there are any outstanding when `OpenShotApp.gui()` is called.

#### Other changes
* I've completely removed `classes.settings.get_settings()`. Settings should now be requested from the app instance, using `get_app().get_settings()`. There's also a convenience function `get_settings()` in `classes.app`, just like the old one in `classes.settings`, but you shouldn't use `classes.app.get_settings()` either. Go through the application instance.

