### PR TITLE
Some query class / unit tests fixes and enhancements

### DIFF
--- a/src/classes/query.py
+++ b/src/classes/query.py
@@ -32,11 +32,6 @@ from classes import info
 from classes.app import get_app
 
 
-# Get project data reference
-app = get_app()
-project = app.project
-
-
 class QueryObject:
     """ This class allows one or more project data objects to be queried """
 
@@ -56,7 +51,7 @@ class QueryObject:
         if not self.id and self.type == "insert":
 
             # Insert record, and Generate id
-            self.id = project.generate_id()
+            self.id = get_app().project.generate_id()
 
             # save id in data (if attribute found)
             self.data["id"] = copy.deepcopy(self.id)
@@ -67,7 +62,7 @@ class QueryObject:
                 self.key.append({"id": self.id})
 
             # Insert into project data
-            app.updates.insert(copy.deepcopy(OBJECT_TYPE.object_key), copy.deepcopy(self.data))
+            get_app().updates.insert(copy.deepcopy(OBJECT_TYPE.object_key), copy.deepcopy(self.data))
 
             # Mark record as 'update' now... so another call to this method won't insert it again
             self.type = "update"
@@ -75,7 +70,7 @@ class QueryObject:
         elif self.id and self.type == "update":
 
             # Update existing project data
-            app.updates.update(self.key, self.data)
+            get_app().updates.update(self.key, self.data)
 
     def delete(self, OBJECT_TYPE):
         """ Delete the object from the project data store """
@@ -83,7 +78,7 @@ class QueryObject:
         # Delete if object found and not pending insert
         if self.id and self.type == "update":
             # Delete from project data store
-            app.updates.delete(self.key)
+            get_app().updates.delete(self.key)
             self.type = "delete"
 
     def title(self):
@@ -95,7 +90,7 @@ class QueryObject:
         """ Take any arguments given as filters, and find a list of matching objects """
 
         # Get a list of all objects of this type
-        parent = project.get(OBJECT_TYPE.object_key)
+        parent = get_app().project.get(OBJECT_TYPE.object_key)
 
         if not parent:
             return []
@@ -242,30 +237,25 @@ class File(QueryObject):
     def absolute_path(self):
         """ Get absolute file path of file """
 
-        # Get project folder (if any)
-        project_folder = None
-        if project.current_filepath:
-            project_folder = os.path.dirname(project.current_filepath)
-
-        # Convert relative file path into absolute (if needed)
         file_path = self.data["path"]
-        if not os.path.isabs(file_path) and project_folder:
-            file_path = os.path.abspath(os.path.join(project_folder, self.data["path"]))
+        if os.path.isabs(file_path):
+            return file_path
 
-        # Return absolute path of file
+            # Try to expand path relative to project folder
+        app = get_app()
+        if (app and hasattr("project", app)
+           and hasattr("current_filepath", app.project)):
+            project_folder = os.path.dirname(app.project.current_filepath)
+            file_path = os.path.abspath(os.path.join(project_folder, file_path))
+
         return file_path
 
     def relative_path(self):
         """ Get relative path (based on the current working directory) """
 
-        # Get absolute file path
         file_path = self.absolute_path()
-
         # Convert path to relative (based on current working directory of Python)
-        file_path = os.path.relpath(file_path, info.CWD)
-
-        # Return relative path
-        return file_path
+        return os.path.relpath(file_path, info.CWD)
 
 
 class Marker(QueryObject):
@@ -317,6 +307,7 @@ class Track(QueryObject):
     def __gt__(self, other):
         return self.data.get('number', 0) > other.data.get('number', 0)
 
+
 class Effect(QueryObject):
     """ This class allows Effects to be queried, updated, and deleted from the project data. """
     object_name = "effects"  # Derived classes should define this
@@ -334,7 +325,7 @@ class Effect(QueryObject):
         """ Take any arguments given as filters, and find a list of matching objects """
 
         # Get a list of clips
-        clips = project.get("clips")
+        clips = get_app().project.get("clips")
         matching_objects = []
 
         # Loop through all clips

--- a/src/classes/query.py
+++ b/src/classes/query.py
@@ -241,7 +241,7 @@ class File(QueryObject):
         if os.path.isabs(file_path):
             return file_path
 
