### PR TITLE
Caching & Playback Timing Improvements (UI)

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -202,7 +202,7 @@ if sys.platform == "win32":
     extra_exe = {"base": None, "name": exe_name + "-cli.exe"}
 
     # Standard graphical Win32 launcher
-    base = "Win32GUI"
+    #base = "Win32GUI"
     build_exe_options["include_msvcr"] = True
     exe_name += ".exe"
 

--- a/freeze.py
+++ b/freeze.py
@@ -202,7 +202,7 @@ if sys.platform == "win32":
     extra_exe = {"base": None, "name": exe_name + "-cli.exe"}
 
     # Standard graphical Win32 launcher
-    #base = "Win32GUI"
+    base = "Win32GUI"
     build_exe_options["include_msvcr"] = True
     exe_name += ".exe"
 

--- a/src/classes/effect_init.py
+++ b/src/classes/effect_init.py
@@ -61,7 +61,7 @@ effect_options = {
             "title": "Default Audio Sample Rate",
             "min": 22050,
             "setting": "default-samplerate",
-            "value": 44100,
+            "value": 48000,
             "values": [
                 {
                     "value": 22050,

--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -87,6 +87,9 @@ class TimelineSync(UpdateInterface):
                 # The timeline's profile changed, so update all clips
                 self.timeline.ApplyMapperToClips()
 
+                # Always seek back to frame 1
+                self.window.SeekSignal.emit(1)
+
                 # Refresh current frame (since the entire timeline was updated)
                 self.window.refreshFrameSignal.emit()
 

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -150,7 +150,7 @@
     "category": "Preview",
     "min": 22050,
     "setting": "default-samplerate",
-    "value": 44100,
+    "value": 48000,
     "values": [
       {
         "value": 22050,

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -264,7 +264,7 @@
   {
     "min": 0,
     "max": 9999999,
-    "value": 250,
+    "value": 1024,
     "title": "Cache Limit (MB)",
     "type": "spinner-int",
     "category": "Cache",

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -492,7 +492,6 @@
     "category": "Tutorial",
     "setting": "tutorial_ids"
   },
-
   {
     "category": "Keyboard",
     "title": "Preferences",

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -330,6 +330,14 @@
     "restart": false
   },
   {
+    "value": false,
+    "title": "Show Playback Performance (FPS)",
+    "type": "bool",
+    "category": "Debug",
+    "setting": "preview-fps",
+    "restart": false
+  },
+  {
     "min": 0,
     "max": 9999,
     "value": 5556,

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -40,7 +40,7 @@ App.controller("TimelineCtrl", function ($scope) {
     duration: 300, //length of project in seconds
     scale: 16.0, //seconds per tick
     tick_pixels: 100, //pixels between tick mark
-    playhead_position: 10, //position of play head
+    playhead_position: 0.0, //position of play head
     clips: [],
     effects: [],
     layers: [
@@ -1527,8 +1527,8 @@ App.controller("TimelineCtrl", function ($scope) {
       scrollLeft: 0
     }, "slow");
 
-    // Update playhead position and time readout
-    $scope.movePlayhead($scope.project.playhead_position);
+    // Update playhead position and time readout (reset to zero)
+    $scope.movePlayhead(0.0);
 
     // return true
     return true;

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -544,7 +544,6 @@ App.controller("TimelineCtrl", function ($scope) {
 
   // Update cache json
   $scope.renderCache = function (cache_json) {
-    // Push new clip onto stack
     $scope.project.progress = cache_json;
 
     //clear the canvas first
@@ -567,7 +566,7 @@ App.controller("TimelineCtrl", function ($scope) {
       var stop_pixel = $scope.canvasMaxWidth(stop_second * $scope.pixelsPerSecond);
       var rect_length = stop_pixel - start_pixel;
       if (rect_length < 1) {
-        break;
+        continue;
       }
       //get the element and draw the rects
       ctx.beginPath();

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -94,8 +94,8 @@ class Export(QDialog):
         self.close_button.setVisible(False)
         self.exporting = False
 
-        # Pause playback (to prevent crash since we are fixing to change the timeline's max size)
-        get_app().window.actionPlay_trigger(None, force="pause")
+        # Pause playback
+        get_app().window.PauseSignal.emit()
 
         # Hide audio channels
         self.lblChannels.setVisible(False)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -436,8 +436,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Stop preview thread
         self.SpeedSignal.emit(0)
-        ui_util.setup_icon(self, self.actionPlay, "actionPlay", "media-playback-start")
-        self.actionPlay.setChecked(False)
+        self.PauseSignal.emit()
         QCoreApplication.processEvents()
 
         # Do we have unsaved changes?
@@ -802,8 +801,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def actionPreferences_trigger(self, checked=True):
         # Stop preview thread
         self.SpeedSignal.emit(0)
-        ui_util.setup_icon(self, self.actionPlay, "actionPlay", "media-playback-start")
-        self.actionPlay.setChecked(False)
+        self.PauseSignal.emit()
 
         # Set cursor to waiting
         get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
@@ -901,20 +899,29 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             QMessageBox.information(self, "Error !", "Unable to open the Download web page")
             log.error("Unable to open the download page", exc_info=1)
 
-    def actionPlay_trigger(self, checked=True, force=None):
-        if force == "pause":
-            self.actionPlay.setChecked(False)
-        elif force == "play":
-            self.actionPlay.setChecked(True)
+    def should_play(self, requested_speed=0):
+        """Determine if we should start playback, based on the current frame
+        and the total number of frames in our timeline clips. For example,
+        if we are at the end of our last clip, and the user clicks play, we
+        do not want to start playback."""
+        # Get max frame (based on last clip) and current frame
+        max_frame = get_app().window.timeline_sync.timeline.GetMaxFrame()
+        current_frame = self.preview_thread.current_frame
+        if current_frame is not None:
+            next_frame = current_frame + requested_speed
+            return next_frame < max_frame
+        return False
 
-        if self.actionPlay.isChecked():
-            # Determine max frame (based on clips)
-            max_frame = get_app().window.timeline_sync.timeline.GetMaxFrame()
-            ui_util.setup_icon(self, self.actionPlay, "actionPlay", "media-playback-pause")
-            self.PlaySignal.emit(max_frame)
-
+    def actionPlay_trigger(self):
+        """Toggle play/pause on video preview"""
+        player = self.preview_thread.player
+        if player.Mode() == openshot.PLAYBACK_PAUSED:
+            # Start playback
+            if self.should_play():
+                max_frame = get_app().window.timeline_sync.timeline.GetMaxFrame()
+                self.PlaySignal.emit(max_frame)
         else:
-            ui_util.setup_icon(self, self.actionPlay, "actionPlay")  # to default
+            # Pause playback
             self.PauseSignal.emit()
 
     def actionPreview_File_trigger(self, checked=True):
@@ -942,10 +949,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Notify properties dialog
         self.propertyTableView.select_frame(position_frames)
 
-    def handlePausedVideo(self):
-        """Handle the pause signal, by refreshing the properties dialog"""
-        self.propertyTableView.select_frame(self.preview_thread.player.Position())
-
     def movePlayhead(self, position_frames):
         """Update playhead position"""
         # Notify preview thread
@@ -956,30 +959,32 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.timeline.SetPlayheadFollow(enable_follow)
 
     def actionFastForward_trigger(self, checked=True):
-
-        # Get the video player object
+        """Fast forward the video playback"""
         player = self.preview_thread.player
-
-        if player.Speed() + 1 != 0:
-            self.SpeedSignal.emit(player.Speed() + 1)
-        else:
-            self.SpeedSignal.emit(player.Speed() + 2)
+        requested_speed = player.Speed() + 1
+        if requested_speed == 0:
+            # If paused, fast forward starting at faster than normal playback speed
+            requested_speed = 2
 
         if player.Mode() == openshot.PLAYBACK_PAUSED:
             self.actionPlay.trigger()
+
+        if self.should_play(requested_speed):
+            self.SpeedSignal.emit(requested_speed)
 
     def actionRewind_trigger(self, checked=True):
-        # Get the video player object
+        """Rewind the video playback"""
         player = self.preview_thread.player
-
-        new_speed = player.Speed() - 1
-        if new_speed == 0:
-            new_speed -= 1
-        log.debug("Setting speed to %s", new_speed)
+        requested_speed = player.Speed() - 1
+        if requested_speed == 0:
+            # If paused, rewind starting at normal playback speed (in reverse)
+            requested_speed = -1
 
         if player.Mode() == openshot.PLAYBACK_PAUSED:
             self.actionPlay.trigger()
-        self.SpeedSignal.emit(new_speed)
+
+        if self.should_play(requested_speed):
+            self.SpeedSignal.emit(requested_speed)
 
     def actionJumpStart_trigger(self, checked=True):
         log.debug("actionJumpStart_trigger")
@@ -993,6 +998,19 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Determine last frame (based on clips) & seek there
         max_frame = get_app().window.timeline_sync.timeline.GetMaxFrame()
         self.SeekSignal.emit(max_frame)
+
+    def onPlayCallback(self):
+        """Handle when playback is started"""
+        # Set icon on Play button
+        ui_util.setup_icon(self, self.actionPlay, "actionPlay", "media-playback-pause")
+
+    def onPauseCallback(self):
+        """Handle when playback is paused"""
+        # Refresh property window
+        self.propertyTableView.select_frame(self.preview_thread.player.Position())
+
+        # Set icon on Pause button
+        ui_util.setup_icon(self, self.actionPlay, "actionPlay")
 
     def actionSaveFrame_trigger(self, checked=True):
         log.info("actionSaveFrame_trigger")
@@ -1031,8 +1049,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         app.updates.update_untracked(["export_path"], os.path.dirname(framePath))
         log.info("Saving frame to %s", framePath)
 
-        # Pause playback (to prevent crash since we are fixing to change the timeline's max size)
-        self.actionPlay_trigger(force="pause")
+        # Pause playback
+        self.SpeedSignal.emit(0)
+        self.PauseSignal.emit()
 
         # Save current cache object and create a new CacheMemory object (ignore quality and scale prefs)
         old_cache_object = self.cache_object
@@ -1496,10 +1515,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Basic shortcuts i.e just a letter
         if key.matches(self.getShortcutByName("seekPreviousFrame")) == QKeySequence.ExactMatch:
             # Pause video
-            self.actionPlay_trigger(force="pause")
-            # Set speed to 0
-            if player.Speed() != 0:
-                self.SpeedSignal.emit(0)
+            self.PauseSignal.emit()
+            self.SpeedSignal.emit(0)
             # Seek to previous frame
             self.SeekSignal.emit(player.Position() - 1)
 
@@ -1508,10 +1525,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         elif key.matches(self.getShortcutByName("seekNextFrame")) == QKeySequence.ExactMatch:
             # Pause video
-            self.actionPlay_trigger(force="pause")
-            # Set speed to 0
-            if player.Speed() != 0:
-                self.SpeedSignal.emit(0)
+            self.PauseSignal.emit()
+            self.SpeedSignal.emit(0)
             # Seek to next frame
             self.SeekSignal.emit(player.Position() + 1)
 
@@ -1521,14 +1536,10 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         elif key.matches(self.getShortcutByName("rewindVideo")) == QKeySequence.ExactMatch:
             # Toggle rewind and start playback
             self.actionRewind.trigger()
-            ui_util.setup_icon(self, self.actionPlay, "actionPlay", "media-playback-pause")
-            self.actionPlay.setChecked(True)
 
         elif key.matches(self.getShortcutByName("fastforwardVideo")) == QKeySequence.ExactMatch:
             # Toggle fastforward button and start playback
             self.actionFastForward.trigger()
-            ui_util.setup_icon(self, self.actionPlay, "actionPlay", "media-playback-pause")
-            self.actionPlay.setChecked(True)
 
         elif any([
                 key.matches(self.getShortcutByName("playToggle")) == QKeySequence.ExactMatch,
@@ -2589,7 +2600,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.videoToolbar.addAction(self.actionPlay)
         self.videoToolbar.addAction(self.actionFastForward)
         self.videoToolbar.addAction(self.actionJumpEnd)
-        self.actionPlay.setCheckable(True)
 
         # Add right spacer
         spacer = QWidget(self)
@@ -2982,8 +2992,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.preview_thread = self.preview_parent.worker
         self.sliderZoomWidget.connect_playback()
 
-        # Set pause callback
-        self.PauseSignal.connect(self.handlePausedVideo)
+        # Set play/pause callbacks
+        self.PauseSignal.connect(self.onPauseCallback)
+        self.PlaySignal.connect(self.onPlayCallback)
 
         # QTimer for Autosave
         minutes = 1000 * 60

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -44,7 +44,8 @@ class PreviewParent(QObject):
         self.parent.movePlayhead(current_frame)
 
         # Check if we are at the end of the timeline
-        if self.worker.player.Mode() == openshot.PLAYBACK_PLAY and current_frame >= self.worker.timeline_length and self.worker.timeline_length != -1:
+        if self.worker.player.Mode() == openshot.PLAYBACK_PLAY and self.worker.player.Speed() != 0.0 \
+                and ((current_frame >= self.worker.timeline_length != -1) or current_frame <= 1):
             # Yes, pause the video
             self.parent.actionPlay.trigger()
             self.worker.timeline_length = -1

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -47,7 +47,7 @@ class PreviewParent(QObject):
         if self.worker.player.Mode() == openshot.PLAYBACK_PLAY and self.worker.player.Speed() != 0.0 \
                 and ((current_frame >= self.worker.timeline_length != -1) or current_frame <= 1):
             # Yes, pause the video
-            self.parent.actionPlay.trigger()
+            self.parent.PauseSignal.emit()
             self.worker.timeline_length = -1
 
     # Signal when the playback mode changes in the preview player (i.e PLAY, PAUSE, STOP)

--- a/src/windows/process_effect.py
+++ b/src/windows/process_effect.py
@@ -78,8 +78,8 @@ class ProcessEffect(QDialog):
         # get translations
         _ = get_app()._tr
 
-        # Pause playback (to prevent crash since we are fixing to change the timeline's max size)
-        get_app().window.actionPlay_trigger(None, force="pause")
+        # Pause playback
+        get_app().window.PauseSignal.emit()
 
         # Track metrics
         track_metric_screen("process-effect-screen")

--- a/src/windows/profile.py
+++ b/src/windows/profile.py
@@ -57,8 +57,8 @@ class Profile(QDialog):
         # get translations
         _ = get_app()._tr
 
-        # Pause playback (to prevent crash since we are fixing to change the timeline's max size)
-        get_app().window.actionPlay_trigger(None, force="pause")
+        # Pause playback
+        get_app().window.PauseSignal.emit()
 
         # Track metrics
         track_metric_screen("profile-screen")

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -26,6 +26,7 @@
  """
 
 import json
+import time
 
 from PyQt5.QtCore import (
     Qt, QCoreApplication, QMutex, QTimer,
@@ -267,10 +268,36 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         # Remove transform
         painter.resetTransform()
 
+    def update_title(self):
+        """Update the widget title"""
+        # Translate object
+        _ = get_app()._tr
+        rect = self.centeredViewport(self.width(), self.height())
+        scale = self.devicePixelRatioF()
+
+        if self.settings.get("preview-fps"):
+            # Update window title with FPS output
+            self.parent().parent().setWindowTitle(_("Video Preview") + " " + _("(Paint: %d FPS, Render: %d FPS, %dx%d)")
+                                                  % (self.paint_fps, self.present_fps,
+                                                     rect.width() * scale, rect.height() * scale))
+        else:
+            # Restore window title
+            self.parent().parent().setWindowTitle(_("Video Preview"))
+
     def paintEvent(self, event, *args):
         """ Custom paint event """
         event.accept()
         self.mutex.lock()
+
+        # Calculate "paint" FPS (and update widget title)
+        current_sec = time.localtime(time.time()).tm_sec
+        if current_sec != self.paint_fps_sec:
+            self.paint_fps = self.paint_fps_counter
+            self.update_title()
+            self.paint_fps_sec = current_sec
+            self.paint_fps_counter = 1
+        else:
+            self.paint_fps_counter += 1
 
         # Paint custom frame image on QWidget
         painter = QPainter(self)
@@ -529,6 +556,15 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
     def present(self, image, *args):
         """ Present the current frame """
+
+        # Calculate "render" / "present" FPS
+        current_sec = time.localtime(time.time()).tm_sec
+        if current_sec != self.present_fps_sec:
+            self.present_fps = self.present_fps_counter
+            self.present_fps_sec = current_sec
+            self.present_fps_counter = 1
+        else:
+            self.present_fps_counter += 1
 
         # Get frame's QImage from libopenshot
         self.current_image = image
@@ -1347,6 +1383,9 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         # Translate object
         _ = get_app()._tr
 
+        # Settings object
+        self.settings = get_app().get_settings()
+
         # Init aspect ratio settings (default values)
         self.aspect_ratio = openshot.Fraction(16, 9)
         self.pixel_ratio = openshot.Fraction(1, 1)
@@ -1385,6 +1424,14 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.resize_button.setStyleSheet('QPushButton { margin: 10px; padding: 2px; }')
         self.resize_button.clicked.connect(self.resize_button_clicked)
         self.resize_button.setMouseTracking(True)
+
+        # FPS calculations
+        self.paint_fps = 0.0
+        self.paint_fps_counter = 1
+        self.paint_fps_sec = None
+        self.present_fps = 0.0
+        self.present_fps_counter = 1
+        self.present_fps_sec = None
 
         # Load icon (using display DPI)
         self.cursors = {}

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -275,14 +275,23 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         rect = self.centeredViewport(self.width(), self.height())
         scale = self.devicePixelRatioF()
 
+        # Find parent dockWidget (if any)
+        dock = None
+        if self.parent() and self.parent().parent():
+            # TODO: Find a better way to find the QDockWidget parent (if any)
+            dock = self.parent().parent()
+        else:
+            # Not a dock widget, ignore title
+            return
+
         if self.settings.get("preview-fps"):
             # Update window title with FPS output
-            self.parent().parent().setWindowTitle(_("Video Preview") + " " + _("(Paint: %d FPS, Render: %d FPS, %dx%d)")
-                                                  % (self.paint_fps, self.present_fps,
-                                                     rect.width() * scale, rect.height() * scale))
+            dock.setWindowTitle(_("Video Preview") + " " + _("(Paint: %d FPS, Render: %d FPS, %dx%d)")
+                                                      % (self.paint_fps, self.present_fps,
+                                                         rect.width() * scale, rect.height() * scale))
         else:
             # Restore window title
-            self.parent().parent().setWindowTitle(_("Video Preview"))
+            dock.setWindowTitle(_("Video Preview"))
 
     def paintEvent(self, event, *args):
         """ Custom paint event """
@@ -1324,7 +1333,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.delayed_resize_timer.start()
 
         # Pause playback (to prevent crash since we are fixing to change the timeline's max size)
-        self.win.actionPlay_trigger(force="pause")
+        self.win.PauseSignal.emit()
 
     def delayed_resize_callback(self):
         """Callback for resize event timer (to delay the resize event, and prevent lots of similar resize events)"""

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -3217,7 +3217,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         # QTimer for cache rendering
         self.cache_renderer_version = None
         self.cache_renderer = QTimer(self)
-        self.cache_renderer.setInterval(500)
+        self.cache_renderer.setInterval(300)
         self.cache_renderer.timeout.connect(self.render_cache_json)
 
         # Connect shutdown signals


### PR DESCRIPTION
Related to https://github.com/OpenShot/libopenshot/pull/796/. (will break without 796 being merged first)

**Fixes in this PR:**
 - Fixing some **audio playback issues** where opening a project / creating a project would not use the correct sample rate
 - Fixing **cache rendering issue**, which would leave blanks unrendered (i.e. blue bar)
 - Increase **default cache** size to **1024 MB**
 - Change of **default sample rate** to **48000** (which is the default on Windows 10+ now)
 - Adding **Playback FPS** to the UI (for troubleshooting)
 - Logging **default system sample rate**, for troubleshooting (especially on Windows if audio plays back at the wrong rate, too slow or too fast). Sample rate must match OpenShot's preferences if you experience an issue with audio pitch/speed.
 - Always **reset playhead to 0** when opening / creating a project
 - **Refactor to Play/Pause buttons**, and cleaned up a bunch of sloppy icon, toggle playback code.
 - Fixed a bug which would **increment +1 timeline position** by clicking Play on an empty timeline