### PR TITLE
project_data: Also sanity-check 2.5.1-dev*

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -719,7 +719,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                                             point.get("handle_right")["X"] = 0.5
                                             point.get("handle_right")["Y"] = 0.0
 
-        elif openshot_version == "2.5.1":
+        elif openshot_version.startswith("2.5.1"):
             # Replace missing crop properties from 2.5.x
             for clip in self._data["clips"]:
                 # Loop through keyframes for alpha

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -719,9 +719,10 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                                             point.get("handle_right")["X"] = 0.5
                                             point.get("handle_right")["Y"] = 0.0
 
-        elif openshot_version.startswith("2.5.1"):
+        elif openshot_version.startswith("2.5."):
             # Replace missing crop properties from 2.5.x
-            for clip in self._data["clips"]:
+            log.debug("Scanning OpenShot 2.5 project for legacy cropping")
+            for clip in self._data.get("clips", []):
                 # Loop through keyframes for alpha
                 crop_x = clip.pop("crop_x", {})
                 crop_y = clip.pop("crop_y", {})
@@ -734,27 +735,22 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                         self.is_keyframe_valid(crop_height, 1.0),
                        ]):
                     # Apply crop effect to clip (which wasn't available in 2.5.x)
+                    log.info(
+                        "Migrating OpenShot 2.5 crop properties for clip %s",
+                        clip.get("id", "<unknown>")
+                    )
+                    from json import loads as jl
                     effect = openshot.EffectInfo().CreateEffect("Crop")
                     effect.Id(get_app().project.generate_id())
-                    effect_json = json.loads(effect.Json())
+                    effect_json = jl(effect.Json())
 
-                    # Append previous clip crop values
-                    if crop_x:
-                        effect_json["x"] = crop_x
-                    else:
-                        effect_json["x"] = json.loads(openshot.Keyframe(0.0).Json())
-                    if crop_y:
-                        effect_json["y"] = crop_y
-                    else:
-                        effect_json["y"] = json.loads(openshot.Keyframe(0.0).Json())
-                    if crop_width:
-                        effect_json["right"] = crop_width
-                    else:
-                        effect_json["right"] = json.loads(openshot.Keyframe(0.0).Json())
-                    if crop_height:
-                        effect_json["bottom"] = crop_height
-                    else:
-                        effect_json["bottom"] = json.loads(openshot.Keyframe(0.0).Json())
+                    # Attach previous clip crop values
+                    effect_json.update({
+                        "x": crop_x or jl(openshot.Keyframe(0.0).Json()),
+                        "y": crop_y or jl(openshot.Keyframe(0.0).Json()),
+                        "right": crop_width or jl(openshot.Keyframe(1.0).Json()),
+                        "bottom": crop_height or jl(openshot.Keyframe(1.0).Json()),
+                    })
 
                     # Reverse values on right & bottom
                     for prop in ["right", "bottom"]:

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -728,10 +728,11 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                 crop_width = clip.pop("crop_width", {})
                 crop_height = clip.pop("crop_height", {})
 
-                if self.is_keyframe_valid(crop_x, 0.0) or \
-                        self.is_keyframe_valid(crop_y, 0.0) or \
-                        self.is_keyframe_valid(crop_width, 1.0) or \
-                        self.is_keyframe_valid(crop_height, 1.0):
+                if any([self.is_keyframe_valid(crop_x, 0.0),
+                        self.is_keyframe_valid(crop_y, 0.0),
+                        self.is_keyframe_valid(crop_width, 1.0),
+                        self.is_keyframe_valid(crop_height, 1.0),
+                       ]):
                     # Apply crop effect to clip (which wasn't available in 2.5.x)
                     effect = openshot.EffectInfo().CreateEffect("Crop")
                     effect.Id(get_app().project.generate_id())
@@ -769,10 +770,13 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
     def is_keyframe_valid(self, keyframe, default_value):
         """Check if a keyframe is not empty (i.e. > 1 point, or a non default_value)"""
-        if len(keyframe.get("Points", [])) == 0:
+        points = keyframe.get("Points", [])
+        if not points or not isinstance(points, list):
             return False
-        return len(keyframe.get("Points", [])) > 1 or \
-               keyframe.get("Points", [])[0].get("co", {}).get("Y", 0.0) != default_value
+        return any([
+            len(points) > 1,
+            points[0].get("co", {}).get("Y", default_value) != default_value,
+        ])
 
     def save(self, file_path, move_temp_files=True, make_paths_relative=True):
         """ Save project file to disk """


### PR DESCRIPTION
Hey @jonoomph @JacksonRG 

Shouldn't the check for bad crop data be `openshot_version.startswith("2.5.1")`? Surely some of the development builds had the same issues as the release, no?