### PR TITLE
Improved Waveforms (highly optimized)

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -322,6 +322,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
     def load(self, file_path, clear_thumbnails=True):
         """ Load project from file """
 
+        from classes.app import get_app
         self.new()
 
         if file_path:
@@ -337,6 +338,13 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                 # Fix history (if broken)
                 if not project_data.get("history"):
                     project_data["history"] = {"undo": [], "redo": []}
+
+                # If project has waveforms, enable removing waveforms
+                get_app().window.actionClearWaveformData.setEnabled(False)
+                for file in project_data["files"]:
+                    if file.get("ui",{}).get("audio_data", []):
+                        get_app().window.actionClearWaveformData.setEnabled(True)
+                        break
 
             except Exception:
                 try:
@@ -382,7 +390,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             self.apply_default_audio_settings()
 
         # Get app, and distribute all project data through update manager
-        from classes.app import get_app
         get_app().updates.load(self._data)
 
     def rescale_keyframes(self, scale_factor):

--- a/src/classes/query.py
+++ b/src/classes/query.py
@@ -30,8 +30,6 @@ import copy
 
 from classes import info
 from classes.app import get_app
-from classes.logger import log
-import openshot
 
 
 class QueryObject:

--- a/src/classes/query.py
+++ b/src/classes/query.py
@@ -172,48 +172,6 @@ class Clip(QueryObject):
         path = self.data.get("reader", {}).get("path")
         return os.path.basename(path)
 
-    def showAudioData(self):
-        
-        if "ui" not in self.data:
-            self.data["ui"] = {}
-            self.save()
-
-        # Get File
-        file_path = self.data.get("reader").get("path")
-        file = File.get(path = file_path)
-        # Get File's audio data
-        file_audio_data = file.data.get("ui",{}).get("audio_data", False)
-        if not file_audio_data:
-            log.info("clip.showAudioData was called, but file has no audio data")
-            return
-
-        sample_count = len(file_audio_data)
-        file_duration = file.data.get("duration")
-        time_per_sample = file_duration / sample_count
-        def sample_from_time(time):
-            sample_num = max(0, round(time / time_per_sample))
-            sample_num = min(sample_count - 1, sample_num)
-            return file_audio_data[sample_num]
-
-        audio_data = []
-        # clip = Clip.get(id = self.data.get("id"))
-        clip = get_app().window.timeline_sync.timeline.GetClip(self.data.get("id"))
-        num_frames = int(self.data.get("reader").get("video_length"))
-        fps = get_app().project.get("fps")
-        fps_frac = fps["num"] / fps["den"]
-        for frame_num in range(1, num_frames):
-            print(f"Clipshow: frame {frame_num}")
-            volume = clip.volume.GetValue(frame_num)
-            display_frame =  clip.time.GetValue(frame_num)
-            time = display_frame / fps_frac
-            audio_data.append(sample_from_time(time) * volume)
-
-        self.data["ui"]["audio_data"] = audio_data
-        self.save()
-        return
-
-    def removeAudioData(self):
-        pass
 
 class Transition(QueryObject):
     """ This class allows Transitions (i.e. timeline effects) to be queried, updated, and deleted from the project data. """
@@ -301,48 +259,6 @@ class File(QueryObject):
         file_path = self.absolute_path()
         # Convert path to relative (based on current working directory of Python)
         return os.path.relpath(file_path, info.CWD)
