### PR TITLE
Trigger a redraw of the zoom slider when the timeline auto-shortens

### DIFF
--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -760,7 +760,7 @@ App.controller("TimelineCtrl", function ($scope) {
     if (furthest_right_edge > $scope.project.duration - min_timeline_padding || furthest_right_edge < $scope.project.duration - max_timeline_padding) {
       if ($scope.Qt) {
         let new_timeline_length = Math.max(min_timeline_length, furthest_right_edge + min_timeline_padding);
-        $scope.project.duration = new_timeline_length;
+        timeline.resizeTimeline(new_timeline_length);
       }
     }
   };

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -112,6 +112,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     CaptionTextLoaded = pyqtSignal(str, object)
     TimelineZoom = pyqtSignal(float)     # Signal to zoom into timeline from zoom slider
     TimelineScrolled = pyqtSignal(list)  # Scrollbar changed signal from timeline
+    TimelineResize = pyqtSignal()  # Timeline length changed signal from timeline
     TimelineScroll = pyqtSignal(float)   # Signal to force scroll timeline to specific point
     TimelineCenter = pyqtSignal()        # Signal to force center scroll on playhead
     SelectionAdded = pyqtSignal(str, str, bool)  # Signal to add a selection

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2919,8 +2919,13 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
     def resizeTimeline(self, new_duration):
         """Resize the duration of the timeline"""
         log.debug(f"Changing timeline to length: {new_duration}")
-        get_app().updates.update_untracked(["duration"], new_duration)
-        get_app().window.TimelineResize.emit()
+        duration_diff = abs(get_app().project.get('duration') - new_duration)
+        if (duration_diff > 1.0):
+            log.debug("Updating duration")
+            get_app().updates.update_untracked(["duration"], new_duration)
+            get_app().window.TimelineResize.emit()
+        else:
+            log.debug("Duration unchanged. Not updating")
 
     # Add Transition
     def addTransition(self, file_ids, event_position):

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2918,7 +2918,9 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
     @pyqtSlot(float)
     def resizeTimeline(self, new_duration):
         """Resize the duration of the timeline"""
+        log.debug(f"Changing timeline to length: {new_duration}")
         get_app().updates.update_untracked(["duration"], new_duration)
+        get_app().window.TimelineResize.emit()
 
     # Add Transition
     def addTransition(self, file_ids, event_position):

--- a/src/windows/views/zoom_slider.py
+++ b/src/windows/views/zoom_slider.py
@@ -524,6 +524,8 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
         # Connect zoom functionality
         self.win.TimelineScrolled.connect(self.update_scrollbars)
 
+        self.win.TimelineResize.connect(self.delayed_resize_callback)
+
         # Connect Selection signals
         self.win.SelectionChanged.connect(self.handle_selection)
 


### PR DESCRIPTION
# issue
My update to (#4703) lengthens or shortens the timeline to fit the clips in the project. But it wasn't updating the zoom slider with that new duration.

# Solution
I added a signal (`resizeTimeline`) and have the zoom slider update itself in response to that signal.

# Possible issue:
The zoom slider keeps its handles at the same positions they were at.
This means if your zoom slider was covering the first half of your project, and your project doubled in length,
your zoom slider will still be covering half of your project. (Now twice as much time)


https://user-images.githubusercontent.com/42394129/157952043-e7ef532a-da73-4f1c-bfd5-4e18077a87c2.mp4



# Testing:
1) Run in debug mode
2) Start a new project.
3) Add a clip, and set it's `position` higher than 300.
4) Watch the debug console.
    - Should see `DEBUG webview: Updating duration`
    - Then the debug window shouldn't keep moving until you interact with OpenShot again.