### PR TITLE
Fixing thumbnail image size

### DIFF
--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -181,7 +181,7 @@ class FilesListView(QListView):
         self.setDropIndicatorShown(True)
 
         # Setup header columns and layout
-        self.setIconSize(QSize(131, 108))
+        self.setIconSize(QSize(98, 64))
         self.setGridSize(QSize(102, 92))
         self.setViewMode(QListView.IconMode)
         self.setResizeMode(QListView.Adjust)


### PR DESCRIPTION
Fixing thumbnail image size which can be larger than the grid size Noticeable on audio thumbnails.