### PR TITLE
Don't autocreate user dirs immediately when importing classes.info

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -80,7 +80,7 @@ class OpenShotApp(QApplication):
 
         try:
             # Import modules
-            from classes import info, sentry
+            from classes import info
             from classes.logger import log, reroute_output
 
             # Log the session's start
@@ -90,9 +90,9 @@ class OpenShotApp(QApplication):
                 log.info(time.asctime().center(48))
                 log.info('Starting new session'.center(48))
 
-            log.debug("Command line: {}".format(self.args))
+            log.debug("Command line: %s", self.args)
 
-            from classes import settings, project_data, updates
+            from classes import settings, project_data, updates, sentry
             import openshot
 
             # Re-route stdout and stderr to logger

--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -124,7 +124,7 @@ try:
 except ImportError:
     language_path = os.path.join(PATH, 'language')
     print("Compiled translation resources missing!")
-    print("Loading translations from: {}".format(language_path))
+    print(f"Loading translations from: {language_path}")
 
 # Compile language list from :/locale resource
 try:
@@ -192,13 +192,7 @@ SETUP = {
 def setup_userdirs():
     """Create user paths if they do not exist (this is where
     temp files are stored... such as cached thumbnails)"""
-    for folder in [
-            USER_PATH, BACKUP_PATH, RECOVERY_PATH, THUMBNAIL_PATH,
-            CACHE_PATH, BLENDER_PATH, TITLE_PATH, TRANSITIONS_PATH,
-            PREVIEW_CACHE_PATH, USER_PROFILES_PATH, USER_PRESETS_PATH,
-            USER_TITLES_PATH, EMOJIS_PATH, PROTOBUF_DATA_PATH,
-            YOLO_PATH,
-            ]:
+    for folder in _path_defaults.values():
         if not os.path.exists(os.fsencode(folder)):
             os.makedirs(folder, exist_ok=True)
 
@@ -209,6 +203,20 @@ def setup_userdirs():
     ]):
         print("Migrating default project file to new name")
         os.rename(LEGACY_DEFAULT_PROJECT, USER_DEFAULT_PROJECT)
+
+
+def reset_userdirs():
+    """Reset all info.FOO_PATH attributes back to their initial values,
+    as they may have been modified by the runtime code (retargeting
+    info.THUMBNAIL_PATH to a project assets directory, for example)"""
+    for k, v in _path_defaults.items():
+        globals()[k] = v
+
+
+def get_default_path(varname):
+    """Return the default value of the named info.FOO_PATH attribute,
+    even if it's been modified"""
+    return _path_defaults.get(varname, None)
 
 
 def website_language():

--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -68,6 +68,13 @@ BACKUP_FILE = os.path.join(BACKUP_PATH, "backup.osp")
 USER_DEFAULT_PROJECT = os.path.join(USER_PATH, "default.osp")
 LEGACY_DEFAULT_PROJECT = USER_DEFAULT_PROJECT.replace(".osp", ".project")
 
+# Back up "default" values for user paths
+_path_defaults = {
+    k: v for k, v in locals().items()
+    if k.endswith("_PATH")
+    and v.startswith(USER_PATH)
+}
+
 try:
     from PyQt5.QtCore import QSize
 

--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -66,27 +66,7 @@ YOLO_PATH = os.path.join(USER_PATH, "yolo")
 # User files
 BACKUP_FILE = os.path.join(BACKUP_PATH, "backup.osp")
 USER_DEFAULT_PROJECT = os.path.join(USER_PATH, "default.osp")
-
-# Create user paths if they do not exist
-# (this is where temp files are stored... such as cached thumbnails)
-for folder in [
-    USER_PATH, BACKUP_PATH, RECOVERY_PATH, THUMBNAIL_PATH, CACHE_PATH,
-        BLENDER_PATH, TITLE_PATH, TRANSITIONS_PATH, PREVIEW_CACHE_PATH,
-        USER_PROFILES_PATH, USER_PRESETS_PATH, USER_TITLES_PATH, EMOJIS_PATH,
-        PROTOBUF_DATA_PATH, YOLO_PATH]:
-    try:
-        if not os.path.exists(os.fsencode(folder)):
-            os.makedirs(folder, exist_ok=True)
-    except PermissionError:
-        # Fail gracefully if we have no permission to create these folders
-        # This happens on build servers, such as Launchpad (imported by Sphinx)
-        print(f"Failed to create `{folder}` folder due to permissions (ignoring exception)")
-
-# Migrate USER_DEFAULT_PROJECT from former name
 LEGACY_DEFAULT_PROJECT = USER_DEFAULT_PROJECT.replace(".osp", ".project")
