### PR TITLE
Revert "detect duration too long"

### DIFF
--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -742,12 +742,9 @@ App.controller("TimelineCtrl", function ($scope) {
     return Math.min(32767, desired_width);
   };
 
-// Find the furthest right edge on the timeline (and resize it if too small or too large)
+// Find the furthest right edge on the timeline (and resize it if too small)
   $scope.resizeTimeline = function () {
-    let max_timeline_padding = 20;
-    let min_timeline_padding = 10;
-    let min_timeline_length = 300; // Length of the default OpenShot project
-    // Find latest end of a clip
+    // Unselect all clips
     var furthest_right_edge = 0;
     for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
       var clip = $scope.project.clips[clip_index];
@@ -757,11 +754,10 @@ App.controller("TimelineCtrl", function ($scope) {
       }
     }
     // Resize timeline
-    if (furthest_right_edge > $scope.project.duration - min_timeline_padding || $scope.project.duration - furthest_right_edge > max_timeline_padding) {
+    if (furthest_right_edge > $scope.project.duration) {
       if ($scope.Qt) {
-        let new_timeline_length = Math.max(min_timeline_length, furthest_right_edge + min_timeline_padding);
-        timeline.resizeTimeline(new_timeline_length);
-        $scope.project.duration = new_timeline_length;
+        timeline.resizeTimeline(furthest_right_edge + 10);
+        $scope.project.duration = furthest_right_edge + 10;
       }
     }
   };

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -498,11 +498,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 self.remove_recent_project(file_path)
                 self.load_recent_menu()
 
-            # Ensure that playhead, preview thread, and cache all agree that
-            # Frame 1 is being previewed
-            self.preview_thread.player.Seek(1)
-            self.movePlayhead(1)
-
         except Exception as ex:
             log.error("Couldn't open project %s.", file_path, exc_info=1)
             QMessageBox.warning(self, _("Error Opening Project"), str(ex))

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2918,7 +2918,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
     @pyqtSlot(float)
     def resizeTimeline(self, new_duration):
         """Resize the duration of the timeline"""
-        get_app().updates.update_untracked(["duration"], new_duration)
+        get_app().updates.update(["duration"], new_duration)
 
     # Add Transition
     def addTransition(self, file_ids, event_position):


### PR DESCRIPTION
Reverts OpenShot/openshot-qt#4539

The duration detection causes an infinite loop. Not sure how we missed this in testing. Reverting until we can rework this fix.