### PR TITLE
Code cleanup in windows.region and windows.process_effect

### DIFF
--- a/src/windows/process_effect.py
+++ b/src/windows/process_effect.py
@@ -31,15 +31,23 @@ import json
 import functools
 import webbrowser
 
-from PyQt5.QtCore import *
+from PyQt5.QtCore import (
+    Qt, QCoreApplication, pyqtSignal,
+)
 from PyQt5.QtGui import QBrush
-from PyQt5.QtWidgets import *
-import openshot  # Python module for libopenshot (required video editing module installed separately)
+from PyQt5.QtWidgets import (
+    QDialog, QDialogButtonBox,
+    QLabel, QLineEdit,
+    QSpinBox, QDoubleSpinBox, QCheckBox, QComboBox, QPushButton,
+    QSizePolicy,
+)
 
-from classes import info, ui_util, qt_types, updates
+import openshot
+
+from classes import info, ui_util
 from classes.app import get_app
 from classes.logger import log
-from classes.metrics import *
+from classes.metrics import track_metric_screen
 
 
 class ProcessEffect(QDialog):

--- a/src/windows/process_effect.py
+++ b/src/windows/process_effect.py
@@ -251,7 +251,7 @@ class ProcessEffect(QDialog):
             # Attempt to load value from QTextEdit (i.e. multi-line)
             if not value:
                 value = widget.toPlainText()
-        except:
+        except Exception:
             log.debug('Failed to get plain text from widget')
 
         self.context[param["setting"]] = value

--- a/src/windows/process_effect.py
+++ b/src/windows/process_effect.py
@@ -354,7 +354,7 @@ class ProcessEffect(QDialog):
                 processing.CancelProcessing()
                 while(not processing.IsDone() ):
                     continue
-                super(ProcessEffect, self).reject()
+                super().reject()
 
         # get processing status
         while(not processing.IsDone() ):
@@ -377,10 +377,10 @@ class ProcessEffect(QDialog):
             self.effect.Id(ID)
 
             # Accept dialog
-            super(ProcessEffect, self).accept()
+            super().accept()
 
     def reject(self):
         # Cancel dialog
         self.exporting = False
         self.cancel_clip_processing = True
-        super(ProcessEffect, self).reject()
+        super().reject()

--- a/src/windows/process_effect.py
+++ b/src/windows/process_effect.py
@@ -69,7 +69,7 @@ class ProcessEffect(QDialog):
         self.effect_name = effect_name
         self.context = {}
 
-        # Access C++ timeline and find the Clip instance which this effect should be applied to
+        # Get the target Clip for this effect from the C++ timeline
         timeline_instance = get_app().window.timeline_sync.timeline
         for clip_instance in timeline_instance.Clips():
             if clip_instance.Id() == self.clip_id:
@@ -108,7 +108,8 @@ class ProcessEffect(QDialog):
                 # create a clickable link
                 label.setText('<a href="%s" style="color: #FFFFFF">%s</a>' % (param["value"], _(param["title"])))
                 label.setTextInteractionFlags(Qt.TextBrowserInteraction)
-                label.linkActivated.connect(functools.partial(self.link_activated, widget, param))
+                label.linkActivated.connect(
+                    functools.partial(self.link_activated, widget, param))
 
             if param["type"] == "spinner":
                 # create QDoubleSpinBox
@@ -118,20 +119,29 @@ class ProcessEffect(QDialog):
                 widget.setValue(float(param["value"]))
                 widget.setSingleStep(1.0)
                 widget.setToolTip(_(param["title"]))
-                widget.valueChanged.connect(functools.partial(self.spinner_value_changed, widget, param))
+                widget.valueChanged.connect(
+                    functools.partial(
+                        self.spinner_value_changed, widget, param))
 
                 # Set initial context
                 self.context[param["setting"]] = float(param["value"])
 
             if param["type"] == "rect":
-                # create QPushButton which opens up a display of the clip, with ability to select Rectangle
+                # QPushButton which displays the clip,
+                # allowing area selection of a region rectangle
                 widget = QPushButton(_("Click to Select"))
                 widget.setMinimumHeight(80)
                 widget.setToolTip(_(param["title"]))
