### PR TITLE
Fixes and Improvements to ZoomSlider (fixing feedback and jitters)

### DIFF
--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -69,7 +69,6 @@ App.controller("TimelineCtrl", function ($scope) {
   $scope.track_label = "Track %s";
   $scope.enable_sorting = true;
   $scope.ThumbServer = "http://127.0.0.1/";
-  $scope.ignore_scroll = false;
 
   // Method to set if Qt is detected (which clears demo data
   // and updates the document_is_ready variable in openshot-qt)
@@ -286,9 +285,6 @@ App.controller("TimelineCtrl", function ($scope) {
     var scrolling_tracks = $("#scrolling_tracks");
     var horz_scroll_offset = normalizedScrollValue * timeline_length;
     scrolling_tracks.scrollLeft(horz_scroll_offset);
-
-    $scope.ignore_scroll = true;
-    $("#scrolling_ruler").scrollLeft(horz_scroll_offset);
   };
 
   // Scroll the timeline horizontally of a certain amount
@@ -296,9 +292,6 @@ App.controller("TimelineCtrl", function ($scope) {
     var scrolling_tracks = $("#scrolling_tracks");
     var horz_scroll_offset = scrolling_tracks.scrollLeft();
     scrolling_tracks.scrollLeft(horz_scroll_offset + scroll_value);
-
-    $scope.ignore_scroll = true;
-    $("#scrolling_ruler").scrollLeft(horz_scroll_offset + scroll_value);
   };
 
   // Center the timeline on a given time position

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -54,21 +54,9 @@ App.directive("tlScrollableTracks", function () {
         $("#scrolling_ruler").scrollLeft(element.scrollLeft());
         $("#progress_container").scrollLeft(element.scrollLeft());
 
-        if (scope.ignore_scroll == true) {
-          // Reset flag and ignore scroll propagation
-          scope.$apply( () => {
-            scope.ignore_scroll = false;
-            scope.scrollLeft = element[0].scrollLeft;
-          })
-          // exit at this point
-          return;
-
-        } else {
-          // Only update scroll position
-          scope.$apply( () => {
-            scope.scrollLeft = element[0].scrollLeft;
-          })
-        }
+        scope.$apply( () => {
+          scope.scrollLeft = element[0].scrollLeft;
+        })
 
         // Send scrollbar position to Qt
         if (scope.Qt) {

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2750,10 +2750,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         # Get access to timeline scope and set scale to new computed value
         self.run_js(JS_SCOPE_SELECTOR + ".setScroll(" + str(newScroll) + ");")
 
-        # This seems to make web-engine zoom slider scroll events go smoother
-        # TODO: remove this if we can find a better approach.
-        QCoreApplication.processEvents()
-
     # Handle changes to zoom level, update js
     def update_zoom(self, newScale):
         _ = get_app()._tr

--- a/src/windows/views/zoom_slider.py
+++ b/src/windows/views/zoom_slider.py
@@ -295,14 +295,14 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
             if self.left_handle_dragging:
                 # Update scrollbar position
                 delta = (self.mouse_position - mouse_pos) / self.width()
-                new_left_pos = self.scrollbar_position[0] - delta
+                new_left_pos = self.scrollbar_position_previous[0] - delta
                 is_left = True
                 if int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0 and \
-                        (self.scrollbar_position[1] + delta) - new_left_pos > self.min_distance:
+                        (self.scrollbar_position_previous[1] + delta) - new_left_pos > self.min_distance:
                     # SHIFT key pressed (move both handles if we don't exceed min distance)
-                    new_right_pos = self.scrollbar_position[1] + delta
+                    new_right_pos = self.scrollbar_position_previous[1] + delta
                 else:
-                    new_right_pos = self.scrollbar_position[1]
+                    new_right_pos = self.scrollbar_position_previous[1]
 
                 # Enforce limits (don't allow handles to go past each other, or out of bounds)
                 new_left_pos, new_right_pos = self.set_handle_limits(new_left_pos, new_right_pos, is_left)
@@ -316,13 +316,13 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
             elif self.right_handle_dragging:
                 delta = (self.mouse_position - mouse_pos) / self.width()
                 is_left = False
-                new_right_pos = self.scrollbar_position[1] - delta
+                new_right_pos = self.scrollbar_position_previous[1] - delta
                 if int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0 and \
-                        new_right_pos - (self.scrollbar_position[0] + delta) > self.min_distance:
+                        new_right_pos - (self.scrollbar_position_previous[0] + delta) > self.min_distance:
                     # SHIFT key pressed (move both handles if we don't exceed min distance)
-                    new_left_pos = self.scrollbar_position[0] + delta
+                    new_left_pos = self.scrollbar_position_previous[0] + delta
                 else:
-                    new_left_pos = self.scrollbar_position[0]
+                    new_left_pos = self.scrollbar_position_previous[0]
 
                 # Enforce limits (don't allow handles to go past each other, or out of bounds)
                 new_left_pos, new_right_pos = self.set_handle_limits(new_left_pos, new_right_pos, is_left)
@@ -348,7 +348,7 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
                                            self.scrollbar_position[3]]
 
                 # Emit signal to scroll Timeline
-                get_app().window.TimelineScroll.emit(self.scrollbar_position[0])
+                get_app().window.TimelineScroll.emit(new_left_pos)
 
             # Force re-paint
             self.update()
@@ -436,6 +436,9 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
 
     def update_scrollbars(self, new_positions):
         """Consume the current scroll bar positions from the webview timeline"""
+        if self.mouse_dragging:
+            return
+
         self.scrollbar_position = new_positions
 
         # Check for empty clips rects

--- a/src/windows/views/zoom_slider.py
+++ b/src/windows/views/zoom_slider.py
@@ -220,6 +220,7 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
         self.mouse_pressed = True
         self.mouse_dragging = False
         self.mouse_position = event.pos().x()
+        self.scrollbar_position_previous = self.scrollbar_position
 
         # Ignore undo/redo history temporarily (to avoid a huge pile of undo/redo history)
         get_app().updates.ignore_history = True
@@ -335,8 +336,8 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
             elif self.scroll_bar_dragging:
                 # Update scrollbar position
                 delta = (self.mouse_position - mouse_pos) / self.width()
-                new_left_pos = self.scrollbar_position[0] - delta
-                new_right_pos = self.scrollbar_position[1] - delta
+                new_left_pos = self.scrollbar_position_previous[0] - delta
+                new_right_pos = self.scrollbar_position_previous[1] - delta
 
                 # Enforce limits (don't allow handles to go past each other, or out of bounds)
                 new_left_pos, new_right_pos = self.set_handle_limits(new_left_pos, new_right_pos)
@@ -353,7 +354,7 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
             self.update()
 
         # Update mouse position
-        self.mouse_position = mouse_pos
+        # self.mouse_position = mouse_pos
 
     def resizeEvent(self, event):
         """Widget resize event"""
@@ -484,6 +485,7 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
         self.mouse_position = None
         self.zoom_factor = 15.0
         self.scrollbar_position = [0.0, 0.0, 0.0, 0.0]
+        self.scrollbar_position_previous = [0.0, 0.0, 0.0, 0.0]
         self.left_handle_rect = QRectF()
         self.left_handle_dragging = False
         self.right_handle_rect = QRectF()


### PR DESCRIPTION
To address the sliding of the zoom slider out from under the mouse, I'm saving the starting position of the zoom slider, and adding the horizontal movement of the mouse (from the position it was pressed)