### PR TITLE
Add Instructions to Object Detector effect

### DIFF
--- a/src/classes/effect_init.py
+++ b/src/classes/effect_init.py
@@ -151,6 +151,12 @@ effect_options = {
 
     "Object Detector": [
         {
+            "value": "https://github.com/OpenShot/openshot-qt/wiki/Object-Detection-Effect-(dependencies)",
+            "title": "Click here for instructions and dependencies...",
+            "type": "link",
+            "setting": "model-instructions"
+        },
+        {
             "value": os.path.join(YOLO_PATH,"yolov3.weights"),
             "title": "Model Weights",
             "type": "text",

--- a/src/windows/ui/process-effect.ui
+++ b/src/windows/ui/process-effect.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>410</width>
-    <height>250</height>
+    <height>270</height>
    </rect>
   </property>
   <property name="minimumSize">


### PR DESCRIPTION
Add a new link widget to our pre-processing effect dialog, so we can give further instructions/link to users who want to download the object detector dependencies.