-                widget.clicked.connect(functools.partial(self.rect_select_clicked, widget, param))
+                widget.clicked.connect(
+                    functools.partial(
+                        self.rect_select_clicked, widget, param))
 
                 # Set initial context
-                self.context[param["setting"]] = {"button-clicked": False, "x": 0, "y": 0, "width": 0, "height": 0}
+                self.context[param["setting"]] = {
+                    "button-clicked": False,
+                    "x": 0, "y": 0,
+                    "width": 0, "height": 0,
+                }
 
             if param["type"] == "spinner-int":
                 # create QDoubleSpinBox
@@ -141,7 +151,9 @@ class ProcessEffect(QDialog):
                 widget.setValue(int(param["value"]))
                 widget.setSingleStep(1)
                 widget.setToolTip(_(param["title"]))
-                widget.valueChanged.connect(functools.partial(self.spinner_value_changed, widget, param))
+                widget.valueChanged.connect(
+                    functools.partial(
+                        self.spinner_value_changed, widget, param))
 
                 # Set initial context
                 self.context[param["setting"]] = int(param["value"])
@@ -150,7 +162,8 @@ class ProcessEffect(QDialog):
                 # create QLineEdit
                 widget = QLineEdit()
                 widget.setText(_(param["value"]))
-                widget.textChanged.connect(functools.partial(self.text_value_changed, widget, param))
+                widget.textChanged.connect(
+                    functools.partial(self.text_value_changed, widget, param))
 
                 # Set initial context
                 self.context[param["setting"]] = param["value"]
@@ -164,7 +177,8 @@ class ProcessEffect(QDialog):
                 else:
                     widget.setCheckState(Qt.Unchecked)
                     self.context[param["setting"]] = False
-                widget.stateChanged.connect(functools.partial(self.bool_value_changed, widget, param))
+                widget.stateChanged.connect(
+                    functools.partial(self.bool_value_changed, widget, param))
 
             elif param["type"] == "dropdown":
 
@@ -189,13 +203,16 @@ class ProcessEffect(QDialog):
                         # Set initial context
                         self.context[param["setting"]] = param["value"]
 
-                widget.currentIndexChanged.connect(functools.partial(self.dropdown_index_changed, widget, param))
+                widget.currentIndexChanged.connect(functools.partial(
+                    self.dropdown_index_changed, widget, param))
 
             # Add Label and Widget to the form
             if widget and label:
                 # Add minimum size
-                label.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
-                widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+                label.setSizePolicy(
+                    QSizePolicy.Minimum, QSizePolicy.Preferred)
+                widget.setSizePolicy(
+                    QSizePolicy.Expanding, QSizePolicy.Expanding)
 
                 # Create HBoxLayout for each field
                 layout.addRow(label, widget)
@@ -213,8 +230,10 @@ class ProcessEffect(QDialog):
         # Add buttons
         self.cancel_button = QPushButton(_('Cancel'))
         self.process_button = QPushButton(_('Process Effect'))
-        self.buttonBox.addButton(self.process_button, QDialogButtonBox.AcceptRole)
-        self.buttonBox.addButton(self.cancel_button, QDialogButtonBox.RejectRole)
+        self.buttonBox.addButton(
+            self.process_button, QDialogButtonBox.AcceptRole)
+        self.buttonBox.addButton(
+            self.cancel_button, QDialogButtonBox.RejectRole)
 
         # flag to close the clip processing thread
         self.cancel_clip_processing = False
@@ -333,7 +352,8 @@ class ProcessEffect(QDialog):
 
         # Create protobuf data path
         protobufPath = os.path.join(info.PROTOBUF_DATA_PATH, ID + '.data')
-        if os.name == 'nt' : protobufPath = protobufPath.replace("\\", "/")
+        if os.name == 'nt':
+            protobufPath = protobufPath.replace("\\", "/")
 
         self.context["protobuf_data_path"] = protobufPath
 
@@ -344,8 +364,10 @@ class ProcessEffect(QDialog):
         processing = openshot.ClipProcessingJobs(self.effect_name, jsonString)
         processing.processClip(self.clip_instance, jsonString)
 
