### PR TITLE
Fix blender integration on AppImage (for newer distros)

### DIFF
--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -735,6 +735,13 @@ class Worker(QObject):
         self.version = None
         self.process = None
         self.canceled = False
+        self.env = dict(os.environ)
+        if sys.platform == "linux" and os.path.exists('/lib/x86_64-linux-gnu/'):
+            # If on Linux, verify we have the following LD library path defined.
+            # This is needed for Blender to use the system libraries instead
+            # of our AppImage libraries (i.e. our libtiff.so.5 is missing symbols,
+            # compared to libtiff.so.5 on newer distros for some reason).
+            self.env['LD_LIBRARY_PATH'] = '/lib/x86_64-linux-gnu/'
 
         self.startupinfo = None
         if sys.platform == 'win32':
@@ -766,7 +773,7 @@ class Worker(QObject):
             self.process = subprocess.Popen(
                 command_get_version,
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                startupinfo=self.startupinfo,
+                startupinfo=self.startupinfo, env=self.env
             )
             # Give Blender up to 10 seconds to respond
             (out, err) = self.process.communicate(timeout=10)
@@ -876,7 +883,7 @@ class Worker(QObject):
             self.process = subprocess.Popen(
                 command_render, bufsize=512,
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                startupinfo=self.startupinfo,
+                startupinfo=self.startupinfo, env=self.env
             )
             # Signal UI that background task is running
             self.start_processing.emit()

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -724,7 +724,7 @@ class Worker(QObject):
 
         # Init regex expression used to determine blender's render progress
         self.blender_version_re = re.compile(
-            r"^Blender ([0-9a-z\.]*)", flags=re.MULTILINE)
+            r"Blender ([0-9a-z\.]*)", flags=re.MULTILINE)
         self.blender_frame_re = re.compile(r"Fra:([0-9,]+)")
         self.blender_saved_re = re.compile(r"Saved: '(.*\.png)")
         self.blender_syncing_re = re.compile(


### PR DESCRIPTION
On Ubuntu 22.04 (and probably other newish distros), the system version of `libtiff.so.5` contains new symbols... compared to the version we include in our AppImage. Thus, when launching Blender from our AppImage, we get a missing symbols error: `blender: symbol lookup error: /lib/libgdal.so.30: undefined symbol: TIFFGetStrileByteCount, version LIBTIFF_4.0`

This can be fixed by simply including the `/lib/x86_64-linux-gnu/` path when launching Blender, to force it to use the system libraries instead of our AppImage libraries. This seems to fix the issue nicely, both on older systems and newer systems.

Also, I have simplified the **regex** to support text before and after the Blender version, which I have found during testing.