### PR TITLE
WIP [still testing]: Delay SVG During User Input

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2212,6 +2212,30 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         app = get_app()
         _ = app._tr
 
+        if len(self.selected_effects) == 0:
+            log.error("No caption effect selected")
+            return
+        effect_data = Effect.filter(id=self.selected_effects[0])[0].data
+        effect_id = effect_data.get("id")
+        if effect_data.get("type") != "Caption":
+            log.error("Captioning an effect that is not a Caption")
+            return
+
+        # Get the Clip that owns this caption effect
+        clip_data = None
+        for clip in Clip.filter():
+            for effect in clip.data.get('effects'):
+                if effect.get("id") == effect_id:
+                    clip_data = clip.data
+                    break
+            if clip_data != None:
+                break
+
+        if clip_data == None:
+            log.error("No clip owns this caption effect")
+            return
+
+
         if self.captionTextEdit.isReadOnly():
             return
 
@@ -2219,6 +2243,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
         current_position = (self.preview_thread.current_frame - 1) / fps_float
+        relative_position = current_position - clip_data.get("position")
 
         # Get cursor / current line of text (where cursor is located)
         cursor = self.captionTextEdit.textCursor()
@@ -2227,11 +2252,11 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.captionTextEdit.moveCursor(QTextCursor.EndOfLine)
 
         # Insert text at cursor position
-        current_timestamp = secondsToTimecode(current_position, fps["num"], fps["den"], use_milliseconds=True)
+        current_timestamp = secondsToTimecode(relative_position, fps["num"], fps["den"], use_milliseconds=True)
         if "-->" in line_text:
             self.captionTextEdit.insertPlainText("%s\n%s" % (current_timestamp, _("Enter caption text...")))
         else:
-            self.captionTextEdit.insertPlainText("%s --> " % (current_timestamp))
+            self.captionTextEdit.insertPlainText("\n%s --> " % (current_timestamp))
 
     def captionTextEdit_TextChanged(self):
         """Caption text was edited, start the save timer (to prevent spamming saves)"""

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -65,6 +65,10 @@ class TitleEditor(QDialog):
 
     def __init__(self, *args, edit_file_path=None, duplicate=False, **kwargs):
 
+        # A timer to pause until user input stops before updating the svg
+        self.update_timer = QTimer()
+        self.update_timer.timeout.connect(self.save_and_reload)
+
         # Create dialog class
         super().__init__(*args, **kwargs)
 
@@ -150,7 +154,7 @@ class TitleEditor(QDialog):
                 node.appendChild(new_text_node)
 
         # Something changed, so update temp SVG
-        self.save_and_reload()
+        self.update_timer.start(500) # Start (or restart) 0.5 second timer
 
     def display_svg(self):
         # Create a temp file for this thumbnail image
@@ -374,7 +378,7 @@ class TitleEditor(QDialog):
             return
         save_fn(color.name(), color.alphaF())
         refresh_fn()
-        self.save_and_reload()
+        self.update_timer.start(500)
 
     @staticmethod
     def best_contrast(bg: QtGui.QColor) -> QtGui.QColor:
@@ -437,7 +441,7 @@ class TitleEditor(QDialog):
             self.font_weight = fontinfo.weight()
             self.font_size_pixel = fontinfo.pixelSize()
             self.set_font_style()
-            self.save_and_reload()
+            self.update_timer.start(500)
 
     def update_font_color_button(self):
         """Updates the color shown on the font color button"""


### PR DESCRIPTION
# Issue
On windows in particular OpenShot's title editor would be slow, and even give a "Not Responding" error.

# Solution
Don't write to the svg or update the preview until the user has stopped typing for an interval.

# Demonstration
https://user-images.githubusercontent.com/42394129/155200740-e86c4b91-fc79-4920-8df1-0e51663e14b9.mp4



# Todo:
- [ ] Test on windows myself
- [ ] Get other users to test on Mac and Windows