-if all([os.path.exists(LEGACY_DEFAULT_PROJECT), not os.path.exists(USER_DEFAULT_PROJECT)]):
-    print("Migrating default project file to new name")
-    os.rename(LEGACY_DEFAULT_PROJECT, USER_DEFAULT_PROJECT)
 
 try:
     from PyQt5.QtCore import QSize
@@ -122,11 +102,6 @@ LOG_LEVEL_CONSOLE = 'INFO'
 # Web backend selection, overridable at launch
 WEB_BACKEND = 'auto'
 
-# Languages
-CMDLINE_LANGUAGE = None
-CURRENT_LANGUAGE = 'en_US'
-SUPPORTED_LANGUAGES = ['en_US']
-
 # Sentry.io error reporting rate (0.0 TO 1.0)
 # 0.0 = no error reporting to Sentry
 # 0.5 = 1/2 of errors reported to Sentry
@@ -137,6 +112,11 @@ SUPPORTED_LANGUAGES = ['en_US']
 ERROR_REPORT_RATE_STABLE = 0.0
 ERROR_REPORT_RATE_UNSTABLE = 0.0
 ERROR_REPORT_STABLE_VERSION = None
+
+# Languages
+CMDLINE_LANGUAGE = None
+CURRENT_LANGUAGE = 'en_US'
+SUPPORTED_LANGUAGES = ['en_US']
 
 try:
     from language import openshot_lang
@@ -209,6 +189,28 @@ SETUP = {
     }
 }
 
+def setup_userdirs():
+    """Create user paths if they do not exist (this is where
+    temp files are stored... such as cached thumbnails)"""
+    for folder in [
+            USER_PATH, BACKUP_PATH, RECOVERY_PATH, THUMBNAIL_PATH,
+            CACHE_PATH, BLENDER_PATH, TITLE_PATH, TRANSITIONS_PATH,
+            PREVIEW_CACHE_PATH, USER_PROFILES_PATH, USER_PRESETS_PATH,
+            USER_TITLES_PATH, EMOJIS_PATH, PROTOBUF_DATA_PATH,
+            YOLO_PATH,
+            ]:
+        if not os.path.exists(os.fsencode(folder)):
+            os.makedirs(folder, exist_ok=True)
+
+    # Migrate USER_DEFAULT_PROJECT from former name
+    if all([
+        os.path.exists(LEGACY_DEFAULT_PROJECT),
+        not os.path.exists(USER_DEFAULT_PROJECT),
+    ]):
+        print("Migrating default project file to new name")
+        os.rename(LEGACY_DEFAULT_PROJECT, USER_DEFAULT_PROJECT)
+
+
 def website_language():
     """Get the current website language code for URLs"""
     return {
@@ -216,3 +218,4 @@ def website_language():
         "zh_TW": "zh-hant/",
         "en_US": ""}.get(CURRENT_LANGUAGE,
                          "%s/" % CURRENT_LANGUAGE.split("_")[0].lower())
+

--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -213,9 +213,7 @@ class JsonDataStore:
             msg = "Couldn't load {} file".format(self.data_type)
             log.error(msg, exc_info=1)
             raise Exception(msg) from ex
-        msg = ()
-        log.warning(msg)
-        raise Exception(msg)
+        raise Exception("Unknown error (should be unreachable)")
 
     def write_to_file(self, file_path, data, path_mode="ignore", previous_path=None):
         """ Save JSON settings to a file """
@@ -229,7 +227,7 @@ class JsonDataStore:
         except Exception as ex:
             msg = "Couldn't save {} file:\n{}\n{}".format(self.data_type, file_path, ex)
             log.error(msg)
