### PR TITLE
Small Title Editor fixes

### DIFF
--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -65,21 +65,18 @@ class TitleEditor(QDialog):
 
     def __init__(self, *args, edit_file_path=None, duplicate=False, **kwargs):
 
+        # Create dialog class
+        super().__init__(*args, **kwargs)
+
         # A timer to pause until user input stops before updating the svg
         self.update_timer = QTimer()
         self.update_timer.setInterval(300)
         self.update_timer.timeout.connect(self.save_and_reload)
 
-        # Create dialog class
-        super().__init__(*args, **kwargs)
-
         self.app = get_app()
         self.project = self.app.project
         self.edit_file_path = edit_file_path
         self.duplicate = duplicate
-
-        # Get translation object
-        _ = self.app._tr
 
         # Load UI from designer
         ui_util.load_ui(self, self.ui_path)

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -293,7 +293,7 @@ class TitleEditor(QDialog):
             ard = style_to_dict(s)
             fs = ard.get("font-size")
             if fs and fs.endswith("px"):
-                self.qfont.setPixelSize(float(fs[:-2]))
+                self.qfont.setPixelSize(int(float(fs[:-2])))
             elif fs and fs.endswith("pt"):
                 self.qfont.setPointSizeF(float(fs[:-2]))
 

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -69,8 +69,9 @@ class TitleEditor(QDialog):
         super().__init__(*args, **kwargs)
 
         # A timer to pause until user input stops before updating the svg
-        self.update_timer = QTimer()
+        self.update_timer = QTimer(self)
         self.update_timer.setInterval(300)
+        self.update_timer.setSingleShot(True)
         self.update_timer.timeout.connect(self.save_and_reload)
 
         self.app = get_app()
@@ -366,7 +367,6 @@ class TitleEditor(QDialog):
 
     def save_and_reload(self):
         """Something changed, so update temp SVG and redisplay"""
-        self.update_timer.stop()
         self.writeToFile(self.xmldoc)
         self.display_svg()
 


### PR DESCRIPTION
* Update timer:
  - Made the update timer single-shot, so there's no need to `stop()` it explicitly
  - Parented the timer to the class, so it'll be cleaned up by Qt when the dialog closes
  - Moved the `super().__init__()` call _before_ the timer creation (required for parenting)

* `QFont.setPixelSize()` only takes **`int`** arguments (and throws a `ValueError` on Python 3.10+ if you pass it a `float`)
* Removed a useless binding of the `_` translation function where it isn't needed.