### PR TITLE
Client side error filtering

### DIFF
--- a/src/classes/sentry.py
+++ b/src/classes/sentry.py
@@ -43,10 +43,11 @@ try:
 except ModuleNotFoundError:
     sdk = None
 
-
-min_error_freq = 1 # seconds required between errors
+# seconds required between errors
+min_error_freq = 1
 last_send_time = None
 last_event_message = None
+
 def init_tracing():
     """Init all Sentry tracing"""
     if not sdk:
@@ -71,6 +72,9 @@ def init_tracing():
                                                                                        traces_sample_rate))
 
     def before_send(event,hint):
+        """
+        Function to filter out repetitive Sentry.io errors before sending them
+        """
         global last_send_time
         global last_event_message
 

--- a/src/classes/sentry.py
+++ b/src/classes/sentry.py
@@ -97,9 +97,7 @@ def init_tracing():
         # This error will send. Update the last time and last message
         log.debug("Sending Error")
         last_send_time = current_time
-        last_event_message = event.\
-            get("logentry", {"message": None}).\
-            get("message", None)
+        last_event_message = event_message
         return event
 
     # Initialize sentry exception tracing


### PR DESCRIPTION
Prevent errors from being reported too rapidly, or if it's a repeated error.

# Example
I added errors (not in included in the PR) to three buttons to show how errors in under a second, or errors of the same name will be prevented. 

https://user-images.githubusercontent.com/42394129/158903687-591bd94e-2ac2-493a-ab94-ea5eeaabdfe2.mp4

