### PR TITLE
Changing floats to integers to prevent crash with Python 3.10

### DIFF
--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -343,7 +343,7 @@ class PropertiesTableView(QTableView):
                 blue = cur_property[1]["blue"]["value"]
 
                 # Show color dialog
-                currentColor = QColor(red, green, blue)
+                currentColor = QColor(int(red), int(green), int(blue))
                 log.debug("Launching ColorPicker for %s", currentColor.name())
                 ColorPicker(
                     currentColor, parent=self, title=_("Select a Color"),


### PR DESCRIPTION
The colour selector in the Chroma Key effect causes a crash due to the
change in Python 3.10 for no longer automatically converting floats to integers.
Changing the inputs to currentColor to intgegers to correct this.