### PR TITLE
Webkit feature parity

### DIFF
--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -60,6 +60,10 @@ App.directive("tlScrollableTracks", function () {
             timeline.zoomIn();
           }
         }
+        if (e.shiftKey) {
+          let current_scroll = $("#scrolling_tracks").scrollLeft()
+          $("#scrolling_tracks").scrollLeft(current_scroll + e.originalEvent.deltaY);
+        }
       });
 
       // Sync ruler to track scrolling
@@ -146,7 +150,6 @@ App.directive("tlBody", function () {
     }
   };
 });
-
 
 // The HTML5 canvas ruler
 App.directive("tlRuler", function ($timeout) {

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -62,7 +62,8 @@ App.directive("tlScrollableTracks", function () {
           }
         }
         else if (e.shiftKey) {
-          let current_scroll = $("#scrolling_tracks").scrollLeft()
+          e.preventDefault();
+          let current_scroll = $("#scrolling_tracks").scrollLeft();
           $("#scrolling_tracks").scrollLeft(current_scroll + e.originalEvent.deltaY);
         }
       });

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -261,12 +261,10 @@ App.directive("tlRuler", function ($timeout) {
       };
 
       scope.$watch("project.scale + project.duration + scrollLeft + element.width()", function (val) {
-        if (val) {
-          $timeout(function () {
-            drawTimes();
-            return;
-          } , 0);
-        }
+        $timeout(function () {
+          drawTimes();
+          return;
+        } , 0);
       });
 
     }

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -52,7 +52,8 @@ App.directive("tlScrollableTracks", function () {
       element.on("wheel",function (e) {
         if (e.ctrlKey) {
           e.preventDefault(); // Don't scroll like a browser
-          if (e.originalEvent.deltaY > 0) { // Scroll down: Zoom out
+          var delta = e.originalEvent.deltaY * (e.shiftKey ? -1 : 1);
+          if (delta > 0) { // Scroll down: Zoom out
             /*global timeline*/
             timeline.zoomOut();
           } else { // Scroll Up: Zoom in
@@ -60,7 +61,7 @@ App.directive("tlScrollableTracks", function () {
             timeline.zoomIn();
           }
         }
-        if (e.shiftKey) {
+        else if (e.shiftKey) {
           let current_scroll = $("#scrolling_tracks").scrollLeft()
           $("#scrolling_tracks").scrollLeft(current_scroll + e.originalEvent.deltaY);
         }


### PR DESCRIPTION
1) When the window is resized, parts of the ruler that weren't visible had no ruler marks. Now, changes in `width` attribute the ruler's parent container should trigger redrawing. (Thought that was fixed in my last PR)
2) Horizontal scrolling hasn't worked for me when running with the webkit backend. Now both web backends should respond to `shift+mousewheel` as horizontal scrolling