### PR TITLE
Take 2: Qt6 readiness: Use typed enums

### DIFF
--- a/src/classes/language.py
+++ b/src/classes/language.py
@@ -49,14 +49,18 @@ def init_language():
     # Get app instance
     app = QCoreApplication.instance()
 
+    # Path to installed Qt translations
+    qt_trans = QLibraryInfo.location(QLibraryInfo.LibraryLocation.TranslationsPath)
+
     # Setup of our list of translators and paths
     translator_types = (
+        # Default installed system translations
         {"type": 'QT',
-         "prefix": 'qt_',        # Older versions of Qt use this file (built-in translations)
-         "path": QLibraryInfo.location(QLibraryInfo.TranslationsPath)},
+         "prefix": 'qt_',
+         "path": qt_trans},
         {"type": 'QT',
-         "prefix": 'qtbase_',    # Newer versions of Qt use this file (built-in translations)
-         "path": QLibraryInfo.location(QLibraryInfo.TranslationsPath)},
+         "prefix": 'qtbase_',
+         "path": qt_trans},
         {"type": 'QT',
          "prefix": 'qt_',
          "path": os.path.join(info.PATH, 'language')}, # Optional path where we package QT translations

--- a/src/classes/ui_util.py
+++ b/src/classes/ui_util.py
@@ -106,33 +106,33 @@ def get_default_icon(theme_name):
 
 
 def make_dark_palette(darkPalette: QPalette) -> QPalette:
-    darkPalette.setColor(QPalette.Window, QColor(53, 53, 53))
-    darkPalette.setColor(QPalette.WindowText, Qt.white)
-    darkPalette.setColor(QPalette.Base, QColor(25, 25, 25))
-    darkPalette.setColor(QPalette.AlternateBase, QColor(53, 53, 53))
-    darkPalette.setColor(QPalette.Light, QColor(68, 68, 68))
-    darkPalette.setColor(QPalette.Text, Qt.white)
-    darkPalette.setColor(QPalette.Button, QColor(53, 53, 53))
-    darkPalette.setColor(QPalette.ButtonText, Qt.white)
-    darkPalette.setColor(QPalette.Highlight, QColor(42, 130, 218, 192))
-    darkPalette.setColor(QPalette.HighlightedText, Qt.black)
+    darkPalette.setColor(QPalette.ColorRole.Window, QColor(53, 53, 53))
+    darkPalette.setColor(QPalette.ColorRole.WindowText, Qt.GlobalColor.white)
+    darkPalette.setColor(QPalette.ColorRole.Base, QColor(25, 25, 25))
+    darkPalette.setColor(QPalette.ColorRole.AlternateBase, QColor(53, 53, 53))
+    darkPalette.setColor(QPalette.ColorRole.Light, QColor(68, 68, 68))
+    darkPalette.setColor(QPalette.ColorRole.Text, Qt.GlobalColor.white)
+    darkPalette.setColor(QPalette.ColorRole.Button, QColor(53, 53, 53))
+    darkPalette.setColor(QPalette.ColorRole.ButtonText, Qt.GlobalColor.white)
+    darkPalette.setColor(QPalette.ColorRole.Highlight, QColor(42, 130, 218, 192))
+    darkPalette.setColor(QPalette.ColorRole.HighlightedText, Qt.GlobalColor.black)
     #
     # Disabled palette
     #
-    darkPalette.setColor(QPalette.Disabled, QPalette.WindowText, QColor(255, 255, 255, 128))
-    darkPalette.setColor(QPalette.Disabled, QPalette.Base, QColor(68, 68, 68))
-    darkPalette.setColor(QPalette.Disabled, QPalette.Text, QColor(255, 255, 255, 128))
-    darkPalette.setColor(QPalette.Disabled, QPalette.Button, QColor(53, 53, 53, 128))
-    darkPalette.setColor(QPalette.Disabled, QPalette.ButtonText, QColor(255, 255, 255, 128))
-    darkPalette.setColor(QPalette.Disabled, QPalette.Highlight, QColor(151, 151, 151, 192))
-    darkPalette.setColor(QPalette.Disabled, QPalette.HighlightedText, Qt.black)
+    darkPalette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.WindowText, QColor(255, 255, 255, 128))
+    darkPalette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Base, QColor(68, 68, 68))
+    darkPalette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text, QColor(255, 255, 255, 128))
+    darkPalette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Button, QColor(53, 53, 53, 128))
+    darkPalette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.ButtonText, QColor(255, 255, 255, 128))
+    darkPalette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Highlight, QColor(151, 151, 151, 192))
+    darkPalette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.HighlightedText, Qt.GlobalColor.black)
 
     # Tooltips
-    darkPalette.setColor(QPalette.ToolTipBase, QColor(42, 130, 218))
-    darkPalette.setColor(QPalette.ToolTipText, Qt.white)
+    darkPalette.setColor(QPalette.ColorRole.ToolTipBase, QColor(42, 130, 218))
+    darkPalette.setColor(QPalette.ColorRole.ToolTipText, Qt.GlobalColor.white)
     # Links
-    darkPalette.setColor(QPalette.Link, QColor(85, 170, 255))
-    darkPalette.setColor(QPalette.LinkVisited, QColor(136, 85, 255))
+    darkPalette.setColor(QPalette.ColorRole.Link, QColor(85, 170, 255))
+    darkPalette.setColor(QPalette.ColorRole.LinkVisited, QColor(136, 85, 255))
 
     return darkPalette
 

--- a/src/launch.py
+++ b/src/launch.py
@@ -50,7 +50,7 @@ from PyQt5.QtWidgets import QApplication
 try:
     # This apparently has to be done before loading QtQuick
     # (via QtWebEgine) AND before creating the QApplication instance
-    QApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
+    QApplication.setAttribute(Qt.ApplicationAttribute.AA_ShareOpenGLContexts)
     from OpenGL import GL  # noqa
 except (ImportError, AttributeError):
     pass
@@ -65,8 +65,8 @@ except ImportError:
 
 try:
     # Enable High-DPI resolutions
-    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
-    QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps)
+    QApplication.setAttribute(Qt.ApplicationAttribute.AA_EnableHighDpiScaling)
+    QApplication.setAttribute(Qt.ApplicationAttribute.AA_UseHighDpiPixmaps)
 except AttributeError:
     pass  # Quietly fail for older Qt5 versions
 

--- a/src/windows/about.py
+++ b/src/windows/about.py
@@ -196,7 +196,7 @@ class About(QDialog):
         libopenshot_version = "libopenshot: %s" % openshot.OPENSHOT_VERSION_FULL
         self.txtversion.setText(
             "<b>%s</b><br/>%s%s" % (openshot_qt_version, libopenshot_version, frozen_version_label))
-        self.txtversion.setAlignment(Qt.AlignCenter)
+        self.txtversion.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         # Track metrics
         track_metric_screen("about-screen")
@@ -287,7 +287,6 @@ class Credits(QDialog):
         self.lblBecomeSupporter.setText(supporter_html)
 
         # Get list of developers
-        developer_list = []
         with codecs.open(
                 os.path.join(info.RESOURCES_PATH, 'contributors.json'), 'r', 'utf_8'
                 ) as contributors_file:
@@ -334,7 +333,6 @@ class Credits(QDialog):
             self.tabCredits.removeTab(1)
 
         # Get list of supporters
-        supporter_list = []
         with codecs.open(
                 os.path.join(info.RESOURCES_PATH, 'supporters.json'), 'r', 'utf_8'
                 ) as supporter_file:

--- a/src/windows/animated_title.py
+++ b/src/windows/animated_title.py
@@ -60,8 +60,8 @@ class AnimatedTitle(QDialog):
         # Add render controls
         self.btnRender = QPushButton(_('Render'))
         self.btnCancel = QPushButton(_('Cancel'))
-        self.buttonBox.addButton(self.btnRender, QDialogButtonBox.AcceptRole)
-        self.buttonBox.addButton(self.btnCancel, QDialogButtonBox.RejectRole)
+        self.buttonBox.addButton(self.btnRender, QDialogButtonBox.ButtonRole.AcceptRole)
+        self.buttonBox.addButton(self.btnCancel, QDialogButtonBox.ButtonRole.RejectRole)
 
         # Hide render progress until needed
         self.statusContainer.hide()

--- a/src/windows/color_picker.py
+++ b/src/windows/color_picker.py
@@ -28,7 +28,7 @@
 from classes.logger import log
 
 from PyQt5.QtCore import Qt, QTimer, QRect, QPoint
-from PyQt5.QtGui import QColor, QBrush, QPen, QPalette, QPainter, QPixmap
+from PyQt5.QtGui import QColor, QPainter, QPixmap
 from PyQt5.QtWidgets import QColorDialog, QWidget, QLabel
 
 
@@ -41,7 +41,7 @@ class ColorPicker(QWidget):
         super().__init__(parent=parent, *args, **kwargs)
         self.setObjectName("ColorPicker")
         # Merge any additional user-supplied options with our own
-        options = QColorDialog.DontUseNativeDialog
+        options = QColorDialog.ColorDialogOption.DontUseNativeDialog
         if extra_options > 0:
             options = options | extra_options
         # Set up non-modal color dialog (to avoid blocking the eyedropper)
@@ -52,7 +52,7 @@ class ColorPicker(QWidget):
         self.dialog.setObjectName("CPDialog")
         if title:
             self.dialog.setWindowTitle(title)
-        self.dialog.setWindowFlags(Qt.Tool)
+        self.dialog.setWindowFlags(Qt.WindowType.Tool)
         self.dialog.setOptions(options)
         # Avoid signal loops
         self.dialog.blockSignals(True)
@@ -134,7 +134,7 @@ class CPAlphaShowLabel(QLabel):
         n = self.checkerboard_size
         pat = QPixmap(2 * n, 2 * n)
         p = QPainter(pat)
-        p.setPen(Qt.NoPen)
+        p.setPen(Qt.PenStyle.NoPen)
         # Paint a checkerboard pattern for the color to be overlaid on
         self.bg0 = QColor("#aaa")
         self.bg1 = QColor("#ccc")
@@ -148,7 +148,7 @@ class CPAlphaShowLabel(QLabel):
         """Show the current color, with checkerboard alpha"""
         event.accept()
         p = QPainter(self)
-        p.setPen(Qt.NoPen)
+        p.setPen(Qt.PenStyle.NoPen)
         if self.color.alphaF() < 1.0:
             # Draw a checkerboard pattern under the color
             p.drawTiledPixmap(event.rect(), self.pattern, QPoint(4,4))

--- a/src/windows/cutting.py
+++ b/src/windows/cutting.py
@@ -100,7 +100,8 @@ class Cutting(QDialog):
 
         # Add Video Widget
         self.videoPreview = VideoWidget()
-        self.videoPreview.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
+        self.videoPreview.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
         self.verticalLayout.insertWidget(0, self.videoPreview)
 
         # Set max size of video preview (for speed)

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -41,7 +41,7 @@ except ImportError:
 
 from xml.parsers.expat import ExpatError
 
-from PyQt5.QtCore import Qt, QCoreApplication, QTimer, QSize, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import Qt, QCoreApplication, QSize, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
     QMessageBox, QDialog, QFileDialog, QDialogButtonBox, QPushButton
 )
@@ -88,9 +88,9 @@ class Export(QDialog):
         self.cancel_button = QPushButton(_('Cancel'))
         self.export_button = QPushButton(_('Export Video'))
         self.close_button = QPushButton(_('Done'))
-        self.buttonBox.addButton(self.close_button, QDialogButtonBox.RejectRole)
-        self.buttonBox.addButton(self.export_button, QDialogButtonBox.AcceptRole)
-        self.buttonBox.addButton(self.cancel_button, QDialogButtonBox.RejectRole)
+        self.buttonBox.addButton(self.close_button, QDialogButtonBox.ButtonRole.RejectRole)
+        self.buttonBox.addButton(self.export_button, QDialogButtonBox.ButtonRole.AcceptRole)
+        self.buttonBox.addButton(self.cancel_button, QDialogButtonBox.ButtonRole.RejectRole)
         self.close_button.setVisible(False)
         self.exporting = False
 
@@ -739,7 +739,7 @@ class Export(QDialog):
             ret = QMessageBox.question(self,
                 _("Export Video"),
                 _("%s is an input file.\nPlease choose a different name.") % file_name_with_ext,
-                QMessageBox.Ok)
+                QMessageBox.StandardButton.Ok)
             self.enableControls()
             self.exporting = False
             return
@@ -750,8 +750,8 @@ class Export(QDialog):
             ret = QMessageBox.question(self,
                 _("Export Video"),
                 _("%s already exists.\nDo you want to replace it?") % file_name_with_ext,
-                QMessageBox.No | QMessageBox.Yes)
-            if ret == QMessageBox.No:
+                QMessageBox.StandardButton.No | QMessageBox.StandardButton.Yes)
+            if ret == QMessageBox.StandardButton.No:
                 # Stop and don't do anything
                 # Re-enable controls
                 self.enableControls()
@@ -1009,7 +1009,7 @@ class Export(QDialog):
             # Make progress bar green (to indicate we are done)
             from PyQt5.QtGui import QPalette
             p = QPalette()
-            p.setColor(QPalette.Highlight, Qt.green)
+            p.setColor(QPalette.Highlight, Qt.GlobalColor.green)
             self.progressExportVideo.setPalette(p)
 
             # Raise the window
@@ -1026,8 +1026,8 @@ class Export(QDialog):
                 self,
                 _("Export Video"),
                 _("Are you sure you want to cancel the export?"),
-                QMessageBox.No | QMessageBox.Yes)
-            if result == QMessageBox.No:
+                QMessageBox.StandardButton.No | QMessageBox.StandardButton.Yes)
+            if result == QMessageBox.StandardButton.No:
                 # Resume export
                 return
 

--- a/src/windows/export_clips.py
+++ b/src/windows/export_clips.py
@@ -146,7 +146,7 @@ class clipExportWindow(QDialog):
     def _getDestination(self):
         settings = get_app().get_settings()
         fd = QFileDialog()
-        fd.setOption(QFileDialog.ShowDirsOnly)
+        fd.setOption(QFileDialog.Option.ShowDirsOnly)
         fd.setDirectory(
             settings.getDefaultPath(settings.actionType.EXPORT)
         )
@@ -171,12 +171,12 @@ class clipExportWindow(QDialog):
         # Make progress bar look like the one in the export dialog
         from PyQt5.QtGui import QPalette
         p = QPalette()
-        p.setColor(QPalette.Highlight, Qt.green)
+        p.setColor(QPalette.ColorRole.Highlight, Qt.GlobalColor.green)
         self.progressExportVideo.setPalette(p)
 
-        self.buttonBox.addButton(self.cancel_button, QDialogButtonBox.ActionRole)
-        self.buttonBox.addButton(self.export_button, QDialogButtonBox.ActionRole)
-        self.buttonBox.addButton(self.done_button, QDialogButtonBox.ActionRole)
+        self.buttonBox.addButton(self.cancel_button, QDialogButtonBox.ButtonRole.ActionRole)
+        self.buttonBox.addButton(self.export_button, QDialogButtonBox.ButtonRole.ActionRole)
+        self.buttonBox.addButton(self.done_button, QDialogButtonBox.ButtonRole.ActionRole)
         self.done_button.setHidden(True)
         self.progressExportVideo.setValue(0)
 

--- a/src/windows/file_properties.py
+++ b/src/windows/file_properties.py
@@ -71,8 +71,8 @@ class FileProperties(QDialog):
 
         # Add buttons to interface
         self.update_button = QPushButton(_('Update'))
