### PR TITLE
launch: Fix --list-languages

### DIFF
--- a/src/launch.py
+++ b/src/launch.py
@@ -137,7 +137,7 @@ def main():
     if args.list_languages:
         from classes.language import get_all_languages
         print("Supported Languages:")
-        for code, lang in get_all_languages():
+        for code, lang, country in get_all_languages():
             print("  {:>12}  {}".format(code, lang))
         sys.exit()
 


### PR DESCRIPTION
Apparently the `--list-languages` command line option has been broken for... who knows how long, since `get_all_languages()` returns a list of 3-tuples and it was expecting only 2.

I... don't know how that got out of sync. I know I tested it when it was originally written!