### PR TITLE
Logging overhaul, to solve issues caused by stdout/stderr redirection

### DIFF
--- a/src/classes/logger.py
+++ b/src/classes/logger.py
@@ -133,3 +133,4 @@ def set_level_file(level=logging.INFO):
 def set_level_console(level=logging.INFO):
     """Adjust the minimum log level for output to the terminal"""
     sh.setLevel(level)
+

--- a/src/classes/logger.py
+++ b/src/classes/logger.py
@@ -40,65 +40,96 @@ streams = {}
 
 class StreamToLogger(object):
     """Custom class to log all stdout and stderr streams (from libopenshot / and other libraries)"""
-    def __init__(self, logger, log_level=logging.INFO):
-        self.logger = logger
+    def __init__(self, parent_stream, log_level=logging.INFO):
+        self.parent = parent_stream or sys.__stderr__
+        self.logger = logging.LoggerAdapter(
+            logging.getLogger('OpenShot.stderr'), {'source': 'stream'})
         self.log_level = log_level
-        self.linebuf = ''
+        self.logbuf = ''
 
-    def write(self, buf):
-        for line in buf.rstrip().splitlines():
-            self.logger.log(self.log_level, line.rstrip())
+    def write(self, text):
+        self.logbuf += str(text) or ""
+        self.parent.write(text)
 
     def flush(self):
-        pass
+        if self.logbuf.rstrip():
+            self.logger.log(self.log_level, self.logbuf.rstrip())
+        self.logbuf = ''
 
     def errors(self):
         pass
 
 
-# Create logger instance
-log = logging.Logger('OpenShot')
+class StreamFilter(logging.Filter):
+    """Filter out lines that originated on the output"""
+    def __init__(self, predicate):
+        self.predicate = predicate
+
+    def filter(self, record):
+        source = getattr(record, "source", "")
+        return self.predicate(source)
+
 
 # Set up log formatters
 template = '%(levelname)s %(module)s: %(message)s'
 console_formatter = logging.Formatter(template)
 file_formatter = logging.Formatter('%(asctime)s ' + template, datefmt='%H:%M:%S')
 
-# Add normal stderr stream handler
-sh = logging.StreamHandler()
-sh.setFormatter(console_formatter)
-sh.setLevel(info.LOG_LEVEL_CONSOLE)
-log.addHandler(sh)
-handlers['stream'] = sh
+# Configure root logger for minimal logging
+logging.basicConfig(level=logging.ERROR)
+root_log = logging.getLogger()
 
-# Add rotating file handler
+# Set up our top-level logging context
+log = root_log.getChild('OpenShot')
+log.setLevel(info.LOG_LEVEL_FILE)
+# Don't pass messages on to root logger
+log.propagate = False
+
+#
+# Create rotating file handler
+#
 fh = logging.handlers.RotatingFileHandler(
-    os.path.join(info.USER_PATH, 'openshot-qt.log'), encoding="utf-8", maxBytes=25*1024*1024, backupCount=3)
-fh.setFormatter(file_formatter)
+         os.path.join(info.USER_PATH, 'openshot-qt.log'),
+         encoding="utf-8",
+         maxBytes=25*1024*1024, backupCount=3)
 fh.setLevel(info.LOG_LEVEL_FILE)
+fh.setFormatter(file_formatter)
+
 log.addHandler(fh)
-handlers['file'] = fh
+
+#
+# Create typical stream handler which logs to stderr
+#
+sh = logging.StreamHandler(sys.stderr)
+sh.setLevel(info.LOG_LEVEL_CONSOLE)
+sh.setFormatter(console_formatter)
+
+# Filter out redirected output on console, to avoid duplicates
+#
+# The lambda is used to test the "source" property of the
+# logging record, if present.
+# {"source": "stream"} will be attached to any records generated
+# by the redirection, thanks to LoggingAdapter)
+filt = StreamFilter(lambda x: x != "stream")
+sh.addFilter(filt)
+
+log.addHandler(sh)
 
 
 def reroute_output():
     """Route stdout and stderr to logger (custom handler)"""
