### PR TITLE
Removed broken index (Copy/Paste keyframe issue)

### DIFF
--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1456,10 +1456,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 self.copy_clipboard[clip_id] = clip.data
             elif action == MENU_COPY_KEYFRAMES_ALL:
                 self.copy_clipboard[clip_id]['alpha'] = clip.data['alpha']
-                self.copy_clipboard[clip_id]['crop_height'] = clip.data['crop_height']
-                self.copy_clipboard[clip_id]['crop_width'] = clip.data['crop_width']
-                self.copy_clipboard[clip_id]['crop_x'] = clip.data['crop_x']
-                self.copy_clipboard[clip_id]['crop_y'] = clip.data['crop_y']
                 self.copy_clipboard[clip_id]['gravity'] = clip.data['gravity']
                 self.copy_clipboard[clip_id]['scale_x'] = clip.data['scale_x']
                 self.copy_clipboard[clip_id]['scale_y'] = clip.data['scale_y']


### PR DESCRIPTION
Fixes #4138

Copy/Paste all keyframes was retrieving data from a clip property that didn't exist. This was crashing the copy, and only allowing keyframes for properties before it to be copied.

A rework of this is coming, but here's a quick fix.