### PR TITLE
Set window icon for child windows

### DIFF
--- a/src/windows/about.py
+++ b/src/windows/about.py
@@ -104,9 +104,9 @@ class About(QDialog):
 
     ui_path = os.path.join(info.PATH, 'windows', 'ui', 'about.ui')
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         # Create dialog class
-        QDialog.__init__(self)
+        super().__init__(*args, **kwargs)
 
         # Load UI from designer & init
         ui_util.load_ui(self, self.ui_path)

--- a/src/windows/add_to_timeline.py
+++ b/src/windows/add_to_timeline.py
@@ -377,7 +377,7 @@ class AddToTimeline(QDialog):
             position += (end_time - start_time)
 
         # Accept dialog
-        super(AddToTimeline, self).accept()
+        super().accept()
 
     def ImageLengthChanged(self, value):
         """Handle callback for image length being changed"""
@@ -424,11 +424,11 @@ class AddToTimeline(QDialog):
         log.info('reject')
 
         # Accept dialog
-        super(AddToTimeline, self).reject()
+        super().reject()
 
-    def __init__(self, files=None, position=0.0):
+    def __init__(self, files=None, position=0.0, **kwargs):
         # Create dialog class
-        QDialog.__init__(self)
+        super().__init__(**kwargs)
 
         # Load UI from Designer
         ui_util.load_ui(self, self.ui_path)

--- a/src/windows/animation.py
+++ b/src/windows/animation.py
@@ -40,9 +40,9 @@ class Animation(QDialog):
 
     ui_path = os.path.join(info.PATH, 'windows', 'ui', 'animation.ui')
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         # Create dialog class
-        QDialog.__init__(self)
+        super().__init__(*args, **kwargs)
 
         # Load UI from designer
         ui_util.load_ui(self, self.ui_path)

--- a/src/windows/cutting.py
+++ b/src/windows/cutting.py
@@ -56,11 +56,11 @@ class Cutting(QDialog):
     SpeedSignal = pyqtSignal(float)
     StopSignal = pyqtSignal()
 
-    def __init__(self, file=None, preview=False):
+    def __init__(self, file=None, preview=False, **kwargs):
         _ = get_app()._tr
 
         # Create dialog class
-        QDialog.__init__(self)
+        super().__init__(**kwargs)
 
         # Load UI from designer
         ui_util.load_ui(self, self.ui_path)

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -1029,7 +1029,7 @@ class Export(QDialog):
             self.show()
         else:
             # Accept dialog
-            super(Export, self).accept()
+            super().accept()
 
     def reject(self):
         if self.exporting and not self.close_button.isVisible():
@@ -1049,4 +1049,4 @@ class Export(QDialog):
 
         # Cancel dialog
         self.exporting = False
-        super(Export, self).reject()
+        super().reject()

--- a/src/windows/file_properties.py
+++ b/src/windows/file_properties.py
@@ -47,11 +47,11 @@ class FileProperties(QDialog):
     # Path to ui file
     ui_path = os.path.join(info.PATH, 'windows', 'ui', 'file-properties.ui')
 
-    def __init__(self, file):
+    def __init__(self, file, **kwargs):
         self.file = file
 
         # Create dialog class
-        QDialog.__init__(self)
+        super().__init__(**kwargs)
 
         # Load UI from designer
         ui_util.load_ui(self, self.ui_path)
@@ -195,9 +195,9 @@ class FileProperties(QDialog):
         self.file.save()
 
         # Accept dialog
-        super(FileProperties, self).accept()
+        super().accept()
 
     def reject(self):
 
         # Cancel dialog
-        super(FileProperties, self).reject()
+        super().reject()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -208,7 +208,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             self.SetWindowTitle()
 
             # Show message to user
-            msg = QMessageBox()
+            msg = QMessageBox(self)
             _ = get_app()._tr
             msg.setWindowTitle(_("Backup Recovered"))
             msg.setText(_("Your most recent unsaved project has been recovered."))
@@ -310,7 +310,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def actionAnimatedTitle_trigger(self):
         # show dialog
         from windows.animated_title import AnimatedTitle
-        win = AnimatedTitle()
+        # Not parented, to avoid dimming main window under Linux
+        win = AnimatedTitle(None)
         # Run the dialog event loop - blocking interaction on this window during that time
         result = win.exec_()
         if result == QDialog.Accepted:
@@ -319,9 +320,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             log.info('animated title add cancelled')
 
     def actionAnimation_trigger(self):
-        # show dialog
         from windows.animation import Animation
