### PR TITLE
Link toolbar movability to floating status

### DIFF
--- a/src/classes/logger.py
+++ b/src/classes/logger.py
@@ -59,7 +59,7 @@ class StreamFilter(logging.Filter):
     """Filter out lines that originated on the output"""
     def filter(self, record):
         source = getattr(record, "source", "")
-        return bool(source != "stream")
+        return source != "stream"
 
 
 # Set up log formatters

--- a/src/presets/format_mkv_x264.xml
+++ b/src/presets/format_mkv_x264.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE openshot-export-option>
+<export-option>
+	<type translatable="True">All Formats</type>
+	<title translatable="True">MKV (h.264)</title>
+	<videoformat>mkv</videoformat>
+	<videocodec>libx264</videocodec>
+	<audiocodec>aac</audiocodec>
+	<audiochannels>2</audiochannels>
+	<audiochannellayout>3</audiochannellayout>
+	<videobitrate
+	 low="384 kb/s"
+	 med="5 Mb/s"
+	 high="15.00 Mb/s"></videobitrate>
+	<audiobitrate
+	 low="96 kb/s"
+	 med="128 kb/s"
+	 high="192 kb/s"></audiobitrate>
+	<samplerate>48000</samplerate>
+</export-option>

--- a/src/presets/format_mkv_x264_dx.xml
+++ b/src/presets/format_mkv_x264_dx.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE openshot-export-option>
+<export-option>
+	<type translatable="True">All Formats</type>
+	<title translatable="True">MKV (h.264 dx)</title>
+	<videoformat>mkv</videoformat>
+	<videocodec>h264_dxva2</videocodec>
+	<audiocodec>aac</audiocodec>
+	<audiochannels>2</audiochannels>
+	<audiochannellayout>3</audiochannellayout>
+	<videobitrate
+	 low="384 kb/s"
+	 med="5 Mb/s"
+	 high="15.00 Mb/s"></videobitrate>
+	<audiobitrate
+	 low="96 kb/s"
+	 med="128 kb/s"
+	 high="192 kb/s"></audiobitrate>
+	<samplerate>48000</samplerate>
+</export-option>

--- a/src/presets/format_mkv_x264_hw.xml
+++ b/src/presets/format_mkv_x264_hw.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE openshot-export-option>
+<export-option>
+	<type translatable="True">All Formats</type>
+	<title translatable="True">MP4 (h.264 va)</title>
+	<videoformat>mkv</videoformat>
+	<videocodec>h264_vaapi</videocodec>
+	<audiocodec>aac</audiocodec>
+	<audiochannels>2</audiochannels>
+	<audiochannellayout>3</audiochannellayout>
+	<videobitrate
+	 low="384 kb/s"
+	 med="5 Mb/s"
+	 high="15.00 Mb/s"></videobitrate>
+	<audiobitrate
+	 low="96 kb/s"
+	 med="128 kb/s"
+	 high="192 kb/s"></audiobitrate>
+	<samplerate>48000</samplerate>
+</export-option>

--- a/src/presets/format_mkv_x264_nv.xml
+++ b/src/presets/format_mkv_x264_nv.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE openshot-export-option>
+<export-option>
+	<type translatable="True">All Formats</type>
+	<title translatable="True">MKV (h.264 nv)</title>
+	<videoformat>mkv</videoformat>
+	<videocodec>h264_nvenc</videocodec>
+	<audiocodec>aac</audiocodec>
+	<audiochannels>2</audiochannels>
+	<audiochannellayout>3</audiochannellayout>
+	<videobitrate
+	 low="384 kb/s"
+	 med="5 Mb/s"
+	 high="15.00 Mb/s"></videobitrate>
+	<audiobitrate
+	 low="96 kb/s"
+	 med="128 kb/s"
+	 high="192 kb/s"></audiobitrate>
+	<samplerate>48000</samplerate>
+</export-option>