-
-    def getAudioData(self):
-        # Ensure that UI attribute exists
-        if "ui" not in self.data:
-            self.data["ui"] = {}
-            self.save()
-
-        audio_data = self.data["ui"].get("audio_data", False)
-        if audio_data and len(audio_data) > 1:
-            log.info("Audio Data already retrieved.")
-            return
-        if not audio_data:
-            # Placeholder value. Communicates that data is being retrieved
-            self.data["ui"]["audio_data"] = [-999]
-
-        # Do the audio data stuff.
-        temp_clip = openshot.Clip(self.data["path"])
-        temp_clip.Open()
-        temp_clip.Reader().info.has_video = False
-
-        sample_rate = temp_clip.Reader().info.sample_rate
-        samples_per_second = 20
-        sample_divisor = round(sample_rate / samples_per_second)
-
-        audio_data = []
-        for frame_num in range(1, temp_clip.Reader().info.video_length):
-            print(f"FileShow: frame {frame_num}")
-            frame = temp_clip.Reader().GetFrame(frame_num)
-
-            sample_num = 0
-            max_samples = frame.GetAudioSamplesCount()
-            while sample_num < max_samples:
-                magnitude_range = sample_divisor
-                if sample_num + magnitude_range > frame.GetAudioSamplesCount():
-                    magnitude_range = frame.GetAudioSamplesCount() - sample_num
-                sample_value = frame.GetAudioSample(-1, sample_num, magnitude_range)
-                audio_data.append(sample_value)
-
-                sample_num += sample_divisor
-        self.data["ui"]["audio_data"] = audio_data
-        self.save()
-        return
 
 
 class Marker(QueryObject):

--- a/src/classes/waveform.py
+++ b/src/classes/waveform.py
@@ -37,8 +37,7 @@ s = get_app().get_settings()
 
 
 def get_audio_data(files: dict):
-    """Get a Clip object form libopenshot, and grab audio data"""
-    """
+    """Get a Clip object form libopenshot, and grab audio data
         For for the given files and clips, start threads to gather audio data.
 
         arg1: a dict of clip_ids grouped by their file_id

--- a/src/classes/waveform.py
+++ b/src/classes/waveform.py
@@ -65,6 +65,7 @@ def get_waveform_thread(file_id, clip_list):
         """
         Update the file query object with audio data (if found).
         """
+        get_app().window.actionClearWaveformData.setEnabled(True)
         # Ensure that UI attribute exists
         file_data = file.data
         file_audio_data = file_data.get("ui", {}).get("audio_data", [])

--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -100,11 +100,11 @@
 					</div>
 					<br class="cleared">
 
-					<div ng-if="!clip.ui.audio_data" class="thumb-container">
+					<div ng-if="!clip.ui.audio_data || (clip.ui.audio_data && clip.ui.audio_data.length <= 1)" class="thumb-container">
 						<img class="thumb thumb-start" ng-if="getThumbPath(clip)" ng-src="{{ getThumbPath(clip) }}"/>
 					</div>
-					<div ng-if="clip.ui.audio_data" class="audio-container">
-						<canvas tl-audio height="46px" width="{{canvasMaxWidth((clip.end - clip.start) * pixelsPerSecond)}}px" class="audio"></canvas>
+					<div ng-if="clip.ui.audio_data && clip.ui.audio_data.length > 1" class="audio-container">
+						<canvas id="audio_clip_{{clip.id}}" tl-audio height="46px" width="{{canvasMaxWidth((clip.end - clip.start) * pixelsPerSecond)}}px" class="audio"></canvas>
 					</div>
 
                     <!-- CLIP KEYFRAME POINTS -->

--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -100,10 +100,10 @@
 					</div>
 					<br class="cleared">
 
-					<div ng-if="!clip.show_audio" class="thumb-container">
+					<div ng-if="!clip.ui.audio_data" class="thumb-container">
 						<img class="thumb thumb-start" ng-if="getThumbPath(clip)" ng-src="{{ getThumbPath(clip) }}"/>
 					</div>