-            raise Exception(msg)
+            raise ex
 
     def replace_string_to_absolute(self, match):
         """Replace matched string for converting paths to relative paths"""

--- a/src/classes/logger.py
+++ b/src/classes/logger.py
@@ -80,14 +80,19 @@ log.propagate = False
 #
 # Create rotating file handler
 #
-fh = logging.handlers.RotatingFileHandler(
-         os.path.join(info.USER_PATH, 'openshot-qt.log'),
-         encoding="utf-8",
-         maxBytes=25*1024*1024, backupCount=3)
-fh.setLevel(info.LOG_LEVEL_FILE)
-fh.setFormatter(file_formatter)
-
-log.addHandler(fh)
+if os.path.exists(info.USER_PATH):
+    fh = logging.handlers.RotatingFileHandler(
+             os.path.join(info.USER_PATH, 'openshot-qt.log'),
+             encoding="utf-8",
+             maxBytes=25*1024*1024, backupCount=3)
+    fh.setLevel(info.LOG_LEVEL_FILE)
+    fh.setFormatter(file_formatter)
+    log.addHandler(fh)
+else:
+    class DummyHandler:
+        def setLevel(self, level):
+            return True
+    fh = DummyHandler()
 
 #
 # Create typical stream handler which logs to stderr
@@ -120,3 +125,4 @@ def set_level_file(level=logging.INFO):
 def set_level_console(level=logging.INFO):
     """Adjust the minimum log level for output to the terminal"""
     sh.setLevel(level)
+

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -131,9 +131,9 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
                 # If next part of path isn't in current dictionary, return failure
                 if key_part not in obj:
-                    log.warn("Key not found in project. Mismatch on key part {} (\"{}\").\nKey: {}".format((key_index),
-                                                                                                           key_part,
-                                                                                                           key))
+                    log.warn(
+                        'Key not found in project. Mismatch on key part %s ("%s").\nKey: %s',
+                        key_index, key_part, key)
                     return None
 
                 # Get the matching item
@@ -150,7 +150,8 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         """ Store setting, but adding isn't allowed. All possible settings must be in default settings file. """
 
         log.info(
-            "_set key: {} values: {} add: {} partial: {} remove: {}".format(key, values, add, partial_update, remove))
+            "_set key: %s values: %s add: %s partial: %s remove: %s",
+            key, values, add, partial_update, remove)
         parent, my_key = None, ""
 
         # Verify key is valid type
@@ -170,7 +171,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
             # Key_part must be a string or dictionary
             if not isinstance(key_part, dict) and not isinstance(key_part, str):
-                log.error("Unexpected key part type: {}".format(type(key_part).__name__))
+                log.error("Unexpected key part type: %s", type(key_part).__name__)
                 return None
 
             # If key_part is a dictionary and obj is a list or dict, each key is tested as a property of the items in the current object
@@ -212,7 +213,9 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
                 # If next part of path isn't in current dictionary, return failure
                 if key_part not in obj:
-                    log.warn("Key not found in project. Mismatch on key part {} (\"{}\").\nKey: {}".format((key_index), key_part, key))
+                    log.warn(
+                        'Key not found in project. Mismatch on key part %s ("%s").\nKey: %s',
+                        key_index, key_part, key)
                     return None
 
                 # Get sub-object based on part key as new object, continue to next part
@@ -262,11 +265,14 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             try:
                 self._data = self.read_from_file(info.USER_DEFAULT_PROJECT)
             except (FileNotFoundError, PermissionError):
-                log.warning("Unable to load user project defaults from %s", info.USER_DEFAULT_PROJECT, exc_info=1)
+                log.warning(
+                    "Unable to load user project defaults from %s",
+                    info.USER_DEFAULT_PROJECT, exc_info=1)
             except Exception:
                 raise
             else:
-                log.info("Loaded user project defaults from {}".format(info.USER_DEFAULT_PROJECT))
+                log.info("Loaded user project defaults from %s",
+                         info.USER_DEFAULT_PROJECT)
         else:
             # Fall back to OpenShot defaults, if user defaults didn't load
             self._data = self.read_from_file(self.default_project_filepath)
@@ -284,7 +290,9 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         default_profile = s.get("default-profile")
 
         # Loop through profiles