--- a/src/presets/format_mkv_x264_qsv.xml
+++ b/src/presets/format_mkv_x264_qsv.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE openshot-export-option>
+<export-option>
+	<type translatable="True">All Formats</type>
+	<title translatable="True">MKV (h.264 qsv)</title>
+	<videoformat>mkv</videoformat>
+	<videocodec>h264_qsv</videocodec>
+	<audiocodec>aac</audiocodec>
+	<audiochannels>2</audiochannels>
+	<audiochannellayout>3</audiochannellayout>
+	<videobitrate
+	 low="384 kb/s"
+	 med="5 Mb/s"
+	 high="15.00 Mb/s"></videobitrate>
+	<audiobitrate
+	 low="96 kb/s"
+	 med="128 kb/s"
+	 high="192 kb/s"></audiobitrate>
+	<samplerate>48000</samplerate>
+</export-option>

--- a/src/presets/format_mkv_x264_vtb.xml
+++ b/src/presets/format_mkv_x264_vtb.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE openshot-export-option>
+<export-option>
+	<type translatable="True">All Formats</type>
+	<title translatable="True">MKV (h.264 videotoolbox)</title>
+	<videoformat>mkv</videoformat>
+	<videocodec>h264_videotoolbox</videocodec>
+	<audiocodec>aac</audiocodec>
+	<audiochannels>2</audiochannels>
+	<audiochannellayout>3</audiochannellayout>
+	<videobitrate
+	 low="384 kb/s"
+	 med="5 Mb/s"
+	 high="15.00 Mb/s"></videobitrate>
+	<audiobitrate
+	 low="96 kb/s"
+	 med="128 kb/s"
+	 high="192 kb/s"></audiobitrate>
+	<samplerate>48000</samplerate>
+</export-option>

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -733,7 +733,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             _("Would you like to import %s as an image sequence?") % filename,
             QMessageBox.No | QMessageBox.Yes
         )
-        return bool(ret == QMessageBox.Yes)
+        return ret == QMessageBox.Yes
 
     def actionAdd_to_Timeline_trigger(self, checked=False):
         # Loop through selected files

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2063,6 +2063,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def freezeDocks(self):
         """ Freeze all dockable widgets on the main screen
             (prevent them being closed, floated, or moved) """
+        self.toolBar.setMovable(False)
         for dock in self.getDocks():
             if self.dockWidgetArea(dock) != Qt.NoDockWidgetArea:
                 dock.setFeatures(QDockWidget.NoDockWidgetFeatures)
@@ -2070,6 +2071,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def unFreezeDocks(self):
         """ Un-freeze all dockable widgets on the main screen
             (allow them to be closed, floated, or moved, as appropriate) """
+        self.toolBar.setMovable(True)
         for dock in self.getDocks():
             if self.dockWidgetArea(dock) != Qt.NoDockWidgetArea:
                 if dock is self.dockTimeline:

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -30,13 +30,14 @@
 import os
 import shutil
 import webbrowser
+import functools
 from copy import deepcopy
 from time import sleep
 from uuid import uuid4
 
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 from PyQt5.QtCore import (
-    Qt, pyqtSignal, QCoreApplication, PYQT_VERSION_STR,
+    Qt, pyqtSignal, pyqtSlot, QCoreApplication, PYQT_VERSION_STR,
     QTimer, QDateTime, QFileInfo, QUrl,
     )
 from PyQt5.QtGui import QIcon, QCursor, QKeySequence, QTextCursor
@@ -2060,39 +2061,41 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 # Only show correctly docked widgets
                 dock.show()
 
-    def freezeDocks(self):
-        """ Freeze all dockable widgets on the main screen
-            (prevent them being closed, floated, or moved) """
-        self.toolBar.setMovable(False)
-        for dock in self.getDocks():
-            if self.dockWidgetArea(dock) != Qt.NoDockWidgetArea:
-                dock.setFeatures(QDockWidget.NoDockWidgetFeatures)
+    def freezeDock(self, dock, frozen=True):
+        """ Freeze/unfreeze a dock widget on the main screen."""
+        if self.dockWidgetArea(dock) == Qt.NoDockWidgetArea:
+            # Don't freeze undockable widgets
+            return
+        if frozen:
+            dock.setFeatures(QDockWidget.NoDockWidgetFeatures)
+        else:
+            features = (
+                QDockWidget.DockWidgetFloatable
+                | QDockWidget.DockWidgetMovable)
+            if dock is not self.dockTimeline:
+                features |= QDockWidget.DockWidgetClosable
+            dock.setFeatures(features)
 