-        win = Animation()
+        # Not parented, to avoid dimming main window under Linux
+        win = Animation(None)
         # Run the dialog event loop - blocking interaction on this window during that time
         result = win.exec_()
         if result == QDialog.Accepted:
@@ -330,9 +331,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             log.info('animation cancelled')
 
     def actionTitle_trigger(self):
-        # show dialog
         from windows.title_editor import TitleEditor
-        win = TitleEditor()
+        # Not parented, to avoid dimming main window under Linux
+        win = TitleEditor(None)
         # Run the dialog event loop - blocking interaction on this window during that time
         win.exec_()
 
@@ -349,7 +350,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # show dialog for editing title
         from windows.title_editor import TitleEditor
-        win = TitleEditor(edit_file_path=file_path)
+        # Not parented, to avoid dimming main window under Linux
+        win = TitleEditor(None, edit_file_path=file_path)
         # Run the dialog event loop - blocking interaction on this window during that time
         win.exec_()
 
@@ -383,7 +385,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # show dialog for editing title
         from windows.title_editor import TitleEditor
-        win = TitleEditor(edit_file_path=file_path, duplicate=True)
+        # Not parented, to avoid dimming main window under Linux
+        win = TitleEditor(None, edit_file_path=file_path, duplicate=True)
         # Run the dialog event loop - blocking interaction on this window during that time
         return win.exec_()
 
@@ -751,6 +754,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # show window
         from windows.add_to_timeline import AddToTimeline
+        # Not parented, to avoid dimming main window under Linux
         win = AddToTimeline(files, pos)
         # Run the dialog event loop - blocking interaction on this window during this time
         result = win.exec_()
@@ -762,7 +766,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def actionExportVideo_trigger(self, checked=True):
         # show window
         from windows.export import Export
-        win = Export()
+        # Not parented, to avoid dimming main window under Linux
+        win = Export(None)
         # Run the dialog event loop - blocking interaction on this window during this time
         result = win.exec_()
         if result == QDialog.Accepted:
@@ -811,7 +816,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Show dialog
         from windows.preferences import Preferences
-        win = Preferences()
+        # Not parented, to avoid dimming main window under Linux
+        win = Preferences(None)
         # Run the dialog event loop - blocking interaction on this window during this time
         result = win.exec_()
         if result == QDialog.Accepted:
@@ -863,7 +869,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def actionAbout_trigger(self, checked=True):
         """Show about dialog"""
         from windows.about import About
-        win = About()
+        # Not parented, to avoid dimming main window under Linux
+        win = About(None)
         # Run the dialog event loop - blocking interaction on this window during this time
         win.exec_()
 
@@ -1679,7 +1686,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Show dialog
         from windows.profile import Profile
         log.debug("Showing preferences dialog")
-        win = Profile()
+        # Not parented, to avoid dimming main window under Linux
+        win = Profile(None)
         # Run the dialog event loop - blocking interaction on this window during this time
         win.exec_()
         log.debug("Preferences dialog closed")
@@ -1697,6 +1705,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # show dialog
         from windows.cutting import Cutting
+        # Not parented, to avoid dimming main window under Linux
         win = Cutting(f)
         # Run the dialog event loop - blocking interaction on this window during that time
         result = win.exec_()

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -542,7 +542,7 @@ class FilesModel(QObject, updates.UpdateInterface):
         if cur_id:
             return File.get(id=cur_id)
 
-    def __init__(self, *args):
+    def __init__(self, *args, **kwargs):
 
         # Add self as listener to project data updates
         # (undo/redo, as well as normal actions handled within this class all update the model)
@@ -574,7 +574,7 @@ class FilesModel(QObject, updates.UpdateInterface):
             functools.partial(self.update_model, clear=False))
 
         # Call init for superclass QObject
-        super(QObject, FilesModel).__init__(self, *args)
+        super().__init__(*args, **kwargs)
 
         # Attempt to load model testing interface, if requested
         # (will only succeed with Qt 5.11+)

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -56,10 +56,10 @@ class Preferences(QDialog):
     # Path to ui file
     ui_path = os.path.join(info.PATH, 'windows', 'ui', 'preferences.ui')
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
 
         # Create dialog class
-        QDialog.__init__(self)
+        super().__init__(*args, **kwargs)
 
         # Load UI from designer
         ui_util.load_ui(self, self.ui_path)
@@ -639,4 +639,4 @@ class Preferences(QDialog):
             msg.exec_()
 
         # Close dialog
-        super(Preferences, self).reject()
+        super().reject()

--- a/src/windows/process_effect.py
+++ b/src/windows/process_effect.py
@@ -49,13 +49,14 @@ class ProcessEffect(QDialog):
     # Path to ui file
     ui_path = os.path.join(info.PATH, 'windows', 'ui', 'process-effect.ui')
 
