### PR TITLE
Improved waveforms mk3

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -322,6 +322,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
     def load(self, file_path, clear_thumbnails=True):
         """ Load project from file """
 
+        from classes.app import get_app
         self.new()
 
         if file_path:
@@ -337,6 +338,13 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                 # Fix history (if broken)
                 if not project_data.get("history"):
                     project_data["history"] = {"undo": [], "redo": []}
+
+                # If project has waveforms, enable removing waveforms
+                get_app().window.actionClearWaveformData.setEnabled(False)
+                for file in project_data["files"]:
+                    if file.get("ui",{}).get("audio_data", []):
+                        get_app().window.actionClearWaveformData.setEnabled(True)
+                        break
 
             except Exception:
                 try:
@@ -382,7 +390,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             self.apply_default_audio_settings()
 
         # Get app, and distribute all project data through update manager
-        from classes.app import get_app
         get_app().updates.load(self._data)
 
     def rescale_keyframes(self, scale_factor):

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -322,7 +322,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
     def load(self, file_path, clear_thumbnails=True):
         """ Load project from file """
 
-        from classes.app import get_app
         self.new()
 
         if file_path:
@@ -408,7 +407,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         import sys
         import pickle
         from classes.query import File, Track, Clip, Transition
-        from classes.app import get_app
         import openshot
         import json
 
@@ -421,7 +419,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                                    "libopenshot": openshot.OPENSHOT_VERSION_FULL}
 
         # Get FPS from project
-        from classes.app import get_app
         fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
 
@@ -929,7 +926,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
     def check_if_paths_are_valid(self):
         """Check if all paths are valid, and prompt to update them if needed"""
-        from classes.app import get_app
         app = get_app()
         settings = app.get_settings()
         # Get translation method

--- a/src/classes/waveform.py
+++ b/src/classes/waveform.py
@@ -25,73 +25,149 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-import platform
 import threading
-from copy import deepcopy
-from classes import info
 from classes.app import get_app
 from classes.logger import log
+from classes.query import File, Clip
+from time import sleep
 import openshot
-
 
 # Get settings
 s = get_app().get_settings()
 
 
-def get_audio_data(clip_id, file_path, channel_filter, volume_keyframe):
-    """Get a Clip object form libopenshot, and grab audio data"""
-    clip = openshot.Clip(file_path)
-    clip.Open()
+def get_audio_data(files: dict):
+    """Get a Clip object form libopenshot, and grab audio data
+        For for the given files and clips, start threads to gather audio data.
 
-    # Disable video stream (for speed improvement)
-    clip.Reader().info.has_video = False
+        arg1: a dict of clip_ids grouped by their file_id
+    """
 
-    log.info("Clip loaded, start thread")
-    t = threading.Thread(target=get_waveform_thread, args=[clip, clip_id, file_path, channel_filter, volume_keyframe])
-    t.daemon = True
-    t.start()
+    for file_id in files:
+        clip_list = files[file_id]
 
-def get_waveform_thread(clip, clip_id, file_path, channel_filter=-1, volume_keyframe=None):
-    """Get the audio data from a clip in a separate thread"""
-    audio_data = []
-    sample_rate = clip.Reader().info.sample_rate
+        log.info("Clip loaded, start thread")
+        t = threading.Thread(target=get_waveform_thread,
+                             args=[file_id, clip_list])
+        t.daemon = True
+        t.start()
 
-    # How many samples per second do we need (to approximate the waveform)
-    samples_per_second = 20
-    sample_divisor = round(sample_rate / samples_per_second)
-    log.info("Getting waveform for sample rate: %s" % sample_rate)
 
-    sample = 0
-    for frame_number in range(1, clip.Reader().info.video_length):
-        # Get frame object
-        frame = clip.Reader().GetFrame(frame_number)
+def get_waveform_thread(file_id, clip_list):
+    """
+    For the given file ID and clip IDs, update audio data.
 
-        # Get volume for this frame
-        volume = 1.0
-        if volume_keyframe:
-            volume = volume_keyframe.GetValue(frame_number)
+    arg1: file id to get the audio data of.
+    arg2: list of clips to update when the audio data is ready.
+    """
 
