### PR TITLE
Add button to remove audio data from a project.

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -322,6 +322,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
     def load(self, file_path, clear_thumbnails=True):
         """ Load project from file """
 
+        from classes.app import get_app
         self.new()
 
         if file_path:
@@ -337,6 +338,13 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                 # Fix history (if broken)
                 if not project_data.get("history"):
                     project_data["history"] = {"undo": [], "redo": []}
+
+                # If project has waveforms, enable removing waveforms
+                get_app().window.actionClearWaveformData.setEnabled(False)
+                for file in project_data["files"]:
+                    if file.get("ui",{}).get("audio_data", []):
+                        get_app().window.actionClearWaveformData.setEnabled(True)
+                        break
 
             except Exception:
                 try:
@@ -382,7 +390,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             self.apply_default_audio_settings()
 
         # Get app, and distribute all project data through update manager
-        from classes.app import get_app
         get_app().updates.load(self._data)
 
     def rescale_keyframes(self, scale_factor):

--- a/src/classes/waveform.py
+++ b/src/classes/waveform.py
@@ -65,6 +65,7 @@ def get_waveform_thread(file_id, clip_list):
         """
         Update the file query object with audio data (if found).
         """
+        get_app().window.actionClearWaveformData.setEnabled(True)
         # Ensure that UI attribute exists
         file_data = file.data
         file_audio_data = file_data.get("ui", {}).get("audio_data", [])

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -222,6 +222,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             get_app().project.load("")
             self.actionUndo.setEnabled(False)
             self.actionRedo.setEnabled(False)
+            self.actionClearHistory.setEnabled(False)
             self.SetWindowTitle()
 
     def create_lock_file(self):
@@ -392,7 +393,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Run the dialog event loop - blocking interaction on this window during that time
         return win.exec_()
 
-    def actionClearAudioData_trigger(self):
+    def actionClearWaveformData_trigger(self):
         """Clear audio data from current project"""
         from classes.query import File, Clip
         log.info("Placeholder. Remove ['ui']['audio_data'] from all files that have it.")
@@ -417,6 +418,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                         clip.save()
         # Resume update history
         get_app().updates.ignore_history = False
+        get_app().window.actionClearWaveformData.setEnabled(False)
 
     def actionClearHistory_trigger(self):
         """Clear history for current project"""
@@ -2400,6 +2402,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         log.info('updateStatusChanged')
         self.actionUndo.setEnabled(undo_status)
         self.actionRedo.setEnabled(redo_status)
+        self.actionClearHistory.setEnabled(undo_status | redo_status)
         self.SetWindowTitle()
 
     def addSelection(self, item_id, item_type, clear_existing=False):

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -392,6 +392,32 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Run the dialog event loop - blocking interaction on this window during that time
         return win.exec_()
 
+    def actionClearAudioData_trigger(self):
+        """Clear audio data from current project"""
+        from classes.query import File, Clip
+        log.info("Placeholder. Remove ['ui']['audio_data'] from all files that have it.")
+        files = File.filter()
+
+        # Audio data is a large object. Don't put it in the history
+        get_app().updates.ignore_history = True
+        for file in files:
+            if "audio_data" in file.data.get("ui", {}):
+                file_path = file.data.get("path")
+                log.debug("File %s has audio data. Deleting it." % os.path.split(file_path)[1])
+                del(file.data["ui"]["audio_data"])
+                file.save()
+
+                # Remove audio data from any clips of this file
+                clips = Clip.filter(path = file_path)
+                if clips:
+                    log.debug("Clips of this file exist. Deleting their audio data.")
+                for clip in clips:
+                    if "audio_data" in clip.data.get("ui",{}):
+                        del(clip.data["ui"]["audio_data"])
+                        clip.save()
+        # Resume update history
+        get_app().updates.ignore_history = False
+
     def actionClearHistory_trigger(self):
         """Clear history for current project"""
         project = get_app().project

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -139,10 +139,17 @@
     <property name="title">
      <string>&amp;Edit</string>
     </property>
+    <widget class="QMenu" name="menuClear">
+     <property name="title">
+      <string>Clear</string>
+     </property>
+     <addaction name="actionClearHistory"/>
+     <addaction name="actionClearAudioData"/>
+    </widget>
     <addaction name="actionUndo"/>
     <addaction name="actionRedo"/>
     <addaction name="separator"/>
-    <addaction name="actionClearHistory"/>
+    <addaction name="menuClear"/>
     <addaction name="separator"/>
     <addaction name="actionPreferences"/>
    </widget>
@@ -1711,6 +1718,14 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+C</string>
+   </property>
+  </action>
+  <action name="actionClearAudioData">
+   <property name="icon">
+    <iconset theme="edit-clear"/>
+   </property>
+   <property name="text">
+    <string>Clear Audio Data</string>
    </property>
   </action>
  </widget>

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -144,7 +144,7 @@
       <string>Clear</string>
      </property>
      <addaction name="actionClearHistory"/>
-     <addaction name="actionClearAudioData"/>
+     <addaction name="actionClearWaveformData"/>
     </widget>
     <addaction name="actionUndo"/>
     <addaction name="actionRedo"/>
@@ -1639,10 +1639,10 @@
      <normaloff>:/icons/Humanity/actions/16/edit-clear.svg</normaloff>:/icons/Humanity/actions/16/edit-clear.svg</iconset>
    </property>
    <property name="text">
-    <string>Clear History</string>
+    <string>History</string>
    </property>
    <property name="toolTip">
-    <string>Clear History</string>
+    <string>Remove Undo/Redo History</string>
    </property>
   </action>
   <action name="actionImportEDL">
@@ -1720,12 +1720,18 @@
     <string>Ctrl+C</string>
    </property>
   </action>
-  <action name="actionClearAudioData">
+  <action name="actionClearWaveformData">
+   <property name="enabled">
+   <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="edit-clear"/>
    </property>
    <property name="text">
-    <string>Clear Audio Data</string>
+    <string>Waveform</string>
+   </property>
+   <property name="toolTip">
+    <string>Remove Waveform Display Data</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Example:

https://user-images.githubusercontent.com/42394129/176049611-8e54a41b-4174-48ee-a6cb-937253caf08b.mp4


Clear audio data from all files and clips in the project

Our redesign of how waveforms work in #4819 can make project files pretty big. Here's a button to remove all data for displaying waveforms from a project.