### PR TITLE
Prevent removing clips, effects or transitions if they're on a locked track

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1747,10 +1747,15 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def actionRemoveClip_trigger(self):
         log.debug('actionRemoveClip_trigger')
 
+        locked_tracks = [l.get("number")
+                         for l in get_app().project.get('layers')
+                         if l.get("lock", False)]
+
         # Loop through selected clips
         for clip_id in deepcopy(self.selected_clips):
             # Find matching file
             clips = Clip.filter(id=clip_id)
+            clips = list(filter(lambda x: x.data.get("layer") not in locked_tracks, clips))
             for c in clips:
                 # Clear selected clips
                 self.removeSelection(clip_id, "clip")
@@ -1771,12 +1776,17 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def actionRemoveEffect_trigger(self):
         log.debug('actionRemoveEffect_trigger')
 
+        locked_tracks = [l.get("number")
+                         for l in get_app().project.get('layers')
+                         if l.get("lock", False)]
+
         # Loop through selected clips
         for effect_id in deepcopy(self.selected_effects):
             log.info("effect id: %s" % effect_id)
 
             # Find matching file
             clips = Clip.filter()
+            clips = list(filter(lambda x: x.data.get("layer") not in locked_tracks, clips))
             found_effect = None
             for c in clips:
                 found_effect = False
@@ -1806,10 +1816,15 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def actionRemoveTransition_trigger(self):
         log.debug('actionRemoveTransition_trigger')
 
+        locked_tracks = [l.get("number")
+                         for l in get_app().project.get('layers')
+                         if l.get("lock", False)]
+
         # Loop through selected clips
         for tran_id in deepcopy(self.selected_transitions):
             # Find matching file
             transitions = Transition.filter(id=tran_id)
+            transitions = list(filter(lambda x: x.data.get("layer") not in locked_tracks, transitions))
             for t in transitions:
                 # Clear selected clips
                 self.removeSelection(tran_id, "transition")

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1776,17 +1776,12 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def actionRemoveEffect_trigger(self):
         log.debug('actionRemoveEffect_trigger')
 
-        locked_tracks = [l.get("number")
-                         for l in get_app().project.get('layers')
-                         if l.get("lock", False)]
-
         # Loop through selected clips
         for effect_id in deepcopy(self.selected_effects):
             log.info("effect id: %s" % effect_id)
 
             # Find matching file
             clips = Clip.filter()
-            clips = list(filter(lambda x: x.data.get("layer") not in locked_tracks, clips))
             found_effect = None
             for c in clips:
                 found_effect = False


### PR DESCRIPTION
# The Issue
Currently locking a track doesn't prevent the clips on it from being deleted (or edited for that matter) it only locks them to a position on the timeline.

To me it makes sense that if you care enough to want a clip to stay where it is, you likely don't want to accidentally delete it.
# The fix
Before deleting any of those items, filter out any that are on locked tracks

# Question for reviewers:
How much locking do we want the lock feature to do?

By this I mean that if you lock a track how you like it, you can still edit properties of the clips (like alpha value and rotation). Unless we want to completely freeze all editing on locked clips, I thought it made sense still allow adding and removing of effects.