### PR TITLE
Fixing libopenshot version warning message + Sentry.io fixes

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -185,8 +185,6 @@ class OpenShotApp(QApplication):
                 },
             level="error",
         ))
-        raise RuntimeError(
-            "libopenshot version {} found, minimum is {}".format(ver, min_ver))
 
     def gui(self):
         from classes import language, sentry, ui_util, logger_libopenshot

--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -307,7 +307,7 @@ class JsonDataStore:
             # Remove file from abs path
             orig_abs_folder = os.path.dirname(orig_abs_path)
 
-            # Calculate new relateive path
+            # Calculate new relative path
             new_rel_path_folder = os.path.relpath(orig_abs_folder, path_context.get("new_project_folder", ""))
             new_rel_path = os.path.join(new_rel_path_folder, file_path).replace("\\", "/")
             new_rel_path = json.dumps(new_rel_path, ensure_ascii=False)
@@ -329,7 +329,7 @@ class JsonDataStore:
             data = re.sub(path_regex, self.replace_string_to_relative, data)
 
         except Exception as ex:
-            log.error("Error while converting absolute paths to relative paths: %s" % str(ex))
+            log.warning("Failed converting absolute paths to relative paths: %s" % str(ex))
 
         return data
 

--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -253,8 +253,8 @@ class JsonDataStore:
             # Optimized regex replacement
             data = re.sub(path_regex, self.replace_string_to_absolute, data)
 
-        except Exception as ex:
-            log.error("Error while converting relative paths to absolute paths: %s" % str(ex))
+        except Exception:
+            log.error("Error while converting relative paths to absolute paths", exc_info=1)
 
         return data
 
@@ -266,14 +266,16 @@ class JsonDataStore:
 
         # Determine if thumbnail path is found
         if info.THUMBNAIL_PATH in folder_path:
-            # Convert path to relative thumbnail path
+            log.debug("Generating relative thumbnail path to %s in %s",
+                      file_path, folder_path)
             new_path = os.path.join("thumbnail", file_path).replace("\\", "/")
             new_path = json.dumps(new_path, ensure_ascii=False)
             return '"%s": %s' % (key, new_path)
 
         # Determine if @transitions path is found
         elif os.path.join(info.PATH, "transitions") in folder_path:
-            # Yes, this is an OpenShot transition
+            log.debug("Generating relative @transitions path for %s in %s",
+                      file_path, folder_path)
             folder_path, category_path = os.path.split(folder_path)
 
             # Convert path to @transitions/ path
@@ -283,15 +285,15 @@ class JsonDataStore:
 
         # Determine if @emojis path is found
         elif os.path.join(info.PATH, "emojis") in folder_path:
-            # Yes, this is an OpenShot emoji
-            # Convert path to @emojis/ path
+            log.debug("Generating relative @emojis path for %s in %s",
+                      file_path, folder_path)
             new_path = os.path.join("@emojis", file_path).replace("\\", "/")
             new_path = json.dumps(new_path, ensure_ascii=False)
             return '"%s": %s' % (key, new_path)
 
         # Determine if @assets path is found
         elif path_context["new_project_assets"] in folder_path:
-            # Yes, this is an OpenShot transitions
+            log.debug("Replacing path to %s in %s", file_path, folder_path)
             folder_path = folder_path.replace(path_context["new_project_assets"], "@assets")
 
             # Convert path to @assets/ path
@@ -304,10 +306,20 @@ class JsonDataStore:
             # Convert path to the correct relative path (based on the existing folder)
             orig_abs_path = os.path.abspath(path)
 
+            # Determine windows drives that the project and file are on
+            project_win_drive = os.path.splitdrive(path_context.get("new_project_folder", ""))[0]
+            file_win_drive = os.path.splitdrive(path)[0]
+            if file_win_drive != project_win_drive:
+                log.debug("Drive mismatch, not making path relative: %s", orig_abs_path)
+                # If the file is on different drive. Don't abbreviate the path.
+                clean_path = orig_abs_path.replace("\\", "/")
+                clean_path = json.dumps(clean_path, ensure_ascii=False)
+                return f"{key}: {clean_path}"
+
             # Remove file from abs path
             orig_abs_folder = os.path.dirname(orig_abs_path)
 
