### PR TITLE
app._tr: Pass all arguments to translate()

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -314,8 +314,8 @@ class OpenShotApp(QApplication):
             error = self.errors.pop(0)
             error.show()
 
-    def _tr(self, message):
-        return self.translate("", message)
+    def _tr(self, *args, **kwargs) -> str:
+        return self.translate("", *args, **kwargs)
 
     @pyqtSlot()
     def cleanup(self):


### PR DESCRIPTION
In order to support [plural translations](https://doc.qt.io/qt-5/i18n-source-translation.html#handling-plurals) correctly, the `translate()` function needs to be called with an optional argument `n=`, supplying the quantity used in the translation.

For maximum flexibility, this PR changes the `_tr` method of `classes.app.OpenShotApp` from this:
```python3
def _tr(self, message):
    return self.translate("", message)
```
to this:
```python3
def _tr(self, *args, **kwargs) -> str:
    return self.translate("", *args, **kwargs)
```

This allows us to make use of not only the `n=` argument, but also (potentially) the optional third positional argument to `translate()`, the disambiguation string. The change should be otherwise source-code-transparent, meaning it should have no effect whatsoever on the simple-form `_("translatable string")` calls currently present in the source.


With this change, all of these calls become legal in the Python source:
```python3
# Assume the standard aliasing
_ = get_app()._tr

# Countable quantities
_("%n second(s)", n=freeze_seconds)
# String disambiguation
_("Export", "action")  # vs. e.g. _("Export", "file type")
# Disambiguated countables
_("%n second(s)", "timer length", n=timeout)
_("%n second(s), "zoom factor", n=scale)
```
Note that **making proper _use_ of** any of these features depends on additional metadata being present in the compiled `.qm` translation files, and none of them are currently supported by our existing translation data. This PR is merely laying ground work for further enhancements, but it is a necessary first step towards any such changes.

Addresses #3589 