-    def __init__(self, clip_id, effect_name, effect_params):
+    def __init__(self, clip_id, effect_name, effect_params, **kwargs):
+
+        # Create dialog class
+        super().__init__(**kwargs)
 
         if not openshot.Clip().COMPILED_WITH_CV:
             raise ModuleNotFoundError("Openshot not compiled with OpenCV")
 
-        # Create dialog class
-        QDialog.__init__(self)
         # Track effect details
         self.clip_id = clip_id
         self.effect_name = effect_name
@@ -243,7 +244,7 @@ class ProcessEffect(QDialog):
             # Attempt to load value from QTextEdit (i.e. multi-line)
             if not value:
                 value = widget.toPlainText()
-        except:
+        except Exception:
             log.debug('Failed to get plain text from widget')
 
         self.context[param["setting"]] = value
@@ -344,12 +345,12 @@ class ProcessEffect(QDialog):
             if (time.time() - start) > 3:
                 self.exporting = False
                 processing.CancelProcessing()
-                while(not processing.IsDone() ):
+                while not processing.IsDone():
                     continue
-                super(ProcessEffect, self).reject()
+                super().reject()
 
         # get processing status
-        while(not processing.IsDone() ):
+        while not processing.IsDone():
             # update progressbar
             progressionStatus = processing.GetProgress()
             self.progressBar.setValue(progressionStatus)
@@ -359,20 +360,20 @@ class ProcessEffect(QDialog):
             QCoreApplication.processEvents()
 
             # if the cancel button was pressed, close the processing thread
-            if(self.cancel_clip_processing):
+            if self.cancel_clip_processing:
                 processing.CancelProcessing()
 
-        if(not self.cancel_clip_processing):
+        if not self.cancel_clip_processing:
             # Load processed data into effect
             self.effect = openshot.EffectInfo().CreateEffect(self.effect_name)
-            self.effect.SetJson( '{"protobuf_data_path": "%s"}' % protobufPath )
+            self.effect.SetJson('{"protobuf_data_path": "%s"}' % protobufPath)
             self.effect.Id(ID)
 
             # Accept dialog
-            super(ProcessEffect, self).accept()
+            super().accept()
 
     def reject(self):
         # Cancel dialog
         self.exporting = False
         self.cancel_clip_processing = True
-        super(ProcessEffect, self).reject()
+        super().reject()

--- a/src/windows/profile.py
+++ b/src/windows/profile.py
@@ -44,10 +44,10 @@ class Profile(QDialog):
     # Path to ui file
     ui_path = os.path.join(info.PATH, 'windows', 'ui', 'profile.ui')
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
 
         # Create dialog class
-        QDialog.__init__(self)
+        super().__init__(*args, **kwargs)
 
         # Load UI from designer & init
         ui_util.load_ui(self, self.ui_path)

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -59,11 +59,11 @@ class SelectRegion(QDialog):
     SpeedSignal = pyqtSignal(float)
     StopSignal = pyqtSignal()
 
-    def __init__(self, file=None, clip=None):
+    def __init__(self, file=None, clip=None, **kwargs):
         _ = get_app()._tr
 
         # Create dialog class
-        QDialog.__init__(self)
+        super().__init__(**kwargs)
 
         # Load UI from designer
         ui_util.load_ui(self, self.ui_path)
@@ -251,7 +251,7 @@ class SelectRegion(QDialog):
 
         self.shutdownPlayer()
         get_app().window.SelectRegionSignal.emit("")
-        super(SelectRegion, self).accept()
+        super().accept()
 
     def shutdownPlayer(self):
 
@@ -277,7 +277,7 @@ class SelectRegion(QDialog):
         # Cancel dialog
         self.shutdownPlayer()
         get_app().window.SelectRegionSignal.emit("")
-        super(SelectRegion, self).reject()
+        super().reject()
 
 
 

--- a/src/windows/ui/preferences.ui
+++ b/src/windows/ui/preferences.ui
@@ -19,6 +19,10 @@
   <property name="windowTitle">
    <string>Preferences</string>
   </property>
+  <property name="windowIcon">
+   <iconset resource="../../../images/openshot.qrc">
+    <normaloff>:/openshot.svg</normaloff>:/openshot.svg</iconset>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <widget class="QLineEdit" name="txtSearch">

--- a/src/windows/ui/process-effect.ui
+++ b/src/windows/ui/process-effect.ui
@@ -19,6 +19,10 @@
   <property name="windowTitle">
    <string>%s: Initialize Effect</string>
   </property>