-            # Calculate new relative path
+            log.debug("Generating new relative path for %s", orig_abs_path)
             new_rel_path_folder = os.path.relpath(orig_abs_folder, path_context.get("new_project_folder", ""))
             new_rel_path = os.path.join(new_rel_path_folder, file_path).replace("\\", "/")
             new_rel_path = json.dumps(new_rel_path, ensure_ascii=False)
@@ -328,8 +340,8 @@ class JsonDataStore:
             # Optimized regex replacement
             data = re.sub(path_regex, self.replace_string_to_relative, data)
 
-        except Exception as ex:
-            log.warning("Failed converting absolute paths to relative paths: %s" % str(ex))
+        except Exception:
+            log.error("Error while converting absolute paths to relative paths", exc_info=1)
 
         return data
 

--- a/src/launch.py
+++ b/src/launch.py
@@ -183,10 +183,7 @@ def main():
     argv = [sys.argv[0]]
     argv.extend(extra_args)
     argv.extend(args.remain)
-    try:
-        app = OpenShotApp(argv)
-    except Exception:
-        app.show_errors()
+    app = OpenShotApp(argv)
 
     # Setup Qt application details
     app.setApplicationName('openshot')

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -848,7 +848,9 @@ App.controller("TimelineCtrl", function ($scope) {
       timeline.add_missing_transition(JSON.stringify(missing_transition_details));
     }
     // Remove manual move stylesheet
-    bounding_box.element.removeClass("manual-move");
+    if (bounding_box.element) {
+      bounding_box.element.removeClass("manual-move");
+    }
 
     // Remove CSS class (after the drag)
     bounding_box = {};
@@ -894,7 +896,7 @@ App.controller("TimelineCtrl", function ($scope) {
     bounding_box.track_position = 0;
 
     // Set z-order to be above other clips/transitions
-    if (item_type !== "os_drop") {
+    if (item_type !== "os_drop" && bounding_box.element) {
       bounding_box.element.addClass("manual-move");
     }
   };
@@ -938,8 +940,10 @@ App.controller("TimelineCtrl", function ($scope) {
       }
     }
     //change the element location
-    bounding_box.element.css("left", results.position.left);
-    bounding_box.element.css("top", bounding_box.track_position - scrolling_tracks_offset_top);
+    if (bounding_box.element) {
+      bounding_box.element.css("left", results.position.left);
+      bounding_box.element.css("top", bounding_box.track_position - scrolling_tracks_offset_top);
+    }
   };
 
   // Update X,Y indexes of tracks / layers (anytime the project.layers scope changes)

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -685,6 +685,10 @@ class Export(QDialog):
         # get translations
         _ = get_app()._tr
 
+        # Init some variables
+        seconds_run = 0
+        fps_encode = 0
+
         # Init progress bar
         self.progressExportVideo.setMinimum(self.txtStartFrame.value())
         self.progressExportVideo.setMaximum(self.txtEndFrame.value())
@@ -872,7 +876,6 @@ class Export(QDialog):
 
             progressstep = max(1 , round(( video_settings.get("end_frame") - video_settings.get("start_frame") ) / 1000))
             start_time_export = time.time()
-            seconds_run = 0
             start_frame_export = video_settings.get("start_frame")
             end_frame_export = video_settings.get("end_frame")
             last_exported_time = time.time()
@@ -881,7 +884,7 @@ class Export(QDialog):
             digits_after_decimalpoint = 1
             # Precision of the progress bar
             format_of_progress_string = "%4.1f%% "
-            fps_encode = 0
+
             # Write each frame in the selected range
             for frame in range(video_settings.get("start_frame"), video_settings.get("end_frame") + 1):
                 # Update progress bar (emit signal to main window)

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -195,11 +195,11 @@ class PropertiesModel(updates.UpdateInterface):
         if not c:
             return
 
-        # Create reference 
+        # Create reference
         clip_data = c.data
         if object_id:
             clip_data = c.data.get('objects').get(object_id)
-    
+
         if property_key in clip_data:  # Update clip attribute
             log_id = "{}/{}".format(clip_id, object_id) if object_id else clip_id
             log.debug("%s: remove %s keyframe. %s", log_id, property_key, clip_data.get(property_key))
@@ -281,7 +281,7 @@ class PropertiesModel(updates.UpdateInterface):
                 c = Effect.get(id=clip_id)
 
             if c:
-                # Create reference 
+                # Create reference
                 clip_data = c.data
                 if object_id:
                     clip_data = c.data.get('objects').get(object_id)
@@ -301,7 +301,7 @@ class PropertiesModel(updates.UpdateInterface):
                         # Keyframe
                         # Loop through points, find a matching points on this frame
                         found_point = False
-                        for point in clip_data[property_key][color]["Points"]:
+                        for point in clip_data[property_key][color].get("Points", []):
                             log.debug("looping points: co.X = %s" % point["co"]["X"])
                             if interpolation == -1 and point["co"]["X"] == self.frame_number:
                                 # Found point, Update value
@@ -348,7 +348,7 @@ class PropertiesModel(updates.UpdateInterface):
                         if not found_point:
                             clip_updated = True
                             log.debug("Created new point at X=%d", self.frame_number)
-                            clip_data[property_key][color]["Points"].append({
+                            clip_data[property_key][color].setdefault("Points", []).append({
                                 'co': {'X': self.frame_number, 'Y': new_value},
                                 'interpolation': 1,
                                 })
@@ -357,7 +357,7 @@ class PropertiesModel(updates.UpdateInterface):
                 clip_data = {property_key: clip_data[property_key]}
                 if object_id:
                     clip_data = {'objects': {object_id: clip_data}}
-                
+
                 # Save changes
                 if clip_updated:
                     # Save
@@ -430,8 +430,8 @@ class PropertiesModel(updates.UpdateInterface):
             c = Effect.get(id=clip_id)
 
         if c:
-            
-            # Create reference 
+
+            # Create reference
             clip_data = c.data
             if object_id:
                 clip_data = c.data.get('objects').get(object_id)
@@ -447,7 +447,7 @@ class PropertiesModel(updates.UpdateInterface):
                     # Loop through points, find a matching points on this frame
                     found_point = False
                     point_to_delete = None
-                    for point in clip_data[property_key]["Points"]:
+                    for point in clip_data[property_key].get('Points', []):
                         log.debug("looping points: co.X = %s" % point["co"]["X"])
                         if interpolation == -1 and point["co"]["X"] == self.frame_number:
                             # Found point, Update value
@@ -503,7 +503,7 @@ class PropertiesModel(updates.UpdateInterface):
                     elif not found_point and new_value is not None:
                         clip_updated = True
                         log.debug("Created new point at X=%d", self.frame_number)
-                        clip_data[property_key]["Points"].append({
+                        clip_data[property_key].setdefault('Points', []).append({
                             'co': {'X': self.frame_number, 'Y': new_value},
                             'interpolation': 1})
 

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -224,7 +224,7 @@ class Preferences(QDialog):
                     widget.setMinimum(int(param["min"]))
                     widget.setMaximum(int(param["max"]))
                     widget.setValue(int(param["value"]))
-                    widget.setSingleStep(1.0)
+                    widget.setSingleStep(1)
                     widget.setToolTip(param["title"])
                     widget.valueChanged.connect(functools.partial(self.spinner_value_changed, param))
 

--- a/src/windows/process_effect.py
+++ b/src/windows/process_effect.py
@@ -129,7 +129,7 @@ class ProcessEffect(QDialog):
                 widget.setMinimum(int(param["min"]))
                 widget.setMaximum(int(param["max"]))
                 widget.setValue(int(param["value"]))
-                widget.setSingleStep(1.0)
+                widget.setSingleStep(1)
                 widget.setToolTip(_(param["title"]))
                 widget.valueChanged.connect(functools.partial(self.spinner_value_changed, widget, param))
 

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -905,8 +905,8 @@ class Worker(QObject):
             if self.canceled:
                 return
             if self.frame_count < 1:
-                log.error("No frame detected from Blender!")
-                log.error("Blender output:\n{}".format(
+                log.warning("No frame detected from Blender!")
+                log.warning("Blender output:\n{}".format(
                     self.command_output))
                 # Show Error that no frames are detected.  This is likely caused by
                 # the wrong command being executed... or an error in Blender.

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -513,11 +513,11 @@ class PropertiesTableView(QTableView):
                 # Instantiate the timeline
                 timeline_instance = get_app().window.timeline_sync.timeline
                 current_effect = timeline_instance.GetClipEffect(clip_id)
-                
+
                 # Loop through timeline's clips
                 for clip_instance in timeline_instance.Clips():
                     clip_instance_id = clip_instance.Id()
-                    
+
                     # Avoid attach a clip to it's own object
                     if (clip_instance_id != clip_id and (current_effect and clip_instance_id != current_effect.ParentClip().Id())):
                         # Clip's propertyJSON data
@@ -674,20 +674,6 @@ class PropertiesTableView(QTableView):
                     fontinfo = QFontInfo(font)
                     self.clip_properties_model.value_updated(self.selected_item, value=fontinfo.family())
 
-            elif self.property_type == "color":
-                # Get current value of color
-                red = cur_property[1]["red"]["value"]
-                green = cur_property[1]["green"]["value"]
-                blue = cur_property[1]["blue"]["value"]
-
-                # Show color dialog
-                currentColor = QColor(red, green, blue)
-                log.debug("Launching ColorPicker for %s", currentColor.name())
-                ColorPicker(
-                    currentColor, parent=self, title=_("Select a Color"),
-                    callback=self.color_callback)
-                return
-
             # Define bezier presets
             bezier_presets = [
                 (0.250, 0.100, 0.250, 1.000, _("Ease (Default)")),
@@ -725,6 +711,10 @@ class PropertiesTableView(QTableView):
 
             # Add menu options for keyframes
             menu = QMenu(self)
+            if self.property_type == "color":
+                Color_Action = menu.addAction(_("Select a Color"))
+                Color_Action.triggered.connect(functools.partial(self.Color_Picker_Triggered, cur_property))
+                menu.addSeparator()
             if points > 1:
                 # Menu items only for multiple points
                 Bezier_Menu = menu.addMenu(self.bezier_icon, _("Bezier"))
@@ -764,7 +754,7 @@ class PropertiesTableView(QTableView):
                     SubMenuRoot = menu.addMenu(choice["icon"], choice["name"])
                 else:
                     SubMenuRoot = menu.addMenu(choice["name"])
-                    
+
                 SubMenuSize = 25
                 SubMenuNumber = 0
                 if len(choice["value"]) > SubMenuSize:
@@ -818,6 +808,23 @@ class PropertiesTableView(QTableView):
         else:
             # Update colors interpolation mode
             self.clip_properties_model.color_update(self.selected_item, QColor("#000"), interpolation=2, interpolation_details=[])
+
+    def Color_Picker_Triggered(self, cur_property):
+        log.info("Color_Picker_Triggered")
+
+        _ = get_app()._tr
+
+        # Get current value of color
+        red = cur_property[1]["red"]["value"]
+        green = cur_property[1]["green"]["value"]
+        blue = cur_property[1]["blue"]["value"]
+
+        # Show color dialog
+        currentColor = QColor(red, green, blue)
+        log.debug("Launching ColorPicker for %s", currentColor.name())
+        ColorPicker(
+            currentColor, parent=self, title=_("Select a Color"),
+            callback=self.color_callback)
 
     def Insert_Action_Triggered(self):
         log.info("Insert_Action_Triggered")


### PR DESCRIPTION
Fixing some issues in the release branch, found in my testing and in Sentry.io (with some of our 2.6.0 testers)

- Fixed libopenshot version mis-match error was crashing OpenShot
- Fixed timeline bounding box errors reported on sentry (needed protection)
- Added many guards to accessing variables (reported by sentry)
- Added "Select a Color" context menu for color keyframes, instead of popping up a dialog and blocking our context menu options on the color keyframes
- Fixed default QSpinBox values (which were using float instead of int)
- Fixed windows drive letter relative path detection (to prevent trying to make relative paths across drives)
- Replaced log.error with log.warning on Blender output (since this is a valid outcome of using the wrong version of Blender)