### PR TITLE
WIP: Add missing 720p and 1080p vertical export profiles, add 8K video export profiles and update social media export presets

### DIFF
--- a/src/presets/instagram.xml
+++ b/src/presets/instagram.xml
@@ -17,12 +17,12 @@
 	 med="128 kb/s"
 	 high="192 kb/s"></audiobitrate>
 	<samplerate>48000</samplerate>
-
 	<projectprofile>HD 720p 25 fps</projectprofile>
 	<projectprofile>HD 720p 30 fps</projectprofile>
 	<projectprofile>HD 1080p 25 fps</projectprofile>
 	<projectprofile>HD 1080p 30 fps</projectprofile>
+	<projectprofile>HD Vertical 720p 25 fps</projectprofile>
 	<projectprofile>HD Vertical 720p 30 fps</projectprofile>
+	<projectprofile>HD Vertical 1080p 25 fps</projectprofile>
 	<projectprofile>HD Vertical 1080p 30 fps</projectprofile>
-	
 </export-option>

--- a/src/presets/twitter.xml
+++ b/src/presets/twitter.xml
@@ -21,9 +21,8 @@
 	<projectprofile>HD 720p 30 fps</projectprofile>
 	<projectprofile>HD 1080p 25 fps</projectprofile>
 	<projectprofile>HD 1080p 30 fps</projectprofile>
-	<projectprofile>HD Vertical 720p 30 fps</projectprofile> 
-        <projectprofile>HD Vertical 1080p 30 fps</projectprofile>
-
-
-
+	<projectprofile>HD Vertical 720p 25 fps</projectprofile>
+	<projectprofile>HD Vertical 720p 30 fps</projectprofile>
+	<projectprofile>HD Vertical 1080p 25 fps</projectprofile>
+  <projectprofile>HD Vertical 1080p 30 fps</projectprofile>
 </export-option>

--- a/src/presets/twitter.xml
+++ b/src/presets/twitter.xml
@@ -24,5 +24,5 @@
 	<projectprofile>HD Vertical 720p 25 fps</projectprofile>
 	<projectprofile>HD Vertical 720p 30 fps</projectprofile>
 	<projectprofile>HD Vertical 1080p 25 fps</projectprofile>
-  <projectprofile>HD Vertical 1080p 30 fps</projectprofile>
+	<projectprofile>HD Vertical 1080p 30 fps</projectprofile>
 </export-option>

--- a/src/presets/youtube.xml
+++ b/src/presets/youtube.xml
@@ -27,4 +27,12 @@
 	<projectprofile>HD 720p 50 fps</projectprofile>
 	<projectprofile>HD 720p 59.94 fps</projectprofile>
 	<projectprofile>HD 720p 60 fps</projectprofile>
+	<projectprofile>HD Vertical 720p 23.98 fps</projectprofile>
+	<projectprofile>HD Vertical 720p 24 fps</projectprofile>
+	<projectprofile>HD Vertical 720p 25 fps</projectprofile>
+	<projectprofile>HD Vertical 720p 29.97 fps</projectprofile>
+	<projectprofile>HD Vertical 720p 30 fps</projectprofile>
+	<projectprofile>HD Vertical 720p 50 fps</projectprofile>
+	<projectprofile>HD Vertical 720p 59.94 fps</projectprofile>
+	<projectprofile>HD Vertical 720p 60 fps</projectprofile>
 </export-option>

--- a/src/presets/youtube_8K.xml
+++ b/src/presets/youtube_8K.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE openshot-export-option>
+<export-option>
+	<type translatable="True">Web</type>
+    <title translatable="True">YouTube HD (8K)</title>
+	<videoformat>mp4</videoformat>
+	<videocodec>libx264</videocodec>
+	<audiocodec>libmp3lame</audiocodec>
+	<audiochannels>2</audiochannels>
+	<audiochannellayout>3</audiochannellayout>
+	<videobitrate
+	 low="160 Mb/s"
+	 med="200 Mb/s"
+	 high="240 Mb/s"></videobitrate>
+	<audiobitrate
+	 low="128 kb/s"
+	 med="256 kb/s"
+	 high="320 kb/s"></audiobitrate>
+	<samplerate>48000</samplerate>
+	<projectprofile>8K UHD 4320p 23.98 fps</projectprofile>
+	<projectprofile>8K UHD 4320p 24 fps</projectprofile>
+	<projectprofile>8K UHD 4320p 25 fps</projectprofile>
+	<projectprofile>8K UHD 4320p 29.97 fps</projectprofile>
+	<projectprofile>8K UHD 4320p 30 fps</projectprofile>
+	<projectprofile>8K UHD 4320p 50 fps</projectprofile>
+	<projectprofile>8K UHD 4320p 59.94 fps</projectprofile>
+	<projectprofile>8K UHD 4320p 60 fps</projectprofile>
+</export-option>

