### PR TITLE
Detect shorten project duration rebase

### DIFF
--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -760,6 +760,11 @@ App.controller("TimelineCtrl", function ($scope) {
         timeline.resizeTimeline(furthest_right_edge + 10);
         $scope.project.duration = furthest_right_edge + 10;
       }
+    } else if ( $scope.project.duration - furthest_right_edge > 20) {
+      if ($scope.Qt) {
+        $scope.project.duration = furthest_right_edge;
+        timeline.resizeTimeline(furthest_right_edge);
+      }
     }
   };
 

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -745,7 +745,7 @@ App.controller("TimelineCtrl", function ($scope) {
 
 // Find the furthest right edge on the timeline (and resize it if too small)
   $scope.resizeTimeline = function () {
-    // Unselect all clips
+    // Find latest end of a clip
     var furthest_right_edge = 0;
     for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
       var clip = $scope.project.clips[clip_index];
@@ -755,7 +755,7 @@ App.controller("TimelineCtrl", function ($scope) {
       }
     }
     // Resize timeline
-    if (furthest_right_edge > $scope.project.duration) {
+    if (furthest_right_edge > $scope.project.duration || $scope.project.duration > furthest_right_edge + 20) {
       if ($scope.Qt) {
         timeline.resizeTimeline(furthest_right_edge + 10);
         $scope.project.duration = furthest_right_edge + 10;

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -743,8 +743,10 @@ App.controller("TimelineCtrl", function ($scope) {
     return Math.min(32767, desired_width);
   };
 
-// Find the furthest right edge on the timeline (and resize it if too small)
+// Find the furthest right edge on the timeline (and resize it if too small or too large)
   $scope.resizeTimeline = function () {
+    var max_timeline_padding = 20;
+    var min_timeline_padding = 10;
     // Find latest end of a clip
     var furthest_right_edge = 0;
     for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
@@ -755,15 +757,10 @@ App.controller("TimelineCtrl", function ($scope) {
       }
     }
     // Resize timeline
-    if (furthest_right_edge > $scope.project.duration || $scope.project.duration > furthest_right_edge + 20) {
+    if (furthest_right_edge > $scope.project.duration || $scope.project.duration - furthest_right_edge > max_timeline_padding) {
       if ($scope.Qt) {
-        timeline.resizeTimeline(furthest_right_edge + 10);
-        $scope.project.duration = furthest_right_edge + 10;
-      }
-    } else if ( $scope.project.duration - furthest_right_edge > 20) {
-      if ($scope.Qt) {
-        $scope.project.duration = furthest_right_edge;
-        timeline.resizeTimeline(furthest_right_edge);
+        timeline.resizeTimeline(furthest_right_edge + min_timeline_padding);
+        $scope.project.duration = furthest_right_edge + min_timeline_padding;
       }
     }
   };

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -745,8 +745,9 @@ App.controller("TimelineCtrl", function ($scope) {
 
 // Find the furthest right edge on the timeline (and resize it if too small or too large)
   $scope.resizeTimeline = function () {
-    var max_timeline_padding = 20;
-    var min_timeline_padding = 10;
+    let max_timeline_padding = 20;
+    let min_timeline_padding = 10;
+    let min_timeline_length = 300; // Length of the default OpenShot project
     // Find latest end of a clip
     var furthest_right_edge = 0;
     for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
@@ -757,10 +758,11 @@ App.controller("TimelineCtrl", function ($scope) {
       }
     }
     // Resize timeline
-    if (furthest_right_edge > $scope.project.duration || $scope.project.duration - furthest_right_edge > max_timeline_padding) {
+    if (furthest_right_edge > $scope.project.duration - min_timeline_padding || $scope.project.duration - furthest_right_edge > max_timeline_padding) {
       if ($scope.Qt) {
-        timeline.resizeTimeline(furthest_right_edge + min_timeline_padding);
-        $scope.project.duration = furthest_right_edge + min_timeline_padding;
+        let new_timeline_length = Math.max(min_timeline_length, furthest_right_edge + min_timeline_padding);
+        timeline.resizeTimeline(new_timeline_length);
+        $scope.project.duration = new_timeline_length;
       }
     }
   };

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -758,10 +758,9 @@ App.controller("TimelineCtrl", function ($scope) {
       }
     }
     // Resize timeline
-    if (furthest_right_edge > $scope.project.duration - min_timeline_padding || $scope.project.duration - furthest_right_edge > max_timeline_padding) {
+    if (furthest_right_edge > $scope.project.duration - min_timeline_padding || furthest_right_edge < $scope.project.duration - max_timeline_padding) {
       if ($scope.Qt) {
         let new_timeline_length = Math.max(min_timeline_length, furthest_right_edge + min_timeline_padding);
-        timeline.resizeTimeline(new_timeline_length);
         $scope.project.duration = new_timeline_length;
       }
     }

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -498,6 +498,11 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 self.remove_recent_project(file_path)
                 self.load_recent_menu()
 
+            # Ensure that playhead, preview thread, and cache all agree that
+            # Frame 1 is being previewed
+            self.preview_thread.player.Seek(1)
+            self.movePlayhead(1)
+
         except Exception as ex:
             log.error("Couldn't open project %s.", file_path, exc_info=1)
             QMessageBox.warning(self, _("Error Opening Project"), str(ex))

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2918,7 +2918,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
     @pyqtSlot(float)
     def resizeTimeline(self, new_duration):
         """Resize the duration of the timeline"""
-        get_app().updates.update(["duration"], new_duration)
+        get_app().updates.update_untracked(["duration"], new_duration)
 
     # Add Transition
     def addTransition(self, file_ids, event_position):


### PR DESCRIPTION
# Bug
When a very long clip is added to a project, the timeline expands to fit. If that clip is removed or shortened, the timeline was not shortening back down.
# Fix
If the timeline is beyond maximum extra length, the timeline will be shortened.
# Testing
1) Set a clip's position higher than the ending of the timeline
2) Move that clip to the far left end of the timeline
3) Observe that the timeline has shortened.


Example:

https://user-images.githubusercontent.com/42394129/156685929-882504e6-ad99-4d5e-980e-53fd63e9fc59.mp4


