### PR TITLE
Don't prompt to import as image sequence for titles

### DIFF
--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -243,7 +243,7 @@ class FilesModel(QObject, updates.UpdateInterface):
         # Emit signal when model is updated
         self.ModelRefreshed.emit()
 
-    def add_files(self, files, image_seq_details=None, quiet=False):
+    def add_files(self, files, image_seq_details=None, quiet=False, prevent_image_seq=False):
         # Access translations
         app = get_app()
         _ = app._tr
@@ -288,7 +288,9 @@ class FilesModel(QObject, updates.UpdateInterface):
                 new_file.data = file_data
 
                 # Is this an image sequence / animation?
-                seq_info = image_seq_details or self.get_image_sequence_details(filepath)
+                seq_info = None
+                if not prevent_image_seq:
+                    seq_info = image_seq_details or self.get_image_sequence_details(filepath)
 
                 if seq_info:
                     # Update file with correct path

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -612,7 +612,7 @@ class TitleEditor(QDialog):
                 self.writeToFile(self.xmldoc)
 
                 # Add file to project
-                app.window.files_model.add_files(self.filename)
+                app.window.files_model.add_files(self.filename, prevent_image_seq=True)
 
         # Close window
         super().accept()


### PR DESCRIPTION
# Bug:
In the title editor, certain formats of file names would trigger the "Import as an Image Sequence?" dialog, but titles can only be individual files.

# Solution:
Added an optional argument to prevent the image sequence prompt