### PR TITLE
Allow mousewheel zoom on webengine

### DIFF
--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -56,11 +56,11 @@ App.directive("tlScrollableTracks", function () {
           return;
         }
         if (e.originalEvent.deltaY > 0) { // Scroll down: Zoom out
-          /* global timeline */
-          timeline.zoomIn();
-        } else { // Scroll Up: Zoom in
-          /* global timeline */
+          /*global timeline*/
           timeline.zoomOut();
+        } else { // Scroll Up: Zoom in
+          /*global timeline*/
+          timeline.zoomIn();
         }
       });
 

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -52,15 +52,13 @@ App.directive("tlScrollableTracks", function () {
       element.on("wheel",function (e) {
         if (e.ctrlKey) {
           e.preventDefault(); // Don't scroll like a browser
-        } else {
-          return;
-        }
-        if (e.originalEvent.deltaY > 0) { // Scroll down: Zoom out
-          /*global timeline*/
-          timeline.zoomOut();
-        } else { // Scroll Up: Zoom in
-          /*global timeline*/
-          timeline.zoomIn();
+          if (e.originalEvent.deltaY > 0) { // Scroll down: Zoom out
+            /*global timeline*/
+            timeline.zoomOut();
+          } else { // Scroll Up: Zoom in
+            /*global timeline*/
+            timeline.zoomIn();
+          }
         }
       });
 

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -49,15 +49,17 @@ App.directive("tlScrollableTracks", function () {
        * if ctrl is held, scroll in or out.
        * Implimentation copied from zoomSlider zoomIn zoomOut
        */
-      element.on('wheel',function (e) {
+      element.on("wheel",function (e) {
         if (e.ctrlKey) {
           e.preventDefault(); // Don't scroll like a browser
         } else {
           return;
         }
         if (e.originalEvent.deltaY > 0) { // Scroll down: Zoom out
+          /* global timeline */
           timeline.zoomIn();
         } else { // Scroll Up: Zoom in
+          /* global timeline */
           timeline.zoomOut();
         }
       });

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -45,6 +45,23 @@ App.directive("tlScrollableTracks", function () {
     restrict: "A",
     link: function (scope, element, attrs) {
 
+      /**
+       * if ctrl is held, scroll in or out.
+       * Implimentation copied from zoomSlider zoomIn zoomOut
+       */
+      element.on('wheel',function (e) {
+        if (e.ctrlKey) {
+          e.preventDefault(); // Don't scroll like a browser
+        } else {
+          return;
+        }
+        if (e.originalEvent.deltaY > 0) { // Scroll down: Zoom out
+          timeline.zoomIn();
+        } else { // Scroll Up: Zoom in
+          timeline.zoomOut();
+        }
+      });
+
       // Sync ruler to track scrolling
       element.on("scroll", function () {
         //set amount scrolled

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2745,6 +2745,14 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             level = levels.get(level, logging.INFO)
         self.log_fn(level, message)
 
+    @pyqtSlot()
+    def zoomIn(self):
+        get_app().window.sliderZoomWidget.zoomIn()
+
+    @pyqtSlot()
+    def zoomOut(self):
+        get_app().window.sliderZoomWidget.zoomOut()
+
     def update_scroll(self, newScroll):
         """Force a scroll event on the timeline (i.e. the zoom slider is moving, so we need to scroll the timeline)"""
         # Get access to timeline scope and set scale to new computed value
@@ -2775,20 +2783,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             get_app().updates.ignore_history = True
             get_app().updates.update(["scale"], newScale)
             get_app().updates.ignore_history = False
-
-    # Capture wheel event to alter zoom slider control
-    def wheelEvent(self, event):
-        if event.modifiers() & Qt.ControlModifier:
-            event.accept()
-
-            # Modify zooms factor
-            if event.angleDelta().y() > 0:
-                get_app().window.sliderZoomWidget.zoomIn()
-            else:
-                get_app().window.sliderZoomWidget.zoomOut()
-
-        else:
-            super().wheelEvent(event)
 
     # An item is being dragged onto the timeline (mouse is entering the timeline now)
     def dragEnterEvent(self, event):

--- a/src/windows/views/webview_backend/webkit.py
+++ b/src/windows/views/webview_backend/webkit.py
@@ -123,19 +123,3 @@ class TimelineWebKitView(QWebView):
         else:
             # Ignore most keypresses
             event.ignore()
-
-    def wheelEvent(self, event):
-        """ Mousewheel scrolling """
-        if event.modifiers() & Qt.ShiftModifier:
-            event.accept()
-            frame = self.page().mainFrame()
-            # Compute scroll offset from wheel motion
-            tick_scale = 120
-            steps = int(event.angleDelta().y() / tick_scale)
-            delta = -(steps * 100)
-            log.debug("Scrolling horizontally by %d pixels", delta)
-            # Update the scroll position using AngularJS
-            js = "$('body').scope().scrollLeft({});".format(delta)
-            frame.evaluateJavaScript(js)
-        else:
-            super().wheelEvent(event)


### PR DESCRIPTION
Handle mousewheel zooming in the webview, so that it works the same in either web backend.