-					<div ng-if="clip.show_audio" class="audio-container">
+					<div ng-if="clip.ui.audio_data" class="audio-container">
 						<canvas tl-audio height="46px" width="{{canvasMaxWidth((clip.end - clip.start) * pixelsPerSecond)}}px" class="audio"></canvas>
 					</div>
 

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -373,15 +373,11 @@ App.controller("TimelineCtrl", function ($scope) {
   };
 
   // Set the audio data for a clip
-  $scope.setAudioData = function (clip_id, audio_data) {
+  $scope.setAudioData = function (clip_id) {
     // Find matching clip
     for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
       if ($scope.project.clips[clip_index].id === clip_id) {
         // Set audio data
-        $scope.$apply(function () {
-          $scope.project.clips[clip_index].audio_data = audio_data;
-          $scope.project.clips[clip_index].show_audio = true;
-        });
         timeline.qt_log("DEBUG", "Audio data successful set on clip JSON");
         break;
       }

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -372,56 +372,16 @@ App.controller("TimelineCtrl", function ($scope) {
     clip_selector.attr("src", existing_thumb_path);
   };
 
-  // Set the audio data for a clip
-  $scope.setAudioData = function (clip_id) {
-    // Find matching clip
-    for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-      if ($scope.project.clips[clip_index].id === clip_id) {
-        // Set audio data
-        timeline.qt_log("DEBUG", "Audio data successful set on clip JSON");
-        break;
-      }
-
-      // Draw audio data
-      drawAudio($scope, clip_id);
-    }
-  };
-
-  // Hide the audio waveform for a clip
-  $scope.hideAudioData = function (clip_id) {
-    // Find matching clip
-    for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-      if ($scope.project.clips[clip_index].id === clip_id) {
-        // Set audio data
-        $scope.$apply(function () {
-          $scope.project.clips[clip_index].show_audio = false;
-          $scope.project.clips[clip_index].audio_data = [];
-        });
-        break;
-      }
-    }
-  };
-
-  // Redraw all audio waveforms on the timeline (if any)
+  // Redraw all audio waveforms on the timeline (for example, if the screen is resized)
   $scope.reDrawAllAudioData = function () {
-    // Find matching clip
+    // Loop through all clips (and look for audio data)
     for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-      if ("audio_data" in $scope.project.clips[clip_index] && $scope.project.clips[clip_index].audio_data.length > 0) {
-        // Redraw audio data (since it has audio data)
+      if ("ui" in $scope.project.clips[clip_index] && "audio_data" in $scope.project.clips[clip_index].ui
+        && $scope.project.clips[clip_index].ui.audio_data.length > 1) {
+        // Redraw audio data
         drawAudio($scope, $scope.project.clips[clip_index].id);
       }
     }
-  };
-
-  // Does clip have audio_data?
-  $scope.hasAudioData = function (clip_id) {
-    // Find matching clip
-    for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-      if ($scope.project.clips[clip_index].id === clip_id && "audio_data" in $scope.project.clips[clip_index] && $scope.project.clips[clip_index].audio_data.length > 0) {
-        return true;
-      }
-    }
-    return false;
   };
 
   $scope.setPropertyFilter = function (property) {
@@ -1461,10 +1421,7 @@ App.controller("TimelineCtrl", function ($scope) {
           // Update: If action and current object are Objects
           if (current_object.constructor === Object && action.value.constructor === Object) {
             for (var update_key in action.value) {
-              if (update_key in current_object) {
-                // Only copy over keys that exist in both action and current_object
-                current_object[update_key] = action.value[update_key];
-              }
+              current_object[update_key] = action.value[update_key];
             }
           }
           else {

--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -156,13 +156,15 @@ App.directive("tlClip", function ($timeout) {
           }
 
           //resize the audio canvas to match the new clip width
-          if (scope.clip.show_audio) {
+          if (scope.clip.ui && scope.clip.ui.audio_data) {
             //redraw audio as the resize cleared the canvas
             drawAudio(scope, scope.clip.id);
           }
           dragLoc = null;
         },
         resize: function (e, ui) {
+          element.find(".point").fadeOut(100);
+          element.find(".audio-container").fadeOut(100);
           if (resize_disabled) {
             // disabled, keep the item the same size
             $(this).css(ui.originalPosition);

--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -426,3 +426,16 @@ App.directive("tlMultiSelectable", function () {
     }
   };
 });
+
+// Handle audio waveform drawing (when a tl-audio directive is found)
+App.directive("tlAudio",  function ($timeout) {
+  return {
+    link: function (scope, element, attrs) {
+      $timeout(function () {
+        // Use timeout to wait until after the DOM is manipulated
+        let clip_id = attrs.id.replace("audio_clip_", "");
+        drawAudio(scope, clip_id);
+      }, 0);
+    }
+  };
+});

--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -27,7 +27,7 @@
  */
 
 
-/*global setSelections, setBoundingBox, moveBoundingBox, bounding_box */
+/*global setSelections, setBoundingBox, moveBoundingBox, bounding_box, drawAudio */
 // Init variables
 var dragging = false;
 var resize_disabled = false;

--- a/src/timeline/js/functions.js
+++ b/src/timeline/js/functions.js
@@ -148,7 +148,6 @@ function drawAudio(scope, clip_id) {
         max = 0;
       }
     }
-    element.find(".audio-container").fadeIn(100);
   }
 }
 

--- a/src/timeline/js/functions.js
+++ b/src/timeline/js/functions.js
@@ -58,7 +58,7 @@ function drawAudio(scope, clip_id) {
   //get the clip in the scope
   var clip = findElement(scope.project.clips, "id", clip_id);
 
-  if (clip.show_audio) {
+  if (clip.ui && clip.ui.audio_data) {
     var element = $("#clip_" + clip_id);
 
     // Determine start and stop samples
@@ -71,10 +71,13 @@ function drawAudio(scope, clip_id) {
     var sample_divisor = samples_per_second / scope.pixelsPerSecond;
 
     //show audio container
-    element.find(".audio-container").show();
+    element.find(".audio-container").fadeIn(100);
 
     // Get audio canvas context
     var audio_canvas = element.find(".audio");
+    if (!audio_canvas) {
+      return;
+    }
     var ctx = audio_canvas[0].getContext("2d", {alpha: false});
 
     // Clear canvas
@@ -119,7 +122,7 @@ function drawAudio(scope, clip_id) {
     // And whenever enough are "collected", draw a block
     for (var i = start_sample; i < final_sample; i++) {
       // Flip negative values up
-      sample = Math.abs(clip.audio_data[i]);
+      sample = Math.abs(clip.ui.audio_data[i]);
       // X-Position of *next* sample
       var x = Math.floor((i + 1 - start_sample) / sample_divisor);
 
@@ -145,6 +148,7 @@ function drawAudio(scope, clip_id) {
         max = 0;
       }
     }
+    element.find(".audio-container").fadeIn(100);
   }
 }
 

--- a/src/timeline/media/css/main.css
+++ b/src/timeline/media/css/main.css
@@ -395,11 +395,8 @@ img {
 }
 
 .audio-container {
-  display: none;
   margin-top: -20px;
   height: 46px;
-  overflow: hidden;
-  margin-left: -2px;
 }
 
 /* Clip Animations */

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -99,7 +99,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     SpeedSignal = pyqtSignal(float)
     RecoverBackup = pyqtSignal()
     FoundVersionSignal = pyqtSignal(str)
-    WaveformReady = pyqtSignal(str, list)
     TransformSignal = pyqtSignal(str)
     KeyFrameTransformSignal = pyqtSignal(str, str)
     SelectRegionSignal = pyqtSignal(str)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -222,6 +222,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             get_app().project.load("")
             self.actionUndo.setEnabled(False)
             self.actionRedo.setEnabled(False)
+            self.actionClearHistory.setEnabled(False)
             self.SetWindowTitle()
 
     def create_lock_file(self):
@@ -392,7 +393,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Run the dialog event loop - blocking interaction on this window during that time
         return win.exec_()
 
-    def actionClearAudioData_trigger(self):
+    def actionClearWaveformData_trigger(self):
         """Clear audio data from current project"""
         from classes.query import File, Clip
         log.info("Placeholder. Remove ['ui']['audio_data'] from all files that have it.")
@@ -417,6 +418,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                         clip.save()
         # Resume update history
         get_app().updates.ignore_history = False
+        get_app().window.actionClearWaveformData.setEnabled(False)
 
     def actionClearHistory_trigger(self):
         """Clear history for current project"""
@@ -2400,6 +2402,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         log.info('updateStatusChanged')
         self.actionUndo.setEnabled(undo_status)
         self.actionRedo.setEnabled(redo_status)
+        self.actionClearHistory.setEnabled(undo_status | redo_status)
         self.SetWindowTitle()
 
     def addSelection(self, item_id, item_type, clear_existing=False):

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -392,6 +392,32 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Run the dialog event loop - blocking interaction on this window during that time
         return win.exec_()
 
+    def actionClearAudioData_trigger(self):
+        """Clear audio data from current project"""
+        from classes.query import File, Clip
+        log.info("Placeholder. Remove ['ui']['audio_data'] from all files that have it.")
+        files = File.filter()
+
+        # Audio data is a large object. Don't put it in the history
+        get_app().updates.ignore_history = True
+        for file in files:
+            if "audio_data" in file.data.get("ui", {}):
+                file_path = file.data.get("path")
+                log.debug("File %s has audio data. Deleting it." % os.path.split(file_path)[1])
+                del(file.data["ui"]["audio_data"])
+                file.save()
+
+                # Remove audio data from any clips of this file
+                clips = Clip.filter(path = file_path)
+                if clips:
+                    log.debug("Clips of this file exist. Deleting their audio data.")
+                for clip in clips:
+                    if "audio_data" in clip.data.get("ui",{}):
+                        del(clip.data["ui"]["audio_data"])
+                        clip.save()
+        # Resume update history
+        get_app().updates.ignore_history = False
+
     def actionClearHistory_trigger(self):
         """Clear history for current project"""
         project = get_app().project

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -70,9 +70,11 @@ class PropertiesModel(updates.UpdateInterface):
 
         # Handle change
         if action.key and action.key[0] in ["clips", "effects"] and action.type in ["update", "insert"]:
-            log.debug(action.values)
-            # Update the model data
-            self.update_model(get_app().window.txtPropertyFilter.text())
+            # Ignore "ui" data changes on Property Model (used to display waveforms)
+            if action.values and "ui" not in action.values:
+                log.debug(action.values)
+                # Update the model data
+                self.update_model(get_app().window.txtPropertyFilter.text())
 
     # Update the selected item (which drives what properties show up)
     def update_item(self, item_id, item_type):

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -1642,7 +1642,7 @@
     <string>History</string>
    </property>
    <property name="toolTip">
-    <string>Remove Undo/Redo History</string>
+    <string>Clear History</string>
    </property>
   </action>
   <action name="actionImportEDL">
@@ -1731,7 +1731,7 @@
     <string>Waveform</string>
    </property>
    <property name="toolTip">
-    <string>Remove Waveform Display Data</string>
+    <string>Clear Waveform Display Data</string>
    </property>
   </action>
  </widget>

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -139,10 +139,17 @@
     <property name="title">
      <string>&amp;Edit</string>
     </property>
+    <widget class="QMenu" name="menuClear">
+     <property name="title">
+      <string>Clear</string>
+     </property>
+     <addaction name="actionClearHistory"/>
+     <addaction name="actionClearAudioData"/>
+    </widget>
     <addaction name="actionUndo"/>
     <addaction name="actionRedo"/>
     <addaction name="separator"/>
-    <addaction name="actionClearHistory"/>
+    <addaction name="menuClear"/>
     <addaction name="separator"/>
     <addaction name="actionPreferences"/>
    </widget>
@@ -1711,6 +1718,14 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+C</string>
+   </property>
+  </action>
+  <action name="actionClearAudioData">
+   <property name="icon">
+    <iconset theme="edit-clear"/>
+   </property>
+   <property name="text">
+    <string>Clear Audio Data</string>
    </property>
   </action>
  </widget>

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -144,7 +144,7 @@
       <string>Clear</string>
      </property>
      <addaction name="actionClearHistory"/>
-     <addaction name="actionClearAudioData"/>
+     <addaction name="actionClearWaveformData"/>
     </widget>
     <addaction name="actionUndo"/>
     <addaction name="actionRedo"/>
@@ -1639,10 +1639,10 @@
      <normaloff>:/icons/Humanity/actions/16/edit-clear.svg</normaloff>:/icons/Humanity/actions/16/edit-clear.svg</iconset>
    </property>
    <property name="text">
-    <string>Clear History</string>
+    <string>History</string>
    </property>
    <property name="toolTip">
-    <string>Clear History</string>
+    <string>Remove Undo/Redo History</string>
    </property>
   </action>
   <action name="actionImportEDL">
@@ -1720,12 +1720,18 @@
     <string>Ctrl+C</string>
    </property>
   </action>
-  <action name="actionClearAudioData">
+  <action name="actionClearWaveformData">
+   <property name="enabled">
+   <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="edit-clear"/>
    </property>
    <property name="text">
-    <string>Clear Audio Data</string>
+    <string>Waveform</string>
+   </property>
+   <property name="toolTip">
+    <string>Remove Waveform Display Data</string>
    </property>
   </action>
  </widget>

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -995,7 +995,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         self.waveform_cache[clip_id] = serialized_audio_data
 
         # Pass to javascript timeline (and render)
-        self.run_js(JS_SCOPE_SELECTOR + ".setAudioData('" + clip_id + "', " + serialized_audio_data + ");")
+        self.run_js("drawAudio('" + clip_id + "');")
 
         # Restore normal cursor
         get_app().restoreOverrideCursor()
@@ -1956,8 +1956,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                     self.waveform_cache[right_clip.id] = self.waveform_cache.get(clip_id, '[]')
 
                     # Pass audio to javascript timeline (and render)
-                    self.run_js(JS_SCOPE_SELECTOR + ".setAudioData('{}',{});"
-                        .format(right_clip.id, self.waveform_cache.get(right_clip.id)))
+                    self.run_js("drawAudio('" + right_clip.id + "');")
 
             # Save changes
             self.update_clip_data(clip.data, only_basic_props=False, ignore_reader=True)

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -956,6 +956,8 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
     def Show_Waveform_Triggered(self, clip_ids):
         """Show a waveform for all selected clips"""
 
+        # Group clip IDs under each File ID
+        # Data format:  { "fileID": ["ClipID-1", "ClipID-2", etc...]}
         files = {}
         for clip_id in clip_ids:
             # Get existing clip object
@@ -964,44 +966,20 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
             if file_id not in files:
                 files[file_id] = []
-
             files[file_id].append(clip.data.get("id"))
 
+        # Get audio data for all "selected" files/clips
         get_audio_data(files)
 
     def Hide_Waveform_Triggered(self, clip_ids):
         """Hide the waveform for the selected clip"""
 
-        # Loop through each selected clip
+        # Loop through each selected clip ID
         for clip_id in clip_ids:
-
-            # Get existing clip object
+            # Get existing clip object & clear audio_data
             clip = Clip.get(id=clip_id)
-
-            # clip.removeAudioData()
-            if not "ui" in clip.data["ui"]:
-                clip.data["ui"] =  {}
-            clip.data["ui"]["audio_data"] = []
+            clip.data = {"ui": {"audio_data": []}}
             clip.save()
-
-    def Waveform_Ready(self, clip_id, audio_data):
-        """Callback when audio waveform is ready"""
-        log.info("Waveform_Ready for clip ID: %s" % (clip_id))
-
-        # Convert waveform data to JSON
-        serialized_audio_data = json.dumps(audio_data)
-
-        # Set waveform cache (with clip_id as key)
-        self.waveform_cache[clip_id] = serialized_audio_data
-
-        # Pass to javascript timeline (and render)
-        self.run_js("drawAudio('" + clip_id + "');")
-
-        # Restore normal cursor
-        get_app().restoreOverrideCursor()
-
-        # Start timer to redraw audio
-        self.redraw_audio_timer.start()
 
     def Thumbnail_Updated(self, clip_id):
         """Callback when thumbnail needs to be updated"""
@@ -1075,10 +1053,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 # Save changes
                 clip.save()
 
-                # Generate waveform for new clip
-                log.info("Generate waveform for split audio track clip id: %s" % clip.id)
-                self.Show_Waveform_Triggered([clip.id])
-
             if action == MENU_SPLIT_AUDIO_MULTIPLE:
                 # Get # of channels on clip
                 channels = int(clip.data["reader"]["channels"])
@@ -1120,10 +1094,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
                     # Save changes
                     clip.save()
-
-                    # Generate waveform for new clip
-                    log.info("Generate waveform for split audio track clip id: %s" % clip.id)
-                    self.Show_Waveform_Triggered([clip.id])
 
                     # Remove the ID property from the clip (so next time, it will create a new clip)
                     clip.id = None
@@ -1901,9 +1871,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 # Invalid or locked clip, skip to next item
                 continue
 
-            # Determine if waveform needs to be redrawn
-            has_audio_data = clip_id in self.waveform_cache
-
             if action in [MENU_SLICE_KEEP_LEFT, MENU_SLICE_KEEP_BOTH]:
                 # Get details of original clip
                 position_of_clip = float(clip.data["position"])
@@ -1950,13 +1917,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
                 # Save changes again (with new thumbnail)
                 self.update_clip_data(right_clip.data, only_basic_props=False, ignore_reader=True)
-
-                if has_audio_data:
-                    # Add right clip audio to cache
-                    self.waveform_cache[right_clip.id] = self.waveform_cache.get(clip_id, '[]')
-
-                    # Pass audio to javascript timeline (and render)
-                    self.run_js("drawAudio('" + right_clip.id + "');")
 
             # Save changes
             self.update_clip_data(clip.data, only_basic_props=False, ignore_reader=True)
@@ -2023,18 +1983,10 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         """Callback for volume context menus"""
         log.debug(action)
 
-        # Callback function, to redraw audio data after an update
-        def callback(self, clip_id, callback_data):
-            has_audio_data = callback_data
-            log.info('has_audio_data: %s', has_audio_data)
-
-            if has_audio_data:
-                # Re-generate waveform since volume curve has changed
-                self.Show_Waveform_Triggered(clip_id)
-
         # Get FPS from project
         fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
+        waveform_files = {}
 
         # Loop through each selected clip
         for clip_id in clip_ids:
@@ -2153,8 +2105,16 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             # Save changes
             self.update_clip_data(clip.data, only_basic_props=False, ignore_reader=True)
 
-            # Determine if waveform needs to be redrawn
-            self.run_js(JS_SCOPE_SELECTOR + ".hasAudioData('{}');".format(clip.id), partial(callback, self, clip.id))
+            # Track waveform data (if we are already displaying waveform for this clip)
+            file_id = clip.data.get("file_id")
+            if file_id and len(clip.data.get("ui", {}).get("audio_data", [])) > 1:
+                if file_id not in waveform_files:
+                    waveform_files[file_id] = [clip.id]
+                else:
+                    waveform_files[file_id].append(clip.id)
+
+        # Update clip waveform data (for all selected clips)
+        get_audio_data(waveform_files)
 
     def Rotate_Triggered(self, action, clip_ids, position="Start of Clip"):
         """Callback for rotate context menus"""
@@ -3189,12 +3149,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         window.TimelineScroll.connect(self.update_scroll)
         window.TimelineCenter.connect(self.centerOnPlayhead)
         window.SetKeyframeFilter.connect(self.SetPropertyFilter)
-
-        # Connect waveform generation signal
-        window.WaveformReady.connect(self.Waveform_Ready)
-
-        # Local audio waveform cache
-        self.waveform_cache = {}
 
         # Connect update thumbnail signal
         window.ThumbnailUpdated.connect(self.Thumbnail_Updated)


### PR DESCRIPTION
Building off some experimental work started by @JacksonRG (https://github.com/OpenShot/openshot-qt/pull/4769). Essentially, we are optimizing the waveform generation in OpenShot, and storing the summarized **audio_data** used to draw the waveforms in the *.osp project files.

**Use Cases Improved:**
- Selecting more than 1 clip from the same file, and choosing "Display->Waveform" - instead of duplicating a ton of work, we only generate each file's waveform once, and then share the data to each child clip.
- Re-opening a project with waveforms will now maintain the waveform (since we are storing the audio data)
- Once a file has been processed (i.e. audio_data stored), it is super fast to display waveforms in any clip from that file.

**My Changes:**
Fixed many issues related to waveform generation and reuse. Added an Angular directive to watch for **audio_data** changes. Simplified the waveform process also. When no waveforms are present, *.osp file size does not change. When huge waveforms are displayed on many clips, the size of *.osp project will grow quite a bit. In fact, we might want to consider moving audio_data into some separate cache files, vs baking the audio_data into our *.osp file. Or at a minimum, allow the user to clear all audio data from an *.osp project (to reduce the size).