### PR TITLE
Fixing path support with escaped characters (such as quotes inside a filename)

### DIFF
--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -39,7 +39,7 @@ from classes import info
 from classes.app import get_app
 
 # Compiled path regex
-path_regex = re.compile(r'"(image|path)"\s*:\s*"(.*?)"')
+path_regex = re.compile(r'"(image|path)"\s*:\s*"(.*)"')
 path_context = {}
 
 
@@ -234,6 +234,12 @@ class JsonDataStore:
         key = match.groups(0)[0]
         path = match.groups(0)[1]
 
+        # Convert escaped path back into python str.
+        # Some characters, such as backslashes and quotes
+        # are escaped during the JSON dumps() conversion.
+        #   /Videos/quote \\"/  instead of  /Videos/quote "/
+        path = json.loads('"%s"' % path)
+
         # Find absolute path of file (if needed)
         if "@transitions" in path:
             new_path = path.replace("@transitions", os.path.join(info.PATH, "transitions"))
@@ -277,6 +283,14 @@ class JsonDataStore:
         """Replace matched string for converting paths to relative paths"""
         key = match.groups(0)[0]
         path = match.groups(0)[1]
+
+        # Convert escaped path back into python str.
+        # Some characters, such as backslashes and quotes
+        # are escaped during the JSON dumps() conversion.
+        #   /Videos/quote \\"/  instead of  /Videos/quote "/
+        path = json.loads('"%s"' % path)
+
+        # Split path into folder and file
         folder_path, file_path = os.path.split(os.path.abspath(path))
 
         # Determine if thumbnail path is found


### PR DESCRIPTION
Fixing path support with escaped characters, such as quotes inside a file name. Made regex more greedy, to get the entire string between quotes. Parse regex JSON paths back to Python strings before absolute/relative logic, and then back to escaped JSON string.

Fixes https://github.com/OpenShot/openshot-qt/issues/4551

**Examples**:
```
# Actual absolute file path:
/home/jonathan/Videos/quote "/sintel 100" quote.mp4

# Successfully escaped relative path after Dict => JSON conversion:
"Videos/quote \"/sintel 100\" quote.mp4"
```

**Before this fix** (causing corruption to the *.osp file after saving)
```
# Invalid file path after Dict => JSON conversion:
"Videos/quote /"/sintel 100\" quote.mp4"
```