-    if not getattr(sys, 'frozen', False):
-        # Hang on to the original objects
-        streams.update({
-            'stderr': sys.stderr,
-            'stdout': sys.stdout,
-            })
-        # Re-route output streams
-        handlers['stdout'] = StreamToLogger(log, logging.INFO)
-        sys.stdout = handlers['stdout']
-        handlers['stderr'] = StreamToLogger(log, logging.ERROR)
-        sys.stderr = handlers['stderr']
+    if (getattr(sys, 'frozen', False)
+       or sys.stdout != sys.__stdout__):
+        return
+    sys.stdout = StreamToLogger(sys.stdout, logging.INFO)
+    sys.stderr = StreamToLogger(sys.stderr, logging.WARNING)
 
 
 def set_level_file(level=logging.INFO):
-    handlers['file'].setLevel(level)
+    """Adjust the minimum log level written to our logfile"""
+    fh.setLevel(level)
 
 
 def set_level_console(level=logging.INFO):
-    handlers['stream'].setLevel(level)
-
+    """Adjust the minimum log level for output to the terminal"""
+    sh.setLevel(level)

--- a/src/classes/logger.py
+++ b/src/classes/logger.py
@@ -32,11 +32,6 @@ import logging.handlers
 
 from classes import info
 
-# Dictionary of logging handlers we create, keyed by type
-handlers = {}
-# Another dictionary of streams we've redirected (stdout, stderr)
-streams = {}
-
 
 class StreamToLogger(object):
     """Custom class to log all stdout and stderr streams (from libopenshot / and other libraries)"""
@@ -62,12 +57,9 @@ class StreamToLogger(object):
 
 class StreamFilter(logging.Filter):
     """Filter out lines that originated on the output"""
-    def __init__(self, predicate):
-        self.predicate = predicate
-
     def filter(self, record):
         source = getattr(record, "source", "")
-        return self.predicate(source)
+        return bool(source != "stream")
 
 
 # Set up log formatters
@@ -105,12 +97,7 @@ sh.setLevel(info.LOG_LEVEL_CONSOLE)
 sh.setFormatter(console_formatter)
 
 # Filter out redirected output on console, to avoid duplicates
-#
-# The lambda is used to test the "source" property of the
-# logging record, if present.
-# {"source": "stream"} will be attached to any records generated
-# by the redirection, thanks to LoggingAdapter)
-filt = StreamFilter(lambda x: x != "stream")
+filt = StreamFilter()
 sh.addFilter(filt)
 
 log.addHandler(sh)
@@ -133,4 +120,3 @@ def set_level_file(level=logging.INFO):
 def set_level_console(level=logging.INFO):
     """Adjust the minimum log level for output to the terminal"""
     sh.setLevel(level)
-


### PR DESCRIPTION
This is a major rewrite of `classes.logging`, which I'm **hopeful** solves the long-standing issues caused by the redirection of `sys.stdout` and `sys.stderr` for capture purposes.

This PR doesn't do away with the redirection, instead it does it _cleanly_ and in a manner that doesn't break Python features that depend on the standard I/O streams.

In the new logging, the `StreamToLogger` shims that take over for `sys.stdout` and `sys.stderr` return to buffering the messages written to the streams, logging _only_ when the stream is `flush()`ed. In my testing, this means that multi-line texts like tracebacks will be captured as a _single_ log message. Or in the worst case, as a very small number of partial messages, when other output interrupts the output when it's only partially complete.

All output that's captured on `sys.stdout` or `sys.stderr` is _immediately_ passed along to the real stream outputs; the only thing the shim does is buffer a copy first. When a `flush()` comes through, the buffer is then logged to an `OpenShot.stderr` child logger of our main `OpenShot` logging context, and those log messages are **suppressed** from being re-echoed to the console, to avoid redundant duplication of output.

This means that any output send to the standard output streams, whether by OpenShot, by Python, or by some other code, will be displayed on the terminal unaltered from its original form (no more logging decoration), which should make tools that depend on the format of those messages much happier. (I'm hopeful this includes Sentry, as well.)