### PR TITLE
Protect local event arg in JS

### DIFF
--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -583,11 +583,10 @@ App.controller("TimelineCtrl", function ($scope) {
       $scope.selectTransition("", true);
     }
     // Call slice method and exit (don't actually select the clip)
-    if (id !== "" && $scope.enable_razor) {
-      if ($scope.Qt) {
-        var cursor_seconds = $scope.getJavaScriptPosition(event.clientX, null).position;
-        timeline.RazorSliceAtCursor(id, "", cursor_seconds);
-      }
+    if (id !== "" && $scope.enable_razor && $scope.Qt && event) {
+      var cursor_seconds = $scope.getJavaScriptPosition(event.clientX, null).position;
+      timeline.RazorSliceAtCursor(id, "", cursor_seconds);
+
       // Don't actually select clip
       return;
     }
@@ -637,11 +636,10 @@ App.controller("TimelineCtrl", function ($scope) {
       $scope.selectClip("", true);
     }
     // Call slice method and exit (don't actually select the transition)
-    if (id !== "" && $scope.enable_razor) {
-      if ($scope.Qt) {
-        var cursor_seconds = $scope.getJavaScriptPosition(event.clientX, null).position;
-        timeline.RazorSliceAtCursor("", id, cursor_seconds);
-      }
+    if (id !== "" && $scope.enable_razor && $scope.Qt && event) {
+      var cursor_seconds = $scope.getJavaScriptPosition(event.clientX, null).position;
+      timeline.RazorSliceAtCursor("", id, cursor_seconds);
+
       // Don't actually select transition
       return;
     }


### PR DESCRIPTION
Protect local event arg in JS, since it can be undefined or null in certain cases. Related to sentry issue: https://sentry.io/share/issue/90d9593ebfba41449671552abb1c953f/

This bug represents tens of thousands of errors on Sentry