### PR TITLE
Don't check event.shiftKey if event doesn't exist

### DIFF
--- a/src/timeline/js/functions.js
+++ b/src/timeline/js/functions.js
@@ -273,7 +273,7 @@ function moveBoundingBox(scope, previous_x, previous_y, x_offset, y_offset, left
   snapping_result.top = top;
 
   // Check for shift key
-  if (event.shiftKey) {
+  if ( typeof(event) !== "undefined" && event.shiftKey) {
     // freeze X movement
     x_offset = 0;
     snapping_result.left = previous_x;


### PR DESCRIPTION
Fixing the shift-drag bug #4112 introduced a problem when dragging a clip onto the timeline.

The issue was evaluating an attribute of an event, when there wasn't an event.