### PR TITLE
Don't go past min distance on shift-zoom

### DIFF
--- a/src/windows/views/zoom_slider.py
+++ b/src/windows/views/zoom_slider.py
@@ -297,10 +297,15 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
                 delta = (self.mouse_position - mouse_pos) / self.width()
                 new_left_pos = self.scrollbar_position_previous[0] - delta
                 is_left = True
-                if int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0 and \
-                        (self.scrollbar_position_previous[1] + delta) - new_left_pos > self.min_distance:
-                    # SHIFT key pressed (move both handles if we don't exceed min distance)
-                    new_right_pos = self.scrollbar_position_previous[1] + delta
+                if int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0:
+                    # SHIFT key pressed (move )
+                        if (self.scrollbar_position_previous[1] + delta) - new_left_pos > self.min_distance:
+                            #both handles if we don't exceed min distance
+                            new_right_pos = self.scrollbar_position_previous[1] + delta
+                        else:
+                            midpoint = (self.scrollbar_position_previous[1] + self.scrollbar_position_previous)/2
+                            new_right_pos = midpoint + (self.min_distance/2)
+                            new_left_pos = midpoint - (self.min_distance/2)
                 else:
                     new_right_pos = self.scrollbar_position_previous[1]
 
@@ -317,10 +322,15 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
                 delta = (self.mouse_position - mouse_pos) / self.width()
                 is_left = False
                 new_right_pos = self.scrollbar_position_previous[1] - delta
-                if int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0 and \
-                        new_right_pos - (self.scrollbar_position_previous[0] + delta) > self.min_distance:
-                    # SHIFT key pressed (move both handles if we don't exceed min distance)
-                    new_left_pos = self.scrollbar_position_previous[0] + delta
+                if int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0:
+                    # SHIFT key pressed (move )
+                        if new_right_pos - (self.scrollbar_position_previous[0] + delta) > self.min_distance:
+                            #both handles if we don't exceed min distance
+                            new_left_pos = self.scrollbar_position_previous[0] + delta
+                        else:
+                            midpoint = (self.scrollbar_position_previous[1] + self.scrollbar_position_previous)/2
+                            new_right_pos = midpoint + (self.min_distance/2)
+                            new_left_pos = midpoint - (self.min_distance/2)
                 else:
                     new_left_pos = self.scrollbar_position_previous[0]
 


### PR DESCRIPTION
Doesn't move a handle unexpectedly.

Stops both handles at `midpoint +/- Half_min_distance`

Made this a mini branch since the feedback fix is looking good, and this isn't necessarily part of that.