### PR TITLE
save paths as valid json

### DIFF
--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -314,7 +314,7 @@ class JsonDataStore:
                 # If the file is on different drive. Don't abbreviate the path.
                 clean_path = orig_abs_path.replace("\\", "/")
                 clean_path = json.dumps(clean_path, ensure_ascii=False)
-                return f"{key}: {clean_path}"
+                return f"\"{key}\": {clean_path}"
 
             # Remove file from abs path
             orig_abs_folder = os.path.dirname(orig_abs_path)

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -647,7 +647,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                         # Increment track counter
                         track_counter += 1
 
-            except Exception:
+            except Exception as ex:
                 # Error parsing legacy contents
                 msg = "Failed to load legacy project file %(path)s" % {"path": file_path}
                 log.error(msg, exc_info=1)


### PR DESCRIPTION
I believe this PR #4211 introduced a bug which is causing .osp that can't open.

A user reported an un-openable OpenShot project when saving to a separate drive after updating to 2.6 . The reason is the path attribute didn't have quotes around it, and caused a JSON parsing error.

Also, fixed the exception reporter which was trying to report an undeclared variable.