### PR TITLE
Fixing QtWebEngine Black/not-rendered Timeline

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -501,6 +501,7 @@ elif sys.platform == "linux":
                 paths = ["lib/openshot_qt/",
                          "lib/*opencv*",
                          "lib/libopenshot*",
+                         "translations/",
                          "locales/",
                          "libQt5WebKit.so.5"]
                 for path in paths:

--- a/freeze.py
+++ b/freeze.py
@@ -501,7 +501,6 @@ elif sys.platform == "linux":
                 paths = ["lib/openshot_qt/",
                          "lib/*opencv*",
                          "lib/libopenshot*",
-                         "translations/",
                          "locales/",
                          "libQt5WebKit.so.5"]
                 for path in paths:

--- a/installer/launch-linux.sh
+++ b/installer/launch-linux.sh
@@ -32,6 +32,11 @@ export LD_LIBRARY_PATH="${HERE}"
 # Set some environment variables
 export QT_PLUGIN_PATH="${HERE}"
 
+# Disable sandbox support for QtWebEngine (required on some Linux distros
+# for the QtWebEngineWidgets to be rendered, otherwise no timeline is visible).
+# https://doc.qt.io/qt-5/qtwebengine-platform-notes.html#sandboxing-support
+export QTWEBENGINE_DISABLE_SANDBOX="1"
+
 # For Debian-based systems with newer openssl, see:
 # https://github.com/OpenShot/openshot-qt/issues/3242
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=918727 


### PR DESCRIPTION
Disable sandbox support for QtWebEngine (required on some Linux distros for the QtWebEngineWidgets to be rendered, otherwise no timeline is visible). This was initially reported on OpenSUSE and the latest Ubuntu 22.04.
https://doc.qt.io/qt-5/qtwebengine-platform-notes.html#sandboxing-support

Closes [#4676](https://github.com/OpenShot/openshot-qt/issues/4676)