### PR TITLE
Fix translation testing scripts to actually work!

### DIFF
--- a/src/language/show_translations.py
+++ b/src/language/show_translations.py
@@ -41,28 +41,36 @@ language_path = os.path.dirname(os.path.abspath(__file__))
 app = QCoreApplication(sys.argv)
 
 # Load POT template (all English strings)
-POT_source = open(os.path.join(language_path, 'OpenShot', 'OpenShot.pot')).read()
-all_strings = re.findall('^msgid \"(.*)\"', POT_source, re.MULTILINE)
+all_templates = ['OpenShot.pot', 'OpenShot_transitions.pot', 'OpenShot_blender.pot']
+for template_name in all_templates:
+    POT_source = open(os.path.join(language_path, 'OpenShot', template_name)).read()
+    all_strings = re.findall('^msgid \"(.*)\"', POT_source, re.MULTILINE)
 
-print("Scanning {} strings in all translation files...".format(len(all_strings)))
+    print("Scanning {} strings in all translation files...".format(len(all_strings)))
 
-# Loop through folders/languages
-for filename in fnmatch.filter(os.listdir(language_path), 'OpenShot_*.qm'):
-    lang_code = filename[:-3]
-    # Install language
-    translator = QTranslator(app)
+    # Loop through folders/languages
+    for filename in fnmatch.filter(os.listdir(language_path), 'OpenShot*.qm'):
+        lang_code = filename[:-3]
+        # Install language
+        translator = QTranslator(app)
 
-    # Load translation
-    if translator.load(lang_code, language_path):
-        app.installTranslator(translator)
+        # Load translation
+        if translator.load(lang_code, language_path):
+            app.installTranslator(translator)
 
-        print("\n=================================================")
-        print("Showing translations for {}".format(filename))
-        print("=================================================")
-        # Loop through all test strings
-        for source_string in all_strings:
-            translated_string = app.translate("", source_string)
-            if source_string != translated_string:
-                print('  {} => {}'.format(source_string,translated_string))
-        # Remove translator
-        app.removeTranslator(translator)
+            print("\n=================================================")
+            print("Showing translations for {}".format(filename))
+            print("=================================================")
+            # Loop through all test strings
+            for source_string in all_strings:
+                translated_string = app.translate("", source_string)
+                if source_string != translated_string:
+                    print('  {} => {}'.format(source_string,translated_string))
+
+                if "%s" in source_string or "%s(" in source_string or "%d" in source_string:
+                    if source_string.count('%') != translated_string.count('%'):
+                        raise(Exception('Invalid string replacement found: "%s" vs "%s" [%s]' %
+                              (translated_string, source_string, lang_code)))
+
+            # Remove translator
+            app.removeTranslator(translator)

--- a/src/language/test_translations.py
+++ b/src/language/test_translations.py
@@ -44,7 +44,7 @@ endc='\033[0m'
 app = QCoreApplication(sys.argv)
 
 # Load POT template (all English strings)
-all_templates = ['OpenShot.pot', 'OpenShot_transitions.pot', 'OpenShot_blender.pot', 'OpenShot_transitions.pot']
+all_templates = ['OpenShot.pot', 'OpenShot_transitions.pot', 'OpenShot_blender.pot']
 for template_name in all_templates:
     POT_source = open(os.path.join(language_path, 'OpenShot', template_name)).read()
     all_strings = re.findall('^msgid \"(.*)\"', POT_source, re.MULTILINE)
@@ -52,7 +52,7 @@ for template_name in all_templates:
     print("Testing {} strings in {}...".format(len(all_strings), template_name))
 
     # Loop through folders/languages
-    for filename in fnmatch.filter(os.listdir(language_path), 'OpenShot.*.qm'):
+    for filename in fnmatch.filter(os.listdir(language_path), 'OpenShot*.qm'):
         lang_code = filename[:-3]
         # Install language
         translator = QTranslator(app)


### PR DESCRIPTION
 This caused our 2.6.0 branch to use invalid translations, oops.

```
Invalid string replacement found: "큰 barr 흔들기" vs "Big barr shaking %s" [OpenShot_ko]
Invalid string replacement found: "Išperėjimas" vs "Hatched %s" [OpenShot_lt]
Invalid string replacement found: "Filmo vertinimas" vs "Film rating %s" [OpenShot_lt]
Invalid string replacement found: "Nômade" vs "Wandering %s" [OpenShot_pt_BR]
Invalid string replacement found: "Faixa" vs "Ribbon %s" [OpenShot_pt_BR]
Invalid string replacement found: "Lúč" vs "Ray light %s" [OpenShot_sk]
```