### PR TITLE
Don't start the region selector at frame 1 if a clip is sliced

### DIFF
--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -172,8 +172,9 @@ class SelectRegion(QDialog):
 
         # Determine if a start or end attribute is in this file
         start_frame = 1
-        # if 'start' in self.file.data.keys():
-        #     start_frame = (float(self.file.data['start']) * self.fps) + 1
+        # For sliced clips, use start*fps as the first frame
+        if clip and clip.Json():
+            start_frame = (json.loads(clip.Json()).get("start",0) * self.fps) + 1
 
         # Display start frame (and then the previous frame)
         QTimer.singleShot(500, functools.partial(self.sliderVideo.setValue, start_frame + 1))

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -96,7 +96,6 @@ class SelectRegion(QDialog):
         # Get profile settings
         c_info = clip.Reader().info
         self.fps = c_info.fps.ToInt() #float(self.fps_num) / float(self.fps_den)
-        self.clipStartFrame = round(json.loads(clip.Json()).get('start',0) * self.fps) + 1
         self.fps_num = self.fps #int(file.data['fps']['num'])
         self.fps_den = 1 #int(file.data['fps']['den'])
         self.width = c_info.width #int(file.data['width'])

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -82,15 +82,12 @@ class SelectRegion(QDialog):
 
         # Create region clip with Reader
         self.clip = openshot.Clip(clip.Reader())
-
         self.clip.Open()
 
         # Set region clip start and end
         self.clip.Start(clip.Start())
         self.clip.End(clip.End())
         self.clip.Id( get_app().project.generate_id() )
-
-        print("IDS {} {}".format(clip.Id(), self.clip.Id()))
 
         # Keep track of file object
         self.file = file
@@ -135,9 +132,6 @@ class SelectRegion(QDialog):
         self.r.SetMaxSize(self.viewport_rect.width(), self.viewport_rect.height())
 
         try:
-            # Add clip for current preview file
-            self.clip = openshot.Clip(self.file_path)
-
             # Show waveform for audio files
             if not self.clip.Reader().info.has_video and self.clip.Reader().info.has_audio:
                 self.clip.Waveform(True)
@@ -169,7 +163,6 @@ class SelectRegion(QDialog):
         self.sliderVideo.setMinimum(self.clipStartFrame)
         self.sliderVideo.setMaximum(self.clipStartFrame + self.video_length)
         self.sliderVideo.setSingleStep(1)
-        self.sliderVideo.setSingleStep(1)
         self.sliderVideo.setPageStep(24)
 
         # Determine if a start or end attribute is in this file
@@ -179,8 +172,8 @@ class SelectRegion(QDialog):
             start_frame = (json.loads(clip.Json()).get("start",0) * self.fps) + 1
 
         # Display start frame (and then the previous frame)
-        QTimer.singleShot(500, functools.partial(self.sliderVideo.setValue, start_frame + 1))
-        QTimer.singleShot(600, functools.partial(self.sliderVideo.setValue, start_frame))
+        QTimer.singleShot(500, functools.partial(self.sliderVideo.setValue, 2))
+        QTimer.singleShot(600, functools.partial(self.sliderVideo.setValue, 1))
 
         # Add buttons
         self.cancel_button = QPushButton(_('Cancel'))
@@ -241,7 +234,7 @@ class SelectRegion(QDialog):
 
     def sliderVideo_valueChanged(self, new_frame):
         if self.preview_thread and not self.sliderIgnoreSignal:
-            log.info('sliderVideo_valueChanged')
+            log.info('sliderVideo_valueChanged: %s' % new_frame)
 
             # Pause video
             self.btnPlay_clicked(force="pause")

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -93,7 +93,6 @@ class SelectRegion(QDialog):
         self.file = file
         self.file_path = file.absolute_path()
 
-        # Get profile settings
         c_info = clip.Reader().info
         self.fps = c_info.fps.ToInt() #float(self.fps_num) / float(self.fps_den)
         self.fps_num = self.fps #int(file.data['fps']['num'])

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -96,8 +96,10 @@ class SelectRegion(QDialog):
         self.file = file
         self.file_path = file.absolute_path()
 
+        # Get profile settings
         c_info = clip.Reader().info
         self.fps = c_info.fps.ToInt() #float(self.fps_num) / float(self.fps_den)
+        self.clipStartFrame = round(json.loads(clip.Json()).get('start',0) * self.fps) + 1
         self.fps_num = self.fps #int(file.data['fps']['num'])
         self.fps_den = 1 #int(file.data['fps']['den'])
         self.width = c_info.width #int(file.data['width'])
@@ -164,8 +166,8 @@ class SelectRegion(QDialog):
 
         # Set slider constraints
         self.sliderIgnoreSignal = False
-        self.sliderVideo.setMinimum(1)
-        self.sliderVideo.setMaximum(self.video_length)
+        self.sliderVideo.setMinimum(self.clipStartFrame)
+        self.sliderVideo.setMaximum(self.clipStartFrame + self.video_length)
         self.sliderVideo.setSingleStep(1)
         self.sliderVideo.setSingleStep(1)
         self.sliderVideo.setPageStep(24)

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -160,16 +160,10 @@ class SelectRegion(QDialog):
 
         # Set slider constraints
         self.sliderIgnoreSignal = False
-        self.sliderVideo.setMinimum(self.clipStartFrame)
-        self.sliderVideo.setMaximum(self.clipStartFrame + self.video_length)
+        self.sliderVideo.setMinimum(1)
+        self.sliderVideo.setMaximum(self.video_length)
         self.sliderVideo.setSingleStep(1)
         self.sliderVideo.setPageStep(24)
-
-        # Determine if a start or end attribute is in this file
-        start_frame = 1
-        # For sliced clips, use start*fps as the first frame
-        if clip and clip.Json():
-            start_frame = (json.loads(clip.Json()).get("start",0) * self.fps) + 1
 
         # Display start frame (and then the previous frame)
         QTimer.singleShot(500, functools.partial(self.sliderVideo.setValue, 2))


### PR DESCRIPTION
Fixes #4635

Our tracker effect was always starting at frame 1. This change uses the clip's `start` property if it exists.

Still to test: make sure region selector doesn't show removed frames at the end either.