### PR TITLE
Add dissable sandbox to the environment when openshot launches.

### DIFF
--- a/installer/launch-linux.sh
+++ b/installer/launch-linux.sh
@@ -32,11 +32,6 @@ export LD_LIBRARY_PATH="${HERE}"
 # Set some environment variables
 export QT_PLUGIN_PATH="${HERE}"
 
-# Disable sandbox support for QtWebEngine (required on some Linux distros
-# for the QtWebEngineWidgets to be rendered, otherwise no timeline is visible).
-# https://doc.qt.io/qt-5/qtwebengine-platform-notes.html#sandboxing-support
-export QTWEBENGINE_DISABLE_SANDBOX="1"
-
 # For Debian-based systems with newer openssl, see:
 # https://github.com/OpenShot/openshot-qt/issues/3242
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=918727 

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -37,6 +37,11 @@ import json
 from PyQt5.QtCore import PYQT_VERSION_STR, QT_VERSION_STR, pyqtSlot
 from PyQt5.QtWidgets import QApplication, QStyleFactory, QMessageBox
 
+# Disable sandbox support for QtWebEngine (required on some Linux distros
+# for the QtWebEngineWidgets to be rendered, otherwise no timeline is visible).
+# https://doc.qt.io/qt-5/qtwebengine-platform-notes.html#sandboxing-support
+os.environ["QTWEBENGINE_DISABLE_SANDBOX"] = "1"
+
 
 def get_app():
     """ Get the current QApplication instance of OpenShot """

--- a/src/windows/views/webview_backend/webengine.py
+++ b/src/windows/views/webview_backend/webengine.py
@@ -47,6 +47,7 @@ class LoggingWebEnginePage(QWebEnginePage):
             '%s@L%d: %s', os.path.basename(source), line, msg)
 
     def __init__(self, parent=None):
+        os.environ["QTWEBENGINE_DISABLE_SANDBOX"] = "1"
         super().__init__(parent=parent)
         self.setObjectName("LoggingWebEnginePage")
         self.levels = [logging.INFO, logging.WARNING, logging.ERROR]

--- a/src/windows/views/webview_backend/webengine.py
+++ b/src/windows/views/webview_backend/webengine.py
@@ -47,7 +47,6 @@ class LoggingWebEnginePage(QWebEnginePage):
             '%s@L%d: %s', os.path.basename(source), line, msg)
 
     def __init__(self, parent=None):
-        os.environ["QTWEBENGINE_DISABLE_SANDBOX"] = "1"
         super().__init__(parent=parent)
         self.setObjectName("LoggingWebEnginePage")
         self.levels = [logging.INFO, logging.WARNING, logging.ERROR]


### PR DESCRIPTION
PR #4787 fixed this issue in our AppImages, but certain other setups were still encountering the issue of the timeline never showing up.

This PR moves this definition to `app.py`, so that it can apply to all ways of running openshot.

Tested the appimage, and it still shows timeline.