### PR TITLE
Add check such that clicking "Play" only advance playhead up to end of last clip

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -904,8 +904,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def should_play(self, play_forward=True):
         max_frame = get_app().window.timeline_sync.timeline.GetMaxFrame()
-        log.debug("juliana: max_frame = %d", max_frame)
-        log.debug("juliana: self.preview_thread.current_frame = %d", self.preview_thread.current_frame)
         if play_forward and self.preview_thread.current_frame < max_frame:
             return True
         if not play_forward and self.preview_thread.current_frame <= max_frame:

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -41,7 +41,8 @@ class PreviewParent(QObject):
 
     # Signal when the frame position changes in the preview player
     def onPositionChanged(self, current_frame):
-        self.parent.movePlayhead(current_frame)
+        if self.worker.timeline_length != -1 and current_frame < self.worker.timeline_length:
+            self.parent.movePlayhead(current_frame)
 
         # Check if we are at the end of the timeline
         if self.worker.player.Mode() == openshot.PLAYBACK_PLAY and current_frame >= self.worker.timeline_length and self.worker.timeline_length != -1:

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -41,8 +41,7 @@ class PreviewParent(QObject):
 
     # Signal when the frame position changes in the preview player
     def onPositionChanged(self, current_frame):
-        if self.worker.timeline_length != -1 and current_frame < self.worker.timeline_length:
-            self.parent.movePlayhead(current_frame)
+        self.parent.movePlayhead(current_frame)
 
         # Check if we are at the end of the timeline
         if self.worker.player.Mode() == openshot.PLAYBACK_PLAY and current_frame >= self.worker.timeline_length and self.worker.timeline_length != -1:


### PR DESCRIPTION
Problem:
Launching OpenShot, with no project open, and clicking Play over and over again, causes the playhead to move 1 frame at a time. This is invalid behavior, and playhead should not move past the end of a project, or at all in an empty project.
