### PR TITLE
Waveform Improvements

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -387,6 +387,8 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         from classes.app import get_app
         get_app().updates.load(self._data)
 
+        self.show_waveforms()
+
     def rescale_keyframes(self, scale_factor):
         """Adjust all keyframe coordinates from previous FPS to new FPS (using a scale factor)
            and return scaled project data without modifing the current project."""
@@ -397,6 +399,14 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         # Create copy of active project data and scale
         scaled = scaler(copy.deepcopy(self._data))
         return scaled
+
+    def show_waveforms(self):
+        """Find any clips with waveforms enabled, and change their display"""
+        for clip in self._data["clips"]:
+            path = clip.get("reader", {}).get("path", "")
+
+            if "show_waveform" in clip.keys() and clip["show_waveform"]:
+                get_audio_data(clip.get("id"), path)
 
     def read_legacy_project_file(self, file_path):
         """Attempt to read a legacy version 1.x openshot project file"""

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -42,6 +42,7 @@ from classes.logger import log
 from classes.updates import UpdateInterface
 from classes.assets import get_assets_path
 from windows.views.find_file import find_missing_file
+from .waveform import get_audio_data
 
 from .keyframe_scaler import KeyframeScaler
 
@@ -307,6 +308,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                         self._data["fps"] = {"num": profile.info.fps.num, "den": profile.info.fps.den}
                         self._data["display_ratio"] = {"num": profile.info.display_ratio.num, "den": profile.info.display_ratio.den}
                         self._data["pixel_ratio"] = {"num": profile.info.pixel_ratio.num, "den": profile.info.pixel_ratio.den}
+                        self._data["sound_data"] = {} #dict of file ids and their audio data
                         break
 
                 except RuntimeError as e:

--- a/src/classes/waveform.py
+++ b/src/classes/waveform.py
@@ -31,6 +31,7 @@ from copy import deepcopy
 from classes import info
 from classes.app import get_app
 from classes.logger import log
+from classes.query import Clip
 import openshot
 
 
@@ -38,22 +39,29 @@ import openshot
 s = get_app().get_settings()
 
 
-def get_audio_data(clip_id, file_path, channel_filter, volume_keyframe):
+def get_audio_data(clip_id, file_path, channel_filter=None, volume_keyframe=None):
     """Get a Clip object form libopenshot, and grab audio data"""
-    clip = openshot.Clip(file_path)
-    clip.Open()
+    temp_clip = openshot.Clip(file_path)
+    temp_clip.Open()
 
     # Disable video stream (for speed improvement)
-    clip.Reader().info.has_video = False
+    temp_clip.Reader().info.has_video = False
 
-    log.info("Clip loaded, start thread")
-    t = threading.Thread(target=get_waveform_thread, args=[clip, clip_id, file_path, channel_filter, volume_keyframe])
+    log.info("Clip loaded, start waveform thread")
+    actual_clip = get_app().window.timeline_sync.timeline.GetClip(clip_id)
+    if actual_clip:
+        if channel_filter == None:
+            channel_filter = actual_clip.channel_filter.GetInt(1)
+        if volume_keyframe == None:
+            volume_keyframe = actual_clip.volume
+    t = threading.Thread(target=get_waveform_thread, args=[temp_clip, clip_id, file_path, channel_filter, volume_keyframe])
     t.daemon = True
     t.start()
 
 def get_waveform_thread(clip, clip_id, file_path, channel_filter=-1, volume_keyframe=None):
     """Get the audio data from a clip in a separate thread"""
     audio_data = []
+    audio_data_this_clip = []
     sample_rate = clip.Reader().info.sample_rate
 
     # How many samples per second do we need (to approximate the waveform)
