### PR TITLE
WIP: File Location Settings

### DIFF
--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -970,7 +970,7 @@
   },
   {
     "category": "Locations",
-    "title": "File Import",
+    "title": "File Imports",
     "restart": false,
     "setting": "file_import_directory",
     "value": "",
@@ -978,9 +978,17 @@
   },
   {
     "category": "Locations",
-    "title": "Video Export",
+    "title": "Video Exports",
     "restart": false,
     "setting": "file_export_directory",
+    "value": "",
+    "type": "browse"
+  },
+  {
+    "category": "Locations",
+    "title": "Save Projects",
+    "restart": false,
+    "setting": "project_saving_directory",
     "value": "",
     "type": "browse"
   }

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -967,5 +967,13 @@
     "setting": "actionDuplicateTitle",
     "value": "Ctrl+Shift+C",
     "type": "text"
+  },
+  {
+    "category": "Locations",
+    "title": "File Import",
+    "restart": false,
+    "setting": "file_import_directory",
+    "value": "~",
+    "type": "browse"
   }
 ]

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -973,7 +973,15 @@
     "title": "File Import",
     "restart": false,
     "setting": "file_import_directory",
-    "value": "~",
+    "value": "",
+    "type": "browse"
+  },
+  {
+    "category": "Locations",
+    "title": "Video Export",
+    "restart": false,
+    "setting": "file_export_directory",
+    "value": "",
     "type": "browse"
   }
 ]

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -142,13 +142,18 @@ class Export(QDialog):
         if get_app().project.current_filepath:
             recommended_path = os.path.dirname(get_app().project.current_filepath)
 
-        export_path = get_app().project.get("export_path")
-        if export_path and os.path.exists(export_path):
-            # Use last selected export path
+        # If an export folder has been set, use it.
+        export_path = self.s.get("file_export_directory")
+        if export_path:
             self.txtExportFolder.setText(export_path)
         else:
-            # Default to home dir
-            self.txtExportFolder.setText(recommended_path)
+            export_path = get_app().project.get("export_path")
+            if export_path and os.path.exists(export_path):
+                # Use last selected export path
+                self.txtExportFolder.setText(export_path)
+            else:
+                # Default to home dir
+                self.txtExportFolder.setText(recommended_path)
 
         # Is this a saved project?
         if not get_app().project.current_filepath:

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -575,7 +575,12 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Get current filepath if any, otherwise ask user
         file_path = app.project.current_filepath
         if not file_path:
