### PR TITLE
Rework tracking of preview stats, preview resizing

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2574,14 +2574,26 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def preview_stats(self, paint_fps, present_fps, size):
         """Update the preview dock title with playback stats."""
         _ = get_app()._tr  # Translation function
-        title = _("Video Preview")
         size = f"{size.width()}×{size.height()}"
         rates = tuple(
             f"{a:0.2f}" if a > 0.1 else "--"
             for a in [paint_fps, present_fps]
         )
         stats = _("Paint: %s FPS, Render: %s FPS") % rates
-        self.dockVideo.setWindowTitle(f"{title} | {size} | {stats}")
+        self.video_dock_title(size, stats)
+
+    def stats_enable(self, enabled=True):
+        """Control the display of stats in the preview titlebar"""
+        self.videoPreview.send_stats(enabled)
+        if not enabled:
+            self.video_dock_title()
+
+    def video_dock_title(self, *args):
+        """Optionally display stats in the dock title"""
+        _ = get_app()._tr  # Translations
+        title = _("Video Preview")
+        self.dockVideo.setWindowTitle(
+            " | ".join([title, *args]))
 
     def setup_toolbars(self):
         _ = get_app()._tr  # Get translation function

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -461,28 +461,28 @@ class Preferences(QDialog):
 
     def bool_value_changed(self, widget, param, state):
         # Save setting
-        if state == Qt.Checked:
-            self.s.set(param["setting"], True)
-        else:
-            self.s.set(param["setting"], False)
+        key = param["setting"]
+        value = state == Qt.Checked
+        self.s.set(key, value)
 
         # Trigger specific actions
-        if param["setting"] == "debug-mode":
-            # Update debug setting of timeline
-            log.info("Setting debug-mode to %s", state == Qt.Checked)
-            debug_enabled = (state == Qt.Checked)
 
+        if key == "debug-mode":
+            log.info("Setting debug-mode to %s", value)
             # Enable / Disable logger
-            openshot.ZmqLogger.Instance().Enable(debug_enabled)
+            openshot.ZmqLogger.Instance().Enable(value)
 
-        elif param["setting"] == "enable-auto-save":
+        elif key == "enable-auto-save":
+            timer = get_app().window.auto_save_timer
             # Toggle autosave
-            if (state == Qt.Checked):
-                # Start/Restart autosave timer
-                get_app().window.auto_save_timer.start()
+            if value:
+                timer.start()
             else:
-                # Stop autosave timer
-                get_app().window.auto_save_timer.stop()
+                timer.stop()
+
+        elif key == "preview-fps":
+            # Toggle stats reporting
+            get_app().window.stats_enable(value)
 
         # Check for restart
         self.check_for_restart(param)

--- a/src/windows/profile.py
+++ b/src/windows/profile.py
@@ -179,5 +179,3 @@ class Profile(QDialog):
         win.SeekSignal.emit(1)
         # Refresh frame (since size of preview might have changed)
         QTimer.singleShot(500, win.refreshFrameSignal.emit)
-        QTimer.singleShot(500, functools.partial(win.MaxSizeChanged.emit,
-                                                 win.videoPreview.size()))

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -322,7 +322,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
     def track_size(self):
         scale = self.devicePixelRatioF()
-        viewport = self.centeredViewport(self.width(), self.height())
+        viewport = self.centeredViewport()
         size = QSizeF(viewport.size()) * scale
         self.stats_tracker.viewport_size = size.toSize()
 
@@ -346,7 +346,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         painter.fillRect(event.rect(), QColor("#191919"))
 
         # Find centered viewport
-        viewport_rect = self.centeredViewport(self.width(), self.height())
+        viewport_rect = self.centeredViewport()
 
         if self.current_image:
             # DRAW FRAME
@@ -563,13 +563,15 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         painter.end()
         self.mutex.unlock()
 
-    def centeredViewport(self, width, height):
+    def centeredViewport(self, width=None, height=None):
         """ Calculate size of viewport to maintain aspect ratio """
 
-        window_size = QSizeF(width, height)
+        window_size = QSizeF(
+            width or self.width(),
+            height or self.height())
         window_rect = QRectF(QPointF(0, 0), window_size)
 
-        aspectRatio = self.aspect_ratio.ToFloat() * self.pixel_ratio.ToFloat()
+        aspectRatio = float(self.aspect_ratio * self.pixel_ratio)
         viewport_size = QSizeF(aspectRatio, 1).scaled(
                             window_size, Qt.KeepAspectRatio
                         ) * self.zoom
@@ -764,8 +766,9 @@ class VideoWidget(QWidget, updates.UpdateInterface):
             shear_x = raw_properties.get('shear_x').get('value')
             shear_y = raw_properties.get('shear_y').get('value')
 
-            # Get the rect where the video is actually drawn (without the black borders, etc...)
-            viewport_rect = self.centeredViewport(self.width(), self.height())
+            # Get the rect where the video is actually drawn
+            # (without the black borders, etc...)
+            viewport_rect = self.centeredViewport()
 
             # Make back-up of clip data
             if self.mouse_dragging and not self.transform_mode:
@@ -1045,8 +1048,9 @@ class VideoWidget(QWidget, updates.UpdateInterface):
             playhead_position_frame = float(get_app().window.preview_thread.current_frame)
             clip_frame_number = round(playhead_position_frame - position_of_clip_frame) + start_of_clip_frame
 
-            # Get the rect where the video is actually drawn (without the black borders, etc...)
-            viewport_rect = self.centeredViewport(self.width(), self.height())
+            # Get the rect where the video is actually drawn
+            # (without the black borders, etc...)
+            viewport_rect = self.centeredViewport()
 
             # Make back-up of clip data
             if self.mouse_dragging and not self.transform_mode:

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -592,6 +592,13 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         """ Connect signals to renderer """
         renderer.present.connect(self.present)
 
+    def send_stats(self, enabled=True):
+        """Activate/deactivate the stats tracker"""
+        if enabled:
+            self.stats_tracker.start()
+        else:
+            self.stats_tracker.stop()
+
     def mousePressEvent(self, event):
         """Capture mouse press event on video preview window"""
         event.accept()


### PR DESCRIPTION
#### Update

I've massively reworked this PR, eliminating some of the more-ambitious (but unrelated) stuff centered around signal handling, but adding in some other changes. The current set of changes involve:

### Make preview account for `devicePixelRatioF()`, force values be divisible by 2

Instead of `timeline_sync` applying the device pixel ratio to the size it passes to libopenshot, the `recompute_size()` method of the preview now takes that into account when doing its size math.

I also made sure that both the width and height passed to libopenshot are always divisible by two, in the most obvious way possible (I'm embarrassed it took me this long to think of it): By doing all the math at half-size, then multiplying the final size by 2. The tradeoff here is that the aspect ratio may be slightly less precise, but all of the values will be even numbers.

### Move 'MaxSizeChanged' into `windows.video_preview`,  as a signal emitted by the preview widget

- Previously, MaxSizeChanged was emitted from three or four different locations, each using different math
- To avoid setting wrong sizes, the video widget will have sole control over the preview dimensions set on the libopenshot Timeline object. All logic is confined to its `recompute_size()` function, a slot which other objects can connect signals to (or call manually) if they need to trigger recalculation of the preview size.

Oh, and `MaxSizeChangedCB` will now retain the last size it was called with, and ignore additional calls to apply the same size. So, no more updating libopenshot multiple times, if you resize the preview _widget_ in a way that doesn't alter the preview _size_. (There's also a new method to clear its stored size, so that the next size change will always be applied. The snapshot code calls that, for example, to ensure it can reapply the preview size after changing it. The TimelineSync code also automatically clears the stored size whenever a `load` update event comes through.)

### Make `classes.timeline.TimelineSync` a `QObject`

The `TimelineSync` class is now a `QObject`, and `MaxSizeChangedCB` is decorated as `@pyqtSlot(QSize)`. This means Qt will handle the cleanup of signal connections on application shutdown.

### Add StatsTracker for the Video Preview

In response to this `TODO` comment from @jonoomph:

https://github.com/OpenShot/openshot-qt/blob/70a52ac0907941261f7c3d9e22bbf51ff35fb72d/src/windows/video_widget.py#L278-L283

...this PR provides the requested better way to contact the QDockWidget hosting the video preview — by completely overhauling how the stats are collected and managed, so that the lookup is done from the side that already has the necessary information.

A new class, `StatsTracker`, is added to the `video_preview.py` source file, and all of the handling of tracking and reporting on performance stats is moved _there_. The sum total of code run inside of the (time-critical) `paintEvent` and `present` methods is now these two lines of code:

* In `paintEvent()`:
  ```python
  # Calculate "paint" FPS
  self.stats_tracker.paint_count += 1
  ````
* In `present()`:
   ```python
   # Count "render" / "present" events
   self.stats_tracker.present_count += 1
   ```

Everything else is offloaded into StatsTracker, where it updates on a `QTimer`. (Currently triggering twice a second, which felt about right to me. But it can easily be adjusted to taste.)

Twice a second, `StatsTracker` checks `time.monotonic()` for an updated time (so it won't freak out when daylight savings rolls around, or someone's computer goes to sleep and the clock slips backwards), computes updated stats for the FPS rates, and fires them off as a Qt signal.

That signal is connected to a new slot in `MainWindow`, which then takes care of updating the dock widget's title (since it already has a reference to the dock) so that it shows the stats like so:

> **Video Preview | 1280×720 | Paint: 29.97 FPS, Render: 27.65 FPS**

When it receives 0 values for both rates (actually anything `< 0.1`), instead of numbers it drops back to an inactivity mode. Until it gets new data, the display will be:

> **Video Preview | 1280×720 | Paint: -- FPS, Render: -- FPS**

This is more in line with the intended use of signals: A class **transmits** data from its _own_ signals, and any interested parties listen and respond accordingly.

The display of sats in the Video Preview title is still controlled by the `preview-fps` settings value.

#### (Minor:) Add default values for `centered_viewport()`

Since nearly _every_ call to `centered_viewport()` in the preview code passed it `self.width(), self.height()` as arguments, those are now the defaults if it's not passed other values, so the preview code can just call it without arguments.
