### PR TITLE
Fixing a regression caused by renaming .env files

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -175,7 +175,7 @@ for share_name in ["install-x64", "install-x86"]:
             git_log_filepath = os.path.join(share_path, git_log_filename)
             if os.path.isfile(git_log_filepath):
                 src_files.append((git_log_filepath, "settings/%s" % git_log_filename))
-                if os.path.splitext(git_log_filepath)[1] == "":
+                if os.path.splitext(git_log_filepath)[1] == ".env":
                     # No extension, parse version info
                     version_info.update(parse_version_info(git_log_filepath))
 


### PR DESCRIPTION
Fixing a regression caused by renaming .env files with version_info. This caused the `version.json` file to not be created, and thus, all version info to vanish from all builds.