### PR TITLE
Fix hyperlinks in About dialog, elsewhere?

### DIFF
--- a/src/classes/ui_util.py
+++ b/src/classes/ui_util.py
@@ -130,6 +130,9 @@ def make_dark_palette(darkPalette: QPalette) -> QPalette:
     # Tooltips
     darkPalette.setColor(QPalette.ToolTipBase, QColor(42, 130, 218))
     darkPalette.setColor(QPalette.ToolTipText, Qt.white)
+    # Links
+    darkPalette.setColor(QPalette.Link, QColor(85, 170, 255))
+    darkPalette.setColor(QPalette.LinkVisited, QColor(136, 85, 255))
 
     return darkPalette
 

--- a/src/windows/about.py
+++ b/src/windows/about.py
@@ -139,17 +139,16 @@ class About(QDialog):
             'current_year': str(datetime.datetime.today().year)
             }
         about_html = '''
-            <html><head/><body><hr/>
-            <p align="center">
-            <span style=" font-size:10pt; font-weight:600;">%s</span>
-            </p>
-            <p align="center">
-            <span style=" font-size:10pt;">%s </span>
-            <a href="https://www.openshot.org/%s?r=about-us">
-                <span style=" font-size:10pt; text-decoration: none; color:#55aaff;">%s</span>
-            </a>
-            <span style=" font-size:10pt;">.</span>
-            </p>
+            <html><head/><body style="padding:24px 0;"><hr/>
+            <div align="center" style="margin:12px 0;">
+              <p style="font-size:10pt;font-weight:600;margin-bottom:18px;">
+                %s
+              </p>
+              <p style="font-size:10pt;margin-bottom:12px;">%s
+                <a href="https://www.openshot.org/%s?r=about-us"
+                   style="text-decoration:none;">%s</a>.
+              </p>
+            </div>
             </body></html>
             ''' % (
                 create_text,
@@ -158,15 +157,13 @@ class About(QDialog):
                 learnmore_text)
         company_html = '''
             <html><head/>
-            <body style="font-size:11pt; font-weight:400; font-style:normal;">
+            <body style="font-size:10pt;font-weight:400;font-style:normal;padding:24px 0;">
             <hr />
-            <p align="center"
-               style="margin:12px 12px 0 0; -qt-block-indent:0; text-indent:0;">
-               <span style="font-size:10pt; font-weight:600;">%s </span>
-               <a href="http://www.openshotstudios.com?r=about-us">
-               <span style="font-size:10pt; font-weight:600; text-decoration: none; color:#55aaff;">
-               OpenShot Studios, LLC<br /></span></a>
-            </p>
+            <div style="margin:12px 0;font-weight:600;" align="center">
+              %s
+              <a href="http://www.openshotstudios.com?r=about-us"
+                 style="text-decoration:none;">OpenShot Studios, LLC</a><br/>
+            </div>
             </body></html>
             ''' % (copyright_text)
 
@@ -278,9 +275,7 @@ class Credits(QDialog):
         supporter_html = '''
             <html><head/><body>
             <p align="center">
-                <a href="https://www.openshot.org/%sdonate/?app-about-us">
-                <span style="text-decoration: underline; color:#55aaff;">%s</span>
-                </a>
+              <a href="https://www.openshot.org/%sdonate/?app-about-us">%s</a>
             </p>
             </body></html>
             ''' % (info.website_language(), supporter_text)
@@ -397,9 +392,7 @@ class Changelog(QDialog):
         github_html = '''
             <html><head/><body>
             <p align="center">
-                <a href="https://github.com/OpenShot/">
-                <span style=" text-decoration: underline; color:#55aaff;">%s</span>
-                </a>
+                <a href="https://github.com/OpenShot/">%s</a>
             </p>
             </body></html>
             ''' % (github_text)


### PR DESCRIPTION
@scootergrisen pointed out in #4270 that our links in the About dialog were looking sort of poorly. That's because we had a lot of HTML tags mis-nested (`<br>` inside `<a>`, etc.), and also because we were doing furious amounts of styling directly on tags.

This PR sets the hyperlink color for the dark palette when `ui_utils` first sets it up, eliminating the need for any color styling of link text. It also replaces a lot of HTML `<span>`s with styled `<p> `, styled `<div>`, and styled `<a>`, where appropriate. (Putting `<span>`s and `<br/>`s inside `<a>`s to do formatting is wonky HTML that causes endless problems.)