### PR TITLE
WIP: Patch for folder feature

### DIFF
--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -141,11 +141,11 @@ class SettingStore(JsonDataStore):
         """
         Change the path setting corresponding to the given action
         """
+        if os.path.isfile(recent_path):
+            recent_path=os.path.dirname(recent_path)
         if not os.path.exists(recent_path):
             log.error("recent_path is not a valid path")
             return
-        if os.path.isfile(recent_path):
-            recent_path=os.path.dirname(recent_path)
         try:
             setting = self.pathSettings(action)
             log.debug(f"Setting %s to %s" % (action.value, recent_path))

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -972,15 +972,15 @@
     "category": "Location",
     "title": "File Import",
     "setting": "locationImportType",
-    "value": 0,
+    "value": 1,
     "type": "dropdown",
     "values": [
       {
-        "value": 0,
+        "value": 1,
         "name": "Recent Folder"
       },
       {
-        "value": 1,
+        "value": 2,
         "name": "Project Folder"
       }
     ],
@@ -998,15 +998,15 @@
     "category": "Location",
     "title": "Save or Open Project",
     "setting": "locationProjectType",
-    "value": 0,
+    "value": 1,
     "type": "dropdown",
     "values": [
       {
-        "value": 0,
+        "value": 1,
         "name": "Recent Folder"
       },
       {
-        "value": 1,
+        "value": 2,
         "name": "Project Folder"
       }
     ],
@@ -1024,7 +1024,7 @@
     "category": "Location",
     "title": "Video Export",
     "setting": "locationExportType",
-    "value": 1,
+    "value": 2,
     "type": "dropdown",
     "values": [
       {

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -565,9 +565,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             _("OpenShot Project (*.osp)"))[0]
 
         if file_path:
-            # Don't open if dialog canceled.
-            s.setDefaultPath(s.actionType.LOAD,file_path)
-
             # Load project file
             self.OpenProjectSignal.emit(file_path)
 


### PR DESCRIPTION
1) Update all path settings to use correct Enums.
- Cause paths to update in accordance with the settings.
2) Don't reject paths if the file doesn't exist
- Paths of new projects weren't being saved, because the full path (filename included) didn't exist yet.
3) Don't change save/load path when opening a project.
- Updating "Recent Path" for saving and loading projects on project load makes this option work the same as the "Project Folder" option. Only update on save.