### PR TITLE
Fix a regression in multi-drag for Clips/Transitions

### DIFF
--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -1393,7 +1393,6 @@ App.controller("TimelineCtrl", function ($scope) {
         // Re-index Layer Y values
         $scope.updateLayerIndex();
       }
-      $scope.$digest();
     }
     // return true
     return true;

--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -330,22 +330,16 @@ App.directive("tlClip", function ($timeout) {
 
           // Move all other selected clips with this one if we have more than one clip
           $(".ui-selected").each(function () {
-            clip_name = $(this).attr("id");
-            var newX, newY;
-            if (move_clips[clip_name] && ( move_clips[clip_name]['top'] && move_clips[clip_name]['left'] )) {
-              newY = move_clips[clip_name]['top'] + y_offset;
-              newX = move_clips[clip_name]['left'] + x_offset;
-            } else {
-              move_clips[clip_name] =  {};
-              newY = this.style.top + y_offset;
-              newX = this.style.left + x_offset;
+            if (move_clips[$(this).attr("id")]) {
+              let newY = move_clips[$(this).attr("id")]["top"] + y_offset;
+              let newX = move_clips[$(this).attr("id")]["left"] + x_offset;
+              //update the clip location in the array
+              move_clips[$(this).attr("id")]["top"] = newY;
+              move_clips[$(this).attr("id")]["left"] = newX;
+              //change the element location
+              $(this).css("left", newX);
+              $(this).css("top", newY);
             }
-            //update the clip location in the array
-            move_clips[$(this).attr("id")]["top"] = newY;
-            move_clips[$(this).attr("id")]["left"] = newX;
-            //change the element location
-            $(this).css("left", newX);
-            $(this).css("top", newY);
           });
         },
         revert: function (valid) {

--- a/src/timeline/js/directives/transition.js
+++ b/src/timeline/js/directives/transition.js
@@ -278,24 +278,16 @@ App.directive("tlTransition", function () {
 
           // Move all other selected transitions with this one
           $(".ui-selected").each(function () {
-            transition_name = $(this).attr("id");
-            var newX, newY;
-            if (move_clips[transition_name] && ( move_clips[transition_name]['top'] && move_clips[clip_name]['left'] )) {
-              newY = move_clips[transition_name]['top'] + y_offset;
-              newX = move_clips[transition_name]['left'] + x_offset;
-            } else {
-              // If this transition is not yet in move_clips, add it.
-              move_clips[transition_name] =  {};
-              newY = this.style.top + y_offset;
-              newX = this.style.left + x_offset;
+            if (move_transitions[$(this).attr("id")]) {
+              let newY = move_transitions[$(this).attr("id")]["top"] + y_offset;
+              let newX = move_transitions[$(this).attr("id")]["left"] + x_offset;
+              // Update the transition location in the array
+              move_transitions[$(this).attr("id")]["top"] = newY;
+              move_transitions[$(this).attr("id")]["left"] = newX;
+              // Change the element location
+              $(this).css("left", newX);
+              $(this).css("top", newY);
             }
-            // Update the transition location in the array
-            move_transitions[$(this).attr("id")]["top"] = newY;
-            move_transitions[$(this).attr("id")]["left"] = newX;
-            // Change the element location
-            $(this).css("left", newX);
-            $(this).css("top", newY);
-
           });
 
         },


### PR DESCRIPTION
This is a fix to the regression caused by https://github.com/OpenShot/openshot-qt/pull/4230. Originally, it was designed as a fix for a missing clip/transition ID. Just adding some simple protection instead.