### PR TITLE
Fix Max Preview Size (New & Open Project)

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -308,6 +308,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Seek to frame 0
         self.SeekSignal.emit(1)
 
+        # Update max size (for fast previews)
+        self.MaxSizeChanged.emit(self.videoPreview.size())
+
     def actionAnimatedTitle_trigger(self):
         # show dialog
         from windows.animated_title import AnimatedTitle
@@ -478,6 +481,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
                 # Refresh thumbnail
                 self.refreshFrameSignal.emit()
+
+                # Update max size (for fast previews)
+                self.MaxSizeChanged.emit(self.videoPreview.size())
 
                 # Load recent projects again
                 self.load_recent_menu()

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -509,15 +509,23 @@ class VideoWidget(QWidget, updates.UpdateInterface):
     def centeredViewport(self, width, height):
         """ Calculate size of viewport to maintain aspect ratio """
 
-        window_size = QSizeF(width, height)
-        window_rect = QRectF(QPointF(0, 0), window_size)
+        # Calculate padding
+        top_padding = (height - (height * self.zoom)) / 2.0
+        left_padding = (width - (width * self.zoom)) / 2.0
 
-        aspectRatio = self.aspect_ratio.ToFloat() * self.pixel_ratio.ToFloat()
-        viewport_size = QSizeF(aspectRatio, 1).scaled(window_size, Qt.KeepAspectRatio)
-        viewport_rect = QRectF(QPointF(0, 0), viewport_size)
-        viewport_rect.moveCenter(window_rect.center())
+        # Adjust parameters to zoom
+        width = width * self.zoom
+        height = height * self.zoom
 
-        return viewport_rect.toRect()
+        # Calculate which direction to scale (for perfect centering)
+        aspectRatio = self.aspect_ratio.ToFloat()
+        heightFromWidth = width / aspectRatio
+        widthFromHeight = height * aspectRatio
+
+        if heightFromWidth <= height:
+            return QRect(left_padding, ((height - heightFromWidth) / 2) + top_padding, width, heightFromWidth)
+        else:
+            return QRect(((width - widthFromHeight) / 2.0) + left_padding, top_padding, widthFromHeight, height)
 
     def present(self, image, *args):
         """ Present the current frame """
@@ -1265,8 +1273,12 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
     def regionTriggered(self, clip_id):
         """Handle the 'select region' signal when it's emitted"""
-        # Clear transform
-        self.region_enabled = bool(not clip_id)
+        if self and not clip_id:
+            # Clear transform
+            self.region_enabled = False
+        else:
+            self.region_enabled = True
+
         get_app().window.refreshFrameSignal.emit()
 
     def resizeEvent(self, event):


### PR DESCRIPTION
When opening or creating a project, we lose our timeline max-size optimization. This causes slow downs in preview and some strange visual artifacts, such as text-size changing when displaying frame #'s on a clip.