-        self.buttonBox.addButton(self.update_button, QDialogButtonBox.AcceptRole)
-        self.buttonBox.addButton(QPushButton(_('Cancel')), QDialogButtonBox.RejectRole)
+        self.buttonBox.addButton(self.update_button, QDialogButtonBox.ButtonRole.AcceptRole)
+        self.buttonBox.addButton(QPushButton(_('Cancel')), QDialogButtonBox.ButtonRole.RejectRole)
 
         # Dynamically load tabs from settings data
         self.settings_data = self.s.get_all_settings()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -37,9 +37,8 @@ from uuid import uuid4
 
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 from PyQt5.QtCore import (
-    Qt, pyqtSignal, pyqtSlot, QCoreApplication, PYQT_VERSION_STR,
-    QTimer, QDateTime, QFileInfo, QUrl,
-    )
+    Qt, pyqtSignal, pyqtSlot, QCoreApplication, QTimer, QDateTime, QFileInfo
+)
 from PyQt5.QtGui import QIcon, QCursor, QKeySequence, QTextCursor
 from PyQt5.QtWidgets import (
     QMainWindow, QWidget, QDockWidget,
@@ -142,12 +141,12 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 self,
                 _("Unsaved Changes"),
                 _("Save changes to project before closing?"),
-                QMessageBox.Cancel | QMessageBox.No | QMessageBox.Yes)
-            if ret == QMessageBox.Yes:
+                QMessageBox.StandardButton.Cancel | QMessageBox.StandardButton.No | QMessageBox.StandardButton.Yes)
+            if ret == QMessageBox.StandardButton.Yes:
                 # Save project
                 self.actionSave_trigger()
                 event.accept()
-            elif ret == QMessageBox.Cancel:
+            elif ret == QMessageBox.StandardButton.Cancel:
                 # Show tutorial again, if any
                 self.tutorial_manager.re_show_dialog()
                 # User canceled prompt - don't quit
@@ -281,11 +280,13 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 self,
                 _("Unsaved Changes"),
                 _("Save changes to project first?"),
-                QMessageBox.Cancel | QMessageBox.No | QMessageBox.Yes)
-            if ret == QMessageBox.Yes:
+                QMessageBox.StandardButton.Cancel
+                | QMessageBox.StandardButton.No
+                | QMessageBox.StandardButton.Yes)
+            if ret == QMessageBox.StandardButton.Yes:
                 # Save project
                 self.actionSave_trigger()
-            elif ret == QMessageBox.Cancel:
+            elif ret == QMessageBox.StandardButton.Cancel:
                 # User canceled prompt
                 return
 
@@ -318,8 +319,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         from windows.animated_title import AnimatedTitle
         win = AnimatedTitle()
         # Run the dialog event loop - blocking interaction on this window during that time
-        result = win.exec_()
-        if result == QDialog.Accepted:
+        result = win.exec()
+        if result == QDialog.DialogCode.Accepted:
             log.info('animated title add confirmed')
         else:
             log.info('animated title add cancelled')
@@ -329,8 +330,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         from windows.animation import Animation
         win = Animation()
         # Run the dialog event loop - blocking interaction on this window during that time
-        result = win.exec_()
-        if result == QDialog.Accepted:
+        result = win.exec()
+        if result == QDialog.DialogCode.Accepted:
             log.info('animation confirmed')
         else:
             log.info('animation cancelled')
@@ -450,16 +451,18 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 self,
                 _("Unsaved Changes"),
                 _("Save changes to project first?"),
-                QMessageBox.Cancel | QMessageBox.No | QMessageBox.Yes)
-            if ret == QMessageBox.Yes:
+                QMessageBox.StandardButton.Cancel
+                | QMessageBox.StandardButton.No
+                | QMessageBox.StandardButton.Yes)
+            if ret == QMessageBox.StandardButton.Yes:
                 # Save project
                 self.actionSave.trigger()
-            elif ret == QMessageBox.Cancel:
+            elif ret == QMessageBox.StandardButton.Cancel:
                 # User canceled prompt
                 return
 
         # Set cursor to waiting
-        app.setOverrideCursor(QCursor(Qt.WaitCursor))
+        app.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
         try:
             if os.path.exists(file_path):
@@ -552,11 +555,13 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 self,
                 _("Unsaved Changes"),
                 _("Save changes to project first?"),
-                QMessageBox.Cancel | QMessageBox.No | QMessageBox.Yes)
-            if ret == QMessageBox.Yes:
+                QMessageBox.StandardButton.Cancel
+                | QMessageBox.StandardButton.No
+                | QMessageBox.StandardButton.Yes)
+            if ret == QMessageBox.StandardButton.Yes:
                 # Save project
                 self.actionSave_trigger()
-            elif ret == QMessageBox.Cancel:
+            elif ret == QMessageBox.StandardButton.Cancel:
                 # User canceled prompt
                 return
 
@@ -704,7 +709,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             # Use the folder of the LAST one as the new default path.
             s.setDefaultPath(s.actionType.IMPORT, qurl_list[-1].toLocalFile())
         # Set cursor to waiting
-        app.setOverrideCursor(QCursor(Qt.WaitCursor))
+        app.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
         try:
             # Import list of files
@@ -729,7 +734,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             self,
             None,
             _("%s is not a valid video, audio, or image file.") % filename,
-            QMessageBox.Ok
+            QMessageBox.StandardButton.Ok
         )
 
     def promptImageSequence(self, filename=None):
@@ -749,9 +754,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             self,
             _("Import Image Sequence"),
             _("Would you like to import %s as an image sequence?") % filename,
-            QMessageBox.No | QMessageBox.Yes
+            QMessageBox.StandardButton.No | QMessageBox.StandardButton.Yes
         )
-        return ret == QMessageBox.Yes
+        return ret == QMessageBox.StandardButton.Yes
 
     def actionAdd_to_Timeline_trigger(self, checked=False):
         # Loop through selected files
@@ -770,8 +775,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         from windows.add_to_timeline import AddToTimeline
         win = AddToTimeline(files, pos)
         # Run the dialog event loop - blocking interaction on this window during this time
-        result = win.exec_()
-        if result == QDialog.Accepted:
+        result = win.exec()
+        if result == QDialog.DialogCode.Accepted:
             log.info('confirmed')
         else:
             log.info('canceled')
@@ -781,8 +786,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         from windows.export import Export
         win = Export()
         # Run the dialog event loop - blocking interaction on this window during this time
-        result = win.exec_()
-        if result == QDialog.Accepted:
+        result = win.exec()
+        if result == QDialog.DialogCode.Accepted:
             log.info('Export Video add confirmed')
         else:
             log.info('Export Video add cancelled')
@@ -823,14 +828,14 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.PauseSignal.emit()
 
         # Set cursor to waiting
-        get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
+        get_app().setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
         # Show dialog
         from windows.preferences import Preferences
         win = Preferences()
         # Run the dialog event loop - blocking interaction on this window during this time
-        result = win.exec_()
-        if result == QDialog.Accepted:
+        result = win.exec()
+        if result == QDialog.DialogCode.Accepted:
             log.info('Preferences add confirmed')
         else:
             log.info('Preferences add cancelled')
@@ -1512,7 +1517,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Abort handling if the key sequence is invalid
         if (key_value <= 0 or key_value in
-           [Qt.Key_Shift, Qt.Key_Alt, Qt.Key_Control, Qt.Key_Meta]):
+           [Qt.Key.Key_Shift, Qt.Key.Key_Alt, Qt.Key.Key_Control, Qt.Key.Key_Meta]):
             return
 
         # A valid keysequence was detected
@@ -1528,7 +1533,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         playhead_position = float(self.preview_thread.current_frame - 1) / fps_float
 
         # Basic shortcuts i.e just a letter
-        if key.matches(self.getShortcutByName("seekPreviousFrame")) == QKeySequence.ExactMatch:
+        if key.matches(self.getShortcutByName("seekPreviousFrame")) == QKeySequence.SequenceMatch.ExactMatch:
             # Pause video
             self.PauseSignal.emit()
             self.SpeedSignal.emit(0)
@@ -1538,7 +1543,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             # Notify properties dialog
             self.propertyTableView.select_frame(player.Position())
 
-        elif key.matches(self.getShortcutByName("seekNextFrame")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("seekNextFrame")) == QKeySequence.SequenceMatch.ExactMatch:
             # Pause video
             self.PauseSignal.emit()
             self.SpeedSignal.emit(0)
@@ -1548,109 +1553,109 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             # Notify properties dialog
             self.propertyTableView.select_frame(player.Position())
 
-        elif key.matches(self.getShortcutByName("rewindVideo")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("rewindVideo")) == QKeySequence.SequenceMatch.ExactMatch:
             # Toggle rewind and start playback
             self.actionRewind.trigger()
 
-        elif key.matches(self.getShortcutByName("fastforwardVideo")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("fastforwardVideo")) == QKeySequence.SequenceMatch.ExactMatch:
             # Toggle fastforward button and start playback
             self.actionFastForward.trigger()
 
         elif any([
-                key.matches(self.getShortcutByName("playToggle")) == QKeySequence.ExactMatch,
-                key.matches(self.getShortcutByName("playToggle1")) == QKeySequence.ExactMatch,
-                key.matches(self.getShortcutByName("playToggle2")) == QKeySequence.ExactMatch,
-                key.matches(self.getShortcutByName("playToggle3")) == QKeySequence.ExactMatch,
+                key.matches(self.getShortcutByName("playToggle")) == QKeySequence.SequenceMatch.ExactMatch,
+                key.matches(self.getShortcutByName("playToggle1")) == QKeySequence.SequenceMatch.ExactMatch,
+                key.matches(self.getShortcutByName("playToggle2")) == QKeySequence.SequenceMatch.ExactMatch,
+                key.matches(self.getShortcutByName("playToggle3")) == QKeySequence.SequenceMatch.ExactMatch,
                 ]):
             # Toggle playbutton and show properties
             self.actionPlay.trigger()
             self.propertyTableView.select_frame(player.Position())
 
         elif any([
-                key.matches(self.getShortcutByName("deleteItem")) == QKeySequence.ExactMatch,
-                key.matches(self.getShortcutByName("deleteItem1")) == QKeySequence.ExactMatch,
+                key.matches(self.getShortcutByName("deleteItem")) == QKeySequence.SequenceMatch.ExactMatch,
+                key.matches(self.getShortcutByName("deleteItem1")) == QKeySequence.SequenceMatch.ExactMatch,
                 ]):
             # Delete selected clip / transition
             self.actionRemoveClip.trigger()
             self.actionRemoveTransition.trigger()
 
         # Menu shortcuts
