### PR TITLE
Hide Keyframes during Clip/Transition Resize

### DIFF
--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -86,12 +86,16 @@ App.directive("tlClip", function ($timeout) {
           }
 
           // Hide keyframe points
-          element.find(".point_icon").fadeOut("fast");
-          element.find(".audio-container").fadeOut("fast");
+          element.find(".point").fadeOut(100);
+          element.find(".audio-container").fadeOut(100);
 
         },
         stop: function (e, ui) {
           dragging = false;
+
+          // Show keyframe points
+          element.find(".point").fadeIn(100);
+          element.find(".audio-container").fadeIn(100);
 
           if (resize_disabled) {
             // disabled, do nothing
@@ -101,13 +105,6 @@ App.directive("tlClip", function ($timeout) {
 
           // Hide snapline (if any)
           scope.hideSnapline();
-
-          // Hide keyframe points
-          if (dragLoc === "right") {
-            // Make the keyframe points visible again
-            element.find(".point_icon").show();
-            element.find(".audio-container").show();
-          }
 
           //get amount changed in width
           var delta_x = ui.originalSize.width - ui.element.width();

--- a/src/timeline/js/directives/transition.js
+++ b/src/timeline/js/directives/transition.js
@@ -80,7 +80,7 @@ App.directive("tlTransition", function () {
           }
 
           // Hide keyframe points
-          element.find(".point_icon").hide();
+          element.find(".point").fadeOut(100);
 
         },
         stop: function (e, ui) {
@@ -95,8 +95,8 @@ App.directive("tlTransition", function () {
           // Hide snapline (if any)
           scope.hideSnapline();
 
-          // Make the keyframe points visible again
-          element.find(".point_icon").show();
+          // Show keyframe points
+          element.find(".point").fadeIn(100);
 
           //get amount changed in width
           var delta_x = ui.originalSize.width - ui.element.width();


### PR DESCRIPTION
Fix regression which caused keyframe points to no longer be hidden during resizing (clips and transitions). CSS class name was changed accidentally.