### PR TITLE
Prevent Assets Folder Name Collision

### DIFF
--- a/src/classes/assets.py
+++ b/src/classes/assets.py
@@ -40,23 +40,25 @@ def get_assets_path(file_path=None, create_paths=True):
         # Generate asset folder name filename + "_assets"
         file_path = file_path
         asset_filename = os.path.splitext(os.path.basename(file_path))[0]
-        asset_folder_name = asset_filename + "_assets"
+        asset_folder_name = asset_filename[:248] + "_assets" #Windows max name size is 255. 248 = 255 - len("_assets")
         asset_path = os.path.join(os.path.dirname(file_path), asset_folder_name)
 
         # Previous Assets File Name Convention.
         asset_folder_name_30_char = asset_filename[:30] + "_assets"
         asset_path_30_char = os.path.join(os.path.dirname(file_path), asset_folder_name_30_char)
 
+
         # Create asset folder, if necessary
         if create_paths:
 
-            if os.path.exists(asset_path_30_char):
+            if not os.path.exists(asset_path):
+                if os.path.exists(asset_folder_name_30_char):
                 #update assets folder, if it follows the previous naming convention
-                os.rename(asset_path_30_char, asset_path)
-                log.info("Updating 30 character path to full length {}".format(asset_path))
-            elif not os.path.exists(asset_path):
-                os.mkdir(asset_path)
-                log.info("Asset dir created as {}".format(asset_path))
+                    os.rename(asset_path_30_char, asset_path)
+                    log.info("Updating 30 character path to full length {}".format(asset_path))
+                else:
+                    os.mkdir(asset_path)
+                    log.info("Asset dir created as {}".format(asset_path))
             else:
                 log.info("Using existing asset folder {}".format(asset_path))
 

--- a/src/classes/assets.py
+++ b/src/classes/assets.py
@@ -51,7 +51,6 @@ def get_assets_path(file_path=None, create_paths=True):
 
         # Create asset folder, if necessary
         if create_paths:
-
             if not os.path.exists(asset_path):
                 if os.path.exists(asset_path_30_char):
                     #copy assets folder, if it follows the previous naming convention

--- a/src/classes/assets.py
+++ b/src/classes/assets.py
@@ -53,10 +53,10 @@ def get_assets_path(file_path=None, create_paths=True):
         if create_paths:
 
             if not os.path.exists(asset_path):
-                if os.path.exists(asset_folder_name_30_char):
+                if os.path.exists(asset_path_30_char):
                     #update assets folder, if it follows the previous naming convention
                     try:
-                        shutil.copytree(asset_folder_name_30_char, asset_folder_name)
+                        shutil.copytree(asset_path_30_char, asset_path)
                         log.info("Copying shortened asset folder. {}".format(asset_path))
                     except:
                         log.error("Could not make a copy of assets folder")