@@ -61,7 +69,23 @@ def get_waveform_thread(clip, clip_id, file_path, channel_filter=-1, volume_keyf
     sample_divisor = round(sample_rate / samples_per_second)
     log.info("Getting waveform for sample rate: %s" % sample_rate)
 
+    sound_data = get_app().project.get('sound_data')
+    file_id = Clip.filter(id=clip_id)[0].data.get("file_id")
+    if (file_id in sound_data.keys()) and\
+        str(channel_filter) in sound_data.get(file_id).keys():
+
+        log.debug(f"Loading stored waveform data. File: {file_id}. Channel: {channel_filter} ")
+        audio_data = sound_data.get(file_id).get(str(channel_filter))
+        volume = 1.0
+        for (frame_number, audio_sample) in enumerate(audio_data):
+            if volume_keyframe:
+                volume = volume_keyframe.GetValue(frame_number)
+            audio_data_this_clip.append(audio_sample * volume)
+        get_app().window.WaveformReady.emit(clip_id, audio_data_this_clip)
+        return
+
     sample = 0
+    log.debug(f"Generating waveform data. File: {file_id}. Channel: {channel_filter} ")
     for frame_number in range(1, clip.Reader().info.video_length):
         # Get frame object
         frame = clip.Reader().GetFrame(frame_number)
@@ -80,7 +104,9 @@ def get_waveform_thread(clip, clip_id, file_path, channel_filter=-1, volume_keyf
 
             # Get audio data for this channel
             if sample < frame.GetAudioSamplesCount():
-                audio_data.append(frame.GetAudioSample(channel_filter, sample, magnitude_range) * volume)
+                sample_value = frame.GetAudioSample(channel_filter, sample, magnitude_range)
+                audio_data.append(sample_value)
+                audio_data_this_clip.append(sample_value * volume)
             else:
                 # Adjust starting sample for next frame
                 sample = max(0, sample - frame.GetAudioSamplesCount())
@@ -91,7 +117,10 @@ def get_waveform_thread(clip, clip_id, file_path, channel_filter=-1, volume_keyf
 
     # Close reader
     clip.Close()
-
+    file_sound_data = sound_data.get(file_id, {})
+    file_sound_data[str(channel_filter)] = audio_data
+    sound_data[file_id] = file_sound_data
+    get_app().updates.update(["sound_data"], sound_data)
     # Emit signal when done
     log.info("get_waveform_thread completed")
-    get_app().window.WaveformReady.emit(clip_id, audio_data)
+    get_app().window.WaveformReady.emit(clip_id, audio_data_this_clip)

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -40,6 +40,7 @@ from classes import openshot_rc  # noqa
 from classes.query import Clip, Transition, Effect
 from classes.logger import log
 from classes.app import get_app
+from classes.waveform import get_audio_data
 import openshot
 
 import json
@@ -252,6 +253,12 @@ class PropertiesModel(updates.UpdateInterface):
 
             # Clear selection
             self.parent.clearSelection()
+
+        if c.data.get("show_waveform", False):
+            if property_key in ["volume", "channel_filter"]:
+                clip = get_app().window.timeline_sync.timeline.GetClip(c.data.get("id"))
+                get_audio_data(c.data.get("id"), c.data.get("reader", {}).get("path", ""), \
+                               clip.channel_filter.GetInt(1), clip.volume)
 
     def color_update(self, item, new_color, interpolation=-1, interpolation_details=[]):
         """Insert/Update a color keyframe for the selected row"""
@@ -510,6 +517,13 @@ class PropertiesModel(updates.UpdateInterface):
                         clip_data[property_key].setdefault('Points', []).append({
                             'co': {'X': self.frame_number, 'Y': new_value},
                             'interpolation': 1})
+
+                # If sound has been updated:
+                if clip_data.get("show_waveform",False):
+                    if property_key in ["volume", "channel_filter"]:
+                        clip = get_app().window.timeline_sync.timeline.GetClip(clip_data.get("id"))
+                        get_audio_data(clip_data.get("id"), clip_data.get("reader",{}).get("path",""),\
+                            clip.channel_filter.GetInt(1), clip.volume)
 
             if not clip_updated:
                 # If no keyframe was found, set a basic property

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -956,6 +956,8 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
     def Show_Waveform_Triggered(self, clip_ids):
         """Show a waveform for the selected clip"""
 
+        # Set cursor to waiting
+        get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
         # Loop through each selected clip
         for clip_id in clip_ids:
 
@@ -967,14 +969,12 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
             file_path = clip.data["reader"]["path"]
 
-            # Find actual clip object from libopenshot
+            clip.data["show_waveform"] = True
+            clip.save()
             c = self.window.timeline_sync.timeline.GetClip(clip_id)
             if c and c.Reader() and not c.Reader().info.has_single_image:
                 # Find frame 1 channel_filter property
                 channel_filter = c.channel_filter.GetInt(1)
-
-                # Set cursor to waiting
-                get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
 
                 # Get audio data in a separate thread (so it doesn't block the UI)
                 channel_filter = channel_filter


### PR DESCRIPTION
# Issues
1) Clips that had `show-waveform` enabled didn't keep that setting when a project was closed and opened again.
2) If volume was changed after the waveform was generated, the change wouldn't display in the waveform.
3) (Performance) Even for clips from same file, OpenShot would get retrieve the file's audio data again for each waveform.

# Solution
1) Set `show_waveform` on clips, and check that setting when loading a project
2) Call the waveform function when changes to volume are detected
3) Store audio data in project, and check for stored data before retrieving it.

# Test
1) Open a project, and add clips with sound.
2) Enable waveform
3) Add some volume keyframes. (For instance, volume: 1.0 at the beginning and 0.0 at the end.)
    - Observe that the shape changes.
4) Save and close the project.
5) Reopen and see that the waveforms reappear automatically.