### PR TITLE
Fixing UNDO support for Removing a Project File (and missing thumbnails)

### DIFF
--- a/src/timeline/media/css/main.css
+++ b/src/timeline/media/css/main.css
@@ -138,8 +138,8 @@ img {
     -webkit-gradient(linear, left top, left bottom,
                      color-stop(0%, rgba(255, 255, 255, 0.20)),
                      color-stop(100%, rgba(255, 255, 255, 0)));
-  border-top-left-radiux;
-  border-bottom-left-ra 8px;
+  border-top-left-radius: 8px;
+  border-bottom-left-radius: 8px;
 }
 
 .track_lock {

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1743,15 +1743,14 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             if not f:
                 continue
 
-            f_id = f.data["id"]
-            # Remove file
-            f.delete()
-
             # Find matching clips (if any)
-            clips = Clip.filter(file_id=f_id)
+            clips = Clip.filter(file_id=f.data.get("id"))
             for c in clips:
                 # Remove clip
                 c.delete()
+
+            # Remove file (after clips are deleted)
+            f.delete()
 
         # Refresh preview
         get_app().window.refreshFrameSignal.emit()


### PR DESCRIPTION
Removing a File from a project will now 1st remove any related Clips, and then the File. This allows the Undo action to correctly undo the File first, and then the Clips (preventing a Clip with no File, causing no thumbnail).

**NOTE: This mostly affects Windows (and webkit backends).** 

![Missing-Thumbnail-After-Undo](https://user-images.githubusercontent.com/5551883/156679693-a0b00bd1-e7eb-499f-b94d-fdaa3c05a6ef.png)

**Testing Instructions:**
- Using a Windows build (or `--web-backend webkit`)
- Drag a video File into OpenShot
- Drag the file onto the timeline creating 1 or more clips
- Right click on the File (in Project Files), and select "Remove from Project" (this will cause all related clips to be removed)
- Now click "Undo" or CTRL+Z - the clips should return WITH thumbnails
- NOTE: On Linux/Mac (web-engine backend), it appears to cache the previous thumbnail image (and thus, is not as noticeable of an issue)