+  <property name="windowIcon">
+   <iconset resource="../../../images/openshot.qrc">
+    <normaloff>:/openshot.svg</normaloff>:/openshot.svg</iconset>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QScrollArea" name="scrollArea">

--- a/src/windows/ui/profile.ui
+++ b/src/windows/ui/profile.ui
@@ -13,6 +13,10 @@
   <property name="windowTitle">
    <string>Choose Profile</string>
   </property>
+  <property name="windowIcon">
+   <iconset resource="../../../images/openshot.qrc">
+    <normaloff>:/openshot.svg</normaloff>:/openshot.svg</iconset>
+  </property>
   <layout class="QFormLayout" name="formLayout">
    <item row="1" column="0">
     <widget class="QLabel" name="label">

--- a/src/windows/ui/region.ui
+++ b/src/windows/ui/region.ui
@@ -14,7 +14,7 @@
    <string>Select Region</string>
   </property>
   <property name="windowIcon">
-   <iconset>
+   <iconset resource="../../../images/openshot.qrc">
     <normaloff>:/openshot.svg</normaloff>:/openshot.svg</iconset>
   </property>
   <property name="autoFillBackground">
@@ -52,10 +52,10 @@
            <property name="text">
             <string/>
            </property>
-           <property name="icon">
-            <iconset theme="media-playback-start">
-             <normaloff>.</normaloff>.</iconset>
-           </property>
+            <property name="icon">
+             <iconset theme="media-playback-start" resource="../../../images/openshot.qrc">
+              <normaloff>:/icons/Humanity/actions/16/media-playback-start.svg</normaloff>:/icons/Humanity/actions/16/media-playback-start.svg</iconset>
+            </property>
            <property name="checkable">
             <bool>true</bool>
            </property>
@@ -87,8 +87,8 @@
   </layout>
   <action name="actionPlay">
    <property name="icon">
-    <iconset theme="media-playback-start">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="media-playback-start" resource="../../../images/openshot.qrc">
+     <normaloff>:/icons/Humanity/actions/16/media-playback-start.svg</normaloff>:/icons/Humanity/actions/16/media-playback-start.svg</iconset>
    </property>
    <property name="text">
     <string>Play</string>

--- a/src/windows/views/find_file.py
+++ b/src/windows/views/find_file.py
@@ -61,11 +61,15 @@ def find_missing_file(file_path):
             recommended_path = info.HOME_PATH
         else:
             recommended_path = os.path.dirname(recommended_path)
-        QMessageBox.warning(None, _("Missing File (%s)") % file_name,
-                            _("%s cannot be found.") % file_name)
+        QMessageBox.warning(
+            None,
+            _("Missing File (%s)") % file_name,
+            _("%s cannot be found.") % file_name)
         modified = True
-        folder_to_check = QFileDialog.getExistingDirectory(None, _("Find directory that contains: %s" % file_name),
-                                                           recommended_path)
+        folder_to_check = QFileDialog.getExistingDirectory(
+            None,
+            _("Find directory that contains: %s") % file_name,
+            recommended_path)
         if folder_to_check and folder_to_check not in known_paths:
             known_paths.append(folder_to_check)
         if folder_to_check == "":


### PR DESCRIPTION
This PR corrects our child window icons on Windows, as some were failing to show the OpenShot icon. It also cleans up our class argument handling, and eliminates all remaining Python2-style `super(Parent, Child)` calls.

Fixes #4285

Details: 

- I've made sure any UI files that were missing a `windowIcon` property now have it set.

- All of our `QWidget`-derived classes (`QDialog` subclasses, etc.) now
  AT LEAST take `**kwargs` in their `__init__()` methods, to allow for
  arbitrary arguments.

  The ones that didn't already take arguments
  beyond `self`, I added support for both `*args` and `**kwargs`, so that
  they can be called naturally as `SomeDialog(parent, etc...)` in order
  to assign '`parent`' as the parent.

  The ones that already took positional args, I only added `**kwargs`
  at the end, so they'd have to be parented via kwarg:
  ```python3  
  win = SomeDialog(arg, arg2, parent=parent)
  ```
- Though that previous commit added support for parenting to our
  dialog classes, most windows opened from `MainWindow` SHOULD NOT
  be parented to it. If they are, Linux desktops will freeze their
  position in the middle of a dimmed parent window, which is
  inconvenient. There's an old bug somewhere asking us to fix that,
  which we did.

  Because that's not an obvious thing, I've added a comment before
  each window instantiation that should _not_ be parented, explaining
  why. For the ones that take positional args, I've also explicitly
  set '`None`' as the first argument.