-        # TODO: This is just a temporary fix. We need to find a better way to allow the user to fix the error
-        # The while loop is handling the error message. If pre-processing returns an error, a message
+        # TODO: This is just a temporary fix.
+        # We need to find a better way to allow the user to fix the error
+        # The while loop is handling the error message.
+        # If pre-processing returns an error, a message
         # will be displayed for 3 seconds and the effect will be closed.
         start = time.time()
         while processing.GetError():
@@ -359,7 +381,7 @@ class ProcessEffect(QDialog):
                 super().reject()
 
         # get processing status
-        while(not processing.IsDone() ):
+        while not processing.IsDone():
             # update progressbar
             progressionStatus = processing.GetProgress()
             self.progressBar.setValue(int(progressionStatus))
@@ -369,13 +391,15 @@ class ProcessEffect(QDialog):
             QCoreApplication.processEvents()
 
             # if the cancel button was pressed, close the processing thread
-            if(self.cancel_clip_processing):
+            if self.cancel_clip_processing:
                 processing.CancelProcessing()
 
-        if(not self.cancel_clip_processing):
+        if not self.cancel_clip_processing:
             # Load processed data into effect
             self.effect = openshot.EffectInfo().CreateEffect(self.effect_name)
-            self.effect.SetJson( '{"protobuf_data_path": "%s"}' % protobufPath )
+            self.effect.SetJson(
+                '{"protobuf_data_path": "%s"}' % protobufPath
+                )
             self.effect.Id(ID)
 
             # Accept dialog

--- a/src/windows/process_effect.py
+++ b/src/windows/process_effect.py
@@ -92,8 +92,10 @@ class ProcessEffect(QDialog):
         # Track metrics
         track_metric_screen("process-effect-screen")
 
+        layout = self.mainContents.layout()
+
         # Loop through options and create widgets
-        row_count = 0
+
         for param in effect_params:
 
             # Create Label
@@ -173,22 +175,19 @@ class ProcessEffect(QDialog):
                 value_list = param["values"]
 
                 # Add normal values
-                box_index = 0
-                for value_item in value_list:
+                for i, value_item in enumerate(value_list):
                     k = value_item["name"]
                     v = value_item["value"]
-                    i = value_item.get("icon", None)
 
                     # add dropdown item
                     widget.addItem(_(k), v)
 
                     # select dropdown (if default)
                     if v == param["value"]:
-                        widget.setCurrentIndex(box_index)
+                        widget.setCurrentIndex(i)
 
                         # Set initial context
                         self.context[param["setting"]] = param["value"]
-                    box_index = box_index + 1
 
                 widget.currentIndexChanged.connect(functools.partial(self.dropdown_index_changed, widget, param))
 
@@ -199,18 +198,17 @@ class ProcessEffect(QDialog):
                 widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
                 # Create HBoxLayout for each field
-                self.scrollAreaWidgetContents.layout().insertRow(row_count, label, widget)
+                layout.addRow(label, widget)
 
             elif not widget and label:
-                label.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Preferred)
-                self.scrollAreaWidgetContents.layout().insertRow(row_count, label)
-
-            row_count += 1
+                label.setSizePolicy(
+                    QSizePolicy.Maximum, QSizePolicy.Preferred)
+                layout.addRow(label)
 
         # Add error field
         self.error_label = QLabel("", self)
         self.error_label.setStyleSheet("color: red;")
-        self.scrollAreaWidgetContents.layout().insertRow(row_count, self.error_label)
+        layout.addRow(self.error_label)
 
         # Add buttons
         self.cancel_button = QPushButton(_('Cancel'))
@@ -317,7 +315,7 @@ class ProcessEffect(QDialog):
     def accept(self):
         """ Start processing effect """
         # Disable UI
-        # for child_widget in self.scrollAreaWidgetContents.children():
+        # for child_widget in self.mainContents.children():
         #     child_widget.setEnabled(False)
 
         # Enable ProgressBar

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -147,8 +147,10 @@ class SelectRegion(QDialog):
 
             self.r.AddClip(self.clip)
 
