### PR TITLE
Initial integration of Sentry (crash monitoring)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         sudo apt install libopenshot-audio-dev libopenshot-dev python3-openshot
         sudo apt install qttranslations5-l10n libssl-dev xvfb
         sudo apt install python3-pyqt5 python3-pyqt5.qtsvg python3-pyqt5.qtwebengine python3-pyqt5.qtopengl python3-zmq python3-xdg
-        pip3 install setuptools wheel
+        pip3 install setuptools wheel sentry-sdk
         pip3 install cx_Freeze==6.1 distro defusedxml requests certifi chardet urllib3
 
     - name: Build Python package

--- a/freeze.py
+++ b/freeze.py
@@ -80,6 +80,7 @@ python_packages = ["os",
                    "time",
                    "uuid",
                    "idna",
+                   "sentry_sdk",
                    "shutil",
                    "threading",
                    "subprocess",
@@ -95,7 +96,16 @@ python_packages = ["os",
                    ]
 
 # Modules to include
-python_modules = ["idna.idnadata"]
+python_modules = ["idna.idnadata",
+                  "sentry_sdk.integrations.stdlib",
+                  "sentry_sdk.integrations.excepthook",
+                  "sentry_sdk.integrations.dedupe",
+                  "sentry_sdk.integrations.atexit",
+                  "sentry_sdk.integrations.modules",
+                  "sentry_sdk.integrations.argv",
+                  "sentry_sdk.integrations.logging",
+                  "sentry_sdk.integrations.threading",
+                  ]
 
 # Determine absolute PATH of OpenShot folder
 PATH = os.path.dirname(os.path.realpath(__file__))  # Primary openshot folder

--- a/freeze.py
+++ b/freeze.py
@@ -438,7 +438,7 @@ build_exe_options["packages"] = python_packages
 build_exe_options["include_files"] = src_files + external_so_files
 build_exe_options["includes"] = python_modules
 build_exe_options["excludes"] = ["distutils",
-                                 "django",
+                                 "sentry_sdk.integrations.django",
                                  "numpy",
                                  "setuptools",
                                  "tkinter",

--- a/freeze.py
+++ b/freeze.py
@@ -437,7 +437,14 @@ elif sys.platform == "darwin":
 build_exe_options["packages"] = python_packages
 build_exe_options["include_files"] = src_files + external_so_files
 build_exe_options["includes"] = python_modules
-build_exe_options["excludes"] = ["distutils", "numpy", "setuptools", "tkinter", "pydoc_data", "pycparser", "pkg_resources"]
+build_exe_options["excludes"] = ["distutils",
+                                 "django",
+                                 "numpy",
+                                 "setuptools",
+                                 "tkinter",
+                                 "pydoc_data",
+                                 "pycparser",
+                                 "pkg_resources"]
 
 # Set options
 build_options["build_exe"] = build_exe_options

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -34,6 +34,7 @@ import platform
 import traceback
 import json
 
+from classes import exceptions
 from PyQt5.QtCore import PYQT_VERSION_STR
 from PyQt5.QtCore import QT_VERSION_STR
 from PyQt5.QtCore import pyqtSlot
@@ -136,6 +137,10 @@ class OpenShotApp(QApplication):
         # Set location of OpenShot program (for libopenshot)
         openshot.Settings.Instance().PATH_OPENSHOT_INSTALL = info.PATH
 
+        # Check to disable sentry
+        if not self.settings.get('send_metrics'):
+            exceptions.disable_sentry_tracing()
+
     def show_environment(self, info, openshot):
         log = self.log
         try:
@@ -162,10 +167,6 @@ class OpenShotApp(QApplication):
 
         except Exception:
             log.debug("Error displaying dependency/system details", exc_info=1)
-
-        # Init and attach exception handler
-        from classes import exceptions
-        sys.excepthook = exceptions.ExceptionHandler
 
     def check_libopenshot_version(self, info, openshot):
         """Detect minimum libopenshot version"""

--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -28,7 +28,7 @@
 import os
 from time import strftime
 
-VERSION = "2.5.1-dev2"
+VERSION = "2.5.1-dev3"
 MINIMUM_LIBOPENSHOT_VERSION = "0.2.5"
 DATE = "20200228000000"
 NAME = "openshot-qt"

--- a/src/classes/language.py
+++ b/src/classes/language.py
@@ -28,6 +28,7 @@
 
 import os
 import locale
+import sentry_sdk
 
 from PyQt5.QtCore import QLocale, QLibraryInfo, QTranslator, QCoreApplication
 
@@ -119,6 +120,7 @@ def init_language():
         if found_language:
             log.debug("Exiting translation system (since we successfully loaded: {})".format(locale_name))
             info.CURRENT_LANGUAGE = locale_name
+            sentry_sdk.set_tag("locale", locale_name)
             break
 
 

--- a/src/classes/metrics.py
+++ b/src/classes/metrics.py
@@ -133,13 +133,6 @@ def track_metric_error(error_name, is_fatal=False):
     t.start()
 
 
-def track_exception_stacktrace(stacktrace, source):
-    """Track an exception/stacktrace has occurred"""
-    t = threading.Thread(target=send_exception, args=[stacktrace, source])
-    t.daemon = True
-    t.start()
-
-
 def track_metric_session(is_start=True):
     """Track a GUI screen being shown"""
     metric_params = deepcopy(params)
@@ -183,23 +176,3 @@ def send_metric(params):
         # All metrics have been sent (or attempted to send)
         # Clear the queue
         metric_queue.clear()
-
-
-def send_exception(stacktrace, source):
-    """Send exception stacktrace over HTTP for tracking"""
-    # Check if the user wants to send metrics and errors
-    if s.get("send_metrics"):
-
-        data = urllib.parse.urlencode({"stacktrace": stacktrace,
-                                       "platform": platform.system(),
-                                       "version": info.VERSION,
-                                       "source": source,
-                                       "unique_install_id": s.get("unique_install_id")})
-        url = "http://www.openshot.org/exception/json/"
-
-        # Send exception HTTP data
-        try:
-            r = requests.post(url, data=data, headers={"user-agent": user_agent, "content-type": "application/x-www-form-urlencoded"}, verify=False)
-            log.info("Track exception: [%s] %s | %s", r.status_code, r.url, r.text)
-        except Exception:
-            log.warning("Failed to track exception", exc_info=1)

--- a/src/launch.py
+++ b/src/launch.py
@@ -70,11 +70,14 @@ except AttributeError:
     pass  # Quietly fail for older Qt5 versions
 
 try:
-    from classes import info
+    from classes import info, exceptions
 except ImportError:
     import openshot_qt
     sys.path.append(openshot_qt.OPENSHOT_PATH)
-    from classes import info
+    from classes import info, exceptions
+
+# Initialize sentry exception tracing
+exceptions.init_sentry_tracing()
 
 # Global holder for QApplication instance
 app = None

--- a/src/windows/views/tutorial.py
+++ b/src/windows/views/tutorial.py
@@ -38,6 +38,7 @@ from PyQt5.QtWidgets import (
 from classes.logger import log
 from classes.app import get_app
 from classes.metrics import track_metric_screen
+from classes.exceptions import init_sentry_tracing, disable_sentry_tracing
 
 
 class TutorialDialog(QWidget):
@@ -70,12 +71,14 @@ class TutorialDialog(QWidget):
         if state == Qt.Checked:
             # Enabling metrics sending
             s.set("send_metrics", True)
+            init_sentry_tracing()
 
             # Opt-in for metrics tracking
             track_metric_screen("metrics-opt-in")
         else:
             # Opt-out for metrics tracking
             track_metric_screen("metrics-opt-out")
+            disable_sentry_tracing()
 
             # Disable metric sending
             s.set("send_metrics", False)


### PR DESCRIPTION
Initial integration of Sentry tracing, to better track stack-traces and bugs in OpenShot. Removing the old hooks and HTTP posts to openshot.org, since they would be redundant. Sentry is still gated behind our 'send_metrics' setting, just like before. 

Sentry.io offers far better error reporting than my crude home-made version, and will allow more developers to monitor the exceptions, group them, and convert them into useful information and ultimately bug fixes.