### PR TITLE
Adding execute permission for files inside Mac *.App bundle

### DIFF
--- a/installer/build-mac-dmg.sh
+++ b/installer/build-mac-dmg.sh
@@ -42,8 +42,8 @@ mv "$OS_PATH/MacOS/qt.conf" "$OS_PATH/Resources/qt.conf"; ln -s "../Resources/qt
 mv "$OS_PATH/MacOS/openshot-qt.hqx" "$OS_PATH/Resources/openshot-qt.hqx"; ln -s "../Resources/openshot-qt.hqx" "$OS_PATH/MacOS/openshot-qt.hqx";
 mv "$OS_PATH/MacOS/lib/launch.py" "$OS_PATH/Resources/launch.py"; ln -s "../../Resources/launch.py" "$OS_PATH/MacOS/lib/launch.py";
 
-echo "Fix permissions inside MacOS folder (all files must be readable by all for Monterey+)"
-chmod -R a+r "$OS_PATH/"*
+echo "Fix permissions inside MacOS folder (all everyone to read and execute all the files inside this *.app bundle)"
+chmod -R a+rx "$OS_PATH/"*
 
 echo "Loop through bundled files and sign all binary files"
 find "build" \( -iname '*.dylib' -o -iname '*.so' \) -exec codesign -s "OpenShot Studios, LLC" --timestamp=http://timestamp.apple.com/ts01 --entitlements "installer/openshot.entitlements" --force "{}" \;


### PR DESCRIPTION
Adding execute permission for files inside Mac *.app bundle, to allow different users to run the *.app, and not just the user who installed OpenShot.

Related to https://github.com/OpenShot/openshot-qt/issues/4571