### PR TITLE
Presets: Add MKV (h.264) sw/hw presets

### DIFF
--- a/src/presets/format_mkv_x264.xml
+++ b/src/presets/format_mkv_x264.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE openshot-export-option>
+<export-option>
+	<type translatable="True">All Formats</type>
+	<title translatable="True">MKV (h.264)</title>
+	<videoformat>mkv</videoformat>
+	<videocodec>libx264</videocodec>
+	<audiocodec>aac</audiocodec>
+	<audiochannels>2</audiochannels>
+	<audiochannellayout>3</audiochannellayout>
+	<videobitrate
+	 low="384 kb/s"
+	 med="5 Mb/s"
+	 high="15.00 Mb/s"></videobitrate>
+	<audiobitrate
+	 low="96 kb/s"
+	 med="128 kb/s"
+	 high="192 kb/s"></audiobitrate>
+	<samplerate>48000</samplerate>
+</export-option>

--- a/src/presets/format_mkv_x264_dx.xml
+++ b/src/presets/format_mkv_x264_dx.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE openshot-export-option>
+<export-option>
+	<type translatable="True">All Formats</type>
+	<title translatable="True">MKV (h.264 dx)</title>
+	<videoformat>mkv</videoformat>
+	<videocodec>h264_dxva2</videocodec>
+	<audiocodec>aac</audiocodec>
+	<audiochannels>2</audiochannels>
+	<audiochannellayout>3</audiochannellayout>
+	<videobitrate
+	 low="384 kb/s"
+	 med="5 Mb/s"
+	 high="15.00 Mb/s"></videobitrate>
+	<audiobitrate
+	 low="96 kb/s"
+	 med="128 kb/s"
+	 high="192 kb/s"></audiobitrate>
+	<samplerate>48000</samplerate>
+</export-option>

--- a/src/presets/format_mkv_x264_hw.xml
+++ b/src/presets/format_mkv_x264_hw.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE openshot-export-option>
+<export-option>
+	<type translatable="True">All Formats</type>
+	<title translatable="True">MP4 (h.264 va)</title>
+	<videoformat>mkv</videoformat>
+	<videocodec>h264_vaapi</videocodec>
+	<audiocodec>aac</audiocodec>
+	<audiochannels>2</audiochannels>
+	<audiochannellayout>3</audiochannellayout>
+	<videobitrate
+	 low="384 kb/s"
+	 med="5 Mb/s"
+	 high="15.00 Mb/s"></videobitrate>
+	<audiobitrate
+	 low="96 kb/s"
+	 med="128 kb/s"
+	 high="192 kb/s"></audiobitrate>
+	<samplerate>48000</samplerate>
+</export-option>

--- a/src/presets/format_mkv_x264_nv.xml
+++ b/src/presets/format_mkv_x264_nv.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE openshot-export-option>
+<export-option>
+	<type translatable="True">All Formats</type>
+	<title translatable="True">MKV (h.264 nv)</title>
+	<videoformat>mkv</videoformat>
+	<videocodec>h264_nvenc</videocodec>
+	<audiocodec>aac</audiocodec>
+	<audiochannels>2</audiochannels>
+	<audiochannellayout>3</audiochannellayout>
+	<videobitrate
+	 low="384 kb/s"
+	 med="5 Mb/s"
+	 high="15.00 Mb/s"></videobitrate>
+	<audiobitrate
+	 low="96 kb/s"
+	 med="128 kb/s"
+	 high="192 kb/s"></audiobitrate>
+	<samplerate>48000</samplerate>
+</export-option>

--- a/src/presets/format_mkv_x264_qsv.xml
+++ b/src/presets/format_mkv_x264_qsv.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE openshot-export-option>
+<export-option>
+	<type translatable="True">All Formats</type>
+	<title translatable="True">MKV (h.264 qsv)</title>
+	<videoformat>mkv</videoformat>
+	<videocodec>h264_qsv</videocodec>
+	<audiocodec>aac</audiocodec>
+	<audiochannels>2</audiochannels>
+	<audiochannellayout>3</audiochannellayout>
+	<videobitrate
+	 low="384 kb/s"
+	 med="5 Mb/s"
+	 high="15.00 Mb/s"></videobitrate>
+	<audiobitrate
+	 low="96 kb/s"
+	 med="128 kb/s"
+	 high="192 kb/s"></audiobitrate>
+	<samplerate>48000</samplerate>
+</export-option>

--- a/src/presets/format_mkv_x264_vtb.xml
+++ b/src/presets/format_mkv_x264_vtb.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE openshot-export-option>
+<export-option>
+	<type translatable="True">All Formats</type>
+	<title translatable="True">MKV (h.264 videotoolbox)</title>
+	<videoformat>mkv</videoformat>
+	<videocodec>h264_videotoolbox</videocodec>
+	<audiocodec>aac</audiocodec>
+	<audiochannels>2</audiochannels>
+	<audiochannellayout>3</audiochannellayout>
+	<videobitrate
+	 low="384 kb/s"
+	 med="5 Mb/s"
+	 high="15.00 Mb/s"></videobitrate>
+	<audiobitrate
+	 low="96 kb/s"
+	 med="128 kb/s"
+	 high="192 kb/s"></audiobitrate>
+	<samplerate>48000</samplerate>
+</export-option>


### PR DESCRIPTION
I have no idea why I never opened this PR, I did the initial commit nearly a year ago and then just forgot about it apparently. But, that's OK, as it gave me a chance to go back and add the hardware presets as well, just  now.

This PR creates greater parity between our MKV (Matroska) preset offerings — of which there were previously, like, _two_ — and our MP4 preset offerings, which are extensive.

Every `format_mp4_x64*.xml` preset is cloned into an equivalent `format_mkv_x264*.xml` preset, with only the title and container format changed.

(TBH we should _probably_ do something like what Handbrake does, and just let the user select between MP4 container and MKV container for _every_ MP4 preset, since the containers are virtually interchangeable. Then we'd have a lot less preset clutter, instead of a bit more like this will introduce. But, it's worth giving people options IMHO.)

I _feel like_ this was in response to a request someone made in an Issue, or something, but I'm not going to try and find it because Stale would've closed it long ago anyway.