### PR TITLE
Fixing mask "source" menu in properties

### DIFF
--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -750,7 +750,7 @@ class PropertiesTableView(QTableView):
                 # Divide into smaller QMenus (since large lists cover the entire screen)
                 # For example: Transitions -> 1 -> sub items
                 SubMenu = None
-                if choice["icon"] is not None:
+                if choice.get("icon") is not None:
                     SubMenuRoot = menu.addMenu(choice["icon"], choice["name"])
                 else:
                     SubMenuRoot = menu.addMenu(choice["name"])


### PR DESCRIPTION
Fixing mask "source" menu in properties, which should be showing a list of project files but was breaking due to a missing "icon" property.