-        # Loop through samples in frame (hopping through it to get X # of data points per second)
+    def getAudioData(file):
+        """
+        Update the file query object with audio data (if found).
+        """
+        get_app().window.actionClearWaveformData.setEnabled(True)
+        # Ensure that UI attribute exists
+        file_data = file.data
+        file_audio_data = file_data.get("ui", {}).get("audio_data", [])
+        if file_audio_data:
+            log.info("Audio Data already retrieved (or being retrieved).")
+            return
+        if not file_audio_data:
+            # Placeholder value. Communicates that audio data is being retrieved
+            file.data = {"ui": {"audio_data": [-999]}}
+            file.save()
+
+        # Open file and access audio data (if audio data is found, otherwise return)
+        temp_clip = openshot.Clip(file_data["path"])
+        temp_clip.Open()
+        temp_clip.Reader().info.has_video = False
+        if temp_clip.Reader().info.has_audio == False:
+            log.info(f"file: {file_data['path']} has no audio_data. Skipping")
+            return
+
+        # Calculate sample rate (and how many samples per second)
+        sample_rate = temp_clip.Reader().info.sample_rate
+        samples_per_second = 20
+        sample_divisor = round(sample_rate / samples_per_second)
+
+        # Loop through audio samples, and create a list of amplitudes
+        file_audio_data = []
+        for frame_num in range(1, temp_clip.Reader().info.video_length):
+            frame = temp_clip.Reader().GetFrame(frame_num)
+            sample_num = 0
+            max_samples = frame.GetAudioSamplesCount()
+            while sample_num < max_samples:
+                magnitude_range = sample_divisor
+                if sample_num + magnitude_range > frame.GetAudioSamplesCount():
+                    magnitude_range = frame.GetAudioSamplesCount() - sample_num
+                sample_value = frame.GetAudioSample(-1, sample_num, magnitude_range)
+                file_audio_data.append(sample_value)
+                sample_num += sample_divisor
+
+        # Update file with audio data
+        file.data = {"ui": {"audio_data": file_audio_data}}
+        file.save()
+        return
+
+    # Get file query object
+    file = File.get(id=file_id)
+
+    # Only generate audio for readers that actually contain audio
+    if not file.data.get("has_audio", False):
+        log.info("File does not have audio. Skipping")
+        return
+
+    # If the file doesn't have audio data, generate it.
+    # A pending audio_data process will have audio_data == [-999]
+    file_audio_data = file.data.get("ui", {}).get("audio_data", [])
+    if not file_audio_data:
+        # Generate audio data for a specific file
+        getAudioData(file)
+    else:
+        log.debug("Awaiting audio data for file: %s" % file.data.get("path"))
         while True:
-            # Determine amount of range
-            magnitude_range = sample_divisor
-            if sample + magnitude_range > frame.GetAudioSamplesCount():
-                magnitude_range = frame.GetAudioSamplesCount() - sample
+            # Loop until audio data is ready.
+            sleep(1)
+            if file.data.get("ui", {}).get("audio_data", []) != [-999]:
+                break
+    log.debug("Audio data found for file: %s" % file.data.get("path"))
 
-            # Get audio data for this channel
-            if sample < frame.GetAudioSamplesCount():
-                audio_data.append(frame.GetAudioSample(channel_filter, sample, magnitude_range) * volume)
-            else:
-                # Adjust starting sample for next frame
-                sample = max(0, sample - frame.GetAudioSamplesCount())
-                break # We are done with this frame
+    # Get file query object again (since it's data might have changed)
+    file = File.get(id=file_id)
 
-            # Jump to next sample needed
-            sample += sample_divisor
+    # Loop through each selected clip (which uses this file)
+    for clip_id in clip_list:
+        clip = Clip.get(id=clip_id)
+        clip_reader = clip.data.get("reader")
 
