### PR TITLE
When all clips are exported set progress to 100%

### DIFF
--- a/src/windows/export_clips.py
+++ b/src/windows/export_clips.py
@@ -263,9 +263,10 @@ class clipExportWindow(QDialog):
             # If within 2 frames of complete, show 100 percent.
             self.progressExportVideo.setValue(100)
             return
-        self.progressExportVideo.setValue((count/total) * 100)
+        self.progressExportVideo.setValue(round((count/total) * 100))
 
     def _updateDialogExportFinished(self):
+        self.progressExportVideo.setValue(100)
         self.setWindowTitle(_("Done"))
         self.cancel_button.hide()
         self.done_button.setHidden(False)


### PR DESCRIPTION
# Issue
In some cases when exporting clips, the progress bar would stay at 99%. Even if the export was complete, and the "Done" button had appeared.

## Steps to reproduce
1) import a file
1) Right click > Split Clip.
1) Create 3 clips
1) Highlight all three > right click > export clips
1) Hit Export

# Solution
When done looping through each clip, force the progress bar to 100%.