### PR TITLE
Folder locations mk2

### DIFF
--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -43,9 +43,8 @@ class SettingStore(JsonDataStore):
 
     @unique
     class pathType(Enum):
-        # Using literals to match the setting values
-        RECENT=0 # Return the last used path for the same action
-        PROJECT=1 # Return the current project path
+        RECENT=auto() # Return the last used path for the same action
+        PROJECT=auto() # Return the current project path
 
     @unique
     class actionType(Enum):

--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -184,10 +184,8 @@ class SettingStore(JsonDataStore):
                 log.error("getting setting %s" % setting["path"])
 
         if os.path.isfile(default_path):
-            # Default set to a file, not a dir. Fixing it.
-            log.info("Default path is a file. Correcting.")
+            # Make sure default_path is a directory
             default_path = os.path.dirname(default_path)
-            self.setDefaultPath(action,default_path)
 
         if (not default_path) or (not os.path.exists(default_path)):
             log.debug("Default path invalid. Falling back to home directory")
@@ -195,7 +193,7 @@ class SettingStore(JsonDataStore):
 
         if action == self.actions.SAVE:
             log.info("Adding file name for project path")
-            # Only get project name if one is currently active.
+            # Default name unless a project is currently active.
             project_name = os.path.basename(self.app.project.current_filepath or "") or "%s.osp" % _("Untitled Project")
             default_path = os.path.join(default_path, project_name)
         return default_path

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -967,5 +967,83 @@
     "setting": "actionDuplicateTitle",
     "value": "Ctrl+Shift+C",
     "type": "text"
+  },
+  {
+    "category": "Location",
+    "title": "File Import",
+    "setting": "locationImportType",
+    "value": 0,
+    "type": "dropdown",
+    "values": [
+      {
+        "value": 0,
+        "name": "Recent Folder"
+      },
+      {
+        "value": 1,
+        "name": "Project Folder"
+      }
+    ],
+    "restart": false
+  },
+  {
+    "category": "Location",
+    "title": "File Import Path",
+    "setting": "locationImportPath",
+    "value": "",
+    "type": "hidden",
+    "restart": false
+  },
+  {
+    "category": "Location",
+    "title": "Save or Open Project",
+    "setting": "locationProjectType",
+    "value": 0,
+    "type": "dropdown",
+    "values": [
+      {
+        "value": 0,
+        "name": "Recent Folder"
+      },
+      {
+        "value": 1,
+        "name": "Project Folder"
+      }
+    ],
+    "restart": false
+  },
+  {
+    "category": "Location",
+    "title": "Save or Open Project Path",
+    "setting": "locationProjectPath",
+    "value": "",
+    "type": "hidden",
+    "restart": false
+  },
+  {
+    "category": "Location",
+    "title": "Video Export",
+    "setting": "locationExportType",
+    "value": 1,
+    "type": "dropdown",
+    "values": [
+      {
+        "value": 0,
+        "name": "Recent Folder"
+      },
+      {
+        "value": 1,
+        "name": "Project Folder"
+      }
+    ],
+    "restart": false
+  },
+  {
+    "category": "Location",
+    "title": "Video Export Path",
+    "setting": "locationExportPath",
+    "value": "",
+    "type": "hidden",
+    "restart": false
   }
 ]

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -1028,11 +1028,11 @@
     "type": "dropdown",
     "values": [
       {
-        "value": 0,
+        "value": 1,
         "name": "Recent Folder"
       },
       {
-        "value": 1,
+        "value": 2,
         "name": "Project Folder"
       }
     ],

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -138,7 +138,7 @@ class Export(QDialog):
         self.timeline.Open()
 
         # Default export path
-        recommended_path = self.s.getDefaultPath(self.s.actions.EXPORT)
+        recommended_path = self.s.getDefaultPath(self.s.actionType.EXPORT)
         self.txtExportFolder.setText(recommended_path)
 
         # Is this a saved project?
@@ -587,15 +587,16 @@ class Export(QDialog):
 
         # get translations
         _ = get_app()._tr
-        default_path = self.s.getDefaultPath(self.s.actions.EXPORT)
+        default_path = self.s.getDefaultPath(self.s.actionType.EXPORT)
 
         # update export folder path
         file_path = QFileDialog.getExistingDirectory(self,
                                                      _("Choose a Folder..."),
                                                      default_path)
 
+        # Don't change path if chosen path isn't valid
         if os.path.exists(file_path):
-            self.s.setDefaultPath(self.s.actions.EXPORT, file_path)
+            self.s.setDefaultPath(self.s.actionType.EXPORT, file_path)
             self.txtExportFolder.setText(file_path)
 
     def convert_to_bytes(self, BitRateString):

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -138,17 +138,8 @@ class Export(QDialog):
         self.timeline.Open()
 
         # Default export path
