### PR TITLE
Fixed playhead sliding

### DIFF
--- a/src/timeline/js/directives/playhead.js
+++ b/src/timeline/js/directives/playhead.js
@@ -67,6 +67,9 @@ App.directive("tlPlayhead", function () {
             new_position = results.position.left;
           }
 
+          // contrain playhead position
+          new_position = Math.max(0, new_position);
+
           // Move playhead
           let playhead_seconds = new_position / scope.pixelsPerSecond;
           scope.movePlayhead(playhead_seconds);

--- a/src/timeline/js/directives/playhead.js
+++ b/src/timeline/js/directives/playhead.js
@@ -43,6 +43,15 @@ App.directive("tlPlayhead", function () {
         setBoundingBox(scope, $(this), "playhead");
       });
 
+      // after clicking on playhead all pointer events are redirected to it
+      element.on("pointerdown", function(e){
+        element[0].setPointerCapture(e.originalEvent.pointerId)
+      })
+      // stop after releasing
+      element.on("pointerup", function(e){
+        element[0].releasePointerCapture(e.originalEvent.pointerId)
+      })
+
       // Move playhead to new position (if it's not currently being animated)
       element.on("mousemove", function (e) {
         if (e.which === 1 && !scope.playhead_animating) { // left button

--- a/src/timeline/js/directives/playhead.js
+++ b/src/timeline/js/directives/playhead.js
@@ -45,12 +45,12 @@ App.directive("tlPlayhead", function () {
 
       // after clicking on playhead all pointer events are redirected to it
       element.on("pointerdown", function(e){
-        element[0].setPointerCapture(e.originalEvent.pointerId)
-      })
+        element[0].setPointerCapture(e.originalEvent.pointerId);
+      });
       // stop after releasing
       element.on("pointerup", function(e){
-        element[0].releasePointerCapture(e.originalEvent.pointerId)
-      })
+        element[0].releasePointerCapture(e.originalEvent.pointerId);
+      });
 
       // Move playhead to new position (if it's not currently being animated)
       element.on("mousemove", function (e) {

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -207,6 +207,9 @@ App.directive("tlRuler", function ($timeout) {
             new_position = results.position.left;
           }
 
+          // contrain playhead position
+          new_position = Math.max(0, new_position);
+
           // Move playhead
           let playhead_seconds = new_position / scope.pixelsPerSecond;
           scope.movePlayhead(playhead_seconds);

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -184,12 +184,12 @@ App.directive("tlRuler", function ($timeout) {
 
       // after clicking on ruler all pointer events are redirected to it
       element.on("pointerdown", function(e){
-        element[0].setPointerCapture(e.originalEvent.pointerId)
-      })
+        element[0].setPointerCapture(e.originalEvent.pointerId);
+      });
       // stop after releasing
       element.on("pointerup", function(e){
-        element[0].releasePointerCapture(e.originalEvent.pointerId)
-      })
+        element[0].releasePointerCapture(e.originalEvent.pointerId);
+      });
 
       // Move playhead to new position (if it's not currently being animated)
       element.on("mousemove", function (e) {

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -182,6 +182,15 @@ App.directive("tlRuler", function ($timeout) {
         setBoundingBox(scope, $(this), "playhead");
       });
 
+      // after clicking on ruler all pointer events are redirected to it
+      element.on("pointerdown", function(e){
+        element[0].setPointerCapture(e.originalEvent.pointerId)
+      })
+      // stop after releasing
+      element.on("pointerup", function(e){
+        element[0].releasePointerCapture(e.originalEvent.pointerId)
+      })
+
       // Move playhead to new position (if it's not currently being animated)
       element.on("mousemove", function (e) {
         if (e.which === 1 && !scope.playhead_animating) { // left button


### PR DESCRIPTION
Previously when sliding the playhead you have to keep your mouse in the narrow ruler, in many other applications after clicking and holding a slider you can slide it even when the mouse leaves slider.
Now when when onpointerdown (which includes the mouse) is fired on the playhead or ruler it captures all pointer events and gives them to the playhead so you can slide it when the mouse is not directly over it.