### PR TITLE
End blender render process when cancel button is pressed.

### DIFF
--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -585,7 +585,7 @@ Blender Path: {}
     def Cancel(self):
         """Cancel the current render, if any"""
         #QMetaObject.invokeMethod(self.worker, 'Cancel', Qt.DirectConnection)
-        self.cancel_render.emit()
+        self.worker.Cancel()
 
     def Render(self, frame=None):
         """ Render an images sequence of the current template using Blender 2.62+ and the

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -63,7 +63,6 @@ class BlenderListView(QListView):
 
     # Our signals
     start_render = pyqtSignal(str, str, int)
-    cancel_render = pyqtSignal()
 
     def currentChanged(self, selected, deselected):
         # Get selected item
@@ -584,7 +583,6 @@ Blender Path: {}
 
     def Cancel(self):
         """Cancel the current render, if any"""
-        #QMetaObject.invokeMethod(self.worker, 'Cancel', Qt.DirectConnection)
         self.worker.Cancel()
 
     def Render(self, frame=None):
@@ -615,7 +613,6 @@ Blender Path: {}
         self.background.started.connect(self.worker.Render)
 
         self.worker.render_complete.connect(self.render_finished)
-        self.cancel_render.connect(self.worker.Cancel)
 
         # State changes
         self.worker.end_processing.connect(self.end_processing)
@@ -748,14 +745,13 @@ class Worker(QObject):
             self.startupinfo = subprocess.STARTUPINFO()
             self.startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
-    @pyqtSlot()
     def Cancel(self):
         """Cancel worker render"""
         if self.process:
             # Stop blender process if running
             self.process.terminate()
+            self.process.finished.emit()
         self.canceled = True
-        self.finished.emit()
 
     def blender_version_check(self):
         # Check the version of Blender


### PR DESCRIPTION
# Bug:
When rendering an animated title, clicking cancel doesn't end the render process.

# Test:
1) If you have blender running, close it.
1) Open your task manager, and search blender.
    - You should see only one task
1) Open the Animated Titles Dialog
1) Click render on a title. (I recommend `Fly Towards` title, as it renders pretty quickly)
1) In your task manager, see a process appear.
1) Click cancel on the Animated Title Dialog.
1) The blender process should close soon (a few seconds) after you click cancel.