-        for profile_folder in [info.USER_PROFILES_PATH, info.PROFILES_PATH]:
+        profile_dirs = [info.USER_PROFILES_PATH, info.PROFILES_PATH]
+        available_dirs = [f for f in profile_dirs if os.path.exists(f)]
+        for profile_folder in available_dirs:
             for file in os.listdir(profile_folder):
                 profile_path = os.path.join(profile_folder, file)
                 try:
@@ -343,7 +351,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         self.new()
 
         if file_path:
-            log.info("Loading project file: {}".format(file_path))
+            log.info("Loading project file: %s", file_path)
 
             # Default project data
             default_project = self._data
@@ -662,7 +670,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             raise RuntimeError("Failed to load the following files:\n%s" % ", ".join(failed_files))
 
         # Return mostly empty project_data dict (with just the current version #)
-        log.info("Successfully loaded legacy project file: %s" % file_path)
+        log.info("Successfully loaded legacy project file: %s", file_path)
         return project_data
 
     def upgrade_project_data_structures(self):
@@ -670,7 +678,8 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         openshot_version = self._data["version"]["openshot-qt"]
         libopenshot_version = self._data["version"]["libopenshot"]
 
-        log.info("Project data: openshot {}, libopenshot {}".format(openshot_version, libopenshot_version))
+        log.info("Project data: openshot %s, libopenshot %s",
+                 openshot_version, libopenshot_version)
 
         if openshot_version == "0.0.0":
             # If version = 0.0.0, this is the beta of OpenShot
@@ -778,7 +787,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         """ Save project file to disk """
         import openshot
 
-        log.info("Saving project file: {}".format(file_path))
+        log.info("Saving project file: %s", file_path)
 
         # Move all temp files (i.e. Blender animations) to the project folder
         if move_temp_files:
@@ -851,56 +860,59 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             # Copy any necessary assets for File records
             for file in self._data["files"]:
                 path = file["path"]
+                file_id = file["id"]
 
                 # For now, store thumbnail path for backwards compatibility
-                file["image"] = os.path.join(target_thumb_path, "{}.png".format(file["id"]))
+                file["image"] = os.path.join(target_thumb_path, f"{file_id}.png")
 
                 # Assets which need to be copied
                 new_asset_path = None
                 if info.BLENDER_PATH in path:
                     # Copy directory of blender files
-                    log.info("Copying {}".format(path))
+                    log.info("Copying %s", path)
                     old_dir, asset_name = os.path.split(path)
                     if os.path.isdir(old_dir) and old_dir not in copied:
                         # Copy dir into new folder
                         old_dir_name = os.path.basename(old_dir)
                         copied.append(old_dir)
-                        log.info("Copied dir {} to {}.".format(old_dir_name, target_blender_path))
+                        log.info("Copied dir %s to %s", old_dir_name, target_blender_path)
                     new_asset_path = os.path.join(target_blender_path, old_dir_name, asset_name)
 
                 if info.TITLE_PATH in path:
                     # Copy title files into assets folder
-                    log.info("Copying {}".format(path))
+                    log.info("Copying %s", path)
                     old_dir, asset_name = os.path.split(path)
                     if asset_name not in copied:
                         # Copy title into assets title folder
                         copied.append(asset_name)
-                        log.info("Copied title {} to {}.".format(asset_name, target_title_path))
+                        log.info("Copied title %s to %s", asset_name, target_title_path)
                     new_asset_path = os.path.join(target_title_path, asset_name)
 
                 # Update path in File object to new location
                 if new_asset_path:
                     file["path"] = new_asset_path
-                    file_id = file["id"]
                     reader_paths[file_id] = new_asset_path
-                    log.info("Set file {} path to {}".format(file_id, new_asset_path))
+                    log.info("Set file %s path to %s", file_id, new_asset_path)
 
             # Copy all Clip thumbnails and update reader paths
             for clip in self._data["clips"]:
                 file_id = clip["file_id"]
+                clip_id = clip["id"]
 
                 # For now, store thumbnail path for backwards compatibility
-                clip["image"] = os.path.join(target_thumb_path, "{}.png".format(file_id))
+                clip["image"] = os.path.join(target_thumb_path, f"{file_id}.png")
 
