### PR TITLE
Fix middle click drag, and ruler jitter

### DIFF
--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -222,7 +222,7 @@ App.directive("tlRuler", function ($timeout) {
           let tickSpan = $('<span style="left:'+pos+'px;"></span>');
           tickSpan.addClass("tick_mark");
 
-          if ((frame) % (fpt * 2) == 0) {
+          if ((frame) % (fpt * 2) === 0) {
             // Alternating long marks with times marked
             let timeSpan = $('<span style="left:'+pos+'px;"></span>');
             timeSpan.addClass("ruler_time");

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -80,10 +80,11 @@ App.directive("tlScrollableTracks", function () {
         if (is_scrolling) {
           // Calculate difference from last position
           var difference = {x: starting_mouse_position.x - e.pageX, y: starting_mouse_position.y - e.pageY};
+          var newPos = { x: starting_scrollbar.x + difference.x, y: starting_scrollbar.y + difference.y};
 
           // Scroll the tracks div
-          element.scrollLeft(starting_scrollbar.x + difference.x);
-          element.scrollTop(starting_scrollbar.y + difference.y);
+          element.scrollLeft(newPos.x);
+          element.scrollTop(newPos.y);
         }
       });
 
@@ -119,7 +120,7 @@ App.directive("tlBody", function () {
         if (e.which === 2) { // middle button
           e.preventDefault();
           is_scrolling = true;
-          starting_scrollbar = {x: element.scrollLeft(), y: element.scrollTop()};
+          starting_scrollbar = {x: $('#scrolling_tracks').scrollLeft(), y: $('#scrolling_tracks').scrollTop()};
           starting_mouse_position = {x: e.pageX, y: e.pageY};
           element.addClass("drag_cursor");
         }
@@ -198,16 +199,22 @@ App.directive("tlRuler", function ($timeout) {
 
         startPos = scope.scrollLeft;
         endPos = scope.scrollLeft + $("body").width();
-
+        fpt = framesPerTick(scope.pixelsPerSecond, scope.project.fps.num ,scope.project.fps.den);
         fps = scope.project.fps.num / scope.project.fps.den;
         time = [ startPos / scope.pixelsPerSecond, endPos / scope.pixelsPerSecond];
-        time[0] -= time[0]%2;
+
+        if (fpt > fps) {
+          // Make sure seconds don't change when scrolling right and left
+          time[0] -= time[0]%(fpt/Math.round(fps));
+        }
+        else {
+          time[0] -= time[0]%2;
+        }
         time[1] -= time[1]%1 - 1;
 
         startFrame = time[0] * Math.round(fps);
         endFrame = time[1] * Math.round(fps);
 
-        fpt = framesPerTick(scope.pixelsPerSecond, scope.project.fps.num ,scope.project.fps.den);
         frame = startFrame;
         while ( frame <= endFrame){
           t = frame / fps;
@@ -215,7 +222,7 @@ App.directive("tlRuler", function ($timeout) {
           tickSpan = $('<span style="left:'+pos+'px;"></span>');
           tickSpan.addClass("tick_mark");
 
-          if ((frame - startFrame) % (fpt * 2) == 0) {
+          if ((frame) % (fpt * 2) == 0) {
             // Alternating long marks with times marked
             timeSpan = $('<span style="left:'+pos+'px;"></span>');
             timeSpan.addClass("ruler_time");

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -120,7 +120,7 @@ App.directive("tlBody", function () {
         if (e.which === 2) { // middle button
           e.preventDefault();
           is_scrolling = true;
-          starting_scrollbar = {x: $('#scrolling_tracks').scrollLeft(), y: $('#scrolling_tracks').scrollTop()};
+          starting_scrollbar = {x: $("#scrolling_tracks").scrollLeft(), y: $("#scrolling_tracks").scrollTop()};
           starting_mouse_position = {x: e.pageX, y: e.pageY};
           element.addClass("drag_cursor");
         }
@@ -197,11 +197,11 @@ App.directive("tlRuler", function ($timeout) {
         ruler = $('#ruler');
         $("#ruler span").remove();
 
-        startPos = scope.scrollLeft;
-        endPos = scope.scrollLeft + $("body").width();
-        fpt = framesPerTick(scope.pixelsPerSecond, scope.project.fps.num ,scope.project.fps.den);
-        fps = scope.project.fps.num / scope.project.fps.den;
-        time = [ startPos / scope.pixelsPerSecond, endPos / scope.pixelsPerSecond];
+        let startPos = scope.scrollLeft;
+        let endPos = scope.scrollLeft + $("body").width();
+        let fpt = framesPerTick(scope.pixelsPerSecond, scope.project.fps.num ,scope.project.fps.den);
+        let fps = scope.project.fps.num / scope.project.fps.den;
+        let time = [ startPos / scope.pixelsPerSecond, endPos / scope.pixelsPerSecond];
 
         if (fpt > fps) {
           // Make sure seconds don't change when scrolling right and left
@@ -212,21 +212,21 @@ App.directive("tlRuler", function ($timeout) {
         }
         time[1] -= time[1]%1 - 1;
 
-        startFrame = time[0] * Math.round(fps);
-        endFrame = time[1] * Math.round(fps);
+        let startFrame = time[0] * Math.round(fps);
+        let endFrame = time[1] * Math.round(fps);
 
-        frame = startFrame;
+        let frame = startFrame;
         while ( frame <= endFrame){
-          t = frame / fps;
-          pos = t * scope.pixelsPerSecond;
-          tickSpan = $('<span style="left:'+pos+'px;"></span>');
+          let t = frame / fps;
+          let pos = t * scope.pixelsPerSecond;
+          let tickSpan = $('<span style="left:'+pos+'px;"></span>');
           tickSpan.addClass("tick_mark");
 
           if ((frame) % (fpt * 2) == 0) {
             // Alternating long marks with times marked
-            timeSpan = $('<span style="left:'+pos+'px;"></span>');
+            let timeSpan = $('<span style="left:'+pos+'px;"></span>');
             timeSpan.addClass("ruler_time");
-            timeText = secondsToTime(t, scope.project.fps.num, scope.project.fps.den);
+            let timeText = secondsToTime(t, scope.project.fps.num, scope.project.fps.den);
             timeSpan[0].innerText = timeText['hour'] + ':' +
               timeText['min'] + ':' +
               timeText['sec'];
@@ -234,8 +234,8 @@ App.directive("tlRuler", function ($timeout) {
               timeSpan[0].innerText += ',' + timeText['frame'];
             }
             tickSpan[0].style['height'] = '20px';
+            ruler.append(timeSpan);
           }
-          ruler.append(timeSpan);
           ruler.append(tickSpan);
 
           frame += fpt;
@@ -243,7 +243,7 @@ App.directive("tlRuler", function ($timeout) {
         return;
       };
 
-      scope.$watch("project.scale + project.duration + scrollLeft", function (val) {
+      scope.$watch("project.scale + project.duration + scrollLeft + element.width()", function (val) {
         if (val) {
           $timeout(function () {
             drawTimes();

--- a/src/timeline/js/functions.js
+++ b/src/timeline/js/functions.js
@@ -166,7 +166,7 @@ function secondsToTime(secs, fps_num, fps_den) {
   var week = Math.floor(day / 7);
   day = day % 7;
 
-  var frame = Math.floor((milli / 1000.0) * (fps_num / fps_den)) + 1;
+  var frame = Math.round((milli / 1000.0) * (fps_num / fps_den)) + 1;
   return {
     "week": padNumber(week, 2),
     "day": padNumber(day, 2),

--- a/src/windows/views/webview_backend/webkit.py
+++ b/src/windows/views/webview_backend/webkit.py
@@ -123,19 +123,3 @@ class TimelineWebKitView(QWebView):
         else:
             # Ignore most keypresses
             event.ignore()
-
-    def wheelEvent(self, event):
-        """ Mousewheel scrolling """
-        if event.modifiers() & Qt.ShiftModifier:
-            event.accept()
-            frame = self.page().mainFrame()
-            # Compute scroll offset from wheel motion
-            tick_scale = 120
-            steps = int(event.angleDelta().y() / tick_scale)
-            delta = -(steps * 100)
-            log.debug("Scrolling horizontally by %d pixels", delta)
-            # Update the scroll position using AngularJS
-            js = "$('body').scope().scrollLeft({});".format(delta)
-            frame.evaluateJavaScript(js)
-        else:
-            super().wheelEvent(event)


### PR DESCRIPTION
Issues fixed here:
---
1) Middle click drag was sending the timeline to 00:00:00,0. I made some changes so that it works relative to the timeline's original position.

2) The ruler draws a time on every other mark. As you scroll left, it was always starting with the second mark on screen, breaking up the continuous motion of the ruler. I made sure that the ruler always draws times on the *same* marks, so the scrolling feels continuous.

3) If you resized the timeline in some way, the ruler wasn't redrawing until you scrolled or zoomed. I added `element.width()` to the watched variables that calls `drawRuler`, so that this now causes the ruler to redraw.