-    # Close reader
-    clip.Close()
+        # Get File's audio data (since it has changed)
+        file_audio_data = file.data.get("ui", {}).get("audio_data", [])
+        if not file_audio_data:
+            log.info("File has no audio, so we cannot find any waveform audio data")
+            continue
 
-    # Emit signal when done
-    log.info("get_waveform_thread completed")
-    get_app().window.WaveformReady.emit(clip_id, audio_data)
+        # Method and variables for matching a time in seconds to an audio sample
+        sample_count = len(file_audio_data)
+        file_duration = file.data.get("duration")
+        time_per_sample = file_duration / sample_count
+        def sample_from_time(time):
+            sample_num = max(0, round(time / time_per_sample))
+            sample_num = min(sample_count - 1, sample_num)
+            return file_audio_data[sample_num]
+
+        # Loop through samples from the file, applying this clip's volume curve
+        clip_audio_data = []
+        clip_instance = get_app().window.timeline_sync.timeline.GetClip(clip.id)
+        num_frames = int(clip_reader.get("video_length"))
+        fps = get_app().project.get("fps")
+        fps_frac = fps["num"] / fps["den"]
+        for frame_num in range(1, num_frames):
+            volume = clip_instance.volume.GetValue(frame_num)
+            if clip_instance.time.GetCount() > 1:
+                # Override frame # using time curve (if set)
+                frame_num = clip_instance.time.GetValue(frame_num)
+            time = frame_num / fps_frac
+            clip_audio_data.append(sample_from_time(time) * volume)
+
+        # Save this data to the clip object
+        get_app().window.timeline.audioDataReady.emit(clip.id, {"ui": {"audio_data": clip_audio_data}})

--- a/src/classes/waveform.py
+++ b/src/classes/waveform.py
@@ -143,15 +143,16 @@ def get_waveform_thread(file_id, clip_list):
 
         # If clip already has waveform, remove it to re-calculate.
         # (Used when volume changes the shape of the waveform)
-        if bool(clip.data.get("ui",{}).get("audio_data",[])):
+        if bool(clip.data.get("ui", {}).get("audio_data", [])):
             log.debug("Removing pre-existing audio data")
-            del(clip.data["ui"]["audio_data"])
+            del clip.data["ui"]["audio_data"]
             clip.save()
 
         # Method and variables for matching a time in seconds to an audio sample
         sample_count = len(file_audio_data)
         file_duration = file.data.get("duration")
         time_per_sample = file_duration / sample_count
+
         def sample_from_time(time):
             sample_num = max(0, round(time / time_per_sample))
             sample_num = min(sample_count - 1, sample_num)

--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -100,11 +100,11 @@
 					</div>
 					<br class="cleared">
 
-					<div ng-if="!clip.show_audio" class="thumb-container">
+					<div ng-if="!clip.ui.audio_data || (clip.ui.audio_data && clip.ui.audio_data.length <= 1)" class="thumb-container">
 						<img class="thumb thumb-start" ng-if="getThumbPath(clip)" ng-src="{{ getThumbPath(clip) }}"/>
 					</div>
