### PR TITLE
Fix Sentry crash on old SDK

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -93,7 +93,6 @@ python_packages = ["os",
                    "zmq",
                    "webbrowser",
                    "json",
-                   "packaging"
                    ]
 
 # Modules to include

--- a/freeze.py
+++ b/freeze.py
@@ -93,6 +93,7 @@ python_packages = ["os",
                    "zmq",
                    "webbrowser",
                    "json",
+                   "packaging"
                    ]
 
 # Modules to include


### PR DESCRIPTION
Openshot fails to start due to missing Sentry methods.

```
➜  openshot-qt    
Loaded modules from: /usr/lib/python3/dist-packages/openshot_qt
Traceback (most recent call last):
  File "/usr/bin/openshot-qt", line 11, in <module>
    load_entry_point('openshot-qt==2.6.0.dev0', 'gui_scripts', 'openshot-qt')()
  File "/usr/lib/python3/dist-packages/openshot_qt/launch.py", line 178, in main
    sentry.init_tracing()
  File "/usr/lib/python3/dist-packages/openshot_qt/classes/sentry.py", line 69, in init_tracing
    sdk.set_tag("system", platform.system())
AttributeError: module 'sentry_sdk' has no attribute 'set_tag'
```

This happens on my machine after updating Openshot from 2.4.3 to 2.6.0, Ubuntu 20.04 using the stable PPA. The problem is that the `set_tag`, `set_user`, etc methods do not exist on sentry-sdk older than `0.13.1`.

For the moment I have commented those methods from `/usr/lib/python3/dist-packages/` on my local installation to make Openshot run. I have then applied this PR locally.

Adding `packaging` is the safest way to handle semver parsing, I have added it to `freeze.py`, but I do not know if that is needed to be added anywhere else.

As a first PR to the project I imagine there might be other aspects I have not covered, just wanted to give it a try to see if you guys were interested.