-        except:
-            log.error('Failed to load media file into region select player: %s' % self.file_path)
+        except Exception:
+            log.error(
+                'Failed to load media file into region select player: %s',
+                self.file_path)
             return
 
         # Open reader

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -26,22 +26,27 @@
  """
 
 import os
-import sys
 import functools
-import math
 
-from PyQt5.QtCore import *
-from PyQt5.QtWidgets import *
-import openshot  # Python module for libopenshot (required video editing module installed separately)
+from PyQt5.QtCore import (
+    pyqtSignal,
+    QTimer,
+)
+from PyQt5.QtWidgets import (
+    QDialog, QDialogButtonBox,
+    QSizePolicy,
+    QPushButton,
+)
 
-from classes import info, ui_util, time_parts, qt_types, updates
+import openshot
+
+from classes import info, ui_util, time_parts
 from classes.app import get_app
 from classes.logger import log
-from classes.metrics import *
+from classes.metrics import track_metric_screen
 from windows.preview_thread import PreviewParent
 from windows.video_widget import VideoWidget
 
-import json
 
 class SelectRegion(QDialog):
     """ SelectRegion Dialog """

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -1,6 +1,6 @@
 """
  @file
- @brief This file loads the UI for selecting a region of a video (rectangle used for effect processing)
+ @brief UI for selecting a region of a video (for effect processing)
   @author Jonathan Thomas <jonathan@openshot.org>
 
  @section LICENSE
@@ -92,22 +92,22 @@ class SelectRegion(QDialog):
         # Set region clip start and end
         self.clip.Start(clip.Start())
         self.clip.End(clip.End())
-        self.clip.Id( get_app().project.generate_id() )
+        self.clip.Id(get_app().project.generate_id())
 
         # Keep track of file object
         self.file = file
         self.file_path = file.absolute_path()
 
         c_info = clip.Reader().info
-        self.fps = c_info.fps.ToInt() #float(self.fps_num) / float(self.fps_den)
-        self.fps_num = self.fps #int(file.data['fps']['num'])
-        self.fps_den = 1 #int(file.data['fps']['den'])
-        self.width = c_info.width #int(file.data['width'])
-        self.height = c_info.height #int(file.data['height'])
-        self.sample_rate = c_info.sample_rate #int(file.data['sample_rate'])
-        self.channels = c_info.channels #int(file.data['channels'])
-        self.channel_layout = c_info.channel_layout #int(file.data['channel_layout'])
-        self.video_length = int(self.clip.Duration() * self.fps) + 1 #int(file.data['video_length'])
+        self.fps = c_info.fps.ToInt()
+        self.fps_num = self.fps
+        self.fps_den = 1
+        self.width = c_info.width
+        self.height = c_info.height
+        self.sample_rate = c_info.sample_rate
+        self.channels = c_info.channels
+        self.channel_layout = c_info.channel_layout
+        self.video_length = int(self.clip.Duration() * self.fps) + 1
 
         # Apply effects to region frames
         for effect in clip.Effects():
@@ -118,7 +118,8 @@ class SelectRegion(QDialog):
 
         # Add Video Widget
         self.videoPreview = VideoWidget()
-        self.videoPreview.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
+        self.videoPreview.setSizePolicy(
+            QSizePolicy.Preferred, QSizePolicy.Expanding)
         self.verticalLayout.insertWidget(0, self.videoPreview)
 
         # Set aspect ratio to match source content
@@ -127,16 +128,23 @@ class SelectRegion(QDialog):
         self.videoPreview.aspect_ratio = aspect_ratio
 
         # Set max size of video preview (for speed)
-        self.viewport_rect = self.videoPreview.centeredViewport(self.width, self.height)
+        viewport_rect = self.videoPreview.centeredViewport(
+            self.width, self.height)
 
         # Create an instance of a libopenshot Timeline object
-        self.r = openshot.Timeline(self.viewport_rect.width(), self.viewport_rect.height(), openshot.Fraction(self.fps_num, self.fps_den), self.sample_rate, self.channels, self.channel_layout)
+        self.r = openshot.Timeline(
+            viewport_rect.width(), viewport_rect.height(),
+            openshot.Fraction(self.fps_num, self.fps_den),
+            self.sample_rate, self.channels, self.channel_layout)
         self.r.info.channel_layout = self.channel_layout