-            # Try to expand path relative to project folder
+        # Try to expand path relative to project folder
         app = get_app()
         if (app and hasattr("project", app)
            and hasattr("current_filepath", app.project)):

--- a/src/tests/query_tests.py
+++ b/src/tests/query_tests.py
@@ -52,20 +52,18 @@ from classes import info
 
 app = None
 
-class TestQueryClass(unittest.TestCase):
+
+class QueryTests(unittest.TestCase):
     """ Unit test class for Query class """
 
     @classmethod
-    def setUpClass(TestQueryClass):
+    def setUpClass(cls):
         """ Init unit test data """
         # Create Qt application
-        TestQueryClass.app = QGuiApplication.instance()
-        TestQueryClass.clip_ids = []
-        TestQueryClass.file_ids = []
-        TestQueryClass.transition_ids = []
-
-        # Import additional classes that need the app defined first
-        from classes.query import Clip, File, Transition
+        cls.app = QGuiApplication.instance()
+        cls.clip_ids = []
+        cls.file_ids = []
+        cls.transition_ids = []
 
         clips = []
 
@@ -85,7 +83,7 @@ class TestQueryClass(unittest.TestCase):
             query_clip.save()
 
             # Keep track of the ids
-            TestQueryClass.clip_ids.append(query_clip.id)
+            cls.clip_ids.append(query_clip.id)
             clips.append(query_clip)
 
         # Insert some files into the project data
@@ -104,7 +102,7 @@ class TestQueryClass(unittest.TestCase):
             query_file.save()
 
             # Keep track of the ids
-            TestQueryClass.file_ids.append(query_file.id)
+            cls.file_ids.append(query_file.id)
 
         # Insert some transitions into the project data
         for c in clips:
@@ -124,7 +122,7 @@ class TestQueryClass(unittest.TestCase):
             query_transition.save()
 
             # Keep track of the ids
-            TestQueryClass.transition_ids.append(query_transition.id)
+            cls.transition_ids.append(query_transition.id)
 
         # Don't keep the full query objects around
         del clips
@@ -158,7 +156,7 @@ class TestQueryClass(unittest.TestCase):
     def test_update_clip(self):
         """ Test the Clip.save method """
 
-        update_id = TestQueryClass.clip_ids[0]
+        update_id = self.clip_ids[0]
         clip = Clip.get(id=update_id)
         self.assertTrue(clip)
 
@@ -172,10 +170,13 @@ class TestQueryClass(unittest.TestCase):
         self.assertEqual(clip.data["layer"], 2)
         self.assertEqual(clip.data["title"], "My Title")
 
+        clips = Clip.filter(layer=2)
+        self.assertEqual(len(clips), 1)
+
     def test_delete_clip(self):
         """ Test the Clip.delete method """
 
-        delete_id = TestQueryClass.clip_ids[4]
+        delete_id = self.clip_ids[4]
         clip = Clip.get(id=delete_id)
         self.assertTrue(clip)
 
@@ -193,7 +194,7 @@ class TestQueryClass(unittest.TestCase):
     def test_filter_clip(self):
         """ Test the Clip.filter method """
 
-        clips = Clip.filter(id=TestQueryClass.clip_ids[0])
+        clips = Clip.filter(id=self.clip_ids[0])
         self.assertTrue(clips)
 
         # Do not find a clip
@@ -203,7 +204,7 @@ class TestQueryClass(unittest.TestCase):
     def test_get_clip(self):
         """ Test the Clip.get method """
 
-        clip = Clip.get(id=TestQueryClass.clip_ids[1])
+        clip = Clip.get(id=self.clip_ids[1])
         self.assertTrue(clip)
 
         # Do not find a clip
@@ -254,7 +255,7 @@ class TestQueryClass(unittest.TestCase):
     def test_update_File(self):
         """ Test the File.save method """
 
-        update_id = TestQueryClass.file_ids[0]
+        update_id = self.file_ids[0]
         file = File.get(id=update_id)
         self.assertTrue(file)
 
@@ -271,7 +272,7 @@ class TestQueryClass(unittest.TestCase):
     def test_delete_File(self):
         """ Test the File.delete method """
 
-        delete_id = TestQueryClass.file_ids[4]
+        delete_id = self.file_ids[4]
         file = File.get(id=delete_id)
         self.assertTrue(file)
 