-                log.info("Checking clip {} path for file {}".format(clip["id"], file_id))
+                log.info("Checking clip %s path for file %s", clip_id, file_id)
                 # Update paths to files stored in our working space or old path structure
                 # (should have already been copied during previous File stage)
                 if file_id and file_id in reader_paths:
                     clip["reader"]["path"] = reader_paths[file_id]
-                    log.info("Updated clip {} path for file {}".format(clip["id"], file_id))
+                    log.info("Updated clip %s path for file %s", clip_id, file_id)
 
         except Exception:
-            log.error("Error while moving temp paths to project assets folder %s", asset_path, exc_info=1)
+            log.error(
+                "Error while moving temp paths to project assets folder %s",
+                asset_path, exc_info=1)
 
     def add_to_recent_files(self, file_path):
         """ Add this project to the recent files list """
@@ -949,7 +961,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             path = file["path"]
             parent_path, file_name_with_ext = os.path.split(path)
 
-            log.info("checking file %s" % path)
+            log.info("checking file %s", path)
             if not os.path.exists(path) and "%" not in path:
                 # File is missing
                 path, is_modified, is_skipped = find_missing_file(path)
@@ -957,10 +969,10 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                     # Found file, update path
                     file["path"] = path
                     get_app().updates.update_untracked(["import_path"], os.path.dirname(path))
-                    log.info("Auto-updated missing file: %s" % path)
+                    log.info("Auto-updated missing file: %s", path)
                 elif is_skipped:
                     # Remove missing file
-                    log.info('Removed missing file: %s' % file_name_with_ext)
+                    log.info('Removed missing file: %s', file_name_with_ext)
                     self._data["files"].remove(file)
 
         # Loop through each clip (in reverse order)
@@ -975,10 +987,10 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                 if path and is_modified and not is_skipped:
                     # Found file, update path
                     clip["reader"]["path"] = path
-                    log.info("Auto-updated missing file: %s" % clip["reader"]["path"])
+                    log.info("Auto-updated missing file: %s", clip["reader"]["path"])
                 elif is_skipped:
                     # Remove missing file
-                    log.info('Removed missing clip: %s' % file_name_with_ext)
+                    log.info('Removed missing clip: %s', file_name_with_ext)
                     self._data["clips"].remove(clip)
 
     def changed(self, action):

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -280,10 +280,8 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         self.current_filepath = None
         self.has_unsaved_changes = False
 
-        # Reset info paths
-        info.THUMBNAIL_PATH = os.path.join(info.USER_PATH, "thumbnail")
-        info.TITLE_PATH = os.path.join(info.USER_PATH, "title")
-        info.BLENDER_PATH = os.path.join(info.USER_PATH, "blender")
+        # Reset info paths back to their default/initial values
+        info.reset_userdirs()
 
         # Get default profile
         s = get_app().get_settings()
@@ -392,7 +390,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             self.check_if_paths_are_valid()
 
             # Clear old thumbnails
-            openshot_thumbnails = os.path.join(info.USER_PATH, "thumbnails")
+            openshot_thumbnails = info.get_default_path("THUMBNAIL_PATH")
             if os.path.exists(openshot_thumbnails) and clear_thumbnails:
                 # Clear thumbnails
                 shutil.rmtree(openshot_thumbnails, True)

--- a/src/classes/sentry.py
+++ b/src/classes/sentry.py
@@ -28,7 +28,6 @@
 
 import platform
 
-from classes.logger import log
 from classes import info
 
 try:
@@ -57,7 +56,7 @@ def init_tracing():
         environment = "unstable"
 
     if info.ERROR_REPORT_STABLE_VERSION:
