### PR TITLE
Change user 'default.project' filename to 'default.osp', migrate old files if found

### DIFF
--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -77,6 +77,15 @@ for folder in [
     if not os.path.exists(os.fsencode(folder)):
         os.makedirs(folder, exist_ok=True)
 
+# Migrate USER_DEFAULT_PROJECT from former name
+LEGACY_DEFAULT_PROJECT = USER_DEFAULT_PROJECT.replace(".osp", ".project")
+if all([
+    os.path.exists(LEGACY_DEFAULT_PROJECT),
+    not os.path.exists(USER_DEFAULT_PROJECT),
+]):
+    print("Migrating default project file to new name")
+    os.rename(LEGACY_DEFAULT_PROJECT, USER_DEFAULT_PROJECT)
+
 # Maintainer details, for packaging
 JT = {"name": "Jonathan Thomas",
       "email": "jonathan@openshot.org",

--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -65,7 +65,7 @@ PROTOBUF_DATA_PATH = os.path.join(USER_PATH, "protobuf_data")
 YOLO_PATH = os.path.join(USER_PATH, "yolo")
 # User files
 BACKUP_FILE = os.path.join(BACKUP_PATH, "backup.osp")
-USER_DEFAULT_PROJECT = os.path.join(USER_PATH, "default.project")
+USER_DEFAULT_PROJECT = os.path.join(USER_PATH, "default.osp")
 
 # Create user paths if they do not exist
 # (this is where temp files are stored... such as cached thumbnails)


### PR DESCRIPTION
In retrospect, `default.project` was a terrible name for the user default project file. It's so much easier for users to save their own default project right from OpenShot, by using a default filename with an `.osp` extension. This PR corrects the poor choice of expected filename.
