### PR TITLE
Fix rewind at project start and end.

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -916,7 +916,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         current_frame = self.preview_thread.current_frame
         if current_frame is not None:
             next_frame = current_frame + requested_speed
-            return next_frame < max_frame
+            return next_frame <= max_frame and next_frame > 0
         return False
 
     def actionPlay_trigger(self):
@@ -987,10 +987,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             # If paused, rewind starting at normal playback speed (in reverse)
             requested_speed = -1
 
-        if player.Mode() == openshot.PLAYBACK_PAUSED:
-            self.actionPlay.trigger()
-
         if self.should_play(requested_speed):
+            if player.Mode() == openshot.PLAYBACK_PAUSED:
+                self.actionPlay.trigger()
             self.SpeedSignal.emit(requested_speed)
 
     def actionJumpStart_trigger(self, checked=True):

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -44,11 +44,20 @@ class PreviewParent(QObject):
         self.parent.movePlayhead(current_frame)
 
         # Check if we are at the end of the timeline
-        if self.worker.player.Mode() == openshot.PLAYBACK_PLAY and self.worker.player.Speed() != 0.0 \
-                and ((current_frame >= self.worker.timeline_length != -1) or current_frame <= 1):
-            # Yes, pause the video
-            self.parent.PauseSignal.emit()
-            self.worker.timeline_length = -1
+        if self.worker.player.Mode() == openshot.PLAYBACK_PLAY:
+            if self.worker.player.Speed() > 0.0 \
+                and current_frame >= self.worker.timeline_length:
+                # Yes, pause the video
+                self.parent.PauseSignal.emit()
+                self.worker.timeline_length = -1
+                # If the player got past the end of the project, go back.
+                self.worker.Seek(self.timeline.GetMaxFrame())
+            if self.worker.player.Speed() < 0.0 and ((current_frame <= 1 )):
+                # If rewinding, and the player got past the first frame,
+                # pause and go to frame 1
+                self.parent.PauseSignal.emit()
+                self.worker.timeline_length = -1
+                self.worker.Seek(1)
 
     # Signal when the playback mode changes in the preview player (i.e PLAY, PAUSE, STOP)
     def onModeChanged(self, current_mode):


### PR DESCRIPTION
### Issue
If the playhead is at the end of the project, and you press rewind, the play button wouldn't switch to a pause button. And sometimes, the rewind wouldn't start at all.

### Cause
We checking whether to toggle the play button without taking into account that the playhead is going to move backwards.

I made a change so that the auto-pause jumps the playhead back to the first or last frame of the project. I also made it take the direction into account when toggling the pause button.

### Test 1
Use `ctrl+left_arrow` to move to the end of your project and rewind.
Your player should rewind, but the play button won't toggle.

### Test 2
Set the playhead back from the end and let it play until it stops automatically. (Best way to make sure this happens is with fast forward) This should run past the last frame before Openshot catches it and pauses. Now if you press rewind nothing should happen. (Because even going back a frame is still outside the project)

