### PR TITLE
Formatting change to Caption Effect

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2300,7 +2300,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 self.captionTextEdit.moveCursor(QTextCursor.End)
                 self.captionTextEdit.insertPlainText("\n\n")
             # Add timestamp, and placeholder caption
-            self.captionTextEdit.insertPlainText("%s --> \n %s" % (current_timestamp, _("Enter caption text...")))
+            self.captionTextEdit.insertPlainText("%s --> \n%s" % (current_timestamp, _("Enter caption text...")))
             # Return to timestamp line, to await ending timestamp
             self.captionTextEdit.moveCursor(QTextCursor.Up)
 

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2227,6 +2227,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         """Insert the current timestamp into the caption editor
         In the format: 00:00:23,000 --> 00:00:24,500. first click to set the initial timestamp,
         move the playehad, second click to set the end timestamp.
+
+        If beginning and ending timestamps would be the same, add 5 seconds to the second.
         """
         # Get translation function
         app = get_app()
@@ -2285,15 +2287,22 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             # recalculate the timestamp string
             current_timestamp = secondsToTimecode(relative_position, fps["num"], fps["den"], use_milliseconds=True)
 
-        # Insert text at cursor position
         if "-->" in line_text and line_text.count(':') == 3:
-            self.captionTextEdit.insertPlainText("%s\n%s" % (current_timestamp, _("Enter caption text...")))
+            # Current line has only one timestamp. Add the second and go to the line below it.
+            self.captionTextEdit.insertPlainText(current_timestamp)
+            self.captionTextEdit.moveCursor(QTextCursor.Down)
+            self.captionTextEdit.moveCursor(QTextCursor.EndOfLine)
         else:
-            # If the last line isn't blank, add two blank lines
+            # Current line isn't a starting timestamp, so add a starting timestamp
+
+            # If the current line isn't blank, go to end and add two blank lines
             if (self.captionTextEdit.textCursor().block().text().strip() != ""):
                 self.captionTextEdit.moveCursor(QTextCursor.End)
                 self.captionTextEdit.insertPlainText("\n\n")
-            self.captionTextEdit.insertPlainText("%s --> " % (current_timestamp))
+            # Add timestamp, and placeholder caption
+            self.captionTextEdit.insertPlainText("%s --> \n %s" % (current_timestamp, _("Enter caption text...")))
+            # Return to timestamp line, to await ending timestamp
+            self.captionTextEdit.moveCursor(QTextCursor.Up)
 
     def captionTextEdit_TextChanged(self):
         """Caption text was edited, start the save timer (to prevent spamming saves)"""


### PR DESCRIPTION
# Issue:
In the case that a user adds captions in an unusual order, the caption formatting interferes.
1) Add a starting caption timestamp, and the caption string below it.
2) Play the video, until the next audio to caption
3) Add a caption for that new audio
4) Go back to the first caption to mark it's end.
Demonstrated below:

https://user-images.githubusercontent.com/42394129/156821659-c0acc38b-e2e9-4472-8ee2-e3d4da2484cf.mp4

The logic to prevent a caption of 0 duration checks the current playhead position to where it was on the last timestamp click. Since it hasn't moved between `step 3` and `step 4`, 5 seconds is wrongly added.

(Smaller issue: adding the second timestamp adds `Enter caption text...` where the user has already typed.)

# Solution:
1) Check that the actual timecode isn't in the cursor's line.
2) Add placeholder text: (`Enter caption text...`) with the _first_ timecode, then move the cursor back up a line for the user to specify the end time (or click again for the 5 second default)

# Example with fix:

https://user-images.githubusercontent.com/42394129/156822430-810d9eec-1776-425d-9c38-3e3f70a8f681.mp4


