### PR TITLE
detect duration too long

### DIFF
--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -703,8 +703,10 @@ App.controller("TimelineCtrl", function ($scope) {
     return Math.min(32767, desired_width);
   };
 
-// Find the furthest right edge on the timeline (and resize it if too small)
+// Find the furthest right edge on the timeline (and resize it if too small or too large)
   $scope.resizeTimeline = function () {
+    var max_timeline_padding = 20;
+    var min_timeline_padding = 10;
     // Find latest end of a clip
     var furthest_right_edge = 0;
     for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
@@ -715,15 +717,10 @@ App.controller("TimelineCtrl", function ($scope) {
       }
     }
     // Resize timeline
-    if (furthest_right_edge > $scope.project.duration || $scope.project.duration > furthest_right_edge + 20) {
+    if (furthest_right_edge > $scope.project.duration || $scope.project.duration - furthest_right_edge > max_timeline_padding) {
       if ($scope.Qt) {
-        timeline.resizeTimeline(furthest_right_edge + 10);
-        $scope.project.duration = furthest_right_edge + 10;
-      }
-    } else if ( $scope.project.duration - furthest_right_edge > 20) {
-      if ($scope.Qt) {
-        $scope.project.duration = furthest_right_edge;
-        timeline.resizeTimeline(furthest_right_edge);
+        timeline.resizeTimeline(furthest_right_edge + min_timeline_padding);
+        $scope.project.duration = furthest_right_edge + min_timeline_padding;
       }
     }
   };

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -720,6 +720,11 @@ App.controller("TimelineCtrl", function ($scope) {
         timeline.resizeTimeline(furthest_right_edge + 10);
         $scope.project.duration = furthest_right_edge + 10;
       }
+    } else if ( $scope.project.duration - furthest_right_edge > 20) {
+      if ($scope.Qt) {
+        $scope.project.duration = furthest_right_edge;
+        timeline.resizeTimeline(furthest_right_edge);
+      }
     }
   };
 

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -705,8 +705,9 @@ App.controller("TimelineCtrl", function ($scope) {
 
 // Find the furthest right edge on the timeline (and resize it if too small or too large)
   $scope.resizeTimeline = function () {
-    var max_timeline_padding = 20;
-    var min_timeline_padding = 10;
+    let max_timeline_padding = 20;
+    let min_timeline_padding = 10;
+    let min_timeline_length = 300; // Length of the default OpenShot project
     // Find latest end of a clip
     var furthest_right_edge = 0;
     for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
@@ -717,10 +718,11 @@ App.controller("TimelineCtrl", function ($scope) {
       }
     }
     // Resize timeline
-    if (furthest_right_edge > $scope.project.duration || $scope.project.duration - furthest_right_edge > max_timeline_padding) {
+    if (furthest_right_edge > $scope.project.duration - min_timeline_padding || $scope.project.duration - furthest_right_edge > max_timeline_padding) {
       if ($scope.Qt) {
-        timeline.resizeTimeline(furthest_right_edge + min_timeline_padding);
-        $scope.project.duration = furthest_right_edge + min_timeline_padding;
+        let new_timeline_length = Math.max(min_timeline_length, furthest_right_edge + min_timeline_padding);
+        timeline.resizeTimeline(new_timeline_length);
+        $scope.project.duration = new_timeline_length;
       }
     }
   };

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -705,7 +705,7 @@ App.controller("TimelineCtrl", function ($scope) {
 
 // Find the furthest right edge on the timeline (and resize it if too small)
   $scope.resizeTimeline = function () {
-    // Unselect all clips
+    // Find latest end of a clip
     var furthest_right_edge = 0;
     for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
       var clip = $scope.project.clips[clip_index];
@@ -715,7 +715,7 @@ App.controller("TimelineCtrl", function ($scope) {
       }
     }
     // Resize timeline
-    if (furthest_right_edge > $scope.project.duration) {
+    if (furthest_right_edge > $scope.project.duration || $scope.project.duration > furthest_right_edge + 20) {
       if ($scope.Qt) {
         timeline.resizeTimeline(furthest_right_edge + 10);
         $scope.project.duration = furthest_right_edge + 10;

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -492,6 +492,11 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 self.remove_recent_project(file_path)
                 self.load_recent_menu()
 
+            # Ensure that playhead, preview thread, and cache all agree that
+            # Frame 1 is being previewed
+            self.preview_thread.player.Seek(1)
+            self.movePlayhead(1)
+
         except Exception as ex:
             log.error("Couldn't open project %s.", file_path, exc_info=1)
             QMessageBox.warning(self, _("Error Opening Project"), str(ex))

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2918,7 +2918,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
     @pyqtSlot(float)
     def resizeTimeline(self, new_duration):
         """Resize the duration of the timeline"""
-        get_app().updates.update(["duration"], new_duration)
+        get_app().updates.update_untracked(["duration"], new_duration)
 
     # Add Transition
     def addTransition(self, file_ids, event_position):


### PR DESCRIPTION
Goal
---
[This comment](https://github.com/OpenShot/openshot-qt/issues/652#issuecomment-967706719) pointed out that when a very long project is shortened, the duration doesn't decrease. This can cause the zoom slider's tightest zoom to have a resolution of a minute, even if the projects is only a minute long.

They also provided this wonderful demonstration video. :1st_place_medal: 

https://user-images.githubusercontent.com/77164855/141560890-1d428a2f-f9cb-407c-b18f-e95d0d9ebdcb.mp4

Known issues (Fixed :heavy_check_mark:)
---
1. [x] If a project is empty and you try to zoom, it will crash.
2. [x] Resize currently gets added to undo history

# Additional Bug
I noticed when loading a project, the cache would start where the playhead was,
and the playhead would move to 0:00. So I added a line to move the cache to 0:00 as well