### PR TITLE
WIP: Make caption timestamps relative to the start of the clip

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2212,6 +2212,30 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         app = get_app()
         _ = app._tr
 
+        if len(self.selected_effects) == 0:
+            log.error("No caption effect selected")
+            return
+        effect_data = Effect.filter(id=self.selected_effects[0])[0].data
+        effect_id = effect_data.get("id")
+        if effect_data.get("type") != "Caption":
+            log.error("Captioning an effect that is not a Caption")
+            return
+
+        # Get the Clip that owns this caption effect
+        clip_data = None
+        for clip in Clip.filter():
+            for effect in clip.data.get('effects'):
+                if effect.get("id") == effect_id:
+                    clip_data = clip.data
+                    break
+            if clip_data != None:
+                break
+
+        if clip_data == None:
+            log.error("No clip owns this caption effect")
+            return
+
+
         if self.captionTextEdit.isReadOnly():
             return
 
@@ -2219,6 +2243,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
         current_position = (self.preview_thread.current_frame - 1) / fps_float
+        relative_position = current_position - clip_data.get("position")
 
         # Get cursor / current line of text (where cursor is located)
         cursor = self.captionTextEdit.textCursor()
@@ -2227,11 +2252,11 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.captionTextEdit.moveCursor(QTextCursor.EndOfLine)
 
         # Insert text at cursor position
-        current_timestamp = secondsToTimecode(current_position, fps["num"], fps["den"], use_milliseconds=True)
+        current_timestamp = secondsToTimecode(relative_position, fps["num"], fps["den"], use_milliseconds=True)
         if "-->" in line_text:
             self.captionTextEdit.insertPlainText("%s\n%s" % (current_timestamp, _("Enter caption text...")))
         else:
-            self.captionTextEdit.insertPlainText("%s --> " % (current_timestamp))
+            self.captionTextEdit.insertPlainText("\n%s --> " % (current_timestamp))
 
     def captionTextEdit_TextChanged(self):
         """Caption text was edited, start the save timer (to prevent spamming saves)"""


### PR DESCRIPTION
# Issue:
Timestamps took absolute times for when to start and stop displaying.

This meant that they had to be adjusted any time a clip was moved.

# Solution:
Subtract the `position` (the time at the left edge of a clip) before creating the timestamp.

Note: `libopenshot`'s caption code already accounted for the beginning clips, so no change to libopenshot is needed.