### PR TITLE
TitleEditor: Support SVG contain tspan element without style attribute

### DIFF
--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -289,7 +289,7 @@ class TitleEditor(QDialog):
             title_text.append(text)
 
             # Set font size (for possible font dialog)
-            s = node.attributes["style"].value
+            s = node.getAttribute("style")
             ard = style_to_dict(s)
             fs = ard.get("font-size")
             if fs and fs.endswith("px"):
@@ -451,7 +451,7 @@ class TitleEditor(QDialog):
         for node in self.text_nodes + self.tspan_nodes:
 
             # Get the value in the style attribute and turn into a dict
-            s = node.attributes["style"].value
+            s = node.getAttribute("style")
             ard = style_to_dict(s)
             # Get fill color or default to white
             color = ard.get("fill", "#FFF")
@@ -495,7 +495,7 @@ class TitleEditor(QDialog):
                         for stop_node in ref_node.childNodes:
                             if stop_node.nodeName == "stop":
                                 # get color from stop
-                                ard = style_to_dict(stop_node.attributes["style"].value)
+                                ard = style_to_dict(stop_node.getAttribute("style"))
                                 if "stop-color" in ard:
                                     return ard.get("stop-color")
         return ""
@@ -505,7 +505,7 @@ class TitleEditor(QDialog):
 
         if self.rect_node:
             # All backgrounds should be the first (index 0) rect tag in the svg
-            s = self.rect_node[0].attributes["style"].value
+            s = self.rect_node[0].getAttribute("style")
             ard = style_to_dict(s)
 
             # Get fill color or default to black + full opacity
@@ -530,7 +530,7 @@ class TitleEditor(QDialog):
         # Loop through each TEXT element
         for text_child in self.text_nodes + self.tspan_nodes:
             # set the style elements for the main text node
-            s = text_child.attributes["style"].value
+            s = text_child.getAttribute("style")
             ard = style_to_dict(s)
             set_if_existing(ard, "font-style", self.font_style)
             set_if_existing(ard, "font-family", f"'{self.font_family}'")
@@ -549,7 +549,7 @@ class TitleEditor(QDialog):
 
         if self.rect_node:
             # Turn the style attribute into a dict for modification
-            s = self.rect_node[0].attributes["style"].value
+            s = self.rect_node[0].getAttribute("style")
             ard = style_to_dict(s)
             ard.update({
                 "fill": color,
@@ -564,7 +564,7 @@ class TitleEditor(QDialog):
         # Loop through each TEXT element
         for text_child in self.text_nodes + self.tspan_nodes:
             # SET TEXT PROPERTIES
-            s = text_child.attributes["style"].value
+            s = text_child.getAttribute("style")
             ard = style_to_dict(s)
             ard.update({
                 "fill": color,


### PR DESCRIPTION
## Issue
If the SVG contains a tspan element without style attribute, "Edit Title" will not work.

* sample svg
```svg
<?xml version="1.0" encoding="UTF-8"?>
<!-- Created with Inkscape (http://www.inkscape.org/) -->
<svg xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" version="1.1" width="720" height="486" id="svg2985">
   <defs id="defs2987" />
   <g id="layer1">
      <text x="50.03632" y="273.45352" id="text2993" xml:space="preserve" style="font-size:155.10592651px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans">
         <tspan x="50.03632" y="273.45352" id="tspan2995">My Title</tspan>
      </text>
   </g>
</svg>
```

This svg from https://cloud.openshot.org/doc/text.html#example-svg-contents

* Error log
[error.log](https://github.com/OpenShot/openshot-qt/files/8579846/error.log)


### env
- OS: Debian buster
- OpenShot: latest develop branch (8f363de)
- libopenshot: 0.2.7
- libopenshot-audio: 0.2.2


## Fix
Fixed to treat the value of the style attribute as an empty string when the tspan element does not have the style attribute.

thanks!
