### PR TITLE
Prevent razor on locked tracks

### DIFF
--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1902,15 +1902,17 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
         # Get CLIPS array from IDs
         clips = get_app().project.get("clips")
-        clips = filter( lambda x: x.get("id") in clip_ids, clips)
-        # Get tracks from project
-        locked_tracks = filter( lambda x: x.get("lock") == True, get_app().project.get("layers"))
-        # For t in locked_tracks
-        for t in locked_tracks:
-            # Ignore all clips on that track
-            for c in clips:
-                if int(c.get("layer") / 1000000):
-                    clip_ids.remove(c.get("id"))
+        clips = list(filter(lambda x: x.get("id") in clip_ids, clips))
+        # Get locked tracks from project
+        locked_layers = [
+            t.get("number") // 1000000
+            for t in get_app().project.get("layers")
+            if t.get("lock")
+        ]
+        # Ignore any clips on a locked track
+        for c in clips:
+            if int(c.get("layer") // 1000000) in locked_layers:
+                clip_ids.remove(c.get("id"))
 
         # Get the nearest starting frame position to the playhead (this helps to prevent cutting
         # in-between frames, and thus less likely to repeat or skip a frame).

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1900,6 +1900,18 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         fps_float = fps_num / fps_den
         frame_duration = fps_den / fps_num
 
+        # Get CLIPS array from IDs
+        clips = get_app().project.get("clips")
+        clips = filter( lambda x: x.get("id") in clip_ids, clips)
+        # Get tracks from project
+        locked_tracks = filter( lambda x: x.get("lock") == True, get_app().project.get("layers"))
+        # For t in locked_tracks
+        for t in locked_tracks:
+            # Ignore all clips on that track
+            for c in clips:
+                if int(c.get("layer") / 1000000):
+                    clip_ids.remove(c.get("id"))
+
         # Get the nearest starting frame position to the playhead (this helps to prevent cutting
         # in-between frames, and thus less likely to repeat or skip a frame).
         playhead_position = float(round((playhead_position * fps_num) / fps_den) * fps_den) / fps_num

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1867,6 +1867,16 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
     def RazorSliceAtCursor(self, clip_id, trans_id, cursor_position):
         """Callback from javascript that the razor tool was clicked"""
 
+        #If this clip's track is locked, don't continue
+        print("CLIP ID: ", clip_id, " TYPE: ", type(clip_id))
+        clip = next(filter(lambda x: x.get("id") == clip_id, get_app().project.get("clips")))
+        track_id = int(clip.get("layer", 0) / 1000000) - 1
+        print(track_id)
+        track = get_app().project.get("layers")[track_id]
+        print(track.get("lock"))
+        if track and track.get("lock", False):
+            return
+
         # Determine slice mode (keep both [default], keep left [shift], keep right [ctrl]
         slice_mode = MENU_SLICE_KEEP_BOTH
         if int(QCoreApplication.instance().keyboardModifiers() & Qt.ControlModifier) > 0:
@@ -3220,4 +3230,3 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
         # Delay the start of cache rendering
         QTimer.singleShot(1500, self.cache_renderer.start)
-

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1867,16 +1867,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
     def RazorSliceAtCursor(self, clip_id, trans_id, cursor_position):
         """Callback from javascript that the razor tool was clicked"""
 
-        #If this clip's track is locked, don't continue
-        print("CLIP ID: ", clip_id, " TYPE: ", type(clip_id))
-        clip = next(filter(lambda x: x.get("id") == clip_id, get_app().project.get("clips")))
-        track_id = int(clip.get("layer", 0) / 1000000) - 1
-        print(track_id)
-        track = get_app().project.get("layers")[track_id]
-        print(track.get("lock"))
-        if track and track.get("lock", False):
-            return
-
         # Determine slice mode (keep both [default], keep left [shift], keep right [ctrl]
         slice_mode = MENU_SLICE_KEEP_BOTH
         if int(QCoreApplication.instance().keyboardModifiers() & Qt.ControlModifier) > 0:


### PR DESCRIPTION
I happened to find that clips on locked tracks can be sliced,  so here's a PR to prevent that.

Note: I noticed that layers are stored as multiples of 1 million, so I floor divide the `layer` attribute before comparing, because I suspect that's intended to be used in ordering overlapping clips.