### PR TITLE
Trimming + Snapping Improvements for Clips and Transitions

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1360,10 +1360,12 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
             fps = get_app().project.get("fps")
             fps_float = float(fps["num"]) / float(fps["den"])
+            frame_duration = float(fps["den"]) / float(fps["num"])
 
             clip_start_time = obj.data["position"]
             clip_orig_time = clip_start_time - obj.data["start"]
-            clip_stop_time = clip_orig_time + obj.data["end"]
+            # Last frame on clip is -1 frame's duration
+            clip_stop_time = clip_orig_time + obj.data["end"] - frame_duration
 
             # add clip boundaries
             positions.append(clip_start_time)
@@ -1413,11 +1415,14 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # We can always jump to the beginning of the timeline
         all_marker_positions = [0]
+        fps = get_app().project.get("fps")
+        frame_duration = float(fps["den"]) / float(fps["num"])
 
         # If nothing is selected, also add the end of the last clip
         if not self.selected_clips + self.selected_transitions:
             all_marker_positions.append(
-                get_app().window.timeline_sync.timeline.GetMaxTime())
+                # last frame is -1 frame's duration
+                get_app().window.timeline_sync.timeline.GetMaxTime() - frame_duration)
 
         # Get list of marker and important positions (like selected clip bounds)
         for marker in Marker.filter():
@@ -1470,7 +1475,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             frame_to_seek = round(closest_position * fps_float) + 1
             self.SeekSignal.emit(frame_to_seek)
 
-            # Update the preview and reselct current frame in properties
+            # Update the preview and reselect current frame in properties
             get_app().window.refreshFrameSignal.emit()
             get_app().window.propertyTableView.select_frame(frame_to_seek)
 

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -329,40 +329,65 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
         # Search for matching clip in project data (if any)
         existing_item = Transition.get(id=transition_data["id"])
-        needs_resize = True
         if not existing_item:
             # Create a new clip (if not exists)
             existing_item = Transition()
-            needs_resize = False
         existing_item.data = transition_data
 
         # Get FPS from project
         fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
         duration = existing_item.data["end"] - existing_item.data["start"]
+        position = transition_data["position"]
 
-        # Update the brightness and contrast keyframes to match the duration of the transition
-        # This is a hack until I can think of something better
-        brightness = None
-        contrast = None
-        if needs_resize:
-            # Adjust transition's brightness keyframes to match the size of the transition
-            brightness = existing_item.data["brightness"]
-            if len(brightness["Points"]) > 1:
-                # If multiple points, move the final one to the 'new' end
-                brightness["Points"][-1]["co"]["X"] = round(duration * fps_float) + 1
+        # Determine if transition is intersecting a clip
+        # For example, the left side of a clip, or the right side, so we can determine
+        # which direction the wipe should be moving in
+        is_forward_direction = True
+        for intersecting_clip in Clip.filter(intersect=position):
+            log.debug(f"Intersecting Clip: {intersecting_clip}")
+            diff_from_start = abs(intersecting_clip.data.get("position", 0.0) - position)
+            diff_from_end = abs((intersecting_clip.data.get("position", 0.0) + \
+                                (intersecting_clip.data.get("end", 0.0) - intersecting_clip.data.get("start", 0.0))) \
+                                - position)
+            if diff_from_end < diff_from_start:
+                is_forward_direction = False
+        log.debug(f"Is transition moving a forward direction? {is_forward_direction}")
 
-            # Adjust transition's contrast keyframes to match the size of the transition
-            contrast = existing_item.data["contrast"]
-            if len(contrast["Points"]) > 1:
-                # If multiple points, move the final one to the 'new' end
-                contrast["Points"][-1]["co"]["X"] = round(duration * fps_float) + 1
+        # Determine existing brightness and contrast ranges (if any)
+        brightness_range = []
+        contrast_range = []
+        if existing_item:
+            for point in existing_item.data["brightness"].get("Points", []):
+                point_value = float(point["co"]["Y"])
+                brightness_range.append(point_value)
+            for point in existing_item.data["contrast"].get("Points", []):
+                point_value = float(point["co"]["Y"])
+                contrast_range.append(point_value)
+        if not brightness_range:
+            brightness_range.extend([1, -1])
+        if not contrast_range:
+            contrast_range.extend([3])
+
+        # Create new brightness Keyframes (using the previous value range)
+        b = openshot.Keyframe()
+        if is_forward_direction:
+            b.AddPoint(1, sorted(brightness_range)[-1], openshot.BEZIER)
+            b.AddPoint(round(duration * fps_float), sorted(brightness_range)[0], openshot.BEZIER)
         else:
-            # Create new brightness and contrast Keyframes
-            b = openshot.Keyframe()
-            b.AddPoint(1, 1.0, openshot.BEZIER)
-            b.AddPoint(round(duration * fps_float) + 1, -1.0, openshot.BEZIER)
-            brightness = json.loads(b.Json())
+            b.AddPoint(1, sorted(brightness_range)[0], openshot.BEZIER)
+            b.AddPoint(round(duration * fps_float), sorted(brightness_range)[-1], openshot.BEZIER)
+        brightness = json.loads(b.Json())
+
+        # Create new contrast Keyframes (using the previous value range)
+        c = openshot.Keyframe()
+        if is_forward_direction:
+            c.AddPoint(1, sorted(contrast_range)[-1], openshot.BEZIER)
+            c.AddPoint(round(duration * fps_float), sorted(contrast_range)[0], openshot.BEZIER)
+        else:
+            c.AddPoint(1, sorted(contrast_range)[0], openshot.BEZIER)
+            c.AddPoint(round(duration * fps_float), sorted(contrast_range)[-1], openshot.BEZIER)
+        contrast = json.loads(c.Json())
 
         # Only include the basic properties (performance boost)
         if only_basic_props:
@@ -372,19 +397,13 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             existing_item.data["position"] = transition_data["position"]
             existing_item.data["start"] = transition_data["start"]
             existing_item.data["end"] = transition_data["end"]
-
-            log.debug('transition start: %s' % transition_data["start"])
-            log.debug('transition end: %s' % transition_data["end"])
-
-            if brightness:
-                existing_item.data["brightness"] = brightness
-            if contrast:
-                existing_item.data["contrast"] = contrast
+            existing_item.data["brightness"] = brightness
+            existing_item.data["contrast"] = contrast
 
         # Save transition
         existing_item.save()
 
-        # Update the preview and reselct current frame in properties
+        # Update the preview and reselect current frame in properties
         if not ignore_refresh:
             self.window.refreshFrameSignal.emit()
             self.window.propertyTableView.select_frame(self.window.preview_thread.player.Position())


### PR DESCRIPTION
There are many snapping issues addressed in this PR. 

- Trimming + snapping (Clips and Transitions) has been fixed and now has improved precision (exactly matching the edges suggested with snapping)
- Next Marker + Previous Marker logic has been improved to correctly detect the right edge of clips/transitions. It was previously adding a +1 frame which is a bug
- Auto set the direction of transitions, based on which side of a clip it intersects. On the left side we now fade-in, and on the right side, we fade out (by default) - Custom mask/transitions brightness and contrast are preserved (at least the basic range of values is preserved)
- Fixed a bounding box computation rounding error, caused by JQuery. We now compute width based on `time` data from our scope.