### PR TITLE
Fix font size issues in title editor

### DIFF
--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -436,10 +436,8 @@ class TitleEditor(QDialog):
             self.font_family = fontinfo.family()
             self.font_style = fontinfo.styleName()
             self.font_weight = fontinfo.weight()
-            if (oldfontinfo.pixelSize() != 0):
+            if (oldfontinfo.pixelSize() > 0):
                 self.font_size_ratio = fontinfo.pixelSize() / oldfontinfo.pixelSize()
-            else:
-                self.font_size_ratio = 0
             self.set_font_style()
             self.save_and_reload()
 

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -436,7 +436,10 @@ class TitleEditor(QDialog):
             self.font_family = fontinfo.family()
             self.font_style = fontinfo.styleName()
             self.font_weight = fontinfo.weight()
-            self.font_size_ratio = fontinfo.pixelSize() / oldfontinfo.pixelSize() if oldfontinfo.pixelSize() else 0
+            if (oldfontinfo.pixelSize() != 0):
+                self.font_size_ratio = fontinfo.pixelSize() / oldfontinfo.pixelSize()
+            else:
+                self.font_size_ratio = 0
             self.set_font_style()
             self.save_and_reload()
 

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -99,7 +99,7 @@ class TitleEditor(QDialog):
 
         self.font_weight = 'normal'
         self.font_style = 'normal'
-        self.font_size_pixel = 20
+        self.font_size_ratio = 1
 
         self.new_title_text = ""
         self.sub_title_text = ""
@@ -288,7 +288,7 @@ class TitleEditor(QDialog):
             # Set font size (for possible font dialog)
             s = node.attributes["style"].value
             ard = style_to_dict(s)
-            fs = ard.get("font_size")
+            fs = ard.get("font-size")
             if fs and fs.endswith("px"):
                 self.qfont.setPixelSize(float(fs[:-2]))
             elif fs and fs.endswith("pt"):
@@ -432,10 +432,11 @@ class TitleEditor(QDialog):
         if ok and font is not oldfont:
             self.qfont = font
             fontinfo = QtGui.QFontInfo(font)
+            oldfontinfo = QtGui.QFontInfo(oldfont)
             self.font_family = fontinfo.family()
             self.font_style = fontinfo.styleName()
             self.font_weight = fontinfo.weight()
-            self.font_size_pixel = fontinfo.pixelSize()
+            self.font_size_ratio = fontinfo.pixelSize() / oldfontinfo.pixelSize() if oldfontinfo.pixelSize() else 0
             self.set_font_style()
             self.save_and_reload()
 
@@ -529,7 +530,10 @@ class TitleEditor(QDialog):
             ard = style_to_dict(s)
             set_if_existing(ard, "font-style", self.font_style)
             set_if_existing(ard, "font-family", f"'{self.font_family}'")
-            set_if_existing(ard, "font-size", f"{self.font_size_pixel}px")
+            new_font_size_pixel = 0
+            if 'font-size' in ard:
+                new_font_size_pixel = self.font_size_ratio * float(ard['font-size'][:-2])
+            set_if_existing(ard, "font-size", f"{new_font_size_pixel}px")
             self.title_style_string = dict_to_style(ard)
 
             # set the text node


### PR DESCRIPTION
If you create a 'Bar 2' title (in the title editor), and change the font... the following things fail:
We are looking at the wrong SVG attribute (font_size instead of font-size)
We don't deal with titles like 'bar 2', which contain multiple font sizes

Solution:
We need to determine the % change in font-size... before and after the font dialog is used. If the user has increased/decreased the font size by X%, we need to apply that change for all font-sizes mentioned in the SVG file.