### PR TITLE
Caption relative timestamps rebase

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2233,12 +2233,12 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         _ = app._tr
 
         if len(self.selected_effects) == 0:
-            log.error("No caption effect selected")
+            log.info("No caption effect selected")
             return
         effect_data = Effect.filter(id=self.selected_effects[0])[0].data
         effect_id = effect_data.get("id")
         if effect_data.get("type") != "Caption":
-            log.error("Captioning an effect that is not a Caption")
+            log.info("Captioning an effect that is not a Caption")
             return
 
         # Get the Clip that owns this caption effect
@@ -2252,7 +2252,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 break
 
         if clip_data == None:
-            log.error("No clip owns this caption effect")
+            log.info("No clip owns this caption effect")
             return
 
 


### PR DESCRIPTION
# Issue:
Timestamps took absolute times for when to start and stop displaying.

This meant that they had to be adjusted any time a clip was moved.

# Solution:
Subtract the `position` (the time at the left edge of a clip) before creating the timestamp.

Note: `libopenshot`'s caption code already accounted for the beginning clips, so no change to libopenshot is needed.

Other Improvements:
- Prevent timestamps outside the time of the clip
- Prevent `add timestamp` button from adding after a line has an `ending` timestamp