### PR TITLE
Add required libqt5svg5 library into developer documentation

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -98,6 +98,7 @@ unofficial Ubuntu repository, which has our software packages available to downl
                         pkg-config \
                         python3-dev \
                         qtbase5-dev \
+                        libqt5svg5-dev \
                         qtmultimedia5-dev \
                         swig
 

--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -99,6 +99,7 @@ unofficial Ubuntu repository, which has our software packages available to downl
                         python3-dev \
                         qtbase5-dev \
                         libqt5svg5-dev \
+                        libxcb-xfixes0-dev \
                         qtmultimedia5-dev \
                         swig
 


### PR DESCRIPTION
Running `sudo apt install libqt5svg5-dev` before compiling `libopenshot` is required for success in building all components for developement.