-            recommended_path = os.path.join(info.HOME_PATH, "%s.osp" % _("Untitled Project"))
+            # directory from settings
+            recommended_path = app.settings.get("project_saving_directory")
+            if not recommended_path:
+                # if not set, start at home directory
+                recommended_path = info.HOME_PATH
+            recommended_path = os.path.join(recommended_path, "%s.osp" % _("Untitled Project"))
             file_path = QFileDialog.getSaveFileName(
                 self,
                 _("Save Project..."),
@@ -651,10 +656,14 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         app = get_app()
         _ = app._tr
 
-        recommended_path = app.project.current_filepath
+        recommended_path = app.settings.get("project_saving_directory")
         if not recommended_path:
-            recommended_path = os.path.join(
-                info.HOME_PATH, "%s.osp" % _("Untitled Project"))
+            if app.project.current_filepath:
+                recommended_path = app.project.current_filepath
+            else:
+                recommended_path = info.HOME_PATH
+        recommended_path = os.path.join(
+            recommended_path, "%s.osp" % _("Untitled Project"))
         file_path = QFileDialog.getSaveFileName(
             self,
             _("Save Project As..."),

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -672,9 +672,13 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         app = get_app()
         _ = app._tr
 
-        recommended_path = app.project.get("import_path")
-        if not recommended_path or not os.path.exists(recommended_path):
-            recommended_path = os.path.join(info.HOME_PATH)
+        # Use import directory from settings
+        recommended_path = app.settings.get("file_import_directory")
+        if not recommended_path:
+            # If path is not set, default to last import directory
+            recommended_path = app.project.get("import_path")
+            if not recommended_path or not os.path.exists(recommended_path):
+                recommended_path = os.path.join(info.HOME_PATH)
 
         # PyQt through 5.13.0 had the 'directory' argument mis-typed as str
         if PYQT_VERSION_STR < '5.13.1':
@@ -688,7 +692,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         qurl_list = QFileDialog.getOpenFileUrls(
             self,
             _("Import Files..."),
-            start_location,
+            start_location
             )[0]
 
         # Set cursor to waiting

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -442,7 +442,7 @@ class Preferences(QDialog):
             new_path = QFileDialog.getExistingDirectory(
                 self,
                 _("Choose a Folder..."),
-                startpath
+                info.HOME_PATH
                 )
         else:
             new_path = QFileDialog.getOpenFileName(

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -237,7 +237,8 @@ class Preferences(QDialog):
                     if param["type"] == "browse":
                         # Add filesystem browser button
                         extraWidget = QPushButton(_("Browse..."))
-                        extraWidget.clicked.connect(functools.partial(self.selectExecutable, widget, param))
+                        extraWidget.clicked.connect(functools.partial(self.selectExecutable, widget, param,
+                                                                      directory = param["category"]=="Locations"))
 
                 elif param["type"] == "bool":
                     # create spinner
@@ -421,7 +422,7 @@ class Preferences(QDialog):
         # Delete all tabs and widgets
         self.DeleteAllTabs(onlyInVisible=True)
 
-    def selectExecutable(self, widget, param):
+    def selectExecutable(self, widget, param, directory=False):
         _ = get_app()._tr
 
         # Fallback default to user home
@@ -436,23 +437,31 @@ class Preferences(QDialog):
             if prev_val and os.path.exists(prev_val):
                 startpath = prev_val
 
-        fileName = QFileDialog.getOpenFileName(
-            self,
-            _("Select executable file"),
-            startpath)[0]
-        if fileName:
-            if platform.system() == "Darwin":
+        new_path = ""
+        if directory:
+            new_path = QFileDialog.getExistingDirectory(
+                self,
+                _("Choose a Folder..."),
+                startpath
+                )
+        else:
+            new_path = QFileDialog.getOpenFileName(
+                self,
+                _("Select executable file"),
+                startpath)[0]
+        if new_path:
+            if platform.system() == "Darwin" and not directory:
                 # Check for Mac specific app-bundle executable file (if any)
-                appBundlePath = os.path.join(fileName, 'Contents', 'MacOS')
+                appBundlePath = os.path.join(new_path, 'Contents', 'MacOS')
                 if os.path.exists(os.path.join(appBundlePath, 'blender')):
-                    fileName = os.path.join(appBundlePath, 'blender')
+                    new_path = os.path.join(appBundlePath, 'blender')
                 elif os.path.exists(os.path.join(appBundlePath, 'Blender')):
-                    fileName = os.path.join(appBundlePath, 'Blender')
+                    new_path = os.path.join(appBundlePath, 'Blender')
                 elif os.path.exists(os.path.join(appBundlePath, 'Inkscape')):
-                    fileName = os.path.join(appBundlePath, 'Inkscape')
+                    new_path = os.path.join(appBundlePath, 'Inkscape')
 
-            self.s.set(param["setting"], fileName)
-            widget.setText(fileName)
+            self.s.set(param["setting"], new_path)
+            widget.setText(new_path)
 
     def check_for_restart(self, param):
         """Check if the app needs to restart"""


### PR DESCRIPTION
Closes #4590

This PR adds an option in the settings to set a default location to import files, export videos, and save projects. This could support users creating many projects, and reusing source files.

### Feature
In settings, there is a new "Locations" tab.

![Locations Window](https://user-images.githubusercontent.com/42394129/161655614-015cccdb-2c49-4d2c-8d4b-263b5750ae01.png)

Here you can select the starting locations for saving/opening projects, importing resource files, and exporting videos.

![Locations Window 2](https://user-images.githubusercontent.com/42394129/161655625-bce2fc58-8b4d-433d-9f24-39985ff2b0d2.png)



### Testing
1) Create a new project, and save it to a folder.
    - Folder picker should still start in home directory
2) Import a file
    - File picker should start in home directory, or wherever your last file was imported from
3) Export the the project
    - Should default to the project folder.
4) Open preferences, and set a folder in you `Locations` tab.
    - For instance, I used `$HOME/Videos/Resources`, `$HOME/Videos/Projects`, and `$HOME/Videos/Exports`
5) Repeat steps 1-3. The file dialog should start on the folders you specified.