--- a/src/presets/youtube_HD.xml
+++ b/src/presets/youtube_HD.xml
@@ -25,4 +25,12 @@
 	<projectprofile>HD 1080p 50 fps</projectprofile>
 	<projectprofile>HD 1080p 59.94 fps</projectprofile>
 	<projectprofile>HD 1080p 60 fps</projectprofile>
+	<projectprofile>HD Vertical 1080p 23.98 fps</projectprofile>
+	<projectprofile>HD Vertical 1080p 24 fps</projectprofile>
+	<projectprofile>HD Vertical 1080p 25 fps</projectprofile>
+	<projectprofile>HD Vertical 1080p 29.97 fps</projectprofile>
+	<projectprofile>HD Vertical 1080p 30 fps</projectprofile>
+	<projectprofile>HD Vertical 1080p 50 fps</projectprofile>
+	<projectprofile>HD Vertical 1080p 59.94 fps</projectprofile>
+	<projectprofile>HD Vertical 1080p 60 fps</projectprofile>
 </export-option>

--- a/src/profiles/uhd_4320p_2398
+++ b/src/profiles/uhd_4320p_2398
@@ -1,0 +1,11 @@
+description=8K UHD 4320p 23.98 fps
+frame_rate_num=24000
+frame_rate_den=1001
+width=7680
+height=4320
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=16
+display_aspect_den=9
+colorspace=709

--- a/src/profiles/uhd_4320p_24
+++ b/src/profiles/uhd_4320p_24
@@ -1,0 +1,11 @@
+description=8K UHD 4320p 24 fps
+frame_rate_num=24
+frame_rate_den=1
+width=7680
+height=4320
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=16
+display_aspect_den=9
+colorspace=709

--- a/src/profiles/uhd_4320p_25
+++ b/src/profiles/uhd_4320p_25
@@ -1,0 +1,11 @@
+description=8K UHD 4320p 25 fps
+frame_rate_num=25
+frame_rate_den=1
+width=7680
+height=4320
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=16
+display_aspect_den=9
+colorspace=709

--- a/src/profiles/uhd_4320p_2997
+++ b/src/profiles/uhd_4320p_2997
@@ -1,0 +1,11 @@
+description=8K UHD 4320p 29.97 fps
+frame_rate_num=30000
+frame_rate_den=1001
+width=7680
+height=4320
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=16
+display_aspect_den=9
+colorspace=709

--- a/src/profiles/uhd_4320p_30
+++ b/src/profiles/uhd_4320p_30
@@ -1,0 +1,11 @@
+description=8K UHD 4320p 30 fps
+frame_rate_num=30
+frame_rate_den=1
+width=7680
+height=4320
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=16
+display_aspect_den=9
+colorspace=709

--- a/src/profiles/uhd_4320p_50
+++ b/src/profiles/uhd_4320p_50
@@ -1,0 +1,11 @@
+description=8K UHD 4320p 50 fps
+frame_rate_num=50
+frame_rate_den=1
+width=7680
+height=4320
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=16
+display_aspect_den=9
+colorspace=709

--- a/src/profiles/uhd_4320p_5994
+++ b/src/profiles/uhd_4320p_5994
@@ -1,0 +1,11 @@
+description=8K UHD 4320p 59.94 fps
+frame_rate_num=60000
+frame_rate_den=1001
+width=7680
+height=4320
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=16
+display_aspect_den=9
+colorspace=709

--- a/src/profiles/uhd_4320p_60
+++ b/src/profiles/uhd_4320p_60
@@ -1,0 +1,11 @@
+description=8K UHD 4320p 60 fps
+frame_rate_num=60
+frame_rate_den=1
+width=7680
+height=4320
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=16
+display_aspect_den=9
+colorspace=709

--- a/src/profiles/vertical_1080p_2398
+++ b/src/profiles/vertical_1080p_2398
@@ -1,0 +1,11 @@
+description=HD Vertical 1080p 23.98 fps
+frame_rate_num=24000
+frame_rate_den=1001
+width=1080
+height=1920
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709

