### PR TITLE
A rewrite of test_translations, adding new features & flexibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,3 @@ jobs:
 
     - name: Test
       run: python3 ./src/tests/query_tests.py -platform minimal
-
-    - name: Translation Test
-      run: python3 ./src/language/test_translations.py

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,0 +1,18 @@
+name: Validate translations
+on: 
+  workflow_dispatch:
+  push:
+    paths: src/language/**
+  pull_request:
+    paths: src/language/**
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - uses: actions/checkout@v2
+    - run: sudo apt install qttranslations5-l10n python3-pyqt5
+    - name: Translation Test
+      run: python3 ./src/language/test_translations.py

--- a/src/language/test_translations.py
+++ b/src/language/test_translations.py
@@ -30,52 +30,153 @@ import os
 import re
 import fnmatch
 import sys
-from PyQt5.QtCore import QLocale, QLibraryInfo, QTranslator, QCoreApplication
+from PyQt5.QtCore import QTranslator, QCoreApplication
 
 
-# Get the absolute path of this project
-language_path = os.path.dirname(os.path.abspath(__file__))
+# Absolute path of the translations directory
+LANG_PATH = os.path.dirname(os.path.abspath(__file__))
 
-# Color for errors
-red='\033[31m'
-endc='\033[0m'
+# Match '%(name)x' format placeholders
+TAG_RE = re.compile(r'%\(([^\)]*)\)(.)')
 
-found_errors = False
+
+class color:
+    """Color for message output"""
+    _red = '\u001b[31m'
+    _yellow = '\u001b[33m'
+    _green = '\u001b[32m'
+    _reset = '\u001b[0m'
+
+    @classmethod
+    def red(cls, *args):
+        return cls._red + str(*args) + cls._reset
+
+    @classmethod
+    def yellow(cls, *args):
+        return cls._yellow + str(*args) + cls._reset
+
+    @classmethod
+    def green(cls, *args):
+        return cls._green + str(*args) + cls._reset
+
 
 # Get app instance
 app = QCoreApplication(sys.argv)
 
-# Load POT template (all English strings)
-all_templates = ['OpenShot.pot', 'OpenShot_transitions.pot', 'OpenShot_blender.pot']
-for template_name in all_templates:
-    POT_source = open(os.path.join(language_path, 'OpenShot', template_name)).read()
-    all_strings = re.findall('^msgid \"(.*)\"', POT_source, re.MULTILINE)
 
-    print("Testing {} strings in {}...".format(len(all_strings), template_name))
+def build_stringlists() -> dict:
+    """ Create a dict containing lists of strings, keyed on source filename"""
+    all_strings = {}
 
-    # Loop through folders/languages
-    for filename in fnmatch.filter(os.listdir(language_path), 'OpenShot*.qm'):
-        lang_code = filename[:-3]
-        # Install language
-        translator = QTranslator(app)
-        app.installTranslator(translator)
+    for pot in [
+        'OpenShot.pot',
+        'OpenShot_transitions.pot',
+        'OpenShot_blender.pot',
+        'OpenShot_emojis.pot',
+    ]:
 
-        # Load translation
-        success = translator.load(lang_code, language_path)
-        if not success:
-            print(red, '%s-%s' % (success, lang_code), endc)
+        with open(os.path.join(LANG_PATH, 'OpenShot', pot)) as f:
+            data = f.read()
+        all_strings.update({
+            pot: re.findall('^msgid \"(.*)\"', data, re.MULTILINE)
+        })
+    return all_strings
 
-        # Loop through all test strings
-        for source_string in all_strings:
-            if "%s" in source_string or "%s(" in source_string or "%d" in source_string:
-                translated_string = app.translate("", source_string)
-                if source_string.count('%') != translated_string.count('%'):
-                    found_errors = True
-                    print(red, '\tInvalid string replacement found: "%s" vs "%s" [%s]' %
-                          (translated_string, source_string, lang_code), endc)
 
-        # Remove translator
-        app.removeTranslator(translator)
+def check_trans(strings: list) -> list:
+    """Check all strings in a list against a given .qm file"""
+    # Test translation of all strings
+    translations = {
+        source: app.translate("", source)
+        for source in strings
+    }
+    # Check for replacements with mismatched number of % escapes
+    errors = {
+        s: t for s, t in translations.items()
+        if any([
+            s.count('%s') != t.count('%s'),
+            s.count('%d') != t.count('%d'),
+            s.count('%f') != t.count('%f')])
+    }
+    # Check for missing/added variable names
+    # e.g.: "%(clip_id)s %(value)d" changed to "%(clip)s %(value)d"
+    # or mismatched types
+    # e.g.: "%(seconds)s" changed to "%(seconds)d"
+    named_variables = {
+        s: (TAG_RE.findall(s), TAG_RE.findall(t))
+        for s, t in translations.items()
+        if s.count('%(') > 0
+    }
+    errors.update({
+        s: translations[s]
+        for s, (s_vars, t_vars) in named_variables.items()
+        if sorted(s_vars) != sorted(t_vars)
+    })
+    return list(errors.items())
 
-if found_errors:
-    raise(Exception("Errors detected during translation testing! See above."))
+
+def process_qm(file, stringlists) -> int:
+    """Scan a translation file against all provided strings"""
+    # Attempt to load translation file
+    basename = os.path.splitext(file)[0]
+    translator = QTranslator(app)
+    if not translator.load(basename, LANG_PATH):
+        print(color.red('QTranslator failed to load') + f' {file}')
+        return 1
+
+    app.installTranslator(translator)
+
+    # Build a dict mapping source POTfiles to lists of error pairs
+    error_sets = {
+        sourcefile: check_trans(strings)
+        for sourcefile, strings in stringlists.items()
+    }
+
+    app.removeTranslator(translator)
+
+    # Display any errors found, grouped by source POT file
+    error_count = sum([len(v) for v in error_sets.values()])
+    if error_count:
+        print(f'{file}: ' + color.red(f'{error_count} total errors'))
+    for pot, errset in error_sets.items():
+        if not errset:
+            continue
+        width = len(pot)
+        msg = "Invalid"
+        for source, trans in errset:
+            print(color.yellow(f'{pot}:') + f' {source}')
+            print(color.red(f'{msg:>{width}}:') + f' {trans}\n')
+    return error_count
+
+
+def scan_all(filenames: list = None) -> int:
+    all_strings = build_stringlists()
+    if not filenames:
+        filenames = fnmatch.filter(os.listdir(LANG_PATH), 'OpenShot*.qm')
+    # Loop through language files and count errors
+    total_errors = sum([
+        process_qm(filename, all_strings)
+        for filename in filenames
+    ])
+
+    string_count = sum([len(s) for s in all_strings.values()])
+    lang_count = len(filenames)
+
+    print(f"Tested {color.yellow(string_count)} strings on "
+          + f"{color.yellow(lang_count)} translation files.")
+    if total_errors > 0:
+        msg = f"Found {total_errors} translation errors! See above."
+        raise Exception(msg)
+    return sum([])
+
+
+# Autorun if used as script
+if __name__ == '__main__':
+    try:
+        string_count = scan_all(sys.argv[1:])
+    except Exception as ex:
+        print(color.red(ex))
+        exit(1)
+    else:
+        print(color.green("No errors found!"))
+        exit(0)


### PR DESCRIPTION
I figure if we're gonna do this, let's really do this. The new `test_translations.py` is modular Python containing functions which can be imported, or it can be run as a standalone script. When run as a script, it will exit with a nonzero exit code when errors are encountered. If imported, the `scan_all()` function will raise an exception on error.

Filenames for one or many `.qm` files can be given on the command line in script mode, to check a certain specific file or group of files. If no arguments are given, it falls back to the same method of scanning the directory, then checks all files.

### Errors detected

The error checking is greatly expanded, and now checks all of the following conditions when comparing source strings to translations:
  - The count of `%s`, `%d`, and `%f` escapes is the same for each
  - If any <code>%(<var>var</var>)<var>x</var></code> named placeholders are used:
    - The translation must use all of the same variable names (<code><var>var</var></code>)
    - The type code (<code><var>x</var></code>) for each named variable must be the same

Raw count of `%` characters is NOT used. It's far too inaccurate, both creating false errors _and_ missing real ones. (Like translations containing `% s` instead of `%s` — we have several of those, it turns out.)

- Counts failure to load any translation file as an error, which will result in non-zero exit status

### Example output

When all is well, it just reports success in green, after a summary of the source string and translation file counts (that's always output, for both success and failure):

![image](https://user-images.githubusercontent.com/538020/138364349-91b4bee1-e4d8-4bbf-b504-3858c3c87a81.png)

If there are problems, they're now shown grouped by `.qm` file, with the name of the `.pot` source shown next to each source string, followed by the bad translation. Here are results from a translation file I deliberately inserted errors into:

![image](https://user-images.githubusercontent.com/538020/138364268-4f376e87-df98-40d5-9c2b-4c84566519f2.png)

### `color` utility class
The color-formatting escapes are now provided via a `color` class, which has classmethods (`color.yellow()` and `color.green()` are added to `color.red()`) that will decorate the string representation of its arguments and return an escape-wrapped string. So, for example, you can do this:

![image](https://user-images.githubusercontent.com/538020/138363456-32cca428-c5b4-4580-96b9-0180ca88a81b.png)