-        log.info("Sentry initialized with %s error reporting rate (%s)" % (traces_sample_rate, environment))
+        print("Sentry initialized with %s error reporting rate (%s)" % (traces_sample_rate, environment))
 
     # Initialize sentry exception tracing
     sdk.init(

--- a/src/launch.py
+++ b/src/launch.py
@@ -144,14 +144,15 @@ def main():
 
     if args.py_path:
         for p in args.py_path:
+            newpath = os.path.realpath(p)
             try:
-                if os.path.exists(os.path.realpath(p)):
-                    sys.path.insert(0, os.path.realpath(p))
-                    print("Added {} to PYTHONPATH".format(os.path.realpath(p)))
+                if os.path.exists(newpath):
+                    sys.path.insert(0, newpath)
+                    print(f"Added {newpath} to PYTHONPATH")
                 else:
-                    print("{} does not exist".format(os.path.realpath(p)))
+                    print(f"{newpath} does not exist")
             except TypeError as ex:
-                print("Bad path {}: {}".format(p, ex))
+                print(f"Bad path {newpath}: {ex}")
                 continue
 
     if args.modeltest:
@@ -165,15 +166,18 @@ def main():
         if args.lang in info.SUPPORTED_LANGUAGES:
             info.CMDLINE_LANGUAGE = args.lang
         else:
-            print("Unsupported language '{}'! (See --list-languages)".format(args.lang))
+            print(f"Unsupported language '{args.lang}'! (See --list-languages)")
             sys.exit(-1)
 
     # Normal startup, print module path and lauch application
-    print("Loaded modules from: %s" % info.PATH)
+    print(f"Loaded modules from: {info.PATH}")
 
     # Initialize sentry exception tracing
     from classes import sentry
     sentry.init_tracing()
+
+    # Create any missing paths in the user's settings dir
+    info.setup_userdirs()
 
     # Create Qt application, pass any unprocessed arguments
     from classes.app import OpenShotApp
@@ -188,7 +192,7 @@ def main():
 
     # Setup Qt application details
     app.setApplicationName('openshot')
-    app.setApplicationVersion(info.SETUP['version'])
+    app.setApplicationVersion(info.VERSION)
     try:
         # Qt 5.7+ only
         app.setDesktopFile("org.openshot.OpenShot")

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -130,7 +130,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.tutorial_manager.hide_dialog()
 
         # Prompt user to save (if needed)
-        if app.project.needs_save() and self.mode != "unittest":
+        if app.project.needs_save():
             log.info('Prompt user to save project')
             # Translate object
             _ = app._tr
@@ -2828,11 +2828,10 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.emojiListView = EmojisListView(self.emojis_model)
         self.tabEmojis.layout().addWidget(self.emojiListView)
 
-    def __init__(self, *args, mode=None):
+    def __init__(self, *args):
 
         # Create main window base class
         super().__init__(*args)
-        self.mode = mode    # None or unittest (None is normal usage)
         self.initialized = False
 
         # set window on app for reference during initialization of children
@@ -2891,8 +2890,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         get_current_Version()
 
         # Connect signals
-        if self.mode != "unittest":
-            self.RecoverBackup.connect(self.recover_backup)
+        self.RecoverBackup.connect(self.recover_backup)
 
         # Initialize and start the thumbnail HTTP server
         self.http_server_thread = httpThumbnailServerThread()

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -69,8 +69,7 @@ class PreviewParent(QObject):
         _ = get_app()._tr
 
         # Only JUCE audio errors bubble up here now
-        if get_app().window.mode != "unittest":
-            QMessageBox.warning(self.parent, _("Audio Error"), _("Please fix the following error and restart OpenShot\n%s") % error)
+        QMessageBox.warning(self.parent, _("Audio Error"), _("Please fix the following error and restart OpenShot\n%s") % error)
 
     @pyqtSlot(object, object)
     def Init(self, parent, timeline, video_widget):

--- a/src/windows/views/emojis_listview.py
+++ b/src/windows/views/emojis_listview.py
@@ -183,6 +183,5 @@ class EmojisListView(QListView):
                 # Off by one, due to 'show all' choice above
                 dropdown_index = index + 1
 
-        if self.win.mode != "unittest":
-            self.win.emojiFilterGroup.currentIndexChanged.connect(self.group_changed)
+        self.win.emojiFilterGroup.currentIndexChanged.connect(self.group_changed)
         self.win.emojiFilterGroup.setCurrentIndex(dropdown_index)


### PR DESCRIPTION
Our PPA builds for 2.6.1 are currently broken in Launchpad, because I turned on documentation building which immediately crashed. The problem is that the Sphinx config does an import of `classes.info` to get the OpenShot version, and as soon as it's imported `classes.info` attempts to create all of the preferences directories in `$HOME/.openshot_qt`, a no-no during package builds.

I assume this is also why the unit tests are disabled, in the launchpad configs.

All of this makes the point, though, that we **SHOULDN'T BE** creating a ton of directories simply because a class was _imported_ — especially not one we import _everywhere_, from `setup.py` to `doc/conf.py` to `freeze.py` to `src/tests/query_tests.py`. That's an unacceptable side-effect for a class that's intended as merely a metadata dumping ground.

So, these commits move the creation of directories into a function within `classes.info`, `setup_userdirs()`, which `launch.py` calls immediately prior to setting up the `OpenShotApp` instance. All of the other scripts that import the class _won't_ call it, so they don't trigger the creation of a bunch of unnecessary settings dirs as a side-effect.

To make this work, I had to rearrange a bunch of things in `classes.settings`, `classes.logger`, `classes.project`, and `classes.app` so that they could handle the user preferences dir being entirely absent, since the unit tests need to be able to import `classes.app` and create an `OpenShotApp` instance without ever calling `classes.info.setup_userdirs()`.

I also removed the load of `classes.logger` from `classes.sentry` — if that's going to be loaded at the _very start_ of the launch script, it can't trigger the initialization of the logging class. It's too early. So it just does a `print()` of the info instead, same as how `launch.py` handles its own output.

And I removed all references to the `mode` from the GUI code, as the unit tests haven't started the GUI for some time now. `window.mode` will never be `"unittest"` under any circumstances, anymore. (`app.mode` is still used by the unit tests to adjust certain startup functionality, so it's still there. Also it's now set as an instance variable, so if any of the code ever _does_ need to check the mode, it can test `if get_app().mode == "unittest"`.)

With these changes, it's now possible to do all of these things:
* Build, install, or package the application
* Build the user manual
* Run the unit tests

...WITHOUT triggering the creation of `$HOME/.openshot_qt/` and its many, many subdirs.

Unfortunately I wasn't able to arrange things so that OpenShot itself could run **entirely** without a user dir as a 0-footprint application. That's something I see value in (temporary files would just be written to system default tempdirs, is the idea) since it would allow use of OpenShot in all sorts of scenarios where writing to `$HOME/.openshot_qt` is not feasible, permitted, or desired. But, it's a bigger undertaking that shouldn't hold up these changes.

#### Update

I added a few more commits:

1. `classes.info` now captures all of the initial defaults for user paths. (Any variable with a name that ends with `_PATH`, and a value that matches `info.USER_PATH` at the start is placed into the `info._path_defaults` dict.)
    * That captured dict is now used in `info.setup_userdirs()` (replacing the hardcoded list of variables representing paths to be created)
    * The defaults can be _reapplied_ to reset any modified `info` paths, by calling `info.reset_paths()`.
    * The default value for a path can be retrieved even if the current value has been modified, by calling `info.get_default_path("NAME_OF_VAR")`.
    * Most (hopefully all, but I can't promise that) of the rest of the code that was responsible for resetting `info` paths now does so by simply calling `info.reset_paths()`. 
    * Code that had to ad-hoc things like `os.path.join(info.USER_PATH, "thumbnails")` to work around a modified `info.THUMBNAIL_PATH` now instead just calls `info.get_default_path("THUMBNAIL_PATH")`.

1. I re-worked the autosave code a bit. The `project.save()` method, which used to have two parameters `make_paths_relative` and `move_temp_files`, now has only one: `backup_only`. Setting `backup_only=True` implies both of the previous parameters _`False`_, and also disables some additional logic that's undesirable when making a backup. (Like the storing of `current_filepath` and the resetting of `has_unsaved_changes`, both of which were previously being done in `project.save()`, then immediately **un**-done by the autosave code that called it. Now it's never done in the first place, because `backup_only=True` is passed in with the call.)

1. I renamed `MainWindow.clear_all_thumbnails()` to `MainWindow.clear_temporary_files()`, because I just couldn't abide the previous name for a function that not only cleared _three_ different types of working file, but also deleted the (previous) backup file! A name that bad was just asking for someone to make a wrong assumption, possibly with consequences.
