### PR TITLE
Make sentry_sdk (and distro) optional dependencies

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -34,7 +34,6 @@ import platform
 import traceback
 import json
 
-from classes import exceptions
 from PyQt5.QtCore import PYQT_VERSION_STR
 from PyQt5.QtCore import QT_VERSION_STR
 from PyQt5.QtCore import pyqtSlot
@@ -84,7 +83,7 @@ class OpenShotApp(QApplication):
 
         try:
             # Import modules
-            from classes import info
+            from classes import info, sentry
             from classes.logger import log, reroute_output
 
             # Log the session's start
@@ -139,7 +138,7 @@ class OpenShotApp(QApplication):
 
         # Check to disable sentry
         if not self.settings.get('send_metrics'):
-            exceptions.disable_sentry_tracing()
+            sentry.disable_tracing()
 
     def show_environment(self, info, openshot):
         log = self.log
@@ -190,7 +189,7 @@ class OpenShotApp(QApplication):
             "libopenshot version {} found, minimum is {}".format(ver, min_ver))
 
     def gui(self):
-        from classes import language, ui_util, logger_libopenshot
+        from classes import language, sentry, ui_util, logger_libopenshot
         from PyQt5.QtGui import QFont, QFontDatabase as QFD
 
         _ = self._tr
@@ -199,6 +198,7 @@ class OpenShotApp(QApplication):
 
         # Init translation system
         language.init_language()
+        sentry.set_tag("locale", info.CURRENT_LANGUAGE)
 
         # Load ui theme if not set by OS
         ui_util.load_theme()

