### PR TITLE
WIP: Enable export controls after exception

### DIFF
--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -987,6 +987,7 @@ class Export(QDialog):
             msg.setWindowTitle(_("Export Error"))
             msg.setText(_("Sorry, there was an error exporting your video: \n%s") % friendly_error)
             msg.exec_()
+            self.enableControls()
 
         # Notify window of export started
         self.ExportEnded.emit(export_file_path)


### PR DESCRIPTION
Closes #4537

Previously, a user had to close and re-open the export window after encountering an error.

Todos:
---
- [ ] As per Ferdnyc's comment, check that the second export doesn't have some data from the original attempt, before the exception