@@ -289,7 +290,7 @@ class TestQueryClass(unittest.TestCase):
     def test_filter_File(self):
         """ Test the File.filter method """
 
-        files = File.filter(id=TestQueryClass.file_ids[0])
+        files = File.filter(id=self.file_ids[0])
         self.assertTrue(files)
 
         # Do not find a File
@@ -299,7 +300,7 @@ class TestQueryClass(unittest.TestCase):
     def test_get_File(self):
         """ Test the File.get method """
 
-        file = File.get(id=TestQueryClass.file_ids[1])
+        file = File.get(id=self.file_ids[1])
         self.assertTrue(file)
 
         # Do not find a File

--- a/src/tests/query_tests.py
+++ b/src/tests/query_tests.py
@@ -47,6 +47,7 @@ if PATH not in sys.path:
     sys.path.append(PATH)
 
 from classes.app import OpenShotApp
+from classes.query import Clip, File, Transition
 from classes import info
 
 app = None
@@ -130,22 +131,16 @@ class TestQueryClass(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        "Hook method for deconstructing the class fixture after running all tests in the class."
-        TestQueryClass.app.quit()
+        """ Clean up after running all tests in the class. """
+        cls.app.quit()
 
     def test_add_clip(self):
-        """ Test the Clip.save method by adding multiple clips """
-
-        # Import additional classes that need the app defined first
-        from classes.query import Clip
 
         # Find number of clips in project
         num_clips = len(Clip.filter())
 
         # Create clip
         c = openshot.Clip(os.path.join(info.IMAGES_PATH, "AboutLogo.png"))
-
-        # Parse JSON
         clip_data = json.loads(c.Json())
 
         # Insert into project data
@@ -158,16 +153,11 @@ class TestQueryClass(unittest.TestCase):
 
         # Save the clip again (which should not change the total # of clips)
         query_clip.save()
-
         self.assertEqual(len(Clip.filter()), num_clips + 1)
 
     def test_update_clip(self):
         """ Test the Clip.save method """
 
-        # Import additional classes that need the app defined first
-        from classes.query import Clip
-
-        # Find a clip named file1
         update_id = TestQueryClass.clip_ids[0]
         clip = Clip.get(id=update_id)
         self.assertTrue(clip)
@@ -178,7 +168,6 @@ class TestQueryClass(unittest.TestCase):
         clip.save()
 
         # Verify updated data
-        # Get clip again
         clip = Clip.get(id=update_id)
         self.assertEqual(clip.data["layer"], 2)
         self.assertEqual(clip.data["title"], "My Title")
@@ -186,15 +175,10 @@ class TestQueryClass(unittest.TestCase):
     def test_delete_clip(self):
         """ Test the Clip.delete method """
 
-        # Import additional classes that need the app defined first
-        from classes.query import Clip
-
-        # Find a clip named file1
         delete_id = TestQueryClass.clip_ids[4]
         clip = Clip.get(id=delete_id)
         self.assertTrue(clip)
 
-        # Delete clip
         clip.delete()
 
         # Verify deleted data
@@ -203,18 +187,12 @@ class TestQueryClass(unittest.TestCase):
 
         # Delete clip again (should do nothing)
         clip.delete()
-
-        # Verify deleted data
         deleted_clip = Clip.get(id=delete_id)
         self.assertFalse(deleted_clip)
 
     def test_filter_clip(self):
         """ Test the Clip.filter method """
 
-        # Import additional classes that need the app defined first
-        from classes.query import Clip
-
-        # Find all clips named file1
         clips = Clip.filter(id=TestQueryClass.clip_ids[0])
         self.assertTrue(clips)
 
@@ -225,10 +203,6 @@ class TestQueryClass(unittest.TestCase):
     def test_get_clip(self):
         """ Test the Clip.get method """
 
-        # Import additional classes that need the app defined first
-        from classes.query import Clip
-
-        # Find a clip named file1
         clip = Clip.get(id=TestQueryClass.clip_ids[1])
         self.assertTrue(clip)
 
@@ -238,9 +212,6 @@ class TestQueryClass(unittest.TestCase):
 
     def test_intersect(self):
         """ Test special filter argument 'intersect' """
-
-        # Import additional classes that need the app defined first
-        from classes.query import Clip, Transition
 
         trans = Transition.get(id=self.transition_ids[0])
         self.assertTrue(trans)
@@ -283,10 +254,6 @@ class TestQueryClass(unittest.TestCase):
     def test_update_File(self):
         """ Test the File.save method """
 
-        # Import additional classes that need the app defined first
-        from classes.query import File
-
-        # Find a File named file1
         update_id = TestQueryClass.file_ids[0]
         file = File.get(id=update_id)
         self.assertTrue(file)
@@ -297,7 +264,6 @@ class TestQueryClass(unittest.TestCase):
         file.save()
 
         # Verify updated data
-        # Get File again
         file = File.get(id=update_id)
         self.assertEqual(file.data["height"], 1080)
         self.assertEqual(file.data["width"], 1920)
@@ -305,35 +271,24 @@ class TestQueryClass(unittest.TestCase):
     def test_delete_File(self):
         """ Test the File.delete method """
 
-        # Import additional classes that need the app defined first
-        from classes.query import File
-
-        # Find a File named file1
         delete_id = TestQueryClass.file_ids[4]
         file = File.get(id=delete_id)
         self.assertTrue(file)
 
-        # Delete File
         file.delete()
 
         # Verify deleted data
         deleted_file = File.get(id=delete_id)
         self.assertFalse(deleted_file)
 
-        # Delete File again (should do nothing
+        # Delete File again (should do nothing)
         file.delete()
-
-        # Verify deleted data
         deleted_file = File.get(id=delete_id)
         self.assertFalse(deleted_file)
 
     def test_filter_File(self):
         """ Test the File.filter method """
 
-        # Import additional classes that need the app defined first
-        from classes.query import File
-
-        # Find all Files named file1
         files = File.filter(id=TestQueryClass.file_ids[0])
         self.assertTrue(files)
 
@@ -344,10 +299,6 @@ class TestQueryClass(unittest.TestCase):
     def test_get_File(self):
         """ Test the File.get method """
 
-        # Import additional classes that need the app defined first
-        from classes.query import File
-
-        # Find a File named file1
         file = File.get(id=TestQueryClass.file_ids[1])
         self.assertTrue(file)
 
@@ -356,18 +307,12 @@ class TestQueryClass(unittest.TestCase):
         self.assertEqual(file, None)
 
     def test_add_file(self):
-        """ Test the File.save method by adding multiple files """
-
-        # Import additional classes that need the app defined first
-        from classes.query import File
 
         # Find number of files in project
         num_files = len(File.filter())
 
         # Create file
         r = openshot.DummyReader(openshot.Fraction(24, 1), 640, 480, 44100, 2, 30.0)
-
-        # Parse JSON
         file_data = json.loads(r.Json())
 
         # Insert into project data
@@ -375,14 +320,13 @@ class TestQueryClass(unittest.TestCase):
         query_file.data = file_data
         query_file.data["path"] = os.path.join(info.IMAGES_PATH, "AboutLogo.png")
         query_file.data["media_type"] = "image"
-        query_file.save()
 
+        query_file.save()
         self.assertTrue(query_file)
         self.assertEqual(len(File.filter()), num_files + 1)
 
         # Save the file again (which should not change the total # of files)
         query_file.save()
-
         self.assertEqual(len(File.filter()), num_files + 1)
 
 


### PR DESCRIPTION
My ambitious PRs tend to sit for months on end with no review, often becoming so divergent from the target branch that the conflicts are unresolvable. As a result, I'm trying to submit more, smaller PRs. This is one, containing a first round of tweaks to the project-data query classes and their associated unit tests.

* Add a unit test for `filter(intersect=)`
  Also, make the test data slightly more interesting by varying `Position` values for the clips/transitions in the test data.
* classes.query: Don't hold a reference to `app.project`
  By calling `get_app()` each time we need to access the project data, we delay the lookup until it's needed. As a result, query classes can now be imported even if an application instance has not yet been initialized. (As long as it's initialized before the first call to a query class method).
* Unit tests: 
    * Import query classes at top of file
      (There's no longer any need to delay the imports.)
   * Rename the `TestQueryClass` class to `QueryTests`, which is more in line with typical `unittest` naming
   * Replace explicit `TestQueryClass` references in the class code with `cls` or `self` as appropriate, so any future renaming will be far less of a pain