### PR TITLE
Fixing a regression on Export dialog (FrameMapper was sometimes missing)

### DIFF
--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -811,7 +811,9 @@ class Export(QDialog):
 
             # Re-update the timeline FPS again (since the timeline just got clobbered)
             self.updateFrameRate()
-            self.timeline.ApplyMapperToClips()
+
+        # Apply mappers to timeline readers
+        self.timeline.ApplyMapperToClips()
 
         # Create FFmpegWriter
         try:


### PR DESCRIPTION
Fixing a regression on Export dialog, where we were not correctly applying FrameMapper's to all the clips.. causing audio desync, timing issues with Clips, audio pitch issues. Whoops. :1st_place_medal: 