### PR TITLE
Basic Support for XDG Base Directory Specification

### DIFF
--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -28,6 +28,12 @@
 import os
 from time import strftime
 
+try:
+    from xdg import BaseDirectory
+except ImportError:
+    BaseDirectory = None
+
+
 VERSION = "2.6.1-dev"
 MINIMUM_LIBOPENSHOT_VERSION = "0.2.7"
 DATE = "20210904000000"
@@ -48,16 +54,26 @@ EXPORT_PRESETS_PATH = os.path.join(PATH, "presets")
 
 # User paths
 HOME_PATH = os.path.join(os.path.expanduser("~"))
+
 USER_PATH = os.path.join(HOME_PATH, ".openshot_qt")
+if BaseDirectory and not os.path.exists(os.fsencode(USER_PATH)):
+    USER_PATH = BaseDirectory.save_data_path("openshot_qt")
+    CONFIG_PATH = BaseDirectory.save_config_path("openshot_qt")
+    CACHE_PATH = BaseDirectory.save_cache_path("openshot_qt", "main")
+    PREVIEW_CACHE_PATH = BaseDirectory.save_cache_path("openshot_qt",
+                                                       "preview")
+else:
+    CONFIG_PATH = USER_PATH
+    CACHE_PATH = os.path.join(USER_PATH, "cache")
+    PREVIEW_CACHE_PATH = os.path.join(USER_PATH, "preview-cache")
+
 BACKUP_PATH = os.path.join(USER_PATH)
 RECOVERY_PATH = os.path.join(USER_PATH, "recovery")
 THUMBNAIL_PATH = os.path.join(USER_PATH, "thumbnail")
-CACHE_PATH = os.path.join(USER_PATH, "cache")
 BLENDER_PATH = os.path.join(USER_PATH, "blender")
 TITLE_PATH = os.path.join(USER_PATH, "title")
 TRANSITIONS_PATH = os.path.join(USER_PATH, "transitions")
 EMOJIS_PATH = os.path.join(USER_PATH, "emojis")
-PREVIEW_CACHE_PATH = os.path.join(USER_PATH, "preview-cache")
 USER_PROFILES_PATH = os.path.join(USER_PATH, "profiles")
 USER_PRESETS_PATH = os.path.join(USER_PATH, "presets")
 USER_TITLES_PATH = os.path.join(USER_PATH, "title_templates")

--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -83,11 +83,11 @@ class SettingStore(JsonDataStore):
         self._data = default_settings
 
         # Try to find user settings dir, give up if it's not there
-        if not os.path.exists(info.USER_PATH):
+        if not os.path.exists(info.CONFIG_PATH):
             return True
 
         # Load or create user settings
-        file_path = os.path.join(info.USER_PATH, self.settings_filename)
+        file_path = os.path.join(info.CONFIG_PATH, self.settings_filename)
         if os.path.exists(os.fsencode(file_path)):
             try:
                 user_settings = self.read_from_file(file_path)
@@ -106,8 +106,7 @@ class SettingStore(JsonDataStore):
         """ Save user settings file to disk """
 
         # Try to find user settings file
-        if os.path.exists(info.USER_PATH):
-            file_path = os.path.join(info.USER_PATH, self.settings_filename)
+        if os.path.exists(info.CONFIG_PATH):
+            file_path = os.path.join(info.CONFIG_PATH, self.settings_filename)
             # try to save data to file, will raise exception on failure
             self.write_to_file(file_path, self._data)
-


### PR DESCRIPTION
If the classic `~/.openshot_qt` is there, then continue using it, and ignore XDG.
If [pyxdg](https://www.freedesktop.org/wiki/Software/pyxdg/) is available, then use it.

Some basic XDG style directory setup:

* `XDG_CONFIG_HOME` (`~/.config/openshot_qt/`):
  * `openshot.settings`
* `XDG_CACHE_HOME` (`~/.cache/openshot_qt/`):
  * `preview-cache` as `preview`
  * `cache` as `main`
* `XDG_DATA_HOME` (`~/.local/share/openshot_qt/`):
  * Everything else

NOTE: I wonder whether more files should be moved from the "default" location. For example the `thumbnail` folder sounds like a candidate for cache?

See-Also: https://github.com/OpenShot/openshot-qt/issues/4477