### PR TITLE
Create INSTALL.txt

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,0 +1,10 @@
+On Linux:
+
+1: Install the libopenshot and libopenshot-audio libraries and their dependencies. Install python3-zmq or pyzmq (whichever is inside of your package manager). Optional: Install pip3 or equivalent.
+2: Download the latest release and unpack if applicable.
+3a: Run "sudo pip3 install --upgrade openshot-qt".
+3b: Alternatively, if you are using another package manager, like porg, you can run "python3 setup.py build" and "python3 setup.py install".
+
+If you have an error when trying to run openshot-qt like this:
+"ImportError: libopenshot.so.19: cannot open shared object file: No such file or directory"
+You'll need to set the LD_LIBRARY_PATH. You probably need to set it like this: export LD_LIBRARY_PATH="/usr/local/lib"


### PR DESCRIPTION
This explains how to install openshot-qt.
Fortunately for your project, I'm very used to installing things from source.
It explains how to overcome the following errors:

% openshot-qt
Loaded modules from installed directory: /usr/local/lib/python3.5/dist-packages/openshot_qt-2.5.1-py3.5.egg/openshot_qt
         app:INFO ------------------------------------------------
         app:INFO             Sun Jun 13 22:20:18 2021
         app:INFO               Starting new session
         app:ERROR OpenShotApp::Import Error: libopenshot.so.19: cannot open shared object file: No such file or directory
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/openshot.py", line 18, in swig_import_helper
    return importlib.import_module(mname)
  File "/usr/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 666, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 577, in module_from_spec
  File "<frozen importlib._bootstrap_external>", line 914, in create_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
ImportError: libopenshot.so.19: cannot open shared object file: No such file or directory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/openshot-qt", line 11, in <module>
    load_entry_point('openshot-qt==2.5.1', 'gui_scripts', 'openshot-qt')()
  File "/usr/local/lib/python3.5/dist-packages/openshot_qt-2.5.1-py3.5.egg/openshot_qt/launch.py", line 97, in main
    app = OpenShotApp(argv)
  File "/usr/local/lib/python3.5/dist-packages/openshot_qt-2.5.1-py3.5.egg/openshot_qt/classes/app.py", line 72, in __init__
    from classes import settings, project_data, updates, language, ui_util, logger_libopenshot
  File "/usr/local/lib/python3.5/dist-packages/openshot_qt-2.5.1-py3.5.egg/openshot_qt/classes/logger_libopenshot.py", line 31, in <module>
    import openshot
  File "/usr/local/lib/python3.5/dist-packages/openshot.py", line 21, in <module>
    _openshot = swig_import_helper()
  File "/usr/local/lib/python3.5/dist-packages/openshot.py", line 20, in swig_import_helper
    return importlib.import_module('_openshot')
  File "/usr/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
ImportError: libopenshot.so.19: cannot open shared object file: No such file or directory
         app:INFO             OpenShot's session ended
         app:INFO ================================================












% export LD_LIBRARY_PATH="/usr/local/lib"
% openshot-qt
Loaded modules from installed directory: /usr/local/lib/python3.5/dist-packages/openshot_qt-2.5.1-py3.5.egg/openshot_qt
         app:INFO ------------------------------------------------
         app:INFO             Sun Jun 13 22:22:57 2021
         app:INFO               Starting new session
         app:ERROR OpenShotApp::Import Error: No module named 'zmq'
Traceback (most recent call last):
  File "/usr/local/bin/openshot-qt", line 11, in <module>
    load_entry_point('openshot-qt==2.5.1', 'gui_scripts', 'openshot-qt')()
  File "/usr/local/lib/python3.5/dist-packages/openshot_qt-2.5.1-py3.5.egg/openshot_qt/launch.py", line 97, in main
    app = OpenShotApp(argv)
  File "/usr/local/lib/python3.5/dist-packages/openshot_qt-2.5.1-py3.5.egg/openshot_qt/classes/app.py", line 72, in __init__
    from classes import settings, project_data, updates, language, ui_util, logger_libopenshot
  File "/usr/local/lib/python3.5/dist-packages/openshot_qt-2.5.1-py3.5.egg/openshot_qt/classes/logger_libopenshot.py", line 33, in <module>
    import zmq
ImportError: No module named 'zmq'
         app:INFO             OpenShot's session ended
         app:INFO ================================================