### PR TITLE
Adding back in libglib library, for support of Red Hat based distros

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -354,7 +354,7 @@ elif sys.platform == "linux":
                     "libp11-kit.so.0",
                     "libSM.so.6",
                     # Next 5 are all part of glib2
-                    "libglib-2.0.so.0",
+                    #"libglib-2.0.so.0",  <-- experimental for RHEL 84 support (which have a custom version of glib)
                     "libgobject-2.0.so.0",
                     "libgio-2.0.so.0",
                     "libgmodule-2.0.so.0",

--- a/freeze.py
+++ b/freeze.py
@@ -355,7 +355,7 @@ elif sys.platform == "linux":
                     "libSM.so.6",
                     # Next 5 are all part of glib2
                     #"libglib-2.0.so.0",  <-- experimental for RHEL 84 support (which have a custom version of glib)
-                    "libgobject-2.0.so.0",
+                    #"libgobject-2.0.so.0", <-- experimental for RHEL 84 support (which have a custom version of glib)
                     "libgio-2.0.so.0",
                     "libgmodule-2.0.so.0",
                     "libgthread-2.0.so.0",

--- a/freeze.py
+++ b/freeze.py
@@ -353,7 +353,7 @@ elif sys.platform == "linux":
                     "libICE.so.6",
                     "libp11-kit.so.0",
                     "libSM.so.6",
-                    # Next 5 are all part of glib2
+                    # Next libs are all part of glib2
                     # Adding these back in, for experimental RHEL 84 support (which has a custom version of glib
                     # that breaks our AppImages).
                     #"libglib-2.0.so.0",
@@ -361,14 +361,14 @@ elif sys.platform == "linux":
                     #"libgio-2.0.so.0",
                     #"libgmodule-2.0.so.0",
                     #"libgthread-2.0.so.0",
+                    #"libpango-1.0.so.0",
+                    #"libpangocairo-1.0.so.0",
+                    #"libpangoft2-1.0.so.0",
 
                     "libdrm.so.2",
                     "libfreetype.so.6",
                     "libfontconfig.so.1",
                     "libcairo.so.2",
-                    "libpango-1.0.so.0",
-                    "libpangocairo-1.0.so.0",
-                    "libpangoft2-1.0.so.0",
                     "libharfbuzz.so.0",
                     "libthai.so.0",
                     ]

--- a/freeze.py
+++ b/freeze.py
@@ -354,11 +354,13 @@ elif sys.platform == "linux":
                     "libp11-kit.so.0",
                     "libSM.so.6",
                     # Next 5 are all part of glib2
-                    #"libglib-2.0.so.0",  <-- experimental for RHEL 84 support (which have a custom version of glib)
-                    #"libgobject-2.0.so.0", <-- experimental for RHEL 84 support (which have a custom version of glib)
-                    "libgio-2.0.so.0",
-                    "libgmodule-2.0.so.0",
-                    "libgthread-2.0.so.0",
+                    # Adding these back in, for experimental RHEL 84 support (which has a custom version of glib
+                    # that breaks our AppImages).
+                    #"libglib-2.0.so.0",
+                    #"libgobject-2.0.so.0",
+                    #"libgio-2.0.so.0",
+                    #"libgmodule-2.0.so.0",
+                    #"libgthread-2.0.so.0",
 
                     "libdrm.so.2",
                     "libfreetype.so.6",


### PR DESCRIPTION
Apparently Red Hat has a custom version of `/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0` which breaks our AppImage. The only plausible fix (that I can think of) is to include our build-server's version of `libglib-2.0.so.0`, so the system one no longer breaks.

Useful notes from another open-source project: https://github.com/qTox/qTox/issues/6339, and their fix: https://github.com/sphaerophoria/qTox/commit/e36c59833efc1159178ac50e1248ce27b32dddb2

**Error Message from AppImage on Red Hat:**

```
Traceback (most recent call last):
File "/home/gitlab-runner/.local/lib/python3.6/site-packages/cx_Freeze/initscripts/__startup__.py", line 14, in run
File "/home/gitlab-runner/.local/lib/python3.6/site-packages/cx_Freeze/initscripts/Console.py", line 26, in run
File "openshot_qt/launch.py", line 47, in <module>
from PyQt5.QtCore import Qt
ImportError: /tmp/.mount_ZfPFDf/usr/bin/libgnutls.so.30: version `GNUTLS_3_6_9' not found (required by /lib64/libglib-2.0.so.0)
```

Closes https://github.com/OpenShot/openshot-qt/issues/4444