--- a/src/classes/exceptions.py
+++ b/src/classes/exceptions.py
@@ -26,42 +26,10 @@
  """
 
 import os
-import traceback
 import platform
-import distro
-import sentry_sdk
 
 from classes import info
-
-
-def init_sentry_tracing():
-    """Init all Sentry tracing"""
-
-    # Determine sample rate for exceptions
-    traces_sample_rate = 0.1
-    environment = "production"
-    if "-dev" in info.VERSION:
-        # Dev mode, trace all exceptions
-        traces_sample_rate = 1.0
-        environment = "development"
-
-    # Initialize sentry exception tracing
-    sentry_sdk.init(
-        "https://21496af56ab24e94af8ff9771fbc1600@o772439.ingest.sentry.io/5795985",
-        traces_sample_rate=traces_sample_rate,
-        release=f"openshot@{info.VERSION}",
-        environment=environment
-    )
-    sentry_sdk.set_tag("system", platform.system())
-    sentry_sdk.set_tag("machine", platform.machine())
-    sentry_sdk.set_tag("processor", platform.processor())
-    sentry_sdk.set_tag("platform", platform.platform())
-    sentry_sdk.set_tag("distro", " ".join(distro.linux_distribution()))
-
-
-def disable_sentry_tracing():
-    """Disable all Sentry tracing requests"""
-    sentry_sdk.init()
+from classes import sentry
 
 
 def tail_file(f, n, offset=None):
@@ -133,8 +101,8 @@ def libopenshot_crash_recovery():
 
         # Format and add exception log to Sentry context
         # Split list of lines into smaller lists (so we don't exceed Sentry limits)
-        sentry_sdk.set_context("libopenshot", {"stack-trace": exception_lines})
-        sentry_sdk.set_tag("component", "libopenshot")
+        sentry.set_context("libopenshot", {"stack-trace": exception_lines})
+        sentry.set_tag("component", "libopenshot")
 
     # Clear / normalize log line (so we can roll them up in the analytics)
     if last_log_line:

--- a/src/classes/language.py
+++ b/src/classes/language.py
@@ -28,21 +28,20 @@
 
 import os
 import locale
-import sentry_sdk
 
 from PyQt5.QtCore import QLocale, QLibraryInfo, QTranslator, QCoreApplication
 
 from classes.logger import log
 from classes import info
 
-
 try:
-    from language import openshot_lang
-    language_path=":/locale/"
+    from language import openshot_lang  # noqa
+    language_path = ":/locale/"
     log.debug("Using compiled translation resources")
 except ImportError:
-    language_path=os.path.join(info.PATH, 'language')
+    language_path = os.path.join(info.PATH, 'language')
     log.debug("Loading translations from: {}".format(language_path))
+
 
 def init_language():
     """ Find the current locale, and install the correct translators """
@@ -120,7 +119,6 @@ def init_language():
         if found_language:
             log.debug("Exiting translation system (since we successfully loaded: {})".format(locale_name))
             info.CURRENT_LANGUAGE = locale_name
-            sentry_sdk.set_tag("locale", locale_name)
             break
 
 
@@ -139,6 +137,7 @@ def find_language_match(prefix, path, translator, locale_name):
         log.debug('Successfully loaded {} in \'{}\''.format(filename, path))
     return success
 
+
 def get_all_languages():
     """Get all language names and countries packaged with OpenShot"""
 
@@ -149,12 +148,12 @@ def get_all_languages():
             native_lang_name = QLocale(locale_name).nativeLanguageName().title()
             country_name = QLocale(locale_name).nativeCountryName().title()
             all_languages.append((locale_name, native_lang_name, country_name))
-        except:
+        except Exception:
             log.debug('Failed to parse language for %s', locale_name)
 
     # Return list
     return all_languages
 
+
 def get_current_locale():
     return info.CURRENT_LANGUAGE
-

--- a/src/classes/metrics.py
+++ b/src/classes/metrics.py
@@ -168,11 +168,11 @@ def send_metric(params):
 
         for metric_params in metric_queue:
             url_params = urllib.parse.urlencode(metric_params)
-            url = "http://www.google-analytics.com/collect?%s" % url_params
+            url = "https://www.google-analytics.com/collect?%s" % url_params
 
             # Send metric HTTP data
             try:
-                r = requests.get(url, headers={"user-agent": user_agent}, verify=False)
+                r = requests.get(url, headers={"user-agent": user_agent})
                 log.info("Track metric: [%s] %s | (%s bytes)" % (r.status_code, r.url, len(r.content)))
 
             except Exception:

--- a/src/classes/sentry.py
+++ b/src/classes/sentry.py
@@ -65,7 +65,7 @@ def init_tracing():
     sdk.set_tag("machine", platform.machine())
     sdk.set_tag("processor", platform.processor())
     sdk.set_tag("platform", platform.platform())
-    if distro:
+    if distro and platform.system() == "linux":
         sdk.set_tag("distro", " ".join(distro.linux_distribution()))
     sdk.set_tag("locale", info.CURRENT_LANGUAGE)
 
@@ -89,3 +89,4 @@ def set_user(*args):
 def set_context(*args):
     if sdk:
         sdk.set_context(*args)
+

--- a/src/classes/sentry.py
+++ b/src/classes/sentry.py
@@ -1,0 +1,91 @@
+"""
+ @file
+ @brief This file manages the optional Sentry SDK
+ @author Jonathan Thomas <jonathan@openshot.org>
+ @author FeRD (Frank Dana) <ferdnyc@gmail.com>
+
+ @section LICENSE
+
+ Copyright (c) 2008-2021 OpenShot Studios, LLC
+ (http://www.openshotstudios.com). This file is part of
+ OpenShot Video Editor (http://www.openshot.org), an open-source project
+ dedicated to delivering high quality video editing and animation solutions
+ to the world.
+
+ OpenShot Video Editor is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenShot Video Editor is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
+ """
+
+import platform
+
+from classes import info
+
+try:
+    import distro
+except ModuleNotFoundError:
+    distro = None
+
+try:
+    import sentry_sdk as sdk
+except ModuleNotFoundError:
+    sdk = None
+
+
+def init_tracing():
+    """Init all Sentry tracing"""
+    if not sdk:
+        return
+
+    # Determine sample rate for exceptions
+    traces_sample_rate = 0.1
+    environment = "production"
+    if "-dev" in info.VERSION:
+        # Dev mode, trace all exceptions
+        traces_sample_rate = 1.0
+        environment = "development"
+
+    # Initialize sentry exception tracing
+    sdk.init(
+        "https://21496af56ab24e94af8ff9771fbc1600@o772439.ingest.sentry.io/5795985",
+        traces_sample_rate=traces_sample_rate,
+        release=f"openshot@{info.VERSION}",
+        environment=environment
+    )
+    sdk.set_tag("system", platform.system())
+    sdk.set_tag("machine", platform.machine())
+    sdk.set_tag("processor", platform.processor())
+    sdk.set_tag("platform", platform.platform())
+    if distro:
+        sdk.set_tag("distro", " ".join(distro.linux_distribution()))
+    sdk.set_tag("locale", info.CURRENT_LANGUAGE)
+
+
+def disable_tracing():
+    """Disable all Sentry tracing requests"""
+    if sdk:
+        sdk.init()
+
+
+def set_tag(*args):
+    if sdk:
+        sdk.set_tag(*args)
+
+
+def set_user(*args):
+    if sdk:
+        sdk.set_user(*args)
+
+
+def set_context(*args):
+    if sdk:
+        sdk.set_context(*args)

--- a/src/launch.py
+++ b/src/launch.py
@@ -70,14 +70,11 @@ except AttributeError:
     pass  # Quietly fail for older Qt5 versions
 
 try:
-    from classes import info, exceptions
+    from classes import info
 except ImportError:
     import openshot_qt
     sys.path.append(openshot_qt.OPENSHOT_PATH)
-    from classes import info, exceptions
-
-# Initialize sentry exception tracing
-exceptions.init_sentry_tracing()
+    from classes import info
 
 # Global holder for QApplication instance
 app = None
@@ -172,6 +169,10 @@ def main():
 
     # Normal startup, print module path and lauch application
     print("Loaded modules from: %s" % info.PATH)
+
+    # Initialize sentry exception tracing
+    from classes import sentry
+    sentry.init_tracing()
 
     # Create Qt application, pass any unprocessed arguments
     from classes.app import OpenShotApp

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -29,7 +29,6 @@
 
 import os
 import shutil
-import sentry_sdk
 import webbrowser
 from copy import deepcopy
 from time import sleep
@@ -49,7 +48,7 @@ from PyQt5.QtWidgets import (
     QLineEdit, QComboBox, QTextEdit
 )
 
-from classes import exceptions, info, qt_types, ui_util, updates
+from classes import exceptions, info, qt_types, sentry, ui_util, updates
 from classes.app import get_app
 from classes.exporters.edl import export_edl
 from classes.exporters.final_cut_pro import export_xml
@@ -229,7 +228,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Reset Sentry component (it can be temporarily changed to libopenshot during
         # the call to libopenshot_crash_recovery above)
-        sentry_sdk.set_tag("component", "openshot-qt")
+        sentry.set_tag("component", "openshot-qt")
 
         # Write lock file (try a few times if failure)
         lock_value = str(uuid4())
@@ -2810,7 +2809,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             track_metric_screen("initial-launch-screen")
 
         # Set unique id for Sentry
-        sentry_sdk.set_user({"id": s.get("unique_install_id")})
+        sentry.set_user({"id": s.get("unique_install_id")})
 
         # Track main screen
         track_metric_screen("main-screen")

--- a/src/windows/views/tutorial.py
+++ b/src/windows/views/tutorial.py
@@ -38,7 +38,7 @@ from PyQt5.QtWidgets import (
 from classes.logger import log
 from classes.app import get_app
 from classes.metrics import track_metric_screen
-from classes.exceptions import init_sentry_tracing, disable_sentry_tracing
+from classes import sentry
 
 
 class TutorialDialog(QWidget):
@@ -71,14 +71,14 @@ class TutorialDialog(QWidget):
         if state == Qt.Checked:
             # Enabling metrics sending
             s.set("send_metrics", True)
-            init_sentry_tracing()
+            sentry.init_tracing()
 
             # Opt-in for metrics tracking
             track_metric_screen("metrics-opt-in")
         else:
             # Opt-out for metrics tracking
             track_metric_screen("metrics-opt-out")
-            disable_sentry_tracing()
+            sentry.disable_tracing()
 
             # Disable metric sending
             s.set("send_metrics", False)


### PR DESCRIPTION
### Optional `sentry_sdk`

This PR moves all code that depends on the `sentry_sdk` module into a new `classes.sentry`, and locally attempts to `import sentry_sdk as sdk` if available. If not, `sdk` is set to `None`.

The `sentry_sdk` methods `set_tag`, `set_user`, and `set_context` are mirrored into `classes.sentry`. They are safe to call from other code, and will silently do nothing if `sentry.sdk` is `None`. `sentry.init_tracing()` and `sentry.disable_tracing()` offer the same protections.

Any other `sentry_sdk` methods can be used as needed, but those calls should take the form:
```python3
from classes import sentry
if sentry.sdk:
    sentry.sdk.some_method(...)
```

The Sentry init is moved just _slightly_ later in the `launch.py` initialization, because there's really no point in initializing it just to exit after showing the command-line `--help` or similar. (Also, importing multiple modules before adjusting `sys.path()` has been problematic in the past.)

### Optional `distro`
Additionally, the `distro` module is made optional in `classes.sentry` (as it's not a standard Python module), and is also (optionally) used in `classes.metrics` (in place of the long-since-deprecated `platform.linux_distribution()`).

### Secure Google Analytics metrics
Additionally-additionally, the URLs to deliver Google Analytics metrics are made `https://`, since `sentry_sdk` is using HTTPS so it seems that train has sailed.
Fixes: #3953

cc: @jonoomph 

Fixes: #4194 