### PR TITLE
Add default case form move_clips

### DIFF
--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -334,12 +334,12 @@ App.directive("tlClip", function ($timeout) {
             clip_name = $(this).attr("id");
             var newX, newY;
             if (move_clips[clip_name] && ( move_clips[clip_name]['top'] && move_clips[clip_name]['left'] )) {
-              newY = move_clips[clip_name]['top'] = this.style.top + y_offset;
-              newX = move_clips[clip_name]['left'] + y_offset;
+              newY = move_clips[clip_name]['top'] + y_offset;
+              newX = move_clips[clip_name]['left'] + x_offset;
             } else {
               move_clips[clip_name] =  {};
               newY = this.style.top + y_offset;
-              newX = this.style.top + y_offset;
+              newX = this.style.left + x_offset;
             }
             //update the clip location in the array
             move_clips[$(this).attr("id")]["top"] = newY;

--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -331,8 +331,16 @@ App.directive("tlClip", function ($timeout) {
 
           // Move all other selected clips with this one if we have more than one clip
           $(".ui-selected").each(function () {
-            var newY = move_clips[$(this).attr("id")]["top"] + y_offset;
-            var newX = move_clips[$(this).attr("id")]["left"] + x_offset;
+            clip_name = $(this).attr("id");
+            var newX, newY;
+            if (move_clips[clip_name] && ( move_clips[clip_name]['top'] && move_clips[clip_name]['left'] )) {
+              newY = move_clips[clip_name]['top'] = this.style.top + y_offset;
+              newX = move_clips[clip_name]['left'] + y_offset;
+            } else {
+              move_clips[clip_name] =  {};
+              newY = this.style.top + y_offset;
+              newX = this.style.top + y_offset;
+            }
             //update the clip location in the array
             move_clips[$(this).attr("id")]["top"] = newY;
             move_clips[$(this).attr("id")]["left"] = newX;

--- a/src/timeline/js/directives/transition.js
+++ b/src/timeline/js/directives/transition.js
@@ -285,14 +285,21 @@ App.directive("tlTransition", function () {
 
           // Move all other selected transitions with this one
           $(".ui-selected").each(function () {
-            var newY = move_transitions[$(this).attr("id")]["top"] + y_offset;
-            var newX = move_transitions[$(this).attr("id")]["left"] + x_offset;
-
-            //update the transition location in the array
+            transition_name = $(this).attr("id");
+            var newX, newY;
+            if (move_clips[transition_name] && ( move_clips[transition_name]['top'] && move_clips[clip_name]['left'] )) {
+              newY = move_clips[transition_name]['top'] = this.style.top + y_offset;
+              newX = move_clips[transition_name]['left'] + y_offset;
+            } else {
+              // If this transition is not yet in move_clips, add it.
+              move_clips[transition_name] =  {};
+              newY = this.style.top + y_offset;
+              newX = this.style.top + y_offset;
+            }
+            // Update the transition location in the array
             move_transitions[$(this).attr("id")]["top"] = newY;
             move_transitions[$(this).attr("id")]["left"] = newX;
-
-            //change the element location
+            // Change the element location
             $(this).css("left", newX);
             $(this).css("top", newY);
 
@@ -301,7 +308,7 @@ App.directive("tlTransition", function () {
         },
         revert: function (valid) {
           if (!valid) {
-            //the drop spot was invalid, so we're going to move all transitions to their original position
+            // The drop spot was invalid, so we're going to move all transitions to their original position
             $(".ui-selected").each(function () {
               var oldY = start_transitions[$(this).attr("id")]["top"];
               var oldX = start_transitions[$(this).attr("id")]["left"];

--- a/src/timeline/js/directives/transition.js
+++ b/src/timeline/js/directives/transition.js
@@ -288,13 +288,13 @@ App.directive("tlTransition", function () {
             transition_name = $(this).attr("id");
             var newX, newY;
             if (move_clips[transition_name] && ( move_clips[transition_name]['top'] && move_clips[clip_name]['left'] )) {
-              newY = move_clips[transition_name]['top'] = this.style.top + y_offset;
-              newX = move_clips[transition_name]['left'] + y_offset;
+              newY = move_clips[transition_name]['top'] + y_offset;
+              newX = move_clips[transition_name]['left'] + x_offset;
             } else {
               // If this transition is not yet in move_clips, add it.
               move_clips[transition_name] =  {};
               newY = this.style.top + y_offset;
-              newX = this.style.top + y_offset;
+              newX = this.style.left + x_offset;
             }
             // Update the transition location in the array
             move_transitions[$(this).attr("id")]["top"] = newY;


### PR DESCRIPTION
We have a few thousand sentry events from dragging when a given clip isn't in the array move_clips.

This PR should ensure the clip is in move_clips before accessing the array.