### PR TITLE
Fixing mac OS entitlements for Monterey. It seems pickier now!

### DIFF
--- a/installer/openshot.entitlements
+++ b/installer/openshot.entitlements
@@ -1,8 +1,15 @@
 <plist version="1.0">
 <dict>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
+    <!-- For Python ctypes to work. -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- For loading unsigned dylib plugins. -->
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
-    <key>com.apple.security.get-task-allow</key>
+    <!-- For LLVM. -->
+    <key>com.apple.security.cs.allow-jit</key>
     <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixing mac OS entitlements for Monterey. It seems pickier now when loading python `ctypes module` (crashing with a MemoryError). Found the identical bug fixed in Blender: https://developer.blender.org/T66986.

```
dyld[4378]: <26BB13BD-AAB9-343C-8E8D-0A7D20D51188> /Users/shawn/Desktop/OpenShot Video Editor.app/Contents/MacOS/lib/_ctypes.cpython-37m-darwin.so
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/cx_Freeze-6.4.2-py3.7-macosx-10.15-x86_64.egg/cx_Freeze/initscripts/__startup__.py", line 41, in run
  File "/usr/local/lib/python3.7/site-packages/cx_Freeze-6.4.2-py3.7-macosx-10.15-x86_64.egg/cx_Freeze/initscripts/Console.py", line 36, in run
  File "openshot_qt/launch.py", line 203, in <module>
    main()
  File "openshot_qt/launch.py", line 198, in main
    app.gui()
  File "/Users/shawn/Desktop/OpenShot Video Editor.app/Contents/MacOS/lib/classes/app.py", line 190, in gui
    from classes import language, sentry, ui_util, logger_libopenshot
  File "/Users/shawn/Desktop/OpenShot Video Editor.app/Contents/MacOS/lib/classes/logger_libopenshot.py", line 34, in <module>
    import zmq
  File "/usr/local/lib/python3.7/site-packages/zmq/__init__.py", line 50, in <module>
  File "/usr/local/lib/python3.7/site-packages/zmq/__init__.py", line 16, in _load_libzmq
dyld[4378]: <F64945D3-E0F5-3496-A33F-66C02D2D8ED8> /Users/shawn/Desktop/OpenShot Video Editor.app/Contents/MacOS/lib/unicodedata.cpython-37m-darwin.so
    the Free Software Foundation, either version 3 of the License, or
  File "/usr/local/Cellar/python@3.7/3.7.11/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ctypes/__init__.py", line 551, in <module>
  File "/usr/local/Cellar/python@3.7/3.7.11/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ctypes/__init__.py", line 273, in _reset_cache
MemoryError
```