### PR TITLE
WIP: don't translate unless translation has same number of placeholders

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -83,10 +83,12 @@ class OpenShotApp(QApplication):
 
         # For _tr() to ensure translated string can have
         # data substituted inside of it.
-        self.c_style_sub = re.compile(r"(?<!%)%(?!%)") # Style: "%s" % "insert"
+        # C Style: "%s" % "insert"
+        # Rust Style: "{}".format("insert")
+        self.c_style_sub = re.compile(r"(?<!%)%(?!%)") # '%' on it's own
         self.rust_style_sub = re.compile(r"(?<!{){(?!{).*(?<!})}(?!})") # Style: "{}".format("insert")
-        self.c_sub_names = re.compile(r"(?<!%)%(?!%)") # Style: "%s" % "insert"
-        self.rust_sub_names = re.compile(r"(?<!{){(?!{).*(?<!})}(?!})") # Style: "{}".format("insert")
+        self.c_sub_names = re.compile(r"(?<!%)%\(.*?\).") # Style: "%s" % "insert"
+        self.rust_sub_names = re.compile(r"(?<!{){.*?}(?!})") # Style: "{}".format("insert")
 
         try:
             # Import modules
@@ -333,8 +335,8 @@ class OpenShotApp(QApplication):
         # Fall back to english string
         # (This way the translated string will work as long as the english one does)
         for match in list(re.finditer(self.rust_sub_names, translation)) + \
-        list(re.finditer(self.c_sub_names, message)):
-            if translation.find(match.group()) == -1:
+        list(re.finditer(self.c_sub_names, translation)):
+            if message.find(match.group()) == -1:
                 return message
         return translation
 


### PR DESCRIPTION
If a string that we're translating has any placeholders to substitute data into, only return the translation if it has the same number of placeholders. This will prevent OpenShot from crashing if a bad translation gets through.

__Two froms of python placeholders__

- The C way
```python
print("Here's the value: %s" % variable)
```
- and the Rust way
```python
print("Here's the value: {}".format(variable))
```
__Exception__
The one type of error this won't catch is if a `%s` is replaced with a `%d` or some substitution that can't accept the data given. To ensure against that, I would have to count the different characters after `%` for order number and order, and I believe that's more computation than we want here  

Not merging
---
I'm now planning to incorporate these regular expressions into our CI translation checking. They shouldn't be needed at runtime if we're testing our translation files properly