-        self.r.SetMaxSize(self.viewport_rect.width(), self.viewport_rect.height())
+        self.r.SetMaxSize(viewport_rect.width(), viewport_rect.height())
 
         try:
             # Show waveform for audio files
-            if not self.clip.Reader().info.has_video and self.clip.Reader().info.has_audio:
+            if (
+                not self.clip.Reader().info.has_video
+                and self.clip.Reader().info.has_audio
+            ):
                 self.clip.Waveform(True)
 
             # Set has_audio property
@@ -189,13 +197,14 @@ class SelectRegion(QDialog):
         get_app().window.SelectRegionSignal.emit(clip.Id())
 
     def actionPlay_Triggered(self):
-        # Trigger play button (This action is invoked from the preview thread, so it must exist here)
+        # Trigger play button
+        # (invoked from the preview thread, so it must exist here)
         self.btnPlay.click()
 
     def movePlayhead(self, frame_number):
         """Update the playhead position"""
-
         self.current_frame = frame_number
+
         # Move slider to correct frame position
         self.sliderIgnoreSignal = True
         self.sliderVideo.setValue(frame_number)
@@ -205,8 +214,11 @@ class SelectRegion(QDialog):
         seconds = (frame_number-1) / self.fps
 
         # Convert seconds to time stamp
-        time_text = time_parts.secondsToTime(seconds, self.fps_num, self.fps_den)
-        timestamp = "%s:%s:%s:%s" % (time_text["hour"], time_text["min"], time_text["sec"], time_text["frame"])
+        time_text = time_parts.secondsToTime(
+            seconds, self.fps_num, self.fps_den)
+        timestamp = "%s:%s:%s:%s" % (
+            time_text["hour"], time_text["min"],
+            time_text["sec"], time_text["frame"])
 
         # Update label
         self.lblVideoTime.setText(timestamp)
@@ -221,11 +233,13 @@ class SelectRegion(QDialog):
 
         if self.btnPlay.isChecked():
             log.info('play (icon to pause)')
-            ui_util.setup_icon(self, self.btnPlay, "actionPlay", "media-playback-pause")
+            ui_util.setup_icon(
+                self, self.btnPlay, "actionPlay", "media-playback-pause")
             self.preview_thread.Play(self.video_length)
         else:
             log.info('pause (icon to play)')
-            ui_util.setup_icon(self, self.btnPlay, "actionPlay", "media-playback-start")  # to default
+            ui_util.setup_icon(
+                self, self.btnPlay, "actionPlay", "media-playback-start")
             self.preview_thread.Pause()
 
         # Send focus back to toolbar

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -68,7 +68,7 @@ class SelectRegion(QDialog):
         _ = get_app()._tr
 
         # Create dialog class
-        QDialog.__init__(self)
+        super().__init__()
 
         # Load UI from designer
         ui_util.load_ui(self, self.ui_path)
@@ -244,7 +244,7 @@ class SelectRegion(QDialog):
 
         self.shutdownPlayer()
         get_app().window.SelectRegionSignal.emit("")
-        super(SelectRegion, self).accept()
+        super().accept()
 
     def shutdownPlayer(self):
 
@@ -270,7 +270,4 @@ class SelectRegion(QDialog):
         # Cancel dialog
         self.shutdownPlayer()
         get_app().window.SelectRegionSignal.emit("")
-        super(SelectRegion, self).reject()
-
-
-
+        super().reject()

--- a/src/windows/ui/process-effect.ui
+++ b/src/windows/ui/process-effect.ui
@@ -25,7 +25,7 @@
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
+     <widget class="QWidget" name="mainContents">
       <property name="geometry">
        <rect>
         <x>0</x>


### PR DESCRIPTION
Mostly maintainability / quality-of-life stuff
1. **NO STAR IMPORTS, EVER.**
1. No Pokemon `except:`s. (You _don't_ gotta catch 'em all!)
1. Avoid manual loop-counting wherever possible. (`enumerate()` is your friend)
1. Python3 `super()` semantics
1. Deeply
    * Nesting
        * Your
            * Conditions
                * Is
                    * Bad.
                    * If your code is wandering off the right side of the screen, it's a sign your function should probably be, like, 4 or 5 smaller functions.