-        elif key.matches(self.getShortcutByName("actionNew")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionNew")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionNew.trigger()
-        elif key.matches(self.getShortcutByName("actionOpen")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionOpen")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionOpen.trigger()
-        elif key.matches(self.getShortcutByName("actionSave")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionSave")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionSave.trigger()
-        elif key.matches(self.getShortcutByName("actionUndo")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionUndo")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionUndo.trigger()
-        elif key.matches(self.getShortcutByName("actionSaveAs")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionSaveAs")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionSaveAs.trigger()
-        elif key.matches(self.getShortcutByName("actionImportFiles")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionImportFiles")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionImportFiles.trigger()
-        elif key.matches(self.getShortcutByName("actionRedo")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionRedo")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionRedo.trigger()
-        elif key.matches(self.getShortcutByName("actionExportVideo")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionExportVideo")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionExportVideo.trigger()
-        elif key.matches(self.getShortcutByName("actionQuit")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionQuit")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionQuit.trigger()
-        elif key.matches(self.getShortcutByName("actionPreferences")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionPreferences")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionPreferences.trigger()
-        elif key.matches(self.getShortcutByName("actionAddTrack")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionAddTrack")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionAddTrack.trigger()
-        elif key.matches(self.getShortcutByName("actionAddMarker")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionAddMarker")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionAddMarker.trigger()
-        elif key.matches(self.getShortcutByName("actionPreviousMarker")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionPreviousMarker")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionPreviousMarker.trigger()
-        elif key.matches(self.getShortcutByName("actionNextMarker")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionNextMarker")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionNextMarker.trigger()
-        elif key.matches(self.getShortcutByName("actionCenterOnPlayhead")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionCenterOnPlayhead")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionCenterOnPlayhead.trigger()
-        elif key.matches(self.getShortcutByName("actionTimelineZoomIn")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionTimelineZoomIn")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionTimelineZoomIn.trigger()
-        elif key.matches(self.getShortcutByName("actionTimelineZoomOut")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionTimelineZoomOut")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionTimelineZoomOut.trigger()
-        elif key.matches(self.getShortcutByName("actionTitle")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionTitle")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionTitle.trigger()
-        elif key.matches(self.getShortcutByName("actionAnimatedTitle")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionAnimatedTitle")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionAnimatedTitle.trigger()
-        elif key.matches(self.getShortcutByName("actionDuplicateTitle")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionDuplicateTitle")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionDuplicateTitle.trigger()
-        elif key.matches(self.getShortcutByName("actionEditTitle")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionEditTitle")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionEditTitle.trigger()
-        elif key.matches(self.getShortcutByName("actionFullscreen")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionFullscreen")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionFullscreen.trigger()
-        elif key.matches(self.getShortcutByName("actionAbout")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionAbout")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionAbout.trigger()
-        elif key.matches(self.getShortcutByName("actionThumbnailView")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionThumbnailView")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionThumbnailView.trigger()
-        elif key.matches(self.getShortcutByName("actionDetailsView")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionDetailsView")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionDetailsView.trigger()
-        elif key.matches(self.getShortcutByName("actionProfile")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionProfile")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionProfile.trigger()
-        elif key.matches(self.getShortcutByName("actionAdd_to_Timeline")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionAdd_to_Timeline")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionAdd_to_Timeline.trigger()
-        elif key.matches(self.getShortcutByName("actionSplitClip")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionSplitClip")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionSplitClip.trigger()
-        elif key.matches(self.getShortcutByName("actionSnappingTool")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionSnappingTool")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionSnappingTool.trigger()
-        elif key.matches(self.getShortcutByName("actionJumpStart")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionJumpStart")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionJumpStart.trigger()
-        elif key.matches(self.getShortcutByName("actionJumpEnd")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionJumpEnd")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionJumpEnd.trigger()
-        elif key.matches(self.getShortcutByName("actionSaveFrame")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionSaveFrame")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionSaveFrame.trigger()
-        elif key.matches(self.getShortcutByName("actionProperties")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionProperties")) == QKeySequence.SequenceMatch.ExactMatch:
             self.actionProperties.trigger()
-        elif key.matches(self.getShortcutByName("actionTransform")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionTransform")) == QKeySequence.SequenceMatch.ExactMatch:
             if self.selected_clips:
                 self.TransformSignal.emit(self.selected_clips[0])
-        elif key.matches(self.getShortcutByName("actionInsertKeyframe")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("actionInsertKeyframe")) == QKeySequence.SequenceMatch.ExactMatch:
             log.debug("actionInsertKeyframe")
             if self.selected_clips or self.selected_transitions:
                 self.InsertKeyframe.emit(event)
 
         # Timeline keyboard shortcuts
-        elif key.matches(self.getShortcutByName("sliceAllKeepBothSides")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("sliceAllKeepBothSides")) == QKeySequence.SequenceMatch.ExactMatch:
             intersecting_clips = Clip.filter(intersect=playhead_position)
             intersecting_trans = Transition.filter(intersect=playhead_position)
             if intersecting_clips or intersecting_trans:
@@ -1658,7 +1663,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 clip_ids = [c.id for c in intersecting_clips]
                 trans_ids = [t.id for t in intersecting_trans]
                 self.timeline.Slice_Triggered(0, clip_ids, trans_ids, playhead_position)
-        elif key.matches(self.getShortcutByName("sliceAllKeepLeftSide")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("sliceAllKeepLeftSide")) == QKeySequence.SequenceMatch.ExactMatch:
             intersecting_clips = Clip.filter(intersect=playhead_position)
             intersecting_trans = Transition.filter(intersect=playhead_position)
             if intersecting_clips or intersecting_trans:
@@ -1666,7 +1671,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 clip_ids = [c.id for c in intersecting_clips]
                 trans_ids = [t.id for t in intersecting_trans]
                 self.timeline.Slice_Triggered(1, clip_ids, trans_ids, playhead_position)
-        elif key.matches(self.getShortcutByName("sliceAllKeepRightSide")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("sliceAllKeepRightSide")) == QKeySequence.SequenceMatch.ExactMatch:
             intersecting_clips = Clip.filter(intersect=playhead_position)
             intersecting_trans = Transition.filter(intersect=playhead_position)
             if intersecting_clips or intersecting_trans:
@@ -1674,7 +1679,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 clip_ids = [c.id for c in intersecting_clips]
                 trans_ids = [t.id for t in intersecting_trans]
                 self.timeline.Slice_Triggered(2, clip_ids, trans_ids, playhead_position)
-        elif key.matches(self.getShortcutByName("sliceSelectedKeepBothSides")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("sliceSelectedKeepBothSides")) == QKeySequence.SequenceMatch.ExactMatch:
             intersecting_clips = Clip.filter(intersect=playhead_position)
             intersecting_trans = Transition.filter(intersect=playhead_position)
             if intersecting_clips or intersecting_trans:
@@ -1682,7 +1687,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 clip_ids = [c.id for c in intersecting_clips if c.id in self.selected_clips]
                 trans_ids = [t.id for t in intersecting_trans if t.id in self.selected_transitions]
                 self.timeline.Slice_Triggered(0, clip_ids, trans_ids, playhead_position)
-        elif key.matches(self.getShortcutByName("sliceSelectedKeepLeftSide")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("sliceSelectedKeepLeftSide")) == QKeySequence.SequenceMatch.ExactMatch:
             intersecting_clips = Clip.filter(intersect=playhead_position)
             intersecting_trans = Transition.filter(intersect=playhead_position)
             if intersecting_clips or intersecting_trans:
@@ -1690,7 +1695,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 clip_ids = [c.id for c in intersecting_clips if c.id in self.selected_clips]
                 trans_ids = [t.id for t in intersecting_trans if t.id in self.selected_transitions]
                 self.timeline.Slice_Triggered(1, clip_ids, trans_ids, playhead_position)
-        elif key.matches(self.getShortcutByName("sliceSelectedKeepRightSide")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("sliceSelectedKeepRightSide")) == QKeySequence.SequenceMatch.ExactMatch:
             intersecting_clips = Clip.filter(intersect=playhead_position)
             intersecting_trans = Transition.filter(intersect=playhead_position)
             if intersecting_clips or intersecting_trans:
@@ -1699,20 +1704,20 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 trans_ids = [t.id for t in intersecting_trans if t.id in self.selected_transitions]
                 self.timeline.Slice_Triggered(2, clip_ids, trans_ids, playhead_position)
 
-        elif key.matches(self.getShortcutByName("copyAll")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("copyAll")) == QKeySequence.SequenceMatch.ExactMatch:
             self.timeline.Copy_Triggered(-1, self.selected_clips, self.selected_transitions)
-        elif key.matches(self.getShortcutByName("pasteAll")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("pasteAll")) == QKeySequence.SequenceMatch.ExactMatch:
             self.timeline.Paste_Triggered(9, float(playhead_position), -1, [], [])
-        elif key.matches(self.getShortcutByName("nudgeLeft")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("nudgeLeft")) == QKeySequence.SequenceMatch.ExactMatch:
             self.timeline.Nudge_Triggered(-1, self.selected_clips, self.selected_transitions)
-        elif key.matches(self.getShortcutByName("nudgeRight")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("nudgeRight")) == QKeySequence.SequenceMatch.ExactMatch:
             self.timeline.Nudge_Triggered(1, self.selected_clips, self.selected_transitions)
 
         # Select All / None
-        elif key.matches(self.getShortcutByName("selectAll")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("selectAll")) == QKeySequence.SequenceMatch.ExactMatch:
             self.timeline.SelectAll()
 
-        elif key.matches(self.getShortcutByName("selectNone")) == QKeySequence.ExactMatch:
+        elif key.matches(self.getShortcutByName("selectNone")) == QKeySequence.SequenceMatch.ExactMatch:
             self.timeline.ClearAllSelections()
 
         # If we didn't act on the event, forward it to the base class
@@ -1725,7 +1730,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         log.debug("Showing preferences dialog")
         win = Profile()
         # Run the dialog event loop - blocking interaction on this window during this time
-        win.exec_()
+        win.exec()
         log.debug("Preferences dialog closed")
 
     def actionSplitClip_trigger(self):
@@ -1743,8 +1748,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         from windows.cutting import Cutting
         win = Cutting(f)
         # Run the dialog event loop - blocking interaction on this window during that time
-        result = win.exec_()
-        if result == QDialog.Accepted:
+        result = win.exec()
+        if result == QDialog.DialogCode.Accepted:
             log.info('Cutting Finished')
         else:
             log.info('Cutting Cancelled')
@@ -1959,7 +1964,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def actionFullscreen_trigger(self):
         # Toggle fullscreen state (current state mask XOR WindowFullScreen)
-        self.setWindowState(self.windowState() ^ Qt.WindowFullScreen)
+        self.setWindowState(self.windowState() ^ Qt.WindowState.WindowFullScreen)
 
     def actionFile_Properties_trigger(self):
         log.info("Show file properties")
@@ -1974,8 +1979,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         from windows.file_properties import FileProperties
         win = FileProperties(f)
         # Run the dialog event loop - blocking interaction on this window during that time
-        result = win.exec_()
-        if result == QDialog.Accepted:
+        result = win.exec()
+        if result == QDialog.DialogCode.Accepted:
 
             # BRUTE FORCE approach: go through all clips and update file path
             clips = Clip.filter(file_id=f.data["id"])
@@ -2064,7 +2069,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def removeDocks(self):
         """ Remove all dockable widgets on main screen """
         for dock in self.getDocks():
-            if self.dockWidgetArea(dock) != Qt.NoDockWidgetArea:
+            if self.dockWidgetArea(dock) != Qt.DockWidgetArea.NoDockWidgetArea:
                 self.removeDockWidget(dock)
 
     def addDocks(self, docks, area):
@@ -2075,29 +2080,29 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def floatDocks(self, is_floating):
         """ Float or Un-Float all dockable widgets above main screen """
         for dock in self.getDocks():
-            if self.dockWidgetArea(dock) != Qt.NoDockWidgetArea:
+            if self.dockWidgetArea(dock) != Qt.DockWidgetArea.NoDockWidgetArea:
                 dock.setFloating(is_floating)
 
     def showDocks(self, docks):
         """ Show all dockable widgets on the main screen """
         for dock in docks:
-            if self.dockWidgetArea(dock) != Qt.NoDockWidgetArea:
+            if self.dockWidgetArea(dock) != Qt.DockWidgetArea.NoDockWidgetArea:
                 # Only show correctly docked widgets
                 dock.show()
 
     def freezeDock(self, dock, frozen=True):
         """ Freeze/unfreeze a dock widget on the main screen."""
-        if self.dockWidgetArea(dock) == Qt.NoDockWidgetArea:
+        if self.dockWidgetArea(dock) == Qt.DockWidgetArea.NoDockWidgetArea:
             # Don't freeze undockable widgets
             return
         if frozen:
-            dock.setFeatures(QDockWidget.NoDockWidgetFeatures)
+            dock.setFeatures(QDockWidget.DockWidgetFeature.NoDockWidgetFeatures)
         else:
             features = (
-                QDockWidget.DockWidgetFloatable
-                | QDockWidget.DockWidgetMovable)
+                QDockWidget.DockWidgetFeature.DockWidgetFloatable
+                | QDockWidget.DockWidgetFeature.DockWidgetMovable)
             if dock is not self.dockTimeline:
-                features |= QDockWidget.DockWidgetClosable
+                features |= QDockWidget.DockWidgetFeature.DockWidgetClosable
             dock.setFeatures(features)
 
     @pyqtSlot()
@@ -2121,8 +2126,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         self.docks_menu = self.menuView.addMenu(_("Docks"))
         for dock in sorted(self.getDocks(), key=lambda d: d.windowTitle()):
-            if (dock.features() & QDockWidget.DockWidgetClosable
-               != QDockWidget.DockWidgetClosable):
+            if (dock.features() & QDockWidget.DockWidgetFeature.DockWidgetClosable
+               != QDockWidget.DockWidgetFeature.DockWidgetClosable):
                 # Skip non-closable docs
                 continue
             self.docks_menu.addAction(dock.toggleViewAction())
@@ -2138,7 +2143,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             self.dockEffects,
             self.dockEmojis,
             self.dockVideo,
-            ], Qt.TopDockWidgetArea)
+            ], Qt.DockWidgetArea.TopDockWidgetArea)
 
         self.floatDocks(False)
         self.tabifyDockWidget(self.dockFiles, self.dockTransitions)
@@ -2164,13 +2169,13 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.removeDocks()
 
         # Add Docks
-        self.addDocks([self.dockFiles, self.dockVideo], Qt.TopDockWidgetArea)
+        self.addDocks([self.dockFiles, self.dockVideo], Qt.DockWidgetArea.TopDockWidgetArea)
         self.addDocks([
             self.dockEffects,
             self.dockTransitions,
             self.dockEmojis,
-            ], Qt.RightDockWidgetArea)
-        self.addDocks([self.dockProperties], Qt.LeftDockWidgetArea)
+            ], Qt.DockWidgetArea.RightDockWidgetArea)
+        self.addDocks([self.dockProperties], Qt.DockWidgetArea.LeftDockWidgetArea)
 
         self.floatDocks(False)
         self.tabifyDockWidget(self.dockEmojis, self.dockEffects)
@@ -2286,9 +2291,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Get cursor / current line of text (where cursor is located)
         cursor = self.captionTextEdit.textCursor()
-        self.captionTextEdit.moveCursor(QTextCursor.StartOfLine)
+        self.captionTextEdit.moveCursor(QTextCursor.MoveOperation.StartOfLine)
         line_text = cursor.block().text()
-        self.captionTextEdit.moveCursor(QTextCursor.EndOfLine)
+        self.captionTextEdit.moveCursor(QTextCursor.MoveOperation.EndOfLine)
 
         # Convert time in seconds to hours:minutes:seconds:milliseconds
         current_timestamp = secondsToTimecode(relative_position, fps["num"], fps["den"], use_milliseconds=True)
@@ -2303,19 +2308,19 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         if "-->" in line_text and line_text.count(':') == 3:
             # Current line has only one timestamp. Add the second and go to the line below it.
             self.captionTextEdit.insertPlainText(current_timestamp)
-            self.captionTextEdit.moveCursor(QTextCursor.Down)
-            self.captionTextEdit.moveCursor(QTextCursor.EndOfLine)
+            self.captionTextEdit.moveCursor(QTextCursor.MoveOperation.Down)
+            self.captionTextEdit.moveCursor(QTextCursor.MoveOperation.EndOfLine)
         else:
             # Current line isn't a starting timestamp, so add a starting timestamp
 
             # If the current line isn't blank, go to end and add two blank lines
-            if (self.captionTextEdit.textCursor().block().text().strip() != ""):
-                self.captionTextEdit.moveCursor(QTextCursor.End)
+            if self.captionTextEdit.textCursor().block().text().strip() != "":
+                self.captionTextEdit.moveCursor(QTextCursor.MoveOperation.End)
                 self.captionTextEdit.insertPlainText("\n\n")
             # Add timestamp, and placeholder caption
             self.captionTextEdit.insertPlainText("%s --> \n%s" % (current_timestamp, _("Enter caption text...")))
             # Return to timestamp line, to await ending timestamp
-            self.captionTextEdit.moveCursor(QTextCursor.Up)
+            self.captionTextEdit.moveCursor(QTextCursor.MoveOperation.Up)
 
     def captionTextEdit_TextChanged(self):
         """Caption text was edited, start the save timer (to prevent spamming saves)"""
@@ -2661,7 +2666,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Add left spacer
         spacer = QWidget(self)
-        spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        spacer.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.videoToolbar.addWidget(spacer)
 
         # Playback controls (centered)
@@ -2673,7 +2678,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Add right spacer
         spacer = QWidget(self)
-        spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        spacer.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.videoToolbar.addWidget(spacer)
 
         # Other controls (right-aligned)
@@ -2753,7 +2758,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         if info.VERSION < version:
             # Add spacer and 'New Version Available' toolbar button (default hidden)
             spacer = QWidget(self)
-            spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+            spacer.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
             self.toolBar.addWidget(spacer)
 
             # Update text for QAction
@@ -2764,7 +2769,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             # Add update available button (with icon and text)
             updateButton = QToolButton()
             updateButton.setDefaultAction(self.actionUpdate)
-            updateButton.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+            updateButton.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
             self.toolBar.addWidget(updateButton)
 
         # Initialize sentry exception tracing (now that we know the current version)
@@ -2995,10 +3000,10 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.frameWeb.layout().addWidget(self.timeline)
 
         # Configure the side docks to full-height
-        self.setCorner(Qt.TopLeftCorner, Qt.LeftDockWidgetArea)
-        self.setCorner(Qt.BottomLeftCorner, Qt.LeftDockWidgetArea)
-        self.setCorner(Qt.TopRightCorner, Qt.RightDockWidgetArea)
-        self.setCorner(Qt.BottomRightCorner, Qt.RightDockWidgetArea)
+        self.setCorner(Qt.Corner.TopLeftCorner, Qt.DockWidgetArea.LeftDockWidgetArea)
+        self.setCorner(Qt.Corner.BottomLeftCorner, Qt.DockWidgetArea.LeftDockWidgetArea)
+        self.setCorner(Qt.Corner.TopRightCorner, Qt.DockWidgetArea.RightDockWidgetArea)
+        self.setCorner(Qt.Corner.BottomRightCorner, Qt.DockWidgetArea.RightDockWidgetArea)
 
         self.initModels()
 

--- a/src/windows/models/add_to_timeline_model.py
+++ b/src/windows/models/add_to_timeline_model.py
@@ -79,21 +79,21 @@ class TimelineModel():
             col.setIcon(QIcon(thumb_path))
             col.setText((name[:9] + '...') if len(name) > 10 else name)
             col.setToolTip(filename)
-            col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)
+            col.setFlags(Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsUserCheckable)
             row.append(col)
 
             # Append Name
             col = QStandardItem("Name")
-            col.setData(filename, Qt.DisplayRole)
+            col.setData(filename, Qt.ItemDataRole.DisplayRole)
             col.setText((name[:20] + '...') if len(name) > 15 else name)
-            col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)
+            col.setFlags(Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsUserCheckable)
             row.append(col)
 
             # Append Path
             col = QStandardItem("Path")
-            col.setData(path, Qt.DisplayRole)
+            col.setData(path, Qt.ItemDataRole.DisplayRole)
             col.setText(path)
-            col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)
+            col.setFlags(Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsUserCheckable)
             row.append(col)
 
             # Add row

--- a/src/windows/models/blender_model.py
+++ b/src/windows/models/blender_model.py
@@ -33,8 +33,8 @@ try:
 except ImportError:
     from xml.dom import minidom as xml
 
-from PyQt5.QtCore import Qt, QSize
-from PyQt5.QtGui import QIcon, QPixmap, QStandardItem, QStandardItemModel
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QIcon, QStandardItem, QStandardItemModel
 
 import openshot
 
@@ -107,7 +107,7 @@ class BlenderModel():
                 icon.addFile(thumb_path)
 
                 row = []
-                flags = Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable
+                flags = Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsUserCheckable
                 # Append thumbnail
                 col = QStandardItem(self.app._tr(title))
                 col.setIcon(icon)
@@ -117,19 +117,19 @@ class BlenderModel():
 
                 # Append Name
                 col = QStandardItem(self.app._tr(title))
-                col.setData(self.app._tr(title), Qt.DisplayRole)
+                col.setData(self.app._tr(title), Qt.ItemDataRole.DisplayRole)
                 col.setFlags(flags)
                 row.append(col)
 
                 # Append Path
                 col = QStandardItem(path)
-                col.setData(path, Qt.DisplayRole)
+                col.setData(path, Qt.ItemDataRole.DisplayRole)
                 col.setFlags(flags)
                 row.append(col)
 
                 # Append Service
                 col = QStandardItem(service)
-                col.setData(service, Qt.DisplayRole)
+                col.setData(service, Qt.ItemDataRole.DisplayRole)
                 col.setFlags(flags)
                 row.append(col)
 

--- a/src/windows/models/changelog_model.py
+++ b/src/windows/models/changelog_model.py
@@ -69,7 +69,7 @@ class ChangelogModel():
                 continue
 
             row = []
-            flags = Qt.ItemIsSelectable | Qt.ItemIsEnabled
+            flags = Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEnabled
 
             col = QStandardItem(hash_str)
             col.setToolTip(hash_str)

--- a/src/windows/models/credits_model.py
+++ b/src/windows/models/credits_model.py
@@ -31,8 +31,6 @@ from PyQt5.QtGui import QIcon, QStandardItemModel, QStandardItem
 from classes.logger import log
 from classes.app import get_app
 
-from collections import defaultdict
-
 
 class CreditsStandardItemModel(QStandardItemModel):
     def __init__(self, parent=None):
@@ -74,7 +72,7 @@ class CreditsModel():
                 continue
 
             row = []
-            flags = Qt.ItemIsSelectable | Qt.ItemIsEnabled
+            flags = Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEnabled
 
             # Append type icon (PayPal, Kickstarter, Bitcoin, or Patreon)
             item = QStandardItem()

--- a/src/windows/models/effects_model.py
+++ b/src/windows/models/effects_model.py
@@ -28,10 +28,10 @@
 import os
 
 from PyQt5.QtCore import (
-    QObject, QMimeData, Qt, QSize, pyqtSignal,
+    QObject, QMimeData, Qt, pyqtSignal,
     QSortFilterProxyModel, QPersistentModelIndex, QItemSelectionModel,
 )
-from PyQt5.QtGui import QIcon, QPixmap, QStandardItemModel, QStandardItem
+from PyQt5.QtGui import QIcon, QStandardItemModel, QStandardItem
 from PyQt5.QtWidgets import QMessageBox
 
 import openshot  # Python module for libopenshot (required video editing module installed separately)
@@ -174,45 +174,29 @@ class EffectsModel(QObject):
 
             row = []
 
-            # Append thumbnail
-            col = QStandardItem()
-
+            flags = (
+                Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEnabled |
+                Qt.ItemFlag.ItemIsUserCheckable | Qt.ItemFlag.ItemIsDragEnabled
+            )
             # Load icon (using display DPI)
             icon = QIcon()
             icon.addFile(thumb_path)
 
+            # Thumbnail
+            col = QStandardItem(self.app._tr(title))
             col.setIcon(icon)
-            col.setText(self.app._tr(title))
             col.setToolTip(self.app._tr(title))
-            col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
+            col.setFlags(flags)
             row.append(col)
 
-            # Append Name
-            col = QStandardItem("Name")
-            col.setData(self.app._tr(title), Qt.DisplayRole)
-            col.setText(self.app._tr(title))
-            col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
-            row.append(col)
-
-            # Append Description
-            col = QStandardItem("Description")
-            col.setData(self.app._tr(description), Qt.DisplayRole)
-            col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
-            row.append(col)
-
-            # Append Category
-            col = QStandardItem("Category")
-            col.setData(category, Qt.DisplayRole)
-            col.setText(category)
-            col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
-            row.append(col)
-
-            # Append Path
-            col = QStandardItem("Effect")
-            col.setData(effect_name, Qt.DisplayRole)
-            col.setText(effect_name)
-            col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
-            row.append(col)
+            # Name, Description, Category, Class
+            for label in [
+                self.app._tr(title), self.app._tr(description), category, effect_name,
+            ]:
+                col = QStandardItem(label)
+                col.setData(label, Qt.ItemDataRole.DisplayRole)
+                col.setFlags(flags)
+                row.append(col)
 
             # Append ROW to MODEL (if does not already exist in model)
             if effect_name not in self.model_names:

--- a/src/windows/models/emoji_model.py
+++ b/src/windows/models/emoji_model.py
@@ -89,6 +89,10 @@ class EmojisModel():
         if os.path.exists(info.EMOJIS_PATH) and os.listdir(info.EMOJIS_PATH):
             emoji_paths.append({"type": "user", "dir": info.EMOJIS_PATH, "files": os.listdir(info.EMOJIS_PATH)})
 
+        flags = (
+            Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEnabled |
+            Qt.ItemFlag.ItemIsUserCheckable | Qt.ItemFlag.ItemIsDragEnabled
+        )
         for group in emoji_paths:
             dir = group["dir"]
             files = group["files"]
@@ -154,7 +158,7 @@ class EmojisModel():
                 col.setText(emoji_name)
                 col.setToolTip(emoji_name)
                 col.setData(path)
-                col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
+                col.setFlags(flags)
                 row.append(col)
 
                 # Append filterable group
@@ -178,16 +182,16 @@ class EmojisModel():
         # Create proxy models (for grouping, sorting and filtering)
         self.group_model = QSortFilterProxyModel()
         self.group_model.setDynamicSortFilter(False)
-        self.group_model.setFilterCaseSensitivity(Qt.CaseInsensitive)
-        self.group_model.setSortCaseSensitivity(Qt.CaseSensitive)
+        self.group_model.setFilterCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        self.group_model.setSortCaseSensitivity(Qt.CaseSensitivity.CaseSensitive)
         self.group_model.setSourceModel(self.model)
         self.group_model.setSortLocaleAware(True)
         self.group_model.setFilterKeyColumn(1)
 
         self.proxy_model = QSortFilterProxyModel()
         self.proxy_model.setDynamicSortFilter(False)
-        self.proxy_model.setFilterCaseSensitivity(Qt.CaseInsensitive)
-        self.proxy_model.setSortCaseSensitivity(Qt.CaseSensitive)
+        self.proxy_model.setFilterCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        self.proxy_model.setSortCaseSensitivity(Qt.CaseSensitivity.CaseSensitive)
         self.proxy_model.setSourceModel(self.group_model)
         self.proxy_model.setSortLocaleAware(True)
 

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -191,7 +191,10 @@ class FilesModel(QObject, updates.UpdateInterface):
                 thumb_icon = QIcon(os.path.join(info.PATH, "images", "AudioThumbnail.svg"))
 
             row = []
-            flags = Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsDragEnabled | Qt. ItemNeverHasChildren
+            flags = (
+                Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEnabled |
+                Qt.ItemFlag.ItemIsDragEnabled | Qt.ItemFlag.ItemNeverHasChildren
+            )
 
             # Append thumbnail
             col = QStandardItem(thumb_icon, name)
@@ -201,12 +204,12 @@ class FilesModel(QObject, updates.UpdateInterface):
 
             # Append Filename
             col = QStandardItem(name)
-            col.setFlags(flags | Qt.ItemIsEditable)
+            col.setFlags(flags | Qt.ItemFlag.ItemIsEditable)
             row.append(col)
 
             # Append Tags
             col = QStandardItem(tags)
-            col.setFlags(flags | Qt.ItemIsEditable)
+            col.setFlags(flags | Qt.ItemFlag.ItemIsEditable)
             row.append(col)
 
             # Append Media Type
@@ -221,7 +224,7 @@ class FilesModel(QObject, updates.UpdateInterface):
 
             # Append ID
             col = QStandardItem(id)
-            col.setFlags(flags | Qt.ItemIsUserCheckable)
+            col.setFlags(flags | Qt.ItemFlag.ItemIsUserCheckable)
             row.append(col)
 
             # Append ROW to MODEL (if does not already exist in model)
@@ -233,7 +236,8 @@ class FilesModel(QObject, updates.UpdateInterface):
                 row_added_count += 1
                 if row_added_count % 2 == 0:
                     # Update every X items
-                    get_app().processEvents(QEventLoop.ExcludeUserInputEvents)
+                    get_app().processEvents(
+                        QEventLoop.ProcessEventsFlag.ExcludeUserInputEvents)
 
             # Refresh view and filters (to hide or show this new item)
             get_app().window.resize_contents()
@@ -326,7 +330,6 @@ class FilesModel(QObject, updates.UpdateInterface):
 
                     if seq_info and "fps" in seq_info:
                         # Blender Titles specify their fps in seq_info
-                        fps = seq_info["fps"]
                         fps_num = seq_info.get("fps").get("num", 25)
                         fps_den = seq_info.get("fps").get("den", 1)
                         log.debug("Image Sequence using specified FPS: %s / %s" % (fps_num, fps_den))
@@ -574,8 +577,8 @@ class FilesModel(QObject, updates.UpdateInterface):
         # Create proxy model (for sorting and filtering)
         self.proxy_model = FileFilterProxyModel(parent=self)
         self.proxy_model.setDynamicSortFilter(True)
-        self.proxy_model.setFilterCaseSensitivity(Qt.CaseInsensitive)
-        self.proxy_model.setSortCaseSensitivity(Qt.CaseSensitive)
+        self.proxy_model.setFilterCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        self.proxy_model.setSortCaseSensitivity(Qt.CaseSensitivity.CaseSensitive)
         self.proxy_model.setSourceModel(self.model)
         self.proxy_model.setSortLocaleAware(True)
 

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -35,7 +35,7 @@ from PyQt5.QtGui import (
     QPixmap, QColor,
     )
 
-from classes import info, updates
+from classes import updates
 from classes import openshot_rc  # noqa
 from classes.query import Clip, Transition, Effect
 from classes.logger import log
@@ -613,22 +613,24 @@ class PropertiesModel(updates.UpdateInterface):
         row = []
         if self.new_item:
 
-            # Append Property Name
-            col = QStandardItem("Property")
-            col.setText(_(label))
+            # Property Name
+            col = QStandardItem(_(label))
             col.setData(property)
             if keyframe and points > 1:
                 col.setBackground(QColor("green"))  # Highlight keyframe background
             elif points > 1:
                 col.setBackground(QColor(42, 130, 218))  # Highlight interpolated value background
             if readonly or type in ["color", "font", "caption"] or choices or label == "Track":
-                col.setFlags(Qt.ItemIsEnabled)
+                col.setFlags(Qt.ItemFlag.ItemIsEnabled)
             else:
-                col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)
+                col.setFlags(
+                    Qt.ItemFlag.ItemIsSelectable |
+                    Qt.ItemFlag.ItemIsEnabled |
+                    Qt.ItemFlag.ItemIsUserCheckable)
             row.append(col)
 
-            # Append Value
-            col = QStandardItem("Value")
+            # Value
+            col = QStandardItem()
             if selected_choice:
                 col.setText(_(selected_choice))
             elif type == "string":
@@ -678,7 +680,7 @@ class PropertiesModel(updates.UpdateInterface):
             if points > 1:
                 # Apply icon to cell
                 my_icon = QPixmap(":/curves/keyframe-%s.png" % interpolation)
-                col.setData(my_icon, Qt.DecorationRole)
+                col.setData(my_icon, Qt.ItemDataRole.DecorationRole)
 
                 # Set the background color of the cell
                 if keyframe:
@@ -694,13 +696,13 @@ class PropertiesModel(updates.UpdateInterface):
                 col.setBackground(QColor(red, green, blue))
 
             if readonly or type in ["color", "font", "caption"] or choices or label == "Track":
-                col.setFlags(Qt.ItemIsEnabled)
+                col.setFlags(Qt.ItemFlag.ItemIsEnabled)
             else:
                 col.setFlags(
-                    Qt.ItemIsSelectable
-                    | Qt.ItemIsEnabled
-                    | Qt.ItemIsUserCheckable
-                    | Qt.ItemIsEditable)
+                    Qt.ItemFlag.ItemIsSelectable |
+                    Qt.ItemFlag.ItemIsEnabled |
+                    Qt.ItemFlag.ItemIsUserCheckable |
+                    Qt.ItemFlag.ItemIsEditable)
             row.append(col)
 
             # Append ROW to MODEL (if does not already exist in model)
@@ -771,7 +773,7 @@ class PropertiesModel(updates.UpdateInterface):
             if points > 1:
                 # Apply icon to cell
                 my_icon = QPixmap(":/curves/keyframe-%s.png" % interpolation)
-                col.setData(my_icon, Qt.DecorationRole)
+                col.setData(my_icon, Qt.ItemDataRole.DecorationRole)
 
                 # Set the background color of the cell
                 if keyframe:
@@ -785,7 +787,7 @@ class PropertiesModel(updates.UpdateInterface):
 
                 # clear icon
                 my_icon = QPixmap()
-                col.setData(my_icon, Qt.DecorationRole)
+                col.setData(my_icon, Qt.ItemDataRole.DecorationRole)
 
             if type == "color":
                 # Update the color based on the color curves

--- a/src/windows/models/titles_model.py
+++ b/src/windows/models/titles_model.py
@@ -62,7 +62,7 @@ class TitleStandardItemModel(QStandardItemModel):
 
 
 class TitleRoles:
-    PathRole = Qt.UserRole + 11
+    PathRole = Qt.ItemDataRole.UserRole + 11
 
 
 class TitlesModel(QObject):
@@ -151,7 +151,10 @@ class TitlesModel(QObject):
             icon.addFile(thumb_path)
 
             # Create item entry for model
-            flags = Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled
+            flags = (
+                Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsEnabled |
+                Qt.ItemFlag.ItemIsUserCheckable | Qt.ItemFlag.ItemIsDragEnabled
+            )
             item = QStandardItem(icon, title_name)
             item.setData(path, TitleRoles.PathRole)
             item.setToolTip(title_name)

--- a/src/windows/models/transition_model.py
+++ b/src/windows/models/transition_model.py
@@ -186,41 +186,32 @@ class TransitionsModel(QObject):
                         msg.exec_()
                         continue
 
+                flags = (
+                    Qt.ItemFlag.ItemIsSelectable |
+                    Qt.ItemFlag.ItemIsEnabled |
+                    Qt.ItemFlag.ItemIsUserCheckable |
+                    Qt.ItemFlag.ItemIsDragEnabled
+                )
                 row = []
 
                 # Load icon (using display DPI)
                 icon = QIcon()
                 icon.addFile(thumb_path)
 
-                # Append thumbnail
-                col = QStandardItem()
+                # Thumbnail
+                col = QStandardItem(trans_name)
                 col.setIcon(icon)
-                col.setText(trans_name)
                 col.setToolTip(trans_name)
                 col.setData(type)
-                col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
+                col.setFlags(flags)
                 row.append(col)
 
-                # Append Filename
-                col = QStandardItem("Name")
-                col.setData(trans_name, Qt.DisplayRole)
-                col.setText(trans_name)
-                col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
-                row.append(col)
-
-                # Append Media Type
-                col = QStandardItem("Type")
-                col.setData(type, Qt.DisplayRole)
-                col.setText(type)
-                col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
-                row.append(col)
-
-                # Append Path
-                col = QStandardItem("Path")
-                col.setData(path, Qt.DisplayRole)
-                col.setText(path)
-                col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsDragEnabled)
-                row.append(col)
+                # Filename, Media type, Path
+                for label in [trans_name, type, path]:
+                    col = QStandardItem(label)
+                    col.setData(label, Qt.ItemDataRole.DisplayRole)
+                    col.setFlags(flags)
+                    row.append(col)
 
                 # Append ROW to MODEL (if does not already exist in model)
                 if path not in self.model_paths:

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -155,14 +155,17 @@ class Preferences(QDialog):
                     # Create scrollarea
                     scroll_area = QScrollArea(self)
                     scroll_area.setWidgetResizable(True)
-                    scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
-                    scroll_area.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+                    scroll_area.setVerticalScrollBarPolicy(
+                        Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+                    scroll_area.setSizePolicy(
+                        QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
                     scroll_area.setMinimumSize(675, 100)
 
                     # Create tab widget and layout
                     layout = QVBoxLayout()
                     tabWidget = QWidget(self)
-                    tabWidget.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
+                    tabWidget.setSizePolicy(
+                        QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
                     tabWidget.setLayout(layout)
                     scroll_area.setWidget(tabWidget)
 
@@ -243,9 +246,9 @@ class Preferences(QDialog):
                     # create spinner
                     widget = QCheckBox()
                     if param["value"] is True:
-                        widget.setCheckState(Qt.Checked)
+                        widget.setCheckState(Qt.CheckState.Checked)
                     else:
-                        widget.setCheckState(Qt.Unchecked)
+                        widget.setCheckState(Qt.CheckState.Unchecked)
                     widget.stateChanged.connect(functools.partial(self.bool_value_changed, widget, param))
 
                 elif param["type"] == "dropdown":
@@ -398,8 +401,8 @@ class Preferences(QDialog):
                 if (widget and label and filterFound):
                     # Add minimum size
                     label.setMinimumWidth(180)
-                    label.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
-                    widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+                    label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+                    widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
 
                     # Create HBox layout
                     layout_hbox = QHBoxLayout()
@@ -461,7 +464,7 @@ class Preferences(QDialog):
 
     def bool_value_changed(self, widget, param, state):
         # Save setting
-        if state == Qt.Checked:
+        if state == Qt.CheckState.Checked:
             self.s.set(param["setting"], True)
         else:
             self.s.set(param["setting"], False)
@@ -469,15 +472,15 @@ class Preferences(QDialog):
         # Trigger specific actions
         if param["setting"] == "debug-mode":
             # Update debug setting of timeline
-            log.info("Setting debug-mode to %s", state == Qt.Checked)
-            debug_enabled = (state == Qt.Checked)
+            log.info("Setting debug-mode to %s", state == Qt.CheckState.Checked)
+            debug_enabled = (state == Qt.CheckState.Checked)
 
             # Enable / Disable logger
             openshot.ZmqLogger.Instance().Enable(debug_enabled)
 
         elif param["setting"] == "enable-auto-save":
             # Toggle autosave
-            if (state == Qt.Checked):
+            if state == Qt.CheckState.Checked:
                 # Start/Restart autosave timer
                 get_app().window.auto_save_timer.start()
             else:

--- a/src/windows/process_effect.py
+++ b/src/windows/process_effect.py
@@ -26,7 +26,6 @@
  """
 
 import os
-import time
 import json
 import functools
 import webbrowser
@@ -34,11 +33,8 @@ import webbrowser
 from PyQt5.QtCore import *
 from PyQt5.QtGui import QBrush
 from PyQt5.QtWidgets import *
-import openshot  # Python module for libopenshot (required video editing module installed separately)
 
-from classes import info, ui_util, qt_types, updates
-from classes.app import get_app
-from classes.logger import log
+from classes import ui_util
 from classes.metrics import *
 
 
@@ -105,8 +101,10 @@ class ProcessEffect(QDialog):
             if param["type"] == "link":
                 # create a clickable link
                 label.setText('<a href="%s" style="color: #FFFFFF">%s</a>' % (param["value"], _(param["title"])))
-                label.setTextInteractionFlags(Qt.TextBrowserInteraction)
-                label.linkActivated.connect(functools.partial(self.link_activated, widget, param))
+                label.setTextInteractionFlags(
+                    Qt.TextInteractionFlag.TextBrowserInteraction)
+                label.linkActivated.connect(
+                    functools.partial(self.link_activated, widget, param))
 
             if param["type"] == "spinner":
                 # create QDoubleSpinBox
@@ -157,10 +155,10 @@ class ProcessEffect(QDialog):
                 # create spinner
                 widget = QCheckBox()
                 if param["value"] == True:
-                    widget.setCheckState(Qt.Checked)
+                    widget.setCheckState(Qt.CheckState.Checked)
                     self.context[param["setting"]] = True
                 else:
-                    widget.setCheckState(Qt.Unchecked)
+                    widget.setCheckState(Qt.CheckState.Unchecked)
                     self.context[param["setting"]] = False
                 widget.stateChanged.connect(functools.partial(self.bool_value_changed, widget, param))
 
@@ -195,14 +193,14 @@ class ProcessEffect(QDialog):
             # Add Label and Widget to the form
             if widget and label:
                 # Add minimum size
-                label.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
-                widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+                label.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Preferred)
+                widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
 
                 # Create HBoxLayout for each field
                 self.scrollAreaWidgetContents.layout().insertRow(row_count, label, widget)
 
             elif not widget and label:
-                label.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Preferred)
+                label.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
                 self.scrollAreaWidgetContents.layout().insertRow(row_count, label)
 
             row_count += 1
@@ -215,8 +213,8 @@ class ProcessEffect(QDialog):
         # Add buttons
         self.cancel_button = QPushButton(_('Cancel'))
         self.process_button = QPushButton(_('Process Effect'))
-        self.buttonBox.addButton(self.process_button, QDialogButtonBox.AcceptRole)
-        self.buttonBox.addButton(self.cancel_button, QDialogButtonBox.RejectRole)
+        self.buttonBox.addButton(self.process_button, QDialogButtonBox.ButtonRole.AcceptRole)
+        self.buttonBox.addButton(self.cancel_button, QDialogButtonBox.ButtonRole.RejectRole)
 
         # flag to close the clip processing thread
         self.cancel_clip_processing = False
@@ -233,7 +231,7 @@ class ProcessEffect(QDialog):
 
     def bool_value_changed(self, widget, param, state):
         """Boolean value change callback"""
-        if state == Qt.Checked:
+        if state == Qt.CheckState.Checked:
             self.context[param["setting"]] = True
         else:
             self.context[param["setting"]] = False
@@ -271,13 +269,12 @@ class ProcessEffect(QDialog):
         if f:
             win = SelectRegion(f, self.clip_instance)
             # Run the dialog event loop - blocking interaction on this window during that time
-            result = win.exec_()
-            if result == QDialog.Accepted:
+            result = win.exec()
+            if result == QDialog.DialogCode.Accepted:
                 # self.first_frame = win.current_frame
                 # Region selected (get coordinates if any)
                 topLeft = win.videoPreview.regionTopLeftHandle
                 bottomRight = win.videoPreview.regionBottomRightHandle
-                viewPortSize = win.viewport_rect
                 curr_frame_size = win.videoPreview.curr_frame_size
 
                 x1 = topLeft.x() / curr_frame_size.width()
@@ -290,7 +287,7 @@ class ProcessEffect(QDialog):
                     region_qimage = win.videoPreview.region_qimage
 
                     # Resize QImage to match button size
-                    resized_qimage = region_qimage.scaled(widget.size(), Qt.IgnoreAspectRatio, Qt.SmoothTransformation)
+                    resized_qimage = region_qimage.scaled(widget.size(), Qt.AspectRatioMode.IgnoreAspectRatio, Qt.TransformationMode.SmoothTransformation)
 
                     # Draw Qimage onto QPushButton (to display region selection to user)
                     palette = widget.palette()

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -26,22 +26,16 @@
  """
 
 import os
-import sys
 import functools
-import math
 
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
-import openshot  # Python module for libopenshot (required video editing module installed separately)
 
-from classes import info, ui_util, time_parts, qt_types, updates
-from classes.app import get_app
-from classes.logger import log
+from classes import ui_util, time_parts
 from classes.metrics import *
 from windows.preview_thread import PreviewParent
 from windows.video_widget import VideoWidget
 
-import json
 
 class SelectRegion(QDialog):
     """ SelectRegion Dialog """
@@ -113,7 +107,8 @@ class SelectRegion(QDialog):
 
         # Add Video Widget
         self.videoPreview = VideoWidget()
-        self.videoPreview.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
+        self.videoPreview.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
         self.verticalLayout.insertWidget(0, self.videoPreview)
 
         # Set aspect ratio to match source content
@@ -122,7 +117,8 @@ class SelectRegion(QDialog):
         self.videoPreview.aspect_ratio = aspect_ratio
 
         # Set max size of video preview (for speed)
-        self.viewport_rect = self.videoPreview.centeredViewport(self.width, self.height)
+        self.viewport_rect = self.videoPreview.centeredViewport(
+            self.width, self.height)
 
         # Create an instance of a libopenshot Timeline object
         self.r = openshot.Timeline(self.viewport_rect.width(), self.viewport_rect.height(), openshot.Fraction(self.fps_num, self.fps_den), self.sample_rate, self.channels, self.channel_layout)
@@ -170,8 +166,8 @@ class SelectRegion(QDialog):
         # Add buttons
         self.cancel_button = QPushButton(_('Cancel'))
         self.process_button = QPushButton(_('Select Region'))
-        self.buttonBox.addButton(self.process_button, QDialogButtonBox.AcceptRole)
-        self.buttonBox.addButton(self.cancel_button, QDialogButtonBox.RejectRole)
+        self.buttonBox.addButton(self.process_button, QDialogButtonBox.ButtonRole.AcceptRole)
+        self.buttonBox.addButton(self.cancel_button, QDialogButtonBox.ButtonRole.RejectRole)
 
         # Connect signals
         self.actionPlay.triggered.connect(self.actionPlay_Triggered)

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -38,10 +38,9 @@ import tempfile
 from xml.dom import minidom
 
 from PyQt5.QtCore import Qt, pyqtSlot, QTimer
-from PyQt5 import QtGui
+from PyQt5.QtGui import QColor, QFont, QFontInfo, QIcon
 from PyQt5.QtWidgets import (
-    QWidget, QGraphicsScene,
-    QMessageBox, QDialog, QColorDialog, QFontDialog,
+    QWidget, QMessageBox, QDialog, QDialogButtonBox, QColorDialog, QFontDialog,
     QPushButton, QLineEdit, QLabel
 )
 
@@ -51,7 +50,6 @@ from classes import info, ui_util
 from classes.logger import log
 from classes.app import get_app
 from classes.metrics import track_metric_screen
-from windows.views.titles_listview import TitlesListView
 from windows.color_picker import ColorPicker
 from classes.style_tools import style_to_dict, dict_to_style, set_if_existing
 from windows.views.titles_listview import TitlesListView
@@ -93,8 +91,8 @@ class TitleEditor(QDialog):
         imp = minidom.getDOMImplementation()
         self.xmldoc = imp.createDocument(None, "any", None)
 
-        self.bg_color_code = QtGui.QColor(Qt.black)
-        self.font_color_code = QtGui.QColor(Qt.white)
+        self.bg_color_code = QColor(Qt.GlobalColor.black)
+        self.font_color_code = QColor(Qt.GlobalColor.white)
 
         self.bg_style_string = ""
         self.title_style_string = ""
@@ -112,14 +110,14 @@ class TitleEditor(QDialog):
         self.font_family = "Bitstream Vera Sans"
         self.tspan_nodes = None
 
-        self.qfont = QtGui.QFont(self.font_family)
+        self.qfont = QFont(self.font_family)
 
         # Add titles list view
         self.titlesView = TitlesListView(parent=self, window=self)
         self.verticalLayout.addWidget(self.titlesView)
 
         # Disable Save button on window load
-        self.buttonBox.button(self.buttonBox.Save).setEnabled(False)
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Save).setEnabled(False)
 
         # If editing existing title svg file
         if self.edit_file_path:
@@ -183,7 +181,7 @@ class TitleEditor(QDialog):
         clip.Close()
 
         # Attempt to load saved thumbnail
-        display_pixmap = QtGui.QIcon(tmp_filename).pixmap(self.lblPreviewLabel.size())
+        display_pixmap = QIcon(tmp_filename).pixmap(self.lblPreviewLabel.size())
 
         # Display temp image
         self.lblPreviewLabel.setPixmap(display_pixmap)
@@ -217,7 +215,7 @@ class TitleEditor(QDialog):
         self.font_family = "Bitstream Vera Sans"
         if self.qfont:
             del self.qfont
-        self.qfont = QtGui.QFont(self.font_family)
+        self.qfont = QFont(self.font_family)
 
         # Loop through child widgets (and remove them)
         for child in self.settingsContainer.children():
@@ -370,7 +368,7 @@ class TitleEditor(QDialog):
         self.writeToFile(self.xmldoc)
         self.display_svg()
 
-    @pyqtSlot(QtGui.QColor)
+    @pyqtSlot(QColor)
     def color_callback(self, save_fn, refresh_fn, color):
         """Update SVG color after user selection"""
         if not color or not color.isValid():
@@ -380,14 +378,14 @@ class TitleEditor(QDialog):
         self.update_timer.start()
 
     @staticmethod
-    def best_contrast(bg: QtGui.QColor) -> QtGui.QColor:
+    def best_contrast(bg: QColor) -> QColor:
         """Choose text color for best contrast against a background"""
         colrgb = bg.getRgbF()
         # Compute perceptive luminance of background color
         lum = (0.299 * colrgb[0] + 0.587 * colrgb[1] + 0.114 * colrgb[2])
         if (lum < 0.5):
-            return QtGui.QColor(Qt.white)
-        return QtGui.QColor(Qt.black)
+            return QColor(Qt.GlobalColor.white)
+        return QColor(Qt.GlobalColor.black)
 
     def btnFontColor_clicked(self):
         app = get_app()
@@ -402,7 +400,7 @@ class TitleEditor(QDialog):
         ColorPicker(
             self.font_color_code, parent=self,
             title=_("Select a Color"),
-            extra_options=QColorDialog.ShowAlphaChannel,
+            extra_options=QColorDialog.ColorDialogOption.ShowAlphaChannel,
             callback=callback_func)
 
     def btnBackgroundColor_clicked(self):
@@ -418,7 +416,7 @@ class TitleEditor(QDialog):
         ColorPicker(
             self.bg_color_code, parent=self,
             title=_("Select a Color"),
-            extra_options=QColorDialog.ShowAlphaChannel,
+            extra_options=QColorDialog.ColorDialogOption.ShowAlphaChannel,
             callback=callback_func)
 
     def btnFont_clicked(self):
@@ -434,8 +432,8 @@ class TitleEditor(QDialog):
         # Update SVG font
         if ok and font is not oldfont:
             self.qfont = font
-            fontinfo = QtGui.QFontInfo(font)
-            oldfontinfo = QtGui.QFontInfo(oldfont)
+            fontinfo = QFontInfo(font)
+            oldfontinfo = QFontInfo(oldfont)
             self.font_family = fontinfo.family()
             self.font_style = fontinfo.styleName()
             self.font_weight = fontinfo.weight()
@@ -465,7 +463,7 @@ class TitleEditor(QDialog):
             # Get opacity or default to opaque
             opacity = float(ard.get("opacity", 1.0))
 
-            color = QtGui.QColor(color)
+            color = QColor(color)
             text_color = self.best_contrast(color)
             # Set the color of the button, ignoring alpha
             self.btnFontColor.setStyleSheet(
@@ -512,7 +510,7 @@ class TitleEditor(QDialog):
             color = ard.get("fill", "#000")
             opacity = float(ard.get("opacity", 1.0))
 
-            color = QtGui.QColor(color)
+            color = QColor(color)
             text_color = self.best_contrast(color)
 
             # Set the colors of the button, ignoring opacity
@@ -596,9 +594,10 @@ class TitleEditor(QDialog):
                     ret = QMessageBox.question(
                         self, _("Title Editor"),
                         _("%s already exists.\nDo you want to replace it?") % file_name,
-                        QMessageBox.No | QMessageBox.Yes
+                        QMessageBox.StandardButton.No
+                        | QMessageBox.StandardButton.Yes
                     )
-                    if ret == QMessageBox.No:
+                    if ret == QMessageBox.StandardButton.No:
                         # Do nothing
                         return
 

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -320,9 +320,9 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         # Paint custom frame image on QWidget
         painter = QPainter(self)
         painter.setRenderHints(
-            QPainter.Antialiasing
-            | QPainter.SmoothPixmapTransform
-            | QPainter.TextAntialiasing,
+            QPainter.RenderHint.Antialiasing |
+            QPainter.RenderHint.SmoothPixmapTransform |
+            QPainter.RenderHint.TextAntialiasing,
             True)
 
         # Fill the whole widget with the solid color
@@ -335,12 +335,12 @@ class VideoWidget(QWidget, updates.UpdateInterface):
             # DRAW FRAME
             # Calculate new frame image size, maintaining aspect ratio
             pixSize = self.current_image.size()
-            pixSize.scale(event.rect().size(), Qt.KeepAspectRatio)
+            pixSize.scale(event.rect().size(), Qt.AspectRatioMode.KeepAspectRatio)
             self.curr_frame_size = pixSize
 
             # Scale image (take into account display scaling for High DPI monitors)
             scale = self.devicePixelRatioF()
-            scaledPix = self.current_image.scaled(pixSize * scale, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+            scaledPix = self.current_image.scaled(pixSize * scale, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
 
             # Calculate center of QWidget and Draw image
             painter.drawImage(viewport_rect, scaledPix)
@@ -383,13 +383,13 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                 scale = openshot.SCALE_STRETCH
 
             if scale == openshot.SCALE_FIT:
-                source_size.scale(player_width, player_height, Qt.KeepAspectRatio)
+                source_size.scale(player_width, player_height, Qt.AspectRatioMode.KeepAspectRatio)
 
             elif scale == openshot.SCALE_STRETCH:
-                source_size.scale(player_width, player_height, Qt.IgnoreAspectRatio)
+                source_size.scale(player_width, player_height, Qt.AspectRatioMode.IgnoreAspectRatio)
 
             elif scale == openshot.SCALE_CROP:
-                source_size.scale(player_width, player_height, Qt.KeepAspectRatioByExpanding)
+                source_size.scale(player_width, player_height, Qt.AspectRatioMode.KeepAspectRatioByExpanding)
 
             # Get new source width / height (after scaling mode applied)
             source_width = source_size.width()
@@ -559,7 +559,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
         aspectRatio = self.aspect_ratio.ToFloat() * self.pixel_ratio.ToFloat()
         viewport_size = QSizeF(aspectRatio, 1).scaled(
-                            window_size, Qt.KeepAspectRatio
+                            window_size, Qt.AspectRatioMode.KeepAspectRatio
                         ) * self.zoom
         viewport_rect = QRectF(QPointF(0, 0), viewport_size)
         viewport_rect.moveCenter(window_rect.center())
@@ -636,17 +636,17 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
             # Render QWidget onto scaled QImage
             self.region_qimage = QImage(
-                mapped_region_rect.size(), QImage.Format_RGBA8888)
+                mapped_region_rect.size(), QImage.Format.Format_RGBA8888)
             region_painter = QPainter(self.region_qimage)
             region_painter.setRenderHints(
-                QPainter.Antialiasing
-                | QPainter.SmoothPixmapTransform
-                | QPainter.TextAntialiasing,
+                QPainter.RenderHint.Antialiasing
+                | QPainter.RenderHint.SmoothPixmapTransform
+                | QPainter.RenderHint.TextAntialiasing,
                 True)
             region_painter.scale(scale, scale)
             self.render(
                 region_painter, QPoint(0, 0),
-                QRegion(mapped_region_rect, QRegion.Rectangle))
+                QRegion(mapped_region_rect, QRegion.RegionType.Rectangle))
             region_painter.end()
 
         # Inform UpdateManager to accept updates, and only store our final update
@@ -663,7 +663,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         """Rotate cursor based on the current transform"""
         rotated_pixmap = pixmap.transformed(
             QTransform().rotate(rotation).shear(shear_x, shear_y).scale(0.8, 0.8),
-            Qt.SmoothTransformation)
+            Qt.TransformationMode.SmoothTransformation)
         return QCursor(rotated_pixmap)
 
     def checkTransformMode(self, rotation, shear_x, shear_y, event):
@@ -693,7 +693,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
             and self.resize_button.isVisible()
             and self.resize_button.rect().contains(event.pos())
         ):
-            self.setCursor(Qt.ArrowCursor)
+            self.setCursor(Qt.CursorShape.ArrowCursor)
             self.transform_mode = None
             return
 
@@ -701,7 +701,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         for h in handle_uis:
             if self.transform.mapToPolygon(
                     h["handle"].toRect()
-                    ).containsPoint(event.pos(), Qt.OddEvenFill):
+                    ).containsPoint(event.pos(), Qt.FillRule.OddEvenFill):
                 # Handle contains cursor
                 if self.transform_mode and self.transform_mode != h["mode"]:
                     # We're in different xform mode, skip
@@ -714,7 +714,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
         # If not over any handles, determne inside/outside clip rectangle
         r = non_handle_uis.get("region")
-        if self.transform.mapToPolygon(r.toRect()).containsPoint(event.pos(), Qt.OddEvenFill):
+        if self.transform.mapToPolygon(r.toRect()).containsPoint(event.pos(), Qt.FillRule.OddEvenFill):
             nh = non_handle_uis.get("inside", {})
         else:
             nh = non_handle_uis.get("outside", {})
@@ -931,7 +931,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                     elif self.transform_mode == 'scale_right':
                         scale_x += x_motion / half_w
 
-                    if int(QCoreApplication.instance().keyboardModifiers() & Qt.ControlModifier) > 0:
+                    if int(QCoreApplication.instance().keyboardModifiers() & Qt.KeyboardModifier.ControlModifier) > 0:
                         # If CTRL key is pressed, fix the scale_y to the correct aspect ration
                         if scale_x:
                             scale_y = scale_x
@@ -964,12 +964,12 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                 and self.resize_button.rect().contains(event.pos())
             ):
                 # Mouse over resize button (and not currently dragging)
-                self.setCursor(Qt.ArrowCursor)
+                self.setCursor(Qt.CursorShape.ArrowCursor)
             elif (
                     self.region_transform
                     and self.regionTopLeftHandle
                     and self.region_transform.mapToPolygon(
-                        self.regionTopLeftHandle.toRect()).containsPoint(event.pos(), Qt.OddEvenFill)
+                        self.regionTopLeftHandle.toRect()).containsPoint(event.pos(), Qt.FillRule.OddEvenFill)
                     ):
                 if not self.region_mode or self.region_mode == 'scale_top_left':
                     self.setCursor(self.rotateCursor(self.cursors.get('resize_fdiag'), 0, 0, 0))
@@ -980,7 +980,8 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                     self.region_transform
                     and self.regionBottomRightHandle
                     and self.region_transform.mapToPolygon(
-                        self.regionBottomRightHandle.toRect()).containsPoint(event.pos(), Qt.OddEvenFill)
+                        self.regionBottomRightHandle.toRect()
+                        ).containsPoint(event.pos(), Qt.FillRule.OddEvenFill)
                     ):
                 if not self.region_mode or self.region_mode == 'scale_bottom_right':
                     self.setCursor(self.rotateCursor(self.cursors.get('resize_fdiag'), 0, 0, 0))
@@ -988,7 +989,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                 if self.mouse_dragging and not self.region_mode:
                     self.region_mode = 'scale_bottom_right'
             else:
-                self.setCursor(Qt.ArrowCursor)
+                self.setCursor(Qt.CursorShape.ArrowCursor)
 
             # Initialize new region coordinates at current event.pos()
             if self.mouse_dragging and not self.region_mode:
@@ -1132,7 +1133,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                         elif self.transform_mode == 'scale_right':
                             scale_x += x_motion / half_w
 
-                        if int(QCoreApplication.instance().keyboardModifiers() & Qt.ControlModifier) > 0:
+                        if int(QCoreApplication.instance().keyboardModifiers() & Qt.KeyboardModifier.ControlModifier) > 0:
                             # If CTRL key is pressed, fix the scale_y to the correct aspect ratio
                             if scale_x:
                                 scale_y = scale_x
@@ -1343,7 +1344,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
         # Scale project size (with aspect ratio) to the delayed widget size
         project_size = QSize(get_app().project.get("width"), get_app().project.get("height"))
-        project_size.scale(self.delayed_size, Qt.KeepAspectRatio)
+        project_size.scale(self.delayed_size, Qt.AspectRatioMode.KeepAspectRatio)
 
         if project_size.height() > 0:
             # Ensure width and height are divisible by 2
@@ -1459,8 +1460,8 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.mutex = QMutex()
 
         # Init Qt widget's properties (background repainting, etc...)
-        super().setAttribute(Qt.WA_OpaquePaintEvent)
-        super().setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
+        super().setAttribute(Qt.WidgetAttribute.WA_OpaquePaintEvent)
+        super().setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
 
         # Add self as listener to project data updates (used to update the timeline)
         get_app().updates.add_listener(self)
@@ -1475,11 +1476,11 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.win = get_app().window
 
         # Update title whenever playback speed changes.
-        self.win.PlaySignal.connect(self.update_title, Qt.QueuedConnection)
-        self.win.PlaySignal.connect(self.update_title, Qt.QueuedConnection)
-        self.win.PauseSignal.connect(self.update_title, Qt.QueuedConnection)
-        self.win.SpeedSignal.connect(self.update_title, Qt.QueuedConnection)
-        self.win.StopSignal.connect(self.update_title, Qt.QueuedConnection)
+        self.win.PlaySignal.connect(self.update_title, Qt.ConnectionType.QueuedConnection)
+        self.win.PlaySignal.connect(self.update_title, Qt.ConnectionType.QueuedConnection)
+        self.win.PauseSignal.connect(self.update_title, Qt.ConnectionType.QueuedConnection)
+        self.win.SpeedSignal.connect(self.update_title, Qt.ConnectionType.QueuedConnection)
+        self.win.StopSignal.connect(self.update_title, Qt.ConnectionType.QueuedConnection)
 
         # Show Property timer
         # Timer to use a delay before sending MaxSizeChanged signals (so we don't spam libopenshot)

--- a/src/windows/views/add_to_timeline_treeview.py
+++ b/src/windows/views/add_to_timeline_treeview.py
@@ -25,7 +25,6 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-from PyQt5.QtCore import QSize
 from PyQt5.QtWidgets import QTreeView, QAbstractItemView
 
 from classes import info
@@ -77,8 +76,7 @@ class TimelineTreeView(QTreeView):
         self.setModel(self.timeline_model.model)
         self.setIconSize(info.TREE_ICON_SIZE)
         self.setIndentation(0)
-        self.setSelectionBehavior(QTreeView.SelectRows)
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.setWordWrap(True)
         self.setStyleSheet('QTreeView::item { padding-top: 2px; }')
 

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -41,13 +41,13 @@ except ImportError:
     from xml.dom import minidom as xml
 
 from PyQt5.QtCore import (
-    Qt, QObject, pyqtSlot, pyqtSignal, QThread, QTimer, QSize,
+    Qt, QObject, pyqtSlot, pyqtSignal, QThread, QTimer
 )
 from PyQt5.QtWidgets import (
     QApplication, QListView, QMessageBox,
     QComboBox, QDoubleSpinBox, QLabel, QPushButton, QLineEdit, QPlainTextEdit,
 )
-from PyQt5.QtGui import QColor, QImage, QPixmap, QIcon
+from PyQt5.QtGui import QColor, QIcon
 
 from classes import info
 from classes.logger import log
@@ -270,7 +270,7 @@ class BlenderListView(QListView):
 
         # Show 'Wait' cursor
         if cursor:
-            QApplication.setOverrideCursor(Qt.WaitCursor)
+            QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
 
     @pyqtSlot()
     def end_processing(self):
@@ -588,7 +588,6 @@ Blender Path: {}
 
     def Cancel(self):
         """Cancel the current render, if any"""
-        #QMetaObject.invokeMethod(self.worker, 'Cancel', Qt.DirectConnection)
         self.cancel_render.emit()
 
     def Render(self, frame=None):
@@ -637,7 +636,7 @@ Blender Path: {}
 
         # Cleanup signals all 'round
         self.worker.finished.connect(self.worker.deleteLater)
-        self.worker.finished.connect(self.background.quit, Qt.DirectConnection)
+        self.worker.finished.connect(self.background.quit, Qt.ConnectionType.DirectConnection)
         self.background.finished.connect(self.background.deleteLater)
         self.background.finished.connect(self.worker.deleteLater)
 
@@ -685,11 +684,11 @@ Blender Path: {}
         self.setModel(self.blender_model.model)
         self.setIconSize(info.LIST_ICON_SIZE)
         self.setGridSize(info.LIST_GRID_SIZE)
-        self.setViewMode(QListView.IconMode)
-        self.setResizeMode(QListView.Adjust)
+        self.setViewMode(QListView.ViewMode.IconMode)
+        self.setResizeMode(QListView.ResizeMode.Adjust)
         self.setUniformItemSizes(True)
         self.setWordWrap(True)
-        self.setTextElideMode(Qt.ElideRight)
+        self.setTextElideMode(Qt.TextElideMode.ElideRight)
 
         # Hook up controls
         self.win.btnRefresh.clicked.connect(self.preview_timer.start)

--- a/src/windows/views/changelog_treeview.py
+++ b/src/windows/views/changelog_treeview.py
@@ -26,20 +26,17 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-import os
+
 import webbrowser
-from urllib.parse import urlparse
 from functools import partial
 
-from PyQt5.QtCore import QSize, Qt, QPoint
-from PyQt5.QtWidgets import QListView, QTreeView, QMessageBox, QAbstractItemView, QMenu, QSizePolicy, QHeaderView, QApplication
+from PyQt5.QtWidgets import QListView, QTreeView, QAbstractItemView, QMenu, QSizePolicy, QHeaderView, QApplication
 from PyQt5.QtGui import QCursor
 
 from classes.logger import log
 from classes.app import get_app
 from windows.models.changelog_model import ChangelogModel
 
-import json
 
 class ChangelogTreeView(QTreeView):
     """ A ListView QWidget used on the changelog window """
@@ -50,8 +47,8 @@ class ChangelogTreeView(QTreeView):
         self.changelog_model.update_model(filter=filter)
 
         # Format columns
-        self.header().setSectionResizeMode(0, QHeaderView.Fixed)
-        self.header().setSectionResizeMode(1, QHeaderView.Fixed)
+        self.header().setSectionResizeMode(0, QHeaderView.ResizeMode.Fixed)
+        self.header().setSectionResizeMode(1, QHeaderView.ResizeMode.Fixed)
         self.setColumnWidth(0, 70)
         self.setColumnWidth(1, 85)
         self.setColumnWidth(2, 125)
@@ -101,10 +98,9 @@ class ChangelogTreeView(QTreeView):
         # Setup header columns
         self.setModel(self.changelog_model.model)
         self.setIndentation(0)
-        self.setSelectionBehavior(QTreeView.SelectRows)
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.setSelectionMode(QAbstractItemView.ExtendedSelection)
-        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.setWordWrap(True)
         self.setStyleSheet('QTreeView::item { padding-top: 2px; }')
         self.commit_url = commit_url

--- a/src/windows/views/credits_treeview.py
+++ b/src/windows/views/credits_treeview.py
@@ -26,12 +26,10 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-import os
-from urllib.parse import urlparse
 
 import webbrowser
-from PyQt5.QtCore import QSize, Qt, QPoint
-from PyQt5.QtWidgets import QListView, QTreeView, QMessageBox, QAbstractItemView, QMenu, QSizePolicy, QHeaderView, QApplication
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QListView, QTreeView, QAbstractItemView, QMenu, QSizePolicy, QHeaderView, QApplication
 from PyQt5.QtGui import QCursor
 from functools import partial
 
@@ -39,7 +37,6 @@ from classes.logger import log
 from classes.app import get_app
 from windows.models.credits_model import CreditsModel
 
-import json
 
 class CreditsTreeView(QTreeView):
     """ A ListView QWidget used on the credits window """
@@ -50,14 +47,14 @@ class CreditsTreeView(QTreeView):
         self.credits_model.update_model(filter=filter)
 
         # Format columns
-        self.header().setSectionResizeMode(0, QHeaderView.Fixed)
-        self.header().setSectionResizeMode(1, QHeaderView.Fixed)
+        self.header().setSectionResizeMode(0, QHeaderView.ResizeMode.Fixed)
+        self.header().setSectionResizeMode(1, QHeaderView.ResizeMode.Fixed)
         self.setColumnWidth(0, 22)
         self.setColumnWidth(1, 22)
         self.setColumnWidth(2, 150)
         self.setColumnWidth(3, 150)
         self.setColumnWidth(4, 150)
-        self.sortByColumn(2, Qt.AscendingOrder)
+        self.sortByColumn(2, Qt.SortOrder.AscendingOrder)
 
         if "email" not in self.columns:
             self.setColumnHidden(3, True)
@@ -110,10 +107,9 @@ class CreditsTreeView(QTreeView):
         # Setup header columns
         self.setModel(self.credits_model.model)
         self.setIndentation(0)
-        self.setSelectionBehavior(QTreeView.SelectRows)
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.setSelectionMode(QAbstractItemView.ExtendedSelection)
-        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.setWordWrap(True)
         self.setStyleSheet('QTreeView::item { padding-top: 2px; }')
         self.columns = columns

--- a/src/windows/views/effects_listview.py
+++ b/src/windows/views/effects_listview.py
@@ -25,7 +25,7 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-from PyQt5.QtCore import QSize, QPoint, Qt, QRegExp
+from PyQt5.QtCore import QSize, QPoint, Qt, QRegularExpression
 from PyQt5.QtGui import QDrag
 from PyQt5.QtWidgets import QListView, QMenu, QAbstractItemView
 
@@ -65,7 +65,7 @@ class EffectsListView(QListView):
             return False
 
         # Get icon from column 0 on same row as current item
-        icon = current.sibling(current.row(), 0).data(Qt.DecorationRole)
+        icon = current.sibling(current.row(), 0).data(Qt.ItemDataRole.DecorationRole)
 
         # Start drag operation
         drag = QDrag(self)
@@ -80,9 +80,10 @@ class EffectsListView(QListView):
     def refresh_view(self):
         """Filter transitions with proxy class"""
         filter_text = self.win.effectsFilter.text()
-        self.model().setFilterRegExp(QRegExp(filter_text.replace(' ', '.*')))
-        self.model().setFilterCaseSensitivity(Qt.CaseInsensitive)
-        self.model().sort(Qt.AscendingOrder)
+        self.model().setFilterRegularExpression(QRegularExpression(
+            filter_text.replace(' ', '.*'),
+            QRegularExpression.PatternOption.CaseInsensitiveOption))
+        self.model().sort(Qt.SortOrder.AscendingOrder)
 
     def __init__(self, model):
         # Invoke parent init
@@ -103,18 +104,18 @@ class EffectsListView(QListView):
 
         # Remove the default selection model and wire up to the shared one
         self.selectionModel().deleteLater()
-        self.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        self.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.setSelectionModel(self.effects_model.selection_model)
 
         # Setup header columns
         self.setIconSize(info.LIST_ICON_SIZE)
         self.setGridSize(info.LIST_GRID_SIZE)
-        self.setViewMode(QListView.IconMode)
-        self.setResizeMode(QListView.Adjust)
+        self.setViewMode(QListView.ViewMode.IconMode)
+        self.setResizeMode(QListView.ResizeMode.Adjust)
         self.setUniformItemSizes(True)
         self.setWordWrap(False)
-        self.setTextElideMode(Qt.ElideRight)
+        self.setTextElideMode(Qt.TextElideMode.ElideRight)
         self.setStyleSheet('QListView::item { padding-top: 2px; }')
 
         # setup filter events

--- a/src/windows/views/effects_treeview.py
+++ b/src/windows/views/effects_treeview.py
@@ -66,7 +66,7 @@ class EffectsTreeView(QTreeView):
             return False
 
         # Get icon from column 0 on same row as current item
-        icon = current.sibling(current.row(), 0).data(Qt.DecorationRole)
+        icon = current.sibling(current.row(), 0).data(Qt.ItemDataRole.DecorationRole)
 
         # Start drag operation
         drag = QDrag(self)
@@ -101,14 +101,14 @@ class EffectsTreeView(QTreeView):
 
         # Remove the default selection model and wire up to the shared one
         self.selectionModel().deleteLater()
-        self.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        self.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.setSelectionModel(self.effects_model.selection_model)
 
         # Setup header columns
         self.setIconSize(info.TREE_ICON_SIZE)
         self.setIndentation(0)
-        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.setWordWrap(True)
         self.setStyleSheet('QTreeView::item { padding-top: 2px; }')
         self.effects_model.ModelRefreshed.connect(self.refresh_columns)

--- a/src/windows/views/emojis_listview.py
+++ b/src/windows/views/emojis_listview.py
@@ -25,7 +25,7 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-from PyQt5.QtCore import QMimeData, QSize, QPoint, Qt, pyqtSlot, QRegExp
+from PyQt5.QtCore import QMimeData, QSize, QPoint, Qt, pyqtSlot, QRegularExpression
 from PyQt5.QtGui import QDrag
 from PyQt5.QtWidgets import QListView
 
@@ -45,7 +45,7 @@ class EmojisListView(QListView):
     def dragEnterEvent(self, event):
         # If dragging urls onto widget, accept
         if event.mimeData().hasUrls():
-            event.setDropAction(Qt.CopyAction)
+            event.setDropAction(Qt.DropAction.CopyAction)
             event.accept()
 
     def startDrag(self, event):
@@ -57,7 +57,7 @@ class EmojisListView(QListView):
         # Start drag operation
         drag = QDrag(self)
         drag.setMimeData(self.model.mimeData(selected))
-        icon = self.model.data(selected[0], Qt.DecorationRole)
+        icon = self.model.data(selected[0], Qt.ItemDataRole.DecorationRole)
         drag.setPixmap(icon.pixmap(self.drag_item_size))
         drag.setHotSpot(self.drag_item_center)
 
@@ -128,7 +128,9 @@ class EmojisListView(QListView):
     def filter_changed(self, filter_text=None):
         """Filter emoji with proxy class"""
 
-        self.model.setFilterRegExp(QRegExp(filter_text, Qt.CaseInsensitive))
+        self.model().setFilterRegularExpression(QRegularExpression(
+            filter_text,
+            QRegularExpression.PatternOption.CaseInsensitiveOption))
         self.model.setFilterKeyColumn(0)
         self.refresh_view()
 
@@ -159,8 +161,8 @@ class EmojisListView(QListView):
         self.setModel(self.model)
         self.setIconSize(info.EMOJI_ICON_SIZE)
         self.setGridSize(info.EMOJI_GRID_SIZE)
-        self.setViewMode(QListView.IconMode)
-        self.setResizeMode(QListView.Adjust)
+        self.setViewMode(QListView.ViewMode.IconMode)
+        self.setResizeMode(QListView.ResizeMode.Adjust)
         self.setUniformItemSizes(True)
         self.setWordWrap(False)
         self.setStyleSheet('QListView::item { padding-top: 2px; }')

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -26,7 +26,7 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-from PyQt5.QtCore import QSize, Qt, QPoint, QRegExp
+from PyQt5.QtCore import QSize, Qt, QPoint, QRegularExpression
 from PyQt5.QtGui import QDrag, QCursor
 from PyQt5.QtWidgets import QListView, QAbstractItemView, QMenu
 
@@ -62,7 +62,7 @@ class FilesListView(QListView):
 
             # Look up file_id from 5th column of row
             id_index = index.sibling(index.row(), 5)
-            file_id = model.data(id_index, Qt.DisplayRole)
+            file_id = model.data(id_index, Qt.ItemDataRole.DisplayRole)
 
             # If a valid file selected, show file related options
             menu.addSeparator()
@@ -94,7 +94,7 @@ class FilesListView(QListView):
             event.ignore()
             return
         event.accept()
-        event.setDropAction(Qt.CopyAction)
+        event.setDropAction(Qt.DropAction.CopyAction)
 
     def startDrag(self, supportedActions):
         """ Override startDrag method to display custom icon """
@@ -112,7 +112,7 @@ class FilesListView(QListView):
             return False
 
         # Get icon from column 0 on same row as current item
-        icon = current.sibling(current.row(), 0).data(Qt.DecorationRole)
+        icon = current.sibling(current.row(), 0).data(Qt.ItemDataRole.DecorationRole)
 
         # Start drag operation
         drag = QDrag(self)
@@ -135,7 +135,7 @@ class FilesListView(QListView):
         # Use try/finally so we always reset the cursor
         try:
             # Set cursor to waiting
-            get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
+            get_app().setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
             qurl_list = event.mimeData().urls()
             log.info("Processing drop event for {} urls".format(len(qurl_list)))
@@ -155,7 +155,9 @@ class FilesListView(QListView):
         """Filter files with proxy class"""
         model = self.model()
         filter_text = self.win.filesFilter.text()
-        model.setFilterRegExp(QRegExp(filter_text.replace(' ', '.*'), Qt.CaseInsensitive))
+        self.model().setFilterRegularExpression(QRegularExpression(
+            filter_text.replace(' ', '.*'),
+            QRegularExpression.PatternOption.CaseInsensitiveOption))
 
         col = model.sortColumn()
         model.sort(col)
@@ -176,8 +178,8 @@ class FilesListView(QListView):
 
         # Remove the default selection model and wire up to the shared one
         self.selectionModel().deleteLater()
-        self.setSelectionMode(QAbstractItemView.ExtendedSelection)
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.setSelectionModel(self.files_model.selection_model)
 
         # Keep track of mouse press start position to determine when to start drag
@@ -188,14 +190,14 @@ class FilesListView(QListView):
         # Setup header columns and layout
         self.setIconSize(info.LIST_ICON_SIZE)
         self.setGridSize(info.LIST_GRID_SIZE)
-        self.setViewMode(QListView.IconMode)
-        self.setResizeMode(QListView.Adjust)
+        self.setViewMode(QListView.ViewMode.IconMode)
+        self.setResizeMode(QListView.ResizeMode.Adjust)
 
         self.setUniformItemSizes(True)
         self.setStyleSheet('QListView::item { padding-top: 2px; }')
 
         self.setWordWrap(False)
-        self.setTextElideMode(Qt.ElideRight)
+        self.setTextElideMode(Qt.TextElideMode.ElideRight)
 
         self.files_model.ModelRefreshed.connect(self.refresh_view)
 

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -65,7 +65,7 @@ class FilesTreeView(QTreeView):
 
             # Look up file_id from 5th column of row
             id_index = index.sibling(index.row(), 5)
-            file_id = model.data(id_index, Qt.DisplayRole)
+            file_id = model.data(id_index, Qt.ItemDataRole.DisplayRole)
 
             # If a valid file selected, show file related options
             menu.addSeparator()
@@ -94,7 +94,7 @@ class FilesTreeView(QTreeView):
     def dragEnterEvent(self, event):
         # If dragging urls onto widget, accept
         if event.mimeData().hasUrls():
-            event.setDropAction(Qt.CopyAction)
+            event.setDropAction(Qt.DropAction.CopyAction)
             event.accept()
 
     def startDrag(self, supportedActions):
@@ -113,7 +113,7 @@ class FilesTreeView(QTreeView):
             return False
 
         # Get icon from column 0 on same row as current item
-        icon = current.sibling(current.row(), 0).data(Qt.DecorationRole)
+        icon = current.sibling(current.row(), 0).data(Qt.ItemDataRole.DecorationRole)
 
         # Start drag operation
         drag = QDrag(self)
@@ -136,7 +136,7 @@ class FilesTreeView(QTreeView):
         # Use try/finally so we always reset the cursor
         try:
             # Set cursor to waiting
-            get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
+            get_app().setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
             qurl_list = event.mimeData().urls()
             log.info("Processing drop event for {} urls".format(len(qurl_list)))
@@ -170,8 +170,8 @@ class FilesTreeView(QTreeView):
 
         # Set stretch mode on certain columns
         self.header().setStretchLastSection(False)
-        self.header().setSectionResizeMode(1, QHeaderView.Stretch)
-        self.header().setSectionResizeMode(2, QHeaderView.Interactive)
+        self.header().setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+        self.header().setSectionResizeMode(2, QHeaderView.ResizeMode.Interactive)
 
     def value_updated(self, item):
         """ Name or tags updated """
@@ -211,8 +211,8 @@ class FilesTreeView(QTreeView):
 
         # Remove the default selection model and wire up to the shared one
         self.selectionModel().deleteLater()
-        self.setSelectionMode(QAbstractItemView.ExtendedSelection)
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.setSelectionModel(self.files_model.selection_model)
 
         self.setAcceptDrops(True)
@@ -222,11 +222,11 @@ class FilesTreeView(QTreeView):
         # Setup header columns and layout
         self.setIconSize(info.TREE_ICON_SIZE)
         self.setIndentation(0)
-        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.setStyleSheet('QTreeView::item { padding-top: 2px; }')
 
         self.setWordWrap(False)
-        self.setTextElideMode(Qt.ElideRight)
+        self.setTextElideMode(Qt.TextElideMode.ElideRight)
 
         self.files_model.ModelRefreshed.connect(self.refresh_view)
 

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -32,7 +32,7 @@ from operator import itemgetter
 
 from PyQt5.QtCore import Qt, QRectF, QLocale, pyqtSignal, pyqtSlot, QRect
 from PyQt5.QtGui import (
-    QCursor, QIcon, QColor, QBrush, QPen, QPalette, QPixmap,
+    QIcon, QColor, QBrush, QPen, QPalette, QPixmap,
     QPainter, QPainterPath, QLinearGradient, QFont, QFontInfo,
 )
 from PyQt5.QtWidgets import (
@@ -70,7 +70,7 @@ class PropertyDelegate(QItemDelegate):
 
     def paint(self, painter, option, index):
         painter.save()
-        painter.setRenderHint(QPainter.Antialiasing)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
 
         # Get data model and selection
         model = self.model
@@ -106,7 +106,7 @@ class PropertyDelegate(QItemDelegate):
             value_percent = 0.0
 
         # set background color
-        painter.setPen(QPen(Qt.NoPen))
+        painter.setPen(QPen(Qt.PenStyle.NoPen))
         if property_type == "color":
             # Color keyframe
             red = int(cur_property[1]["red"]["value"])
@@ -115,14 +115,17 @@ class PropertyDelegate(QItemDelegate):
             painter.setBrush(QColor(red, green, blue))
         else:
             # Normal Keyframe
-            if option.state & QStyle.State_Selected:
+            if option.state & QStyle.StateFlag.State_Selected:
                 painter.setBrush(QColor("#575757"))
             else:
                 painter.setBrush(QColor("#3e3e3e"))
 
         if readonly:
             # Set text color for read only fields
-            painter.setPen(QPen(get_app().window.palette().color(QPalette.Disabled, QPalette.Text)))
+            palette = get_app().window.palette()
+            pen = palette.color(
+                QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text)
+            painter.setPen(QPen(pen))
         else:
             path = QPainterPath()
             path.addRoundedRect(QRectF(option.rect), 15, 15)
@@ -133,7 +136,7 @@ class PropertyDelegate(QItemDelegate):
             painter.setBrush(QBrush(QColor("#000000")))
             mask_rect = QRectF(option.rect)
             mask_rect.setWidth(option.rect.width() * value_percent)
-            painter.setClipRect(mask_rect, Qt.IntersectClip)
+            painter.setClipRect(mask_rect, Qt.ClipOperation.IntersectClip)
 
             # gradient for value box
             gradient = QLinearGradient(option.rect.topLeft(), option.rect.topRight())
@@ -157,11 +160,12 @@ class PropertyDelegate(QItemDelegate):
                     self.curve_pixmaps[interpolation])
 
             # Set text color
-            painter.setPen(QPen(Qt.white))
+            painter.setPen(QPen(Qt.GlobalColor.white))
 
-        value = index.data(Qt.DisplayRole)
+        value = index.data(Qt.ItemDataRole.DisplayRole)
         if value:
-            painter.drawText(option.rect, Qt.AlignCenter, value)
+            painter.drawText(
+                option.rect, Qt.AlignmentFlag.AlignCenter, value)
 
         painter.restore()
 
@@ -472,7 +476,7 @@ class PropertiesTableView(QTableView):
                             # Check if the timeline's clip file name matches the clip the user selected
                             if (clip_path == clip_instance_path):
                                 # Generate the clip icon to show in the selection menu
-                                clip_instance_icon = clip_index.data(Qt.DecorationRole)
+                                clip_instance_icon = clip_index.data(Qt.ItemDataRole.DecorationRole)
                         effect_choices = [{"name": "None",
                                             "value": "None",
                                             "selected": False,
@@ -543,7 +547,7 @@ class PropertiesTableView(QTableView):
                             # Check if the timeline's clip file name matches the clip the user selected
                             if (clip_path == clip_instance_path):
                                 # Generate the clip icon to show in the selection menu
-                                clip_instance_icon = clip_index.data(Qt.DecorationRole)
+                                clip_instance_icon = clip_index.data(Qt.ItemDataRole.DecorationRole)
                                 self.choices.append({"name": clip_instance_data["title"],
                                               "value": clip_instance_id,
                                               "selected": False,
@@ -583,11 +587,12 @@ class PropertiesTableView(QTableView):
                             # Check if the timeline's clip file name matches the clip the user selected
                             if (clip_path == clip_instance_path):
                                 # Generate the clip icon to show in the selection menu
-                                clip_instance_icon = clip_index.data(Qt.DecorationRole)
-                                clip_choices.append({"name": clip_instance_data["title"],
-                                              "value": clip_instance_id,
-                                              "selected": False,
-                                              "icon": clip_instance_icon})
+                                clip_instance_icon = clip_index.data(Qt.ItemDataRole.DecorationRole)
+                                clip_choices.append({
+                                    "name": clip_instance_data["title"],
+                                    "value": clip_instance_id,
+                                    "selected": False,
+                                    "icon": clip_instance_icon})
                         # Get the pixmap of the clip icon
                         icon_size = 72
                         icon_pixmap = clip_instance_icon.pixmap(icon_size, icon_size)
@@ -628,7 +633,7 @@ class PropertiesTableView(QTableView):
                     idx = self.files_model.index(i, 0)
                     if not idx.isValid():
                         continue
-                    icon = idx.data(Qt.DecorationRole)
+                    icon = idx.data(Qt.ItemDataRole.DecorationRole)
                     name = idx.sibling(i, 1).data()
                     path = os.path.join(idx.sibling(i, 4).data(), name)
 
@@ -648,7 +653,7 @@ class PropertiesTableView(QTableView):
                     idx = self.transition_model.index(i, 0)
                     if not idx.isValid():
                         continue
-                    icon = idx.data(Qt.DecorationRole)
+                    icon = idx.data(Qt.ItemDataRole.DecorationRole)
                     name = idx.sibling(i, 1).data()
                     path = idx.sibling(i, 3).data()
 
@@ -893,8 +898,8 @@ class PropertiesTableView(QTableView):
 
         # Setup header columns
         self.setModel(self.clip_properties_model.model)
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.setWordWrap(True)
 
         # Set delegate
@@ -904,7 +909,7 @@ class PropertiesTableView(QTableView):
 
         # Get table header
         horizontal_header = self.horizontalHeader()
-        horizontal_header.setSectionResizeMode(QHeaderView.Stretch)
+        horizontal_header.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
         vertical_header = self.verticalHeader()
         vertical_header.setVisible(False)
 
@@ -1062,10 +1067,10 @@ class SelectionLabel(QFrame):
         self.lblSelection.setText("<strong>%s</strong>" % _("No Selection"))
         self.btnSelectionName = QPushButton()
         self.btnSelectionName.setVisible(False)
-        self.btnSelectionName.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.btnSelectionName.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         # Support rich text
-        self.lblSelection.setTextFormat(Qt.RichText)
+        self.lblSelection.setTextFormat(Qt.TextFormat.RichText)
 
         hbox = QHBoxLayout()
         hbox.setContentsMargins(0, 0, 0, 0)

--- a/src/windows/views/titles_listview.py
+++ b/src/windows/views/titles_listview.py
@@ -60,10 +60,10 @@ class TitlesListView(QListView):
         self.setModel(self.title_model.model)
         self.setIconSize(info.LIST_ICON_SIZE)
         self.setGridSize(info.LIST_GRID_SIZE)
-        self.setViewMode(QListView.IconMode)
-        self.setResizeMode(QListView.Adjust)
+        self.setViewMode(QListView.ViewMode.IconMode)
+        self.setResizeMode(QListView.ResizeMode.Adjust)
         self.setUniformItemSizes(True)
         self.setWordWrap(True)
-        self.setTextElideMode(Qt.ElideRight)
+        self.setTextElideMode(Qt.TextElideMode.ElideRight)
 
         self.refresh_view()

--- a/src/windows/views/transitions_listview.py
+++ b/src/windows/views/transitions_listview.py
@@ -25,7 +25,7 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-from PyQt5.QtCore import Qt, QSize, QPoint, QRegExp
+from PyQt5.QtCore import Qt, QSize, QPoint, QRegularExpression
 from PyQt5.QtGui import QDrag
 from PyQt5.QtWidgets import QListView, QAbstractItemView, QMenu
 
@@ -66,7 +66,7 @@ class TransitionsListView(QListView):
             return False
 
         # Get icon from column 0 on same row as current item
-        icon = current.sibling(current.row(), 0).data(Qt.DecorationRole)
+        icon = current.sibling(current.row(), 0).data(Qt.ItemDataRole.DecorationRole)
 
         # Start drag operation
         drag = QDrag(self)
@@ -81,9 +81,10 @@ class TransitionsListView(QListView):
     def refresh_view(self):
         """Filter transitions with proxy class"""
         filter_text = self.win.transitionsFilter.text()
-        self.model().setFilterRegExp(QRegExp(filter_text.replace(' ', '.*')))
-        self.model().setFilterCaseSensitivity(Qt.CaseInsensitive)
-        self.model().sort(Qt.AscendingOrder)
+        self.model().setFilterRegularExpression(QRegularExpression(
+            filter_text.replace(' ', '.*'),
+            QRegularExpression.PatternOption.CaseInsensitiveOption))
+        self.model().sort(Qt.SortOrder.AscendingOrder)
 
     def __init__(self, model):
         # Invoke parent init
@@ -104,18 +105,18 @@ class TransitionsListView(QListView):
 
         # Remove the default selection model and wire up to the shared one
         self.selectionModel().deleteLater()
-        self.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        self.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.setSelectionModel(self.transition_model.selection_model)
 
         # Setup header columns
         self.setIconSize(info.LIST_ICON_SIZE)
         self.setGridSize(info.LIST_GRID_SIZE)
-        self.setViewMode(QListView.IconMode)
-        self.setResizeMode(QListView.Adjust)
+        self.setViewMode(QListView.ViewMode.IconMode)
+        self.setResizeMode(QListView.ResizeMode.Adjust)
         self.setUniformItemSizes(True)
         self.setWordWrap(False)
-        self.setTextElideMode(Qt.ElideRight)
+        self.setTextElideMode(Qt.TextElideMode.ElideRight)
         self.setStyleSheet('QListView::item { padding-top: 2px; }')
 
         # setup filter events

--- a/src/windows/views/transitions_treeview.py
+++ b/src/windows/views/transitions_treeview.py
@@ -64,7 +64,7 @@ class TransitionsTreeView(QTreeView):
             return False
 
         # Get icon from column 0 on same row as current item
-        icon = current.sibling(current.row(), 0).data(Qt.DecorationRole)
+        icon = current.sibling(current.row(), 0).data(Qt.ItemDataRole.DecorationRole)
 
         # Start drag operation
         drag = QDrag(self)
@@ -99,14 +99,14 @@ class TransitionsTreeView(QTreeView):
 
         # Remove the default selection model and wire up to the shared one
         self.selectionModel().deleteLater()
-        self.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        self.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         self.setSelectionModel(self.transition_model.selection_model)
 
         # Setup header columns
         self.setIconSize(info.TREE_ICON_SIZE)
         self.setIndentation(0)
-        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.setWordWrap(True)
         self.setStyleSheet('QTreeView::item { padding-top: 2px; }')
         self.transition_model.ModelRefreshed.connect(self.refresh_columns)

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -37,8 +37,8 @@ import logging
 import json
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 
-from PyQt5.QtCore import QFileInfo, pyqtSlot, QUrl, Qt, QCoreApplication, QTimer
-from PyQt5.QtGui import QCursor, QKeySequence, QColor
+from PyQt5.QtCore import pyqtSlot, Qt, QCoreApplication, QTimer
+from PyQt5.QtGui import QCursor, QKeySequence
 from PyQt5.QtWidgets import QMenu, QDialog
 
 from classes import info, updates
@@ -974,7 +974,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 channel_filter = c.channel_filter.GetInt(1)
 
                 # Set cursor to waiting
-                get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
+                get_app().setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
                 # Get audio data in a separate thread (so it doesn't block the UI)
                 channel_filter = channel_filter
@@ -1869,9 +1869,9 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
         # Determine slice mode (keep both [default], keep left [shift], keep right [ctrl]
         slice_mode = MENU_SLICE_KEEP_BOTH
-        if int(QCoreApplication.instance().keyboardModifiers() & Qt.ControlModifier) > 0:
+        if int(QCoreApplication.instance().keyboardModifiers() & Qt.KeyboardModifier.ControlModifier) > 0:
             slice_mode = MENU_SLICE_KEEP_RIGHT
-        elif int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0:
+        elif int(QCoreApplication.instance().keyboardModifiers() & Qt.KeyboardModifier.ShiftModifier) > 0:
             slice_mode = MENU_SLICE_KEEP_LEFT
 
         if clip_id:
@@ -3023,7 +3023,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                         # Run the dialog event loop - blocking interaction on this window during this time
                         result = win.exec_()
 
-                        if result == QDialog.Accepted:
+                        if result == QDialog.DialogCode.Accepted:
                             log.info('Start processing')
                         else:
                             log.info('Cancel processing')

--- a/src/windows/views/webview_backend/webengine.py
+++ b/src/windows/views/webview_backend/webengine.py
@@ -71,10 +71,11 @@ class TimelineWebEngineView(QWebEngineView):
         self.page().setBackgroundColor(QColor("#363636"))
 
         # Delete the webview when closed
-        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
 
         # Enable smooth scrolling on timeline
-        self.settings().setAttribute(self.settings().ScrollAnimatorEnabled, True)
+        self.settings().setAttribute(
+            self.settings().WebAttribute.ScrollAnimatorEnabled, True)
 
         # Set url from configuration (QUrl takes absolute paths for file system paths, create from QFileInfo)
         self.webchannel = QWebChannel(self.page())
@@ -127,7 +128,7 @@ class TimelineWebEngineView(QWebEngineView):
     def keyPressEvent(self, event):
         """ Keypress callback for timeline """
         key_value = event.key()
-        if key_value in [Qt.Key_Shift, Qt.Key_Control]:
+        if key_value in [Qt.Key.Key_Shift, Qt.Key.Key_Control]:
             # Only pass a few keystrokes to the webview (CTRL and SHIFT)
             return QWebEngineView.keyPressEvent(self, event)
         # Ignore most keypresses

--- a/src/windows/views/webview_backend/webkit.py
+++ b/src/windows/views/webview_backend/webkit.py
@@ -59,7 +59,7 @@ class TimelineWebKitView(QWebView):
         self.html_path = os.path.join(info.PATH, 'timeline', 'index.html')
 
         # Delete the webview when closed
-        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
 
         # Connect logging web page (for console.log)
         self.new_page = LoggingWebKitPage(self)
@@ -117,7 +117,7 @@ class TimelineWebKitView(QWebView):
     def keyPressEvent(self, event):
         """ Keypress callback for timeline """
         key_value = event.key()
-        if key_value in [Qt.Key_Shift, Qt.Key_Control]:
+        if key_value in [Qt.Key.Key_Shift, Qt.Key.Key_Control]:
             # Only pass a few keystrokes to the webview (CTRL and SHIFT)
             return QWebView.keyPressEvent(self, event)
         else:

--- a/src/windows/views/zoom_slider.py
+++ b/src/windows/views/zoom_slider.py
@@ -29,7 +29,7 @@ from PyQt5.QtCore import (
     Qt, QCoreApplication, QRectF, QTimer
 )
 from PyQt5.QtGui import (
-    QPainter, QPixmap, QColor, QPen, QBrush, QCursor, QPainterPath, QIcon
+    QPainter, QColor, QPen, QBrush, QCursor, QPainterPath, QIcon
 )
 from PyQt5.QtWidgets import QSizePolicy, QWidget
 
@@ -107,7 +107,11 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
 
         # Paint timeline preview on QWidget
         painter = QPainter(self)
-        painter.setRenderHints(QPainter.Antialiasing | QPainter.SmoothPixmapTransform | QPainter.TextAntialiasing, True)
+        painter.setRenderHints(
+            QPainter.RenderHint.Antialiasing |
+            QPainter.RenderHint.SmoothPixmapTransform |
+            QPainter.RenderHint.TextAntialiasing,
+            True)
 
         # Fill the whole widget with the solid color (background solid color)
         painter.fillRect(event.rect(), QColor("#191919"))
@@ -128,7 +132,7 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
         marker_pen = QPen(QBrush(marker_color), 1.0)
         marker_pen.setCosmetic(True)
 
-        playhead_color = QColor(Qt.red)
+        playhead_color = QColor(Qt.GlobalColor.red)
         playhead_color.setAlphaF(0.5)
         playhead_pen = QPen(QBrush(playhead_color), 1.0)
         playhead_pen.setCosmetic(True)
@@ -275,7 +279,7 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
             elif self.scroll_bar_rect.contains(event.pos()):
                 self.setCursor(self.cursors.get('move'))
             else:
-                self.setCursor(Qt.ArrowCursor)
+                self.setCursor(Qt.CursorShape.ArrowCursor)
 
         # Detect dragging
         if self.mouse_pressed and not self.mouse_dragging:
@@ -288,7 +292,7 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
             elif self.scroll_bar_rect.contains(event.pos()):
                 self.scroll_bar_dragging = True
             else:
-                self.setCursor(Qt.ArrowCursor)
+                self.setCursor(Qt.CursorShape.ArrowCursor)
 
         # Dragging handle
         if self.mouse_dragging:
@@ -297,7 +301,7 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
                 delta = (self.mouse_position - mouse_pos) / self.width()
                 new_left_pos = self.scrollbar_position_previous[0] - delta
                 is_left = True
-                if int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0:
+                if int(QCoreApplication.instance().keyboardModifiers() & Qt.KeyboardModifier.ShiftModifier) > 0:
                     # SHIFT key pressed (move )
                         if (self.scrollbar_position_previous[1] + delta) - new_left_pos > self.min_distance:
                             #both handles if we don't exceed min distance
@@ -322,7 +326,7 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
                 delta = (self.mouse_position - mouse_pos) / self.width()
                 is_left = False
                 new_right_pos = self.scrollbar_position_previous[1] - delta
-                if int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0:
+                if int(QCoreApplication.instance().keyboardModifiers() & Qt.KeyboardModifier.ShiftModifier) > 0:
                     # SHIFT key pressed (move )
                         if new_right_pos - (self.scrollbar_position_previous[0] + delta) > self.min_distance:
                             #both handles if we don't exceed min distance
@@ -509,8 +513,8 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
             self.cursors[cursor_name] = QCursor(icon.pixmap(24, 24))
 
         # Init Qt widget's properties (background repainting, etc...)
-        super().setAttribute(Qt.WA_OpaquePaintEvent)
-        super().setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        super().setAttribute(Qt.WidgetAttribute.WA_OpaquePaintEvent)
+        super().setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
 
         # Add self as listener to project data updates (used to update the timeline)
         get_app().updates.add_listener(self)


### PR DESCRIPTION
Updating code base (especially Qt enums) to be compatible with Qt6. This is mostly work from @ferdnyc and PR https://github.com/OpenShot/openshot-qt/pull/4833. I've made a few additional changes (formatting, bug fixes), but due to the older base of this PR (I think), I had trouble merging these changes back into the original PR.

Additional changes:
- Removed some unused lines of code
- Removed some unused imports
- Reformatted a few small blocks of code
- Refactored a few small blocks
- Found some duplicate code and removed it

I also did a bunch of local testing with this branch, using Qt5, and did not see any breakages, errors, or stack traces.