--- a/src/classes/assets.py
+++ b/src/classes/assets.py
@@ -26,6 +26,7 @@
  """
 
 import os
+import shutil
 from classes import info
 from classes.logger import log
 
@@ -53,9 +54,12 @@ def get_assets_path(file_path=None, create_paths=True):
 
             if not os.path.exists(asset_path):
                 if os.path.exists(asset_folder_name_30_char):
-                #update assets folder, if it follows the previous naming convention
-                    os.rename(asset_path_30_char, asset_path)
-                    log.info("Updating 30 character path to full length {}".format(asset_path))
+                    #update assets folder, if it follows the previous naming convention
+                    try:
+                        shutil.copytree(asset_folder_name_30_char, asset_folder_name)
+                        log.info("Copying shortened asset folder. {}".format(asset_path))
+                    except:
+                        log.error("Could not make a copy of assets folder")
                 else:
                     os.mkdir(asset_path)
                     log.info("Asset dir created as {}".format(asset_path))

--- a/src/classes/assets.py
+++ b/src/classes/assets.py
@@ -40,12 +40,20 @@ def get_assets_path(file_path=None, create_paths=True):
         # Generate asset folder name, max 30 chars of filename + "_assets"
         file_path = file_path
         asset_filename = os.path.splitext(os.path.basename(file_path))[0]
-        asset_folder_name = asset_filename[:30] + "_assets"
+        asset_folder_name = asset_filename + "_assets"
+        asset_folder_name_30_char = asset_filename[:30] + "_assets"
         asset_path = os.path.join(os.path.dirname(file_path), asset_folder_name)
+        asset_path_30_char = os.path.join(os.path.dirname(file_path), asset_folder_name_30_char)
+
+
 
         # Create asset folder, if necessary
         if create_paths:
-            if not os.path.exists(asset_path):
+
+            if os.path.exists(asset_path_30_char):
+                os.rename(asset_path_30_char, asset_path)
+                log.info("Updating 30 character path to full length {}".format(asset_path))
+            elif not os.path.exists(asset_path):
                 os.mkdir(asset_path)
                 log.info("Asset dir created as {}".format(asset_path))
             else:

--- a/src/classes/assets.py
+++ b/src/classes/assets.py
@@ -45,6 +45,7 @@ def get_assets_path(file_path=None, create_paths=True):
         asset_path = os.path.join(os.path.dirname(file_path), asset_folder_name)
 
         # Previous Assets File Name Convention.
+        # We can remove the 30_char variables after 05/27/2022
         asset_folder_name_30_char = asset_filename[:30] + "_assets"
         asset_path_30_char = os.path.join(os.path.dirname(file_path), asset_folder_name_30_char)
 
@@ -54,7 +55,8 @@ def get_assets_path(file_path=None, create_paths=True):
 
             if not os.path.exists(asset_path):
                 if os.path.exists(asset_path_30_char):
-                    #update assets folder, if it follows the previous naming convention
+                    #copy assets folder, if it follows the previous naming convention
+                    #must leave a copy for possible projects that shared the folder.
                     try:
                         shutil.copytree(asset_path_30_char, asset_path)
                         log.info("Copying shortened asset folder. {}".format(asset_path))

--- a/src/classes/assets.py
+++ b/src/classes/assets.py
@@ -37,20 +37,21 @@ def get_assets_path(file_path=None, create_paths=True):
         return info.USER_PATH
 
     try:
-        # Generate asset folder name, max 30 chars of filename + "_assets"
+        # Generate asset folder name filename + "_assets"
         file_path = file_path
         asset_filename = os.path.splitext(os.path.basename(file_path))[0]
         asset_folder_name = asset_filename + "_assets"
-        asset_folder_name_30_char = asset_filename[:30] + "_assets"
         asset_path = os.path.join(os.path.dirname(file_path), asset_folder_name)
+
+        # Previous Assets File Name Convention.
+        asset_folder_name_30_char = asset_filename[:30] + "_assets"
         asset_path_30_char = os.path.join(os.path.dirname(file_path), asset_folder_name_30_char)
-
-
 
         # Create asset folder, if necessary
         if create_paths:
 
             if os.path.exists(asset_path_30_char):
+                #update assets folder, if it follows the previous naming convention
                 os.rename(asset_path_30_char, asset_path)
                 log.info("Updating 30 character path to full length {}".format(asset_path))
             elif not os.path.exists(asset_path):

--- a/src/classes/assets.py
+++ b/src/classes/assets.py
@@ -49,7 +49,6 @@ def get_assets_path(file_path=None, create_paths=True):
         asset_folder_name_30_char = asset_filename[:30] + "_assets"
         asset_path_30_char = os.path.join(os.path.dirname(file_path), asset_folder_name_30_char)
 
-
         # Create asset folder, if necessary
         if create_paths:
 


### PR DESCRIPTION
Issue #4158 pointed out that if project names were longer than 30 characters, they were truncated to 30 characters, and `_assets` was appended.

# Solution
Aside from MacOS, 255 characters the typical limit for file or folder names. So to avoid, neighboring projects running into each other as much as possible, we now truncate only if the addition of '_assets' would push the folder name over 255.

# Reverse Backwards Compatability.
As Frank pointed out, moving the folder to the new naming convention would cause trouble for anyone with long project files moving back to the stable build.

To solve this, we search for and **copy** the truncated folder if if a full length one doesn't exist. I believe this is the most seamless user experience, as renaming the folder, would mean the first project opened would take the folder that had been shared.

## Testing
1. Created two long named projects on develop
1. Created titles in both with different titles
2. Switched branches
3. Opened each project, finding both had their own assets 