### PR TITLE
Update Preferences for new Audio Device types

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -202,7 +202,7 @@ if sys.platform == "win32":
     extra_exe = {"base": None, "name": exe_name + "-cli.exe"}
 
     # Standard graphical Win32 launcher
-    base = "Win32GUI"
+    base = None # Force CMD window
     build_exe_options["include_msvcr"] = True
     exe_name += ".exe"
 

--- a/freeze.py
+++ b/freeze.py
@@ -202,7 +202,7 @@ if sys.platform == "win32":
     extra_exe = {"base": None, "name": exe_name + "-cli.exe"}
 
     # Standard graphical Win32 launcher
-    base = None # Force CMD window
+    base = "Win32GUI"
     build_exe_options["include_msvcr"] = True
     exe_name += ".exe"
 

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -278,9 +278,8 @@ class Preferences(QDialog):
                         value_list.append({"name": "Default", "value": ""})
                         for audio_device in get_app().window.preview_thread.player.GetAudioDeviceNames():
                             value_list.append({
-                                "name": "%s: %s" % (
-                                    audio_device.type, audio_device.name),
-                                "value": audio_device.name,
+                                "name": "%s: %s" % (audio_device[1], audio_device[0]),
+                                "value": audio_device[0],
                                 })
 
                     # Overwrite value list (for language dropdown)

--- a/src/windows/profile.py
+++ b/src/windows/profile.py
@@ -26,6 +26,7 @@
  """
 
 import os
+import functools
 
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 
@@ -178,3 +179,5 @@ class Profile(QDialog):
         win.SeekSignal.emit(1)
         # Refresh frame (since size of preview might have changed)
         QTimer.singleShot(500, win.refreshFrameSignal.emit)
+        QTimer.singleShot(500, functools.partial(win.MaxSizeChanged.emit,
+                                                 win.videoPreview.size()))


### PR DESCRIPTION
This is related to https://github.com/OpenShot/libopenshot/pull/719, and will break without these libopenshot changes first. 

- Our audio device type data is now a different format, and thus, needs to be handled differently.
- Also, fixed a bug in our Profile screen, which was causing huge performance issues (essentially clearing/resetting our preview window size optimization, causing runaway drift and high CPU usage).