-    def unFreezeDocks(self):
-        """ Un-freeze all dockable widgets on the main screen
-            (allow them to be closed, floated, or moved, as appropriate) """
-        self.toolBar.setMovable(True)
-        for dock in self.getDocks():
-            if self.dockWidgetArea(dock) != Qt.NoDockWidgetArea:
-                if dock is self.dockTimeline:
-                    dock.setFeatures(
-                        QDockWidget.DockWidgetFloatable
-                        | QDockWidget.DockWidgetMovable)
-                else:
-                    dock.setFeatures(
-                        QDockWidget.DockWidgetClosable
-                        | QDockWidget.DockWidgetFloatable
-                        | QDockWidget.DockWidgetMovable)
+    @pyqtSlot()
+    def freezeMainToolBar(self, frozen=None):
+        """Freeze/unfreeze the toolbar if it's attached to the window."""
+        if frozen is None:
+            frozen = self.docks_frozen
+        floating = self.toolBar.isFloating()
+        log.debug(
+            "%s main toolbar%s",
+            "freezing" if frozen and not floating else "unfreezing",
+            " (floating)" if floating else "")
+        if floating:
+            self.toolBar.setMovable(True)
+        else:
+            self.toolBar.setMovable(not frozen)
 
     def addViewDocksMenu(self):
         """ Insert a Docks submenu into the View menu """
         _ = get_app()._tr
 
-        # self.docks_menu = self.createPopupMenu()
-        # self.docks_menu.setTitle(_("Docks"))
-        # self.menuView.addMenu(self.docks_menu)
         self.docks_menu = self.menuView.addMenu(_("Docks"))
-
         for dock in sorted(self.getDocks(), key=lambda d: d.windowTitle()):
             if (dock.features() & QDockWidget.DockWidgetClosable
                != QDockWidget.DockWidgetClosable):
@@ -2176,14 +2179,18 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def actionFreeze_View_trigger(self):
         """ Freeze all dockable widgets on the main screen """
-        self.freezeDocks()
+        for dock in self.getDocks():
+            self.freezeDock(dock, frozen=True)
+        self.freezeMainToolBar(frozen=True)
         self.actionFreeze_View.setVisible(False)
         self.actionUn_Freeze_View.setVisible(True)
         self.docks_frozen = True
 
     def actionUn_Freeze_View_trigger(self):
         """ Un-Freeze all dockable widgets on the main screen """
-        self.unFreezeDocks()
+        for dock in self.getDocks():
+            self.freezeDock(dock, frozen=False)
+        self.freezeMainToolBar(frozen=False)
         self.actionFreeze_View.setVisible(True)
         self.actionUn_Freeze_View.setVisible(False)
         self.docks_frozen = False
@@ -2430,11 +2437,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         if s.get('window_state_v2'):
             self.saved_state = qt_types.str_to_bytes(s.get('window_state_v2'))
         if s.get('docks_frozen'):
-            # Freeze all dockable widgets on the main screen
-            self.freezeDocks()
-            self.actionFreeze_View.setVisible(False)
-            self.actionUn_Freeze_View.setVisible(True)
-            self.docks_frozen = True
+            self.actionFreeze_View_trigger()
+        else:
+            self.actionUn_Freeze_View_trigger()
 
         # Load Recent Projects
         self.load_recent_menu()
@@ -2452,7 +2457,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         recent_projects = s.get("recent_projects")
 
         # Add Recent Projects menu (after Open File)
