### PR TITLE
Don't kill the WebView on aboutToQuit

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -308,7 +308,7 @@ class OpenShotApp(QApplication):
     def show_errors(self):
         count = len(self.errors)
         if count > 0:
-            self.log.warning("Displaying {} startup messages".format(count))
+            self.log.warning("Displaying %d startup messages", count)
         while self.errors:
             error = self.errors.pop(0)
             error.show()
@@ -319,6 +319,7 @@ class OpenShotApp(QApplication):
     @pyqtSlot()
     def cleanup(self):
         """aboutToQuit signal handler for application exit"""
+        self.log.debug("Saving settings in app.cleanup")
         try:
             self.settings.save()
         except Exception:

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -3209,7 +3209,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         # Connect shutdown signals
         app.aboutToQuit.connect(self.redraw_audio_timer.stop)
         app.aboutToQuit.connect(self.cache_renderer.stop)
-        app.aboutToQuit.connect(self.deleteLater)
 
         # Delay the start of cache rendering
         QTimer.singleShot(1500, self.cache_renderer.start)
+


### PR DESCRIPTION
I screwed up. A while back, I connected PyQt5's `QApplication.aboutToQuit` signal to the `deleteLater()` slot of the WebView, intending it to clean up just before shutdown.

Turns out, PyQt5's implementation of QApplication emits that signal every time the user types anything on the input line, when running Python interactively, making the interactive shell essentially useless.

Merging this might bring back some crash-on-quit issues that the signal's destruction of the Timeline was preventing, but we should be able to find another solution. (Maybe connecting  `QApplication.quit` to the slot, instead of `aboutToQuit`.)

I also added a debug log in `OpenShotApp.cleanup()`. It's connected to `OpenShotApp.aboutToQuit` as well, and I'm concerned the same issue could be causing excessive calls to that method, even though we can't see them.