### PR TITLE
repair project files with invalid json for paths

### DIFF
--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -163,7 +163,6 @@ class JsonDataStore:
                 # File contains corruptions, backup and repair
                 self.make_repair_backup(file_path, contents)
 
-
                 # Repair lost slashes, then fix all corrupted escapes
                 contents = self.slash_repair_re.sub(r'\1/\2', contents)
                 contents, subs_count = self.damage_re.subn(r'\\u\1', contents)

--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -153,11 +153,16 @@ class JsonDataStore:
                 contents = f.read()
             if not contents:
                 raise RuntimeError("Couldn't load {} file, no data.".format(self.data_type))
+            
+            if os.path.splitext(file_path) and os.path.splitext(file_path)[1] == '.osp':
+                # Repair lost quotes on json keys
+                contents = re.sub('(\n\s*)(\w*):', r'\1"\2":', contents)
 
             # Scan for and correct possible OpenShot 2.5.0 corruption
             if self.damage_re.search(contents) and self.version_re.search(contents):
                 # File contains corruptions, backup and repair
                 self.make_repair_backup(file_path, contents)
+
 
                 # Repair lost slashes, then fix all corrupted escapes
                 contents = self.slash_repair_re.sub(r'\1/\2', contents)

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -346,7 +346,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             default_project = self._data
 
             try:
-                self.quote_json_keys(file_path)
                 # Attempt to load v2.X project file
                 project_data = self.read_from_file(file_path, path_mode="absolute")
 
@@ -720,21 +719,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         # Fix default project id (if found)
         if self._data.get("id") == "T0":
             self._data["id"] = self.generate_id()
-
-    # Ensure projects can open 
-    # after PR #4211 introduced a bug
-    # which wrote certain projects with invalid JSON.
-    def quote_json_keys(self, file_path):
-        import re
-
-        f = open(file_path)
-        txt = f.read()
-        f.close()
-        newText = re.sub('(\n\s*)(\w*):', r'\1"\2":', txt)
-        f = open(file_path, 'w')
-        f.write(newText)
-        f.close()
-        return
 
     def save(self, file_path, move_temp_files=True, make_paths_relative=True):
         """ Save project file to disk """


### PR DESCRIPTION
#4211 caused a specific case where a user's osp would be written without valid json. (No quotes on the key for a path attribute)

This is meant to find any such errors in a project file, and fix them before attempting to open.