-        recommended_path = os.path.join(info.HOME_PATH)
-        if get_app().project.current_filepath:
-            recommended_path = os.path.dirname(get_app().project.current_filepath)
-
-        export_path = get_app().project.get("export_path")
-        if export_path and os.path.exists(export_path):
-            # Use last selected export path
-            self.txtExportFolder.setText(export_path)
-        else:
-            # Default to home dir
-            self.txtExportFolder.setText(recommended_path)
+        recommended_path = self.s.getDefaultPath(self.s.actions.EXPORT)
+        self.txtExportFolder.setText(recommended_path)
 
         # Is this a saved project?
         if not get_app().project.current_filepath:
@@ -596,11 +587,15 @@ class Export(QDialog):
 
         # get translations
         _ = get_app()._tr
+        default_path = self.s.getDefaultPath(self.s.actions.EXPORT)
 
         # update export folder path
-        file_path = QFileDialog.getExistingDirectory(self, _("Choose a Folder..."), self.txtExportFolder.text())
+        file_path = QFileDialog.getExistingDirectory(self,
+                                                     _("Choose a Folder..."),
+                                                     default_path)
 
         if os.path.exists(file_path):
+            self.s.setDefaultPath(self.s.actions.EXPORT, file_path)
             self.txtExportFolder.setText(file_path)
 
     def convert_to_bytes(self, BitRateString):

--- a/src/windows/export_clips.py
+++ b/src/windows/export_clips.py
@@ -148,10 +148,16 @@ class clipExportWindow(QDialog):
         fd = QFileDialog()
         fd.setOption(QFileDialog.ShowDirsOnly)
         fd.setDirectory(
-            settings.getDefaultPath(settings.actions.EXPORT)
+            settings.getDefaultPath(settings.actionType.EXPORT)
         )
-        self.export_destination = fd.getExistingDirectory()
-        settings.setDefaultPath(settings.actions.EXPORT, self.export_destination)
+        chosen_destination = fd.getExistingDirectory()
+
+        # if dialog is canceled, use default path
+        if chosen_destination:
+            self.export_destination = chosen_destination
+            settings.setDefaultPath(settings.actionType.EXPORT, self.export_destination)
+        else:
+            self.export_destination = settings.getDefaultPath(settings.actionType.EXPORT)
 
     def _createWidgets(self):
         self.FilePickerArea.addWidget(QLabel(_("Export To %s") % self.export_destination))

--- a/src/windows/export_clips.py
+++ b/src/windows/export_clips.py
@@ -144,14 +144,14 @@ class clipExportWindow(QDialog):
         self._createWidgets()
 
     def _getDestination(self):
+        settings = get_app().get_settings()
         fd = QFileDialog()
         fd.setOption(QFileDialog.ShowDirsOnly)
         fd.setDirectory(
-            get_app().project.current_filepath\
-            if get_app().project.current_filepath\
-            else info.HOME_PATH
+            settings.getDefaultPath(settings.actions.EXPORT)
         )
         self.export_destination = fd.getExistingDirectory()
+        settings.setDefaultPath(settings.actions.EXPORT, self.export_destination)
 
     def _createWidgets(self):
         self.FilePickerArea.addWidget(QLabel(_("Export To %s") % self.export_destination))

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -540,9 +540,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def actionOpen_trigger(self):
         app = get_app()
         _ = app._tr
-        recommended_path = app.project.current_filepath
-        if not recommended_path:
-            recommended_path = info.HOME_PATH
+        s = app.get_settings()
+        recommended_path = s.getDefaultPath(s.actions.LOAD)
 
         # Do we have unsaved changes?
         if app.project.needs_save():
@@ -565,22 +564,26 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             recommended_path,
             _("OpenShot Project (*.osp)"))[0]
 
+        s.setDefaultPath(s.actions.LOAD,file_path)
+
         # Load project file
         self.OpenProjectSignal.emit(file_path)
 
     def actionSave_trigger(self):
         app = get_app()
+        s = app.get_settings()
         _ = app._tr
 
         # Get current filepath if any, otherwise ask user
         file_path = app.project.current_filepath
         if not file_path:
-            recommended_path = os.path.join(info.HOME_PATH, "%s.osp" % _("Untitled Project"))
+            recommended_path = s.getDefaultPath(settings.actions.SAVE)
             file_path = QFileDialog.getSaveFileName(
                 self,
                 _("Save Project..."),
                 recommended_path,
                 _("OpenShot Project (*.osp)"))[0]
+            s.setDefaultPath(s.actions.SAVE, file_path)
 
         if file_path:
             # Append .osp if needed
