### PR TITLE
Integrate Sentry.io `sample_rate` and `traces_sample_rate` correctly

### DIFF
--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -109,15 +109,19 @@ LOG_LEVEL_CONSOLE = 'INFO'
 # Web backend selection, overridable at launch
 WEB_BACKEND = 'auto'
 
-# Sentry.io error reporting rate (0.0 TO 1.0)
+# Sentry.io error & transaction reporting rate (0.0 TO 1.0)
 # 0.0 = no error reporting to Sentry
 # 0.5 = 1/2 of errors reported to Sentry
 # 1.0 = all errors reporting to Sentry
+#    ERROR: Exceptions sent to Sentry
+#    TRANS: Transactions sent to Sentry
 #    STABLE: If this version matches the current version (reported on openshot.org)
 #    UNSTABLE: If this version does not match the current version (reported on openshot.org)
 #    STABLE_VERSION: This is the current stable release reported by openshot.org
 ERROR_REPORT_RATE_STABLE = 0.0
 ERROR_REPORT_RATE_UNSTABLE = 0.0
+TRANS_REPORT_RATE_STABLE = 0.0
+TRANS_REPORT_RATE_UNSTABLE = 0.0
 ERROR_REPORT_STABLE_VERSION = None
 
 # Languages

--- a/src/classes/version.py
+++ b/src/classes/version.py
@@ -53,6 +53,8 @@ def get_version_from_http():
         info.ERROR_REPORT_STABLE_VERSION = r.json().get("openshot_version")
         info.ERROR_REPORT_RATE_STABLE = r.json().get("error_rate_stable")
         info.ERROR_REPORT_RATE_UNSTABLE = r.json().get("error_rate_unstable")
+        info.TRANS_REPORT_RATE_STABLE = r.json().get("trans_rate_stable")
+        info.TRANS_REPORT_RATE_UNSTABLE = r.json().get("trans_rate_unstable")
 
         # Emit signal for the UI
         get_app().window.FoundVersionSignal.emit(openshot_version)


### PR DESCRIPTION
Integrate Sentry.io `sample_rate` and `traces_sample_rate` correctly from openshot.org. This should dramatically reduce the # of errors sent to Sentry.io, and setup the potential to use transactions to monitor performance.

We were previously only setting the transaction reporting %, and thus, our error sample_rate was defaulting to 100% of all errors... oops. This was blowing past our Sentry.io limits, and ignoring our web service (which was designed to dynamically set these values so we can adjust them without doing a release)