### PR TITLE
Display playback speed

### DIFF
--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -275,6 +275,19 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         rect = self.centeredViewport(self.width(), self.height())
         scale = self.devicePixelRatioF()
 
+        # Display the playback speed in widget title
+        speed_str = ""
+        try:
+            win = get_app().window
+            mode = win.preview_thread.player.Mode()
+            if mode == openshot.PLAYBACK_PAUSED:
+                speed = 0.0
+            else:
+                speed = win.preview_thread.player.Speed()
+            speed_str = f" {speed}x "
+        except NameError:
+            log.error("Couldn't get player speed for window title")
+
         # Find parent dockWidget (if any)
         dock = None
         if self.parent() and self.parent().parent():
@@ -286,12 +299,12 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
         if self.settings.get("preview-fps"):
             # Update window title with FPS output
-            dock.setWindowTitle(_("Video Preview") + " " + _("(Paint: %d FPS, Render: %d FPS, %dx%d)")
+            dock.setWindowTitle(_("Video Preview") + speed_str + _("(Paint: %d FPS, Render: %d FPS, %dx%d)")
                                                       % (self.paint_fps, self.present_fps,
                                                          rect.width() * scale, rect.height() * scale))
         else:
             # Restore window title
-            dock.setWindowTitle(_("Video Preview"))
+            dock.setWindowTitle(_("Video Preview") + speed_str)
 
     def paintEvent(self, event, *args):
         """ Custom paint event """
@@ -1464,6 +1477,13 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
         # Get a reference to the window object
         self.win = get_app().window
+
+        # Update title whenever playback speed changes.
+        self.win.PlaySignal.connect(self.update_title)
+        self.win.PlaySignal.connect(self.update_title)
+        self.win.PauseSignal.connect(self.update_title)
+        self.win.SpeedSignal.connect(self.update_title)
+        self.win.StopSignal.connect(self.update_title)
 
         # Show Property timer
         # Timer to use a delay before sending MaxSizeChanged signals (so we don't spam libopenshot)

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -278,12 +278,11 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         # Display the playback speed in widget title
         speed_str = ""
         try:
-            win = get_app().window
-            mode = win.preview_thread.player.Mode()
+            mode = self.win.preview_thread.player.Mode()
             if mode == openshot.PLAYBACK_PAUSED:
                 speed = 0.0
             else:
-                speed = win.preview_thread.player.Speed()
+                speed = self.win.preview_thread.player.Speed()
             speed_str = f" {speed}x "
         except NameError:
             log.error("Couldn't get player speed for window title")
@@ -1479,11 +1478,11 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.win = get_app().window
 
         # Update title whenever playback speed changes.
-        self.win.PlaySignal.connect(self.update_title)
-        self.win.PlaySignal.connect(self.update_title)
-        self.win.PauseSignal.connect(self.update_title)
-        self.win.SpeedSignal.connect(self.update_title)
-        self.win.StopSignal.connect(self.update_title)
+        self.win.PlaySignal.connect(self.update_title, Qt.QueuedConnection)
+        self.win.PlaySignal.connect(self.update_title, Qt.QueuedConnection)
+        self.win.PauseSignal.connect(self.update_title, Qt.QueuedConnection)
+        self.win.SpeedSignal.connect(self.update_title, Qt.QueuedConnection)
+        self.win.StopSignal.connect(self.update_title, Qt.QueuedConnection)
 
         # Show Property timer
         # Timer to use a delay before sending MaxSizeChanged signals (so we don't spam libopenshot)

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -276,16 +276,10 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         scale = self.devicePixelRatioF()
 
         # Display the playback speed in widget title
-        speed_str = ""
-        try:
-            mode = self.win.preview_thread.player.Mode()
-            if mode == openshot.PLAYBACK_PAUSED:
-                speed = 0.0
-            else:
-                speed = self.win.preview_thread.player.Speed()
-            speed_str = f" {speed}x "
-        except NameError:
-            log.error("Couldn't get player speed for window title")
+        speed = 0.0
+        mode = self.win.preview_thread.player.Mode()
+        if mode != openshot.PLAYBACK_PAUSED:
+            speed = self.win.preview_thread.player.Speed()
 
         # Find parent dockWidget (if any)
         dock = None
@@ -298,12 +292,15 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
         if self.settings.get("preview-fps"):
             # Update window title with FPS output
-            dock.setWindowTitle(_("Video Preview") + speed_str + _("(Paint: %d FPS, Render: %d FPS, %dx%d)")
-                                                      % (self.paint_fps, self.present_fps,
+            dock.setWindowTitle(_("Video Preview ") + _("(Speed: %dx, Paint: %d FPS, Render: %d FPS, %dx%d)")
+                                                      % (speed, self.paint_fps, self.present_fps,
                                                          rect.width() * scale, rect.height() * scale))
         else:
             # Restore window title
-            dock.setWindowTitle(_("Video Preview") + speed_str)
+            if not speed in [1, 0, -1]:
+                dock.setWindowTitle(_("Video Preview") + f" ({speed}x)")
+            else:
+                dock.setWindowTitle(_("Video Preview"))
 
     def paintEvent(self, event, *args):
         """ Custom paint event """


### PR DESCRIPTION
# Enhancement
Show some visual feedback that fast forward or rewind has been applied, even if the frames take a moment to load.

# Example
https://user-images.githubusercontent.com/42394129/160917948-29a08ce5-87f3-4d7f-8e90-1f8d9714e8af.mp4

> Note: Unlike this example, the time now only shows if its not 1x, 0x, or -1x

# Testing
This one's pretty easy. Just fast forward, rewind, pause, and play several times and see that the displayed playback speed changes accordingly.