@@ -649,17 +652,16 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def actionSaveAs_trigger(self):
         app = get_app()
+        s = app.get_settings()
         _ = app._tr
 
-        recommended_path = app.project.current_filepath
-        if not recommended_path:
-            recommended_path = os.path.join(
-                info.HOME_PATH, "%s.osp" % _("Untitled Project"))
+        recommended_path = s.getDefaultPath(s.actions.SAVE)
         file_path = QFileDialog.getSaveFileName(
             self,
             _("Save Project As..."),
             recommended_path,
             _("OpenShot Project (*.osp)"))[0]
+        s.setDefaultPath(s.actions.SAVE, file_path)
         if file_path:
             # Append .osp if needed
             if ".osp" not in file_path:
@@ -670,11 +672,10 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def actionImportFiles_trigger(self):
         app = get_app()
+        s = app.get_settings()
         _ = app._tr
 
-        recommended_path = app.project.get("import_path")
-        if not recommended_path or not os.path.exists(recommended_path):
-            recommended_path = os.path.join(info.HOME_PATH)
+        recommended_path = s.getDefaultPath(s.actions.IMPORT)
 
         # PyQt through 5.13.0 had the 'directory' argument mis-typed as str
         if PYQT_VERSION_STR < '5.13.1':
@@ -691,6 +692,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             start_location,
             )[0]
 
+        if len(qurl_list):
+            s.setDefaultPath(s.actions.IMPORT, qurl_list[-1].path())
         # Set cursor to waiting
         app.setOverrideCursor(QCursor(Qt.WaitCursor))
 
@@ -1023,6 +1026,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Translate object
         app = get_app()
+        s = app.get_settings()
         _ = app._tr
 
         # Prepare to use the status bar
@@ -1030,18 +1034,14 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.setStatusBar(self.statusBar)
 
         # Determine path for saved frame - Default export path
-        recommended_path = os.path.join(info.HOME_PATH)
-        if app.project.current_filepath:
-            recommended_path = os.path.dirname(app.project.current_filepath)
+        recommended_path = s.getDefaultPath(s.actions.SAVE)
 
-        # Determine path for saved frame - Project's export path
-        if app.project.get("export_path"):
-            recommended_path = app.project.get("export_path")
-
-        framePath = "%s/Frame-%05d.png" % (recommended_path, self.preview_thread.current_frame)
+        framePath = "%s/Frame-%05d.png" % (os.path.basename(recommended_path),
+                                           self.preview_thread.current_frame)
 
         # Ask user to confirm or update framePath
         framePath = QFileDialog.getSaveFileName(self, _("Save Frame..."), framePath, _("Image files (*.png)"))[0]
+        s.setDefaultPath(s.actions.SAVE, framePath)
 
         if not framePath:
             # No path specified (save frame cancelled)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -566,7 +566,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         if file_path:
             # Don't open if dialog canceled.
-            s.setDefaultPath(s.actions.LOAD,file_path)
+            s.setDefaultPath(s.actionType.LOAD,file_path)
 
             # Load project file
             self.OpenProjectSignal.emit(file_path)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -661,10 +661,15 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         s = app.get_settings()
         _ = app._tr
 
+        project_file_path = app.project.current_filepath
+        if project_file_path:
+            recommended_file_name = os.path.basename(project_file_path)
+        else:
+            recommended_file_name = "%s.osp" % _("Untitled Project")
         recommended_folder = s.getDefaultPath(s.actionType.SAVE)
         recommended_path = os.path.join(
             recommended_folder,
-            _("Untitled Project") + ".osp"
+            recommended_file_name
         )
         file_path = QFileDialog.getSaveFileName(
             self,
@@ -703,6 +708,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             )[0]
 
         if len(qurl_list):
+            # If any files were imported,
+            # Use the folder of the LAST one as the new default path.
             s.setDefaultPath(s.actionType.IMPORT, qurl_list[-1].path())
         # Set cursor to waiting
         app.setOverrideCursor(QCursor(Qt.WaitCursor))


### PR DESCRIPTION
closes #4590
# Enhancement
Currently openshot's memory of folder locations is tied to projects. Some users may keep lots (or all) of their resource files in the same folder. If they do, this change will start them off in the folder they last imported from. If not, this can be switched off in `Settings` > `Locations`

# Example
1) Open a project
2) Start to import a file. (Ctrl+f)
3) Go into a sub folder and choose an image to import.
3) Create a new project
4) start to Import another file (Ctrl+f)

Notice that you are not in the same subfolder.

# Test
Repeat the steps from example, and on the last step, You should be in the subfolder navigated to in step 3. (Unless you've changed `Settings` > `Locations`)