-					<div ng-if="clip.show_audio" class="audio-container">
-						<canvas tl-audio height="46px" width="{{canvasMaxWidth((clip.end - clip.start) * pixelsPerSecond)}}px" class="audio"></canvas>
+					<div ng-if="clip.ui.audio_data && clip.ui.audio_data.length > 1" class="audio-container">
+						<canvas id="audio_clip_{{clip.id}}" tl-audio height="46px" width="{{canvasMaxWidth((clip.end - clip.start) * pixelsPerSecond)}}px" class="audio"></canvas>
 					</div>
 
                     <!-- CLIP KEYFRAME POINTS -->

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -372,60 +372,16 @@ App.controller("TimelineCtrl", function ($scope) {
     clip_selector.attr("src", existing_thumb_path);
   };
 
-  // Set the audio data for a clip
-  $scope.setAudioData = function (clip_id, audio_data) {
-    // Find matching clip
-    for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-      if ($scope.project.clips[clip_index].id === clip_id) {
-        // Set audio data
-        $scope.$apply(function () {
-          $scope.project.clips[clip_index].audio_data = audio_data;
-          $scope.project.clips[clip_index].show_audio = true;
-        });
-        timeline.qt_log("DEBUG", "Audio data successful set on clip JSON");
-        break;
-      }
-
-      // Draw audio data
-      drawAudio($scope, clip_id);
-    }
-  };
-
-  // Hide the audio waveform for a clip
-  $scope.hideAudioData = function (clip_id) {
-    // Find matching clip
-    for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-      if ($scope.project.clips[clip_index].id === clip_id) {
-        // Set audio data
-        $scope.$apply(function () {
-          $scope.project.clips[clip_index].show_audio = false;
-          $scope.project.clips[clip_index].audio_data = [];
-        });
-        break;
-      }
-    }
-  };
-
-  // Redraw all audio waveforms on the timeline (if any)
+  // Redraw all audio waveforms on the timeline (for example, if the screen is resized)
   $scope.reDrawAllAudioData = function () {
-    // Find matching clip
+    // Loop through all clips (and look for audio data)
     for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-      if ("audio_data" in $scope.project.clips[clip_index] && $scope.project.clips[clip_index].audio_data.length > 0) {
-        // Redraw audio data (since it has audio data)
+      if ("ui" in $scope.project.clips[clip_index] && "audio_data" in $scope.project.clips[clip_index].ui
+        && $scope.project.clips[clip_index].ui.audio_data.length > 1) {
+        // Redraw audio data
         drawAudio($scope, $scope.project.clips[clip_index].id);
       }
     }
-  };
-
-  // Does clip have audio_data?
-  $scope.hasAudioData = function (clip_id) {
-    // Find matching clip
-    for (var clip_index = 0; clip_index < $scope.project.clips.length; clip_index++) {
-      if ($scope.project.clips[clip_index].id === clip_id && "audio_data" in $scope.project.clips[clip_index] && $scope.project.clips[clip_index].audio_data.length > 0) {
-        return true;
-      }
-    }
-    return false;
   };
 
   $scope.setPropertyFilter = function (property) {
@@ -1465,10 +1421,7 @@ App.controller("TimelineCtrl", function ($scope) {
           // Update: If action and current object are Objects
           if (current_object.constructor === Object && action.value.constructor === Object) {
             for (var update_key in action.value) {
-              if (update_key in current_object) {
-                // Only copy over keys that exist in both action and current_object
-                current_object[update_key] = action.value[update_key];
-              }
+              current_object[update_key] = action.value[update_key];
             }
           }
           else {

--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -27,7 +27,7 @@
  */
 
 
-/*global setSelections, setBoundingBox, moveBoundingBox, bounding_box */
+/*global setSelections, setBoundingBox, moveBoundingBox, bounding_box, drawAudio */
 // Init variables
 var dragging = false;
 var resize_disabled = false;
@@ -156,13 +156,15 @@ App.directive("tlClip", function ($timeout) {
           }
 
           //resize the audio canvas to match the new clip width
-          if (scope.clip.show_audio) {
+          if (scope.clip.ui && scope.clip.ui.audio_data) {
             //redraw audio as the resize cleared the canvas
             drawAudio(scope, scope.clip.id);
           }
           dragLoc = null;
         },
         resize: function (e, ui) {
+          element.find(".point").fadeOut(100);
+          element.find(".audio-container").fadeOut(100);
           if (resize_disabled) {
             // disabled, keep the item the same size
             $(this).css(ui.originalPosition);
@@ -421,6 +423,19 @@ App.directive("tlMultiSelectable", function () {
           scope.$apply();
         }
       });
+    }
+  };
+});
+
+// Handle audio waveform drawing (when a tl-audio directive is found)
+App.directive("tlAudio",  function ($timeout) {
+  return {
+    link: function (scope, element, attrs) {
+      $timeout(function () {
+        // Use timeout to wait until after the DOM is manipulated
+        let clip_id = attrs.id.replace("audio_clip_", "");
+        drawAudio(scope, clip_id);
+      }, 0);
     }
   };
 });

--- a/src/timeline/js/functions.js
+++ b/src/timeline/js/functions.js
@@ -58,7 +58,7 @@ function drawAudio(scope, clip_id) {
   //get the clip in the scope
   var clip = findElement(scope.project.clips, "id", clip_id);
 
-  if (clip.show_audio) {
+  if (clip.ui && clip.ui.audio_data) {
     var element = $("#clip_" + clip_id);
 
     // Determine start and stop samples
@@ -71,10 +71,13 @@ function drawAudio(scope, clip_id) {
     var sample_divisor = samples_per_second / scope.pixelsPerSecond;
 
     //show audio container
-    element.find(".audio-container").show();
+    element.find(".audio-container").fadeIn(100);
 
     // Get audio canvas context
     var audio_canvas = element.find(".audio");
+    if (!audio_canvas) {
+      return;
+    }
     var ctx = audio_canvas[0].getContext("2d", {alpha: false});
 
     // Clear canvas
@@ -119,7 +122,7 @@ function drawAudio(scope, clip_id) {
     // And whenever enough are "collected", draw a block
     for (var i = start_sample; i < final_sample; i++) {
       // Flip negative values up
-      sample = Math.abs(clip.audio_data[i]);
+      sample = Math.abs(clip.ui.audio_data[i]);
       // X-Position of *next* sample
       var x = Math.floor((i + 1 - start_sample) / sample_divisor);
 

--- a/src/timeline/media/css/main.css
+++ b/src/timeline/media/css/main.css
@@ -395,11 +395,8 @@ img {
 }
 
 .audio-container {
-  display: none;
   margin-top: -20px;
   height: 46px;
-  overflow: hidden;
-  margin-left: -2px;
 }
 
 /* Clip Animations */

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -401,16 +401,16 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             if "audio_data" in file.data.get("ui", {}):
                 file_path = file.data.get("path")
                 log.debug("File %s has audio data. Deleting it." % os.path.split(file_path)[1])
-                del(file.data["ui"]["audio_data"])
+                del file.data["ui"]["audio_data"]
                 file.save()
 
                 # Remove audio data from any clips of this file
-                clips = Clip.filter(path = file_path)
+                clips = Clip.filter(path=file_path)
                 if clips:
                     log.debug("Clips of this file exist. Deleting their audio data.")
                 for clip in clips:
-                    if "audio_data" in clip.data.get("ui",{}):
-                        del(clip.data["ui"]["audio_data"])
+                    if "audio_data" in clip.data.get("ui", {}):
+                        del (clip.data["ui"]["audio_data"])
                         clip.save()
         get_app().window.actionClearWaveformData.setEnabled(False)
 

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -99,7 +99,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     SpeedSignal = pyqtSignal(float)
     RecoverBackup = pyqtSignal()
     FoundVersionSignal = pyqtSignal(str)
-    WaveformReady = pyqtSignal(str, list)
     TransformSignal = pyqtSignal(str)
     KeyFrameTransformSignal = pyqtSignal(str, str)
     SelectRegionSignal = pyqtSignal(str)
@@ -223,6 +222,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             get_app().project.load("")
             self.actionUndo.setEnabled(False)
             self.actionRedo.setEnabled(False)
+            self.actionClearHistory.setEnabled(False)
             self.SetWindowTitle()
 
     def create_lock_file(self):
@@ -392,6 +392,28 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         win = TitleEditor(edit_file_path=file_path, duplicate=True)
         # Run the dialog event loop - blocking interaction on this window during that time
         return win.exec_()
+
+    def actionClearWaveformData_trigger(self):
+        """Clear audio data from current project"""
+        from classes.query import File, Clip
+        files = File.filter()
+
+        for file in files:
+            if "audio_data" in file.data.get("ui", {}):
+                file_path = file.data.get("path")
+                log.debug("File %s has audio data. Deleting it." % os.path.split(file_path)[1])
+                del(file.data["ui"]["audio_data"])
+                file.save()
+
+                # Remove audio data from any clips of this file
+                clips = Clip.filter(path = file_path)
+                if clips:
+                    log.debug("Clips of this file exist. Deleting their audio data.")
+                for clip in clips:
+                    if "audio_data" in clip.data.get("ui",{}):
+                        del(clip.data["ui"]["audio_data"])
+                        clip.save()
+        get_app().window.actionClearWaveformData.setEnabled(False)
 
     def actionClearHistory_trigger(self):
         """Clear history for current project"""
@@ -2384,6 +2406,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         log.info('updateStatusChanged')
         self.actionUndo.setEnabled(undo_status)
         self.actionRedo.setEnabled(redo_status)
+        self.actionClearHistory.setEnabled(undo_status | redo_status)
         self.SetWindowTitle()
 
     def addSelection(self, item_id, item_type, clear_existing=False):

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -57,7 +57,7 @@ from classes.importers.edl import import_edl
 from classes.importers.final_cut_pro import import_xml
 from classes.logger import log
 from classes.metrics import track_metric_session, track_metric_screen
-from classes.query import Clip, Transition, Marker, Track, Effect
+from classes.query import File, Clip, Transition, Marker, Track, Effect
 from classes.thumbnail import httpThumbnailServerThread
 from classes.time_parts import secondsToTimecode
 from classes.timeline import TimelineSync
@@ -395,7 +395,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def actionClearWaveformData_trigger(self):
         """Clear audio data from current project"""
-        from classes.query import File, Clip
         files = File.filter()
 
         for file in files:

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -139,10 +139,17 @@
     <property name="title">
      <string>&amp;Edit</string>
     </property>
+    <widget class="QMenu" name="menuClear">
+     <property name="title">
+      <string>Clear</string>
+     </property>
+     <addaction name="actionClearHistory"/>
+     <addaction name="actionClearWaveformData"/>
+    </widget>
     <addaction name="actionUndo"/>
     <addaction name="actionRedo"/>
     <addaction name="separator"/>
-    <addaction name="actionClearHistory"/>
+    <addaction name="menuClear"/>
     <addaction name="separator"/>
     <addaction name="actionPreferences"/>
    </widget>
@@ -1632,7 +1639,7 @@
      <normaloff>:/icons/Humanity/actions/16/edit-clear.svg</normaloff>:/icons/Humanity/actions/16/edit-clear.svg</iconset>
    </property>
    <property name="text">
-    <string>Clear History</string>
+    <string>History</string>
    </property>
    <property name="toolTip">
     <string>Clear History</string>
@@ -1711,6 +1718,20 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+C</string>
+   </property>
+  </action>
+  <action name="actionClearWaveformData">
+   <property name="enabled">
+   <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="edit-clear"/>
+   </property>
+   <property name="text">
+    <string>Waveform</string>
+   </property>
+   <property name="toolTip">
+    <string>Clear Waveform Display Data</string>
    </property>
   </action>
  </widget>

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2005,7 +2005,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         # Get FPS from project
         fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
-        clips_with_waveforms= []
+        clips_with_waveforms = []
 
         # Loop through each selected clip
         for clip_id in clip_ids:


### PR DESCRIPTION
# Goal
- Only retrieve audio samples once for each file, and keep them for re-use on any other clip of that file.
- Rather than calling javascript from the python code, have the  javascript detect the presence of audio data, and create a waveform from that.

# Improvements
No longer directly saving the data to clip objects, instead using a signal. Preventing a crash on windows.