-        import functools
         if not self.recent_menu:
             # Create a new recent menu
             self.recent_menu = self.menuFile.addMenu(
@@ -2892,7 +2896,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Init UI
         ui_util.init_ui(self)
 
-        # Setup toolbars that aren't on main window, set initial state of items, etc
+        # Create dock toolbars, set initial state of items, etc
         self.setup_toolbars()
 
         # Add window as watcher to receive undo/redo status updates
@@ -3060,6 +3064,10 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Connect Selection signals
         self.SelectionAdded.connect(self.addSelection)
         self.SelectionRemoved.connect(self.removeSelection)
+
+        # Ensure toolbar is movable when floated (even with docks frozen)
+        self.toolBar.topLevelChanged.connect(
+            functools.partial(self.freezeMainToolBar, None))
 
         # Show window
         self.show()

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -436,10 +436,8 @@ class TitleEditor(QDialog):
             self.font_family = fontinfo.family()
             self.font_style = fontinfo.styleName()
             self.font_weight = fontinfo.weight()
-            if (oldfontinfo.pixelSize() != 0):
+            if (oldfontinfo.pixelSize() > 0):
                 self.font_size_ratio = fontinfo.pixelSize() / oldfontinfo.pixelSize()
-            else:
-                self.font_size_ratio = 0
             self.set_font_style()
             self.save_and_reload()
 

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -436,7 +436,10 @@ class TitleEditor(QDialog):
             self.font_family = fontinfo.family()
             self.font_style = fontinfo.styleName()
             self.font_weight = fontinfo.weight()
-            self.font_size_ratio = fontinfo.pixelSize() / oldfontinfo.pixelSize() if oldfontinfo.pixelSize() else 0
+            if (oldfontinfo.pixelSize() != 0):
+                self.font_size_ratio = fontinfo.pixelSize() / oldfontinfo.pixelSize()
+            else:
+                self.font_size_ratio = 0
             self.set_font_style()
             self.save_and_reload()
 

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -99,7 +99,7 @@ class TitleEditor(QDialog):
 
         self.font_weight = 'normal'
         self.font_style = 'normal'
-        self.font_size_pixel = 20
+        self.font_size_ratio = 1
 
         self.new_title_text = ""
         self.sub_title_text = ""
@@ -288,7 +288,7 @@ class TitleEditor(QDialog):
             # Set font size (for possible font dialog)
             s = node.attributes["style"].value
             ard = style_to_dict(s)
-            fs = ard.get("font_size")
+            fs = ard.get("font-size")
             if fs and fs.endswith("px"):
                 self.qfont.setPixelSize(float(fs[:-2]))
             elif fs and fs.endswith("pt"):
@@ -432,10 +432,11 @@ class TitleEditor(QDialog):
         if ok and font is not oldfont:
             self.qfont = font
             fontinfo = QtGui.QFontInfo(font)
+            oldfontinfo = QtGui.QFontInfo(oldfont)
             self.font_family = fontinfo.family()
             self.font_style = fontinfo.styleName()
             self.font_weight = fontinfo.weight()
-            self.font_size_pixel = fontinfo.pixelSize()
+            self.font_size_ratio = fontinfo.pixelSize() / oldfontinfo.pixelSize() if oldfontinfo.pixelSize() else 0
             self.set_font_style()
             self.save_and_reload()
 
@@ -529,7 +530,10 @@ class TitleEditor(QDialog):
             ard = style_to_dict(s)
             set_if_existing(ard, "font-style", self.font_style)
             set_if_existing(ard, "font-family", f"'{self.font_family}'")
-            set_if_existing(ard, "font-size", f"{self.font_size_pixel}px")
+            new_font_size_pixel = 0
+            if 'font-size' in ard:
+                new_font_size_pixel = self.font_size_ratio * float(ard['font-size'][:-2])
+            set_if_existing(ard, "font-size", f"{new_font_size_pixel}px")
             self.title_style_string = dict_to_style(ard)
 
             # set the text node

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -641,7 +641,7 @@ Blender Path: {}
         self.inject_params(source_script, target_script, frame)
 
         # Note whether we're rendering a preview or an animation
-        self.final_render = bool(frame is None)
+        self.final_render = frame is None
 
         # Run worker in background thread
         self.background.start()


### PR DESCRIPTION
This PR, targeting @JacksonRG 's PR #4656, will link freezing of the main toolbar to its floating status, so that we don't create an immovable floating toolbar when we freeze the window.

The toolbar's `topLevelChanged` signal (which indicates floating status) is connected to a slot that applies current frozen status if it's docked, and ensures it's always movable if it's floating. The same slot ensures that if a floating toolbar gets docked while the window is frozen, it will freeze in place and no longer be movable until the freeze is deactivated.

I also slightly re-worked how initial freeze state is applied when loading settings, as well as how the docks get frozen/unfrozen, to reduce code duplication.