### PR TITLE
JS: Separate Ctrl, Shift responses to scroll/zoom

### DIFF
--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -52,7 +52,8 @@ App.directive("tlScrollableTracks", function () {
       element.on("wheel",function (e) {
         if (e.ctrlKey) {
           e.preventDefault(); // Don't scroll like a browser
-          if (e.originalEvent.deltaY > 0) { // Scroll down: Zoom out
+          var delta = e.originalEvent.deltaY * (e.shiftKey ? -1 : 1);
+          if (delta > 0) { // Scroll down: Zoom out
             /*global timeline*/
             timeline.zoomOut();
           } else { // Scroll Up: Zoom in
@@ -60,7 +61,7 @@ App.directive("tlScrollableTracks", function () {
             timeline.zoomIn();
           }
         }
-        if (e.shiftKey) {
+        else if (e.shiftKey) {
           let current_scroll = $("#scrolling_tracks").scrollLeft()
           $("#scrolling_tracks").scrollLeft(current_scroll + e.originalEvent.deltaY);
         }


### PR DESCRIPTION
This change will make <kbd>Shift</kbd> reverse the zoom direction, when using <kbd>Ctrl</kbd>+wheel to zoom. (As well as ensuring that <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+wheel doesn't try to _both_ scroll and zoom.)