--- a/src/profiles/vertical_1080p_24
+++ b/src/profiles/vertical_1080p_24
@@ -1,0 +1,11 @@
+description=HD Vertical 1080p 24 fps
+frame_rate_num=24
+frame_rate_den=1
+width=1080
+height=1920
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709

--- a/src/profiles/vertical_1080p_25
+++ b/src/profiles/vertical_1080p_25
@@ -1,0 +1,11 @@
+description=HD Vertical 1080p 25 fps
+frame_rate_num=25
+frame_rate_den=1
+width=1080
+height=1920
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709

--- a/src/profiles/vertical_1080p_2997
+++ b/src/profiles/vertical_1080p_2997
@@ -1,0 +1,11 @@
+description=HD Vertical 1080p 29.97 fps
+frame_rate_num=30000
+frame_rate_den=1001
+width=1080
+height=1920
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709

--- a/src/profiles/vertical_1080p_50
+++ b/src/profiles/vertical_1080p_50
@@ -1,0 +1,11 @@
+description=HD Vertical 1080p 50 fps
+frame_rate_num=50
+frame_rate_den=1
+width=1080
+height=1920
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709

--- a/src/profiles/vertical_1080p_5994
+++ b/src/profiles/vertical_1080p_5994
@@ -1,0 +1,11 @@
+description=HD Vertical 1080p 59.94 fps
+frame_rate_num=60000
+frame_rate_den=1001
+width=1080
+height=1920
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709

--- a/src/profiles/vertical_1080p_60
+++ b/src/profiles/vertical_1080p_60
@@ -1,0 +1,11 @@
+description=HD Vertical 1080p 60 fps
+frame_rate_num=60
+frame_rate_den=1
+width=1080
+height=1920
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709

--- a/src/profiles/vertical_720p_2398
+++ b/src/profiles/vertical_720p_2398
@@ -1,0 +1,11 @@
+description=HD Vertical 720p 23.98 fps
+frame_rate_num=24000
+frame_rate_den=1001
+width=720
+height=1280
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709

--- a/src/profiles/vertical_720p_24
+++ b/src/profiles/vertical_720p_24
@@ -1,0 +1,11 @@
+description=HD Vertical 720p 24 fps
+frame_rate_num=24
+frame_rate_den=1
+width=720
+height=1280
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709

--- a/src/profiles/vertical_720p_25
+++ b/src/profiles/vertical_720p_25
@@ -1,0 +1,11 @@
+description=HD Vertical 720p 25 fps
+frame_rate_num=25
+frame_rate_den=1
+width=720
+height=1280
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709

--- a/src/profiles/vertical_720p_2997
+++ b/src/profiles/vertical_720p_2997
@@ -1,0 +1,11 @@
+description=HD Vertical 720p 29.97 fps
+frame_rate_num=30000
+frame_rate_den=1001
+width=720
+height=1280
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709

--- a/src/profiles/vertical_720p_50
+++ b/src/profiles/vertical_720p_50
@@ -1,0 +1,11 @@
+description=HD Vertical 720p 50 fps
+frame_rate_num=50
+frame_rate_den=1
+width=720
+height=1280
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709

--- a/src/profiles/vertical_720p_5994
+++ b/src/profiles/vertical_720p_5994
@@ -1,0 +1,11 @@
+description=HD Vertical 720p 59.94 fps
+frame_rate_num=60000
+frame_rate_den=1001
+width=720
+height=1280
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709

--- a/src/profiles/vertical_720p_60
+++ b/src/profiles/vertical_720p_60
@@ -1,0 +1,11 @@
+description=HD Vertical 720p 60 fps
+frame_rate_num=60
+frame_rate_den=1
+width=720
+height=1280
+progressive=1
+sample_aspect_num=1
+sample_aspect_den=1
+display_aspect_num=9
+display_aspect_den=16
+colorspace=709


### PR DESCRIPTION
- Created 23.98, 24, 25, 29.97, 50, 59.94 and 60 FPS vertical export profiles for 720p and 1080p videos
- Added all vertical export profiles in the YouTube presets. In particular:
    - 720p vertical export profiles in the `YouTube Standard` preset
    - 1080p vertical export profiles in the `YouTube HD` preset
- Add 25 fps vertical export presets to Twitter and Instagram presets, this because there were already the 25 fps horizontal export profiles and 30 fps vertical export profiles, so now there are 25 and 30 fps export profiles both horizontal and vertical.

I think adding vertical export profiles to the `YouTube` and `YouTube HD` presets is useful due to the growing popularity of YouTube Shorts where people create short vertical videos