### PR TITLE
Make sure keyframes appear at the right place on the timeline

### DIFF
--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -154,7 +154,7 @@ App.controller("TimelineCtrl", function ($scope) {
   $scope.selectPoint = function(object, point) {
     var frames_per_second = $scope.project.fps.num / $scope.project.fps.den;
     var clip_position_frames = object.position * frames_per_second;
-    var absolute_seek_frames = clip_position_frames + parseInt(point);
+    var absolute_seek_frames = clip_position_frames + parseInt(point) - (object.start * frames_per_second);
 
     if ($scope.Qt) {
       timeline.SeekToKeyframe(absolute_seek_frames)


### PR DESCRIPTION
# Issue:
When cutting the beginning off of a clip, clicking a keyframe would send the playhead to a location that wasn't the frame the keyframe affected.

https://user-images.githubusercontent.com/42394129/158725801-2ae34f46-c0e4-4ade-8252-97d488d0eaf0.mp4

# Fix:
Subtracting the start value from the position of each keyframe

https://user-images.githubusercontent.com/42394129/158725840-66b93004-f1d0-4f7f-8228-ae9a38efc961.mp4


