### PR TITLE
WIP: Preserve user choice of waveform display on project reload.

### DIFF
--- a/src/classes/waveform.py
+++ b/src/classes/waveform.py
@@ -31,6 +31,7 @@ from copy import deepcopy
 from classes import info
 from classes.app import get_app
 from classes.logger import log
+from classes.query import Clip
 import openshot
 
 
@@ -38,22 +39,28 @@ import openshot
 s = get_app().get_settings()
 
 
-def get_audio_data(clip_id, file_path, channel_filter=-1, volume_keyframe=None):
+def get_audio_data(clip_id, file_path, channel_filter=None, volume_keyframe=None):
     """Get a Clip object form libopenshot, and grab audio data"""
-    clip = openshot.Clip(file_path)
-    clip.Open()
+    temp_clip = openshot.Clip(file_path)
 
     # Disable video stream (for speed improvement)
-    clip.Reader().info.has_video = False
+    temp_clip.Reader().info.has_video = False
 
-    log.info("Clip loaded, start thread")
-    t = threading.Thread(target=get_waveform_thread, args=[clip, clip_id, file_path, channel_filter, volume_keyframe])
+    log.info("Clip loaded, start waveform thread")
+    actual_clip = get_app().window.timeline_sync.timeline.GetClip(clip_id)
+    if actual_clip:
+        if channel_filter == None:
+            channel_filter = actual_clip.channel_filter.GetInt(1)
+        if volume_keyframe == None:
+            volume_keyframe = actual_clip.volume
+    t = threading.Thread(target=get_waveform_thread, args=[temp_clip, clip_id, file_path, channel_filter, volume_keyframe])
     t.daemon = True
     t.start()
 
-def get_waveform_thread(clip, clip_id, file_path, channel_filter, volume_keyframe):
+def get_waveform_thread(clip, clip_id, file_path, channel_filter=-1, volume_keyframe=None):
     """Get the audio data from a clip in a separate thread"""
     audio_data = []
+    audio_data_this_clip = []
     sample_rate = clip.Reader().info.sample_rate
 
     # How many samples per second do we need (to approximate the waveform)
@@ -61,7 +68,23 @@ def get_waveform_thread(clip, clip_id, file_path, channel_filter, volume_keyfram
     sample_divisor = round(sample_rate / samples_per_second)
     log.info("Getting waveform for sample rate: %s" % sample_rate)
 
+    sound_data = get_app().project.get('sound_data')
+    file_id = Clip.filter(id=clip_id)[0].data.get("file_id")
+    if (file_id in sound_data.keys()) and\
+        str(channel_filter) in sound_data.get(file_id).keys():
+
+        log.debug(f"Loading stored waveform data. File: {file_id}. Channel: {channel_filter} ")
+        audio_data = sound_data.get(file_id).get(str(channel_filter))
+        volume = 1.0
+        for (frame_number, audio_sample) in enumerate(audio_data):
+            if volume_keyframe:
+                volume = volume_keyframe.GetValue(frame_number)
+            audio_data_this_clip.append(audio_sample * volume)
+        get_app().window.WaveformReady.emit(clip_id, audio_data_this_clip)
+        return
+
     sample = 0
+    log.debug(f"Generating waveform data. File: {file_id}. Channel: {channel_filter} ")
     for frame_number in range(1, clip.Reader().info.video_length):
         # Get frame object
         frame = clip.Reader().GetFrame(frame_number)
@@ -80,7 +103,9 @@ def get_waveform_thread(clip, clip_id, file_path, channel_filter, volume_keyfram
 
             # Get audio data for this channel
             if sample < frame.GetAudioSamplesCount():
-                audio_data.append(frame.GetAudioSample(channel_filter, sample, magnitude_range) * volume)
+                sample_value = frame.GetAudioSample(channel_filter, sample, magnitude_range)
+                audio_data.append(sample_value)
+                audio_data_this_clip.append(sample_value * volume)
             else:
                 # Adjust starting sample for next frame
                 sample = max(0, sample - frame.GetAudioSamplesCount())
@@ -91,7 +116,10 @@ def get_waveform_thread(clip, clip_id, file_path, channel_filter, volume_keyfram
 
     # Close reader
     clip.Close()
-
+    file_sound_data = sound_data.get(file_id, {})
+    file_sound_data[str(channel_filter)] = audio_data
+    sound_data[file_id] = file_sound_data
+    get_app().updates.update(["sound_data"], sound_data)
     # Emit signal when done
     log.info("get_waveform_thread completed")
-    get_app().window.WaveformReady.emit(clip_id, audio_data)
+    get_app().window.WaveformReady.emit(clip_id, audio_data_this_clip)

--- a/src/classes/waveform.py
+++ b/src/classes/waveform.py
@@ -38,7 +38,7 @@ import openshot
 s = get_app().get_settings()
 
 
-def get_audio_data(clip_id, file_path, channel_filter, volume_keyframe):
+def get_audio_data(clip_id, file_path, channel_filter=-1, volume_keyframe=None):
     """Get a Clip object form libopenshot, and grab audio data"""
     clip = openshot.Clip(file_path)
     clip.Open()
@@ -51,7 +51,7 @@ def get_audio_data(clip_id, file_path, channel_filter, volume_keyframe):
     t.daemon = True
     t.start()
 
-def get_waveform_thread(clip, clip_id, file_path, channel_filter=-1, volume_keyframe=None):
+def get_waveform_thread(clip, clip_id, file_path, channel_filter, volume_keyframe):
     """Get the audio data from a clip in a separate thread"""
     audio_data = []
     sample_rate = clip.Reader().info.sample_rate

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -40,6 +40,7 @@ from classes import openshot_rc  # noqa
 from classes.query import Clip, Transition, Effect
 from classes.logger import log
 from classes.app import get_app
+from classes.waveform import get_audio_data
 import openshot
 
 import json
@@ -510,6 +511,13 @@ class PropertiesModel(updates.UpdateInterface):
                         clip_data[property_key].setdefault('Points', []).append({
                             'co': {'X': self.frame_number, 'Y': new_value},
                             'interpolation': 1})
+
+                # If sound has been updated:
+                if clip_data.get("show_waveform",False):
+                    if property_key in ["volume", "channel_filter"]:
+                        clip = get_app().window.timeline_sync.timeline.GetClip(clip_data.get("id"))
+                        get_audio_data(clip_data.get("id"), clip_data.get("reader",{}).get("path",""),\
+                            clip.channel_filter.GetInt(1), clip.volume)
 
             if not clip_updated:
                 # If no keyframe was found, set a basic property

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -964,6 +964,8 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             if not clip:
                 # Invalid clip, skip to next item
                 continue
+            clip.data["show_waveform"] = True
+            clip.save()
 
             file_path = clip.data["reader"]["path"]
 
@@ -990,6 +992,8 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             clip = Clip.get(id=clip_id)
 
             if clip:
+                clip.data["show_waveform"] = False
+                clip.save()
                 # Pass to javascript timeline (and render)
                 self.run_js(JS_SCOPE_SELECTOR + ".hideAudioData('" + clip_id + "');")
 


### PR DESCRIPTION
### Issue
1) Right click on a clip with audio
2) Click `Display` > `Show Waveform`
3) Save
3) Click `File` > `Recent` and re-load the current project.
4) See that the waveform no longer shows

### Solution
Store the user setting on each clip, and generate waveforms when loading projects.

### Test
Repeat the steps in _Issue_, and confirm that the waveform does display on reload.