### PR TITLE
Improved Caching Support (openshot-qt)

### DIFF
--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -576,7 +576,7 @@ def main():
             # Sign MSI
             for line in run_command(key_sign_command):
                 output(line)
-                if line:
+                if line and "will expire" not in line:
                     key_sign_success = False
                     key_sign_output = line
 

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -576,7 +576,7 @@ def main():
             # Sign MSI
             for line in run_command(key_sign_command):
                 output(line)
-                if line and "will expire" not in line:
+                if line and "will expire" not in line.decode('UTF-8'):
                     key_sign_success = False
                     key_sign_output = line
 

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -263,6 +263,43 @@
   },
   {
     "min": 0,
+    "max": 1024,
+    "value": 2,
+    "title": "Cache Pre-roll: Min Frames",
+    "type": "spinner-int",
+    "category": "Cache",
+    "setting": "cache-preroll-min-frames"
+  },
+  {
+    "min": 0,
+    "max": 1024,
+    "value": 8,
+    "title": "Cache Pre-roll: Max Frames",
+    "type": "spinner-int",
+    "category": "Cache",
+    "setting": "cache-preroll-max-frames"
+  },
+  {
+    "min": 0.0,
+    "max": 1.0,
+    "step": 0.1,
+    "value": 0.75,
+    "title": "Cache Ahead (Percent)",
+    "type": "spinner",
+    "category": "Cache",
+    "setting": "cache-ahead-percent"
+  },
+  {
+    "min": 0,
+    "max": 1024,
+    "value": 600,
+    "title": "Cache Max Frames",
+    "type": "spinner-int",
+    "category": "Cache",
+    "setting": "cache-max-frames"
+  },
+  {
+    "min": 0,
     "max": 9999999,
     "value": 1024,
     "title": "Cache Limit (MB)",

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -969,6 +969,14 @@
     "type": "text"
   },
   {
+    "category": "Keyboard",
+    "title": "Clear All Cache",
+    "restart": false,
+    "setting": "actionClearAllCache",
+    "value": "Ctrl+Shift+ESC",
+    "type": "text"
+  },
+  {
     "category": "Location",
     "title": "File Import",
     "setting": "locationImportType",

--- a/src/timeline/app.js
+++ b/src/timeline/app.js
@@ -45,7 +45,7 @@ $(document).ready(function () {
   $(document).on("mouseup", function (e) {
       if (body_object.scope().Qt) {
           // Enable caching thread after scrubbing
-          timeline.EnableCacheThread()
+          timeline.EnableCacheThread();
       }
   });
 

--- a/src/timeline/app.js
+++ b/src/timeline/app.js
@@ -39,6 +39,16 @@ $(document).ready(function () {
   // Initialize Qt Mixin (WebEngine or WebKit)
   init_mixin();
 
+  // Always ensure caching thread has been resumed on any mouse-up event.
+  // The cache thread can be disabled while scrubbing, and the normal mouse-up event
+  // can be missed if the cursor is dragged outside the timeline.
+  $(document).on("mouseup", function (e) {
+      if (body_object.scope().Qt) {
+          // Enable caching thread after scrubbing
+          timeline.EnableCacheThread()
+      }
+  });
+
   /// Capture window resize event, and resize scrollable divs (i.e. track container)
   $(window).resize(function () {
 

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -509,26 +509,27 @@ App.controller("TimelineCtrl", function ($scope) {
 
     // Determine fps & and get cached ranges
     var fps = $scope.project.fps.num / $scope.project.fps.den;
-    var progress = $scope.project.progress.ranges;
+    if ($scope.project.progress && $scope.project.progress.hasOwnProperty('ranges')) {
+        // Loop through each cached range of frames, and draw rect
+        let progress = $scope.project.progress.ranges;
+        for (var p = 0; p < progress.length; p++) {
+          //get the progress item details
+          var start_second = parseFloat(progress[p]["start"]) / fps;
+          var stop_second = parseFloat(progress[p]["end"]) / fps;
 
-    // Loop through each cached range of frames, and draw rect
-    for (var p = 0; p < progress.length; p++) {
-      //get the progress item details
-      var start_second = parseFloat(progress[p]["start"]) / fps;
-      var stop_second = parseFloat(progress[p]["end"]) / fps;
-
-      //figure out the actual pixel position, constrained by max width
-      var start_pixel = $scope.canvasMaxWidth(start_second * $scope.pixelsPerSecond);
-      var stop_pixel = $scope.canvasMaxWidth(stop_second * $scope.pixelsPerSecond);
-      var rect_length = stop_pixel - start_pixel;
-      if (rect_length < 1) {
-        continue;
-      }
-      //get the element and draw the rects
-      ctx.beginPath();
-      ctx.rect(start_pixel, 0, rect_length, 5);
-      ctx.fillStyle = "#4B92AD";
-      ctx.fill();
+          //figure out the actual pixel position, constrained by max width
+          var start_pixel = $scope.canvasMaxWidth(start_second * $scope.pixelsPerSecond);
+          var stop_pixel = $scope.canvasMaxWidth(stop_second * $scope.pixelsPerSecond);
+          var rect_length = stop_pixel - start_pixel;
+          if (rect_length < 1) {
+            continue;
+          }
+          //get the element and draw the rects
+          ctx.beginPath();
+          ctx.rect(start_pixel, 0, rect_length, 5);
+          ctx.fillStyle = "#4B92AD";
+          ctx.fill();
+        }
     }
   };
 

--- a/src/timeline/js/directives/playhead.js
+++ b/src/timeline/js/directives/playhead.js
@@ -31,7 +31,7 @@
 // Handles the playhead dragging
 var playhead_y_max = null;
 
-/*global App*/
+/*global App, timeline*/
 App.directive("tlPlayhead", function () {
   return {
     link: function (scope, element, attrs) {
@@ -43,14 +43,14 @@ App.directive("tlPlayhead", function () {
         setBoundingBox(scope, $("#playhead"), "playhead");
         if (scope.Qt) {
             // Disable caching thread during scrubbing
-            timeline.DisableCacheThread()
+            timeline.DisableCacheThread();
         }
       });
 
       element.on("contextmenu", function (e) {
         if (scope.Qt) {
             // Enable caching thread after scrubbing
-            timeline.EnableCacheThread()
+            timeline.EnableCacheThread();
         }
       });
 

--- a/src/timeline/js/directives/playhead.js
+++ b/src/timeline/js/directives/playhead.js
@@ -40,7 +40,18 @@ App.directive("tlPlayhead", function () {
 
       element.on("mousedown", function (e) {
         // Set bounding box for the playhead
-        setBoundingBox(scope, $(this), "playhead");
+        setBoundingBox(scope, $("#playhead"), "playhead");
+        if (scope.Qt) {
+            // Disable caching thread during scrubbing
+            timeline.DisableCacheThread()
+        }
+      });
+
+      element.on("contextmenu", function (e) {
+        if (scope.Qt) {
+            // Enable caching thread after scrubbing
+            timeline.EnableCacheThread()
+        }
       });
 
       // Move playhead to new position (if it's not currently being animated)

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -39,7 +39,7 @@ var scroll_left_pixels = 0;
 
 // This container allows for tracks to be scrolled (with synced ruler)
 // and allows for panning of the timeline with the middle mouse button
-/*global App, secondsToTime*/
+/*global App, timeline, secondsToTime*/
 App.directive("tlScrollableTracks", function () {
   return {
     restrict: "A",
@@ -182,14 +182,14 @@ App.directive("tlRuler", function ($timeout) {
         setBoundingBox(scope, $("#playhead"), "playhead");
         if (scope.Qt) {
             // Disable caching thread during scrubbing
-            timeline.DisableCacheThread()
+            timeline.DisableCacheThread();
         }
       });
 
       element.on("contextmenu", function (e) {
         if (scope.Qt) {
             // Enable caching thread after scrubbing
-            timeline.EnableCacheThread()
+            timeline.EnableCacheThread();
         }
       });
 

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -179,7 +179,18 @@ App.directive("tlRuler", function ($timeout) {
 
       element.on("mousedown", function (e) {
         // Set bounding box for the playhead position
-        setBoundingBox(scope, $(this), "playhead");
+        setBoundingBox(scope, $("#playhead"), "playhead");
+        if (scope.Qt) {
+            // Disable caching thread during scrubbing
+            timeline.DisableCacheThread()
+        }
+      });
+
+      element.on("contextmenu", function (e) {
+        if (scope.Qt) {
+            // Enable caching thread after scrubbing
+            timeline.EnableCacheThread()
+        }
       });
 
       // Move playhead to new position (if it's not currently being animated)

--- a/src/timeline/js/functions.js
+++ b/src/timeline/js/functions.js
@@ -247,7 +247,12 @@ function setBoundingBox(scope, item, item_type="clip") {
 
     // Compute width from `time` duration (for more accuracy). Getting the width from
     // JQuery is not accurate, and is occasionally rounded.
-    let item_width = (item_object.end - item_object.start) * scope.pixelsPerSecond;
+    let item_width = 1;
+    if (item_object) {
+        item_width = (item_object.end - item_object.start) * scope.pixelsPerSecond;
+    } else {
+        item_width = item.width();
+    }
 
     item_bottom = item.position().top + item.height() + vert_scroll_offset;
     item_top = item.position().top + vert_scroll_offset;

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -374,6 +374,10 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Update preview
         self.refreshFrameSignal.emit()
 
+    def actionClearAllCache_trigger(self):
+        """ Clear all timeline cache - deep clear """
+        self.timeline_sync.timeline.ClearAllCache(True)
+
     def actionDuplicateTitle_trigger(self):
 
         file_path = None
@@ -979,14 +983,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         from windows.cutting import Cutting
         win = Cutting(f, preview=True)
         win.show()
-
-    def previewFrame(self, position_frames):
-        """Preview a specific frame"""
-        # Notify preview thread
-        self.previewFrameSignal.emit(position_frames)
-
-        # Notify properties dialog
-        self.propertyTableView.select_frame(position_frames)
 
     def movePlayhead(self, position_frames):
         """Update playhead position"""
@@ -1640,6 +1636,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             self.actionAnimatedTitle.trigger()
         elif key.matches(self.getShortcutByName("actionDuplicateTitle")) == QKeySequence.ExactMatch:
             self.actionDuplicateTitle.trigger()
+        elif key.matches(self.getShortcutByName("actionClearAllCache")) == QKeySequence.ExactMatch:
+            self.actionClearAllCache.trigger()
         elif key.matches(self.getShortcutByName("actionEditTitle")) == QKeySequence.ExactMatch:
             self.actionEditTitle.trigger()
         elif key.matches(self.getShortcutByName("actionFullscreen")) == QKeySequence.ExactMatch:
@@ -2797,6 +2795,11 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         from classes import sentry
         sentry.init_tracing()
 
+    def handleSeek(self, frame):
+        """ Always update the property view when we seek to a new position """
+        # Notify properties dialog
+        self.propertyTableView.select_frame(frame)
+
     def moveEvent(self, event):
         """ Move tutorial dialogs also (if any)"""
         QMainWindow.moveEvent(self, event)
@@ -3165,6 +3168,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Connect Selection signals
         self.SelectionAdded.connect(self.addSelection)
         self.SelectionRemoved.connect(self.removeSelection)
+
+        # Connect playhead moved signals
+        self.SeekSignal.connect(self.handleSeek)
 
         # Ensure toolbar is movable when floated (even with docks frozen)
         self.toolBar.topLevelChanged.connect(

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2853,6 +2853,17 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         log.info("InitCacheSettings")
         log.info("cache-mode: %s" % s.get("cache-mode"))
         log.info("cache-limit-mb: %s" % s.get("cache-limit-mb"))
+        log.info("cache-ahead-percent: %s" % s.get("cache-ahead-percent"))
+        log.info("cache-preroll-min-frames: %s" % s.get("cache-preroll-min-frames"))
+        log.info("cache-preroll-max-frames: %s" % s.get("cache-preroll-max-frames"))
+        log.info("cache-max-frames: %s" % s.get("cache-max-frames"))
+
+        # Set preview cache settings
+        lib_settings = openshot.Settings.Instance()
+        lib_settings.VIDEO_CACHE_PERCENT_AHEAD = s.get("cache-ahead-percent")
+        lib_settings.VIDEO_CACHE_MIN_PREROLL_FRAMES = s.get("cache-preroll-min-frames")
+        lib_settings.VIDEO_CACHE_MAX_PREROLL_FRAMES = s.get("cache-preroll-max-frames")
+        lib_settings.VIDEO_CACHE_MAX_FRAMES = s.get("cache-max-frames")
 
         # Get MB limit of cache (and convert to bytes)
         cache_limit = s.get("cache-limit-mb") * 1024 * 1024  # Convert MB to Bytes

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -148,23 +148,26 @@ class PropertiesModel(updates.UpdateInterface):
 
             # Determine the frame needed for this clip (based on the position on the timeline)
             time_diff = (requested_time - clip.Position()) + clip.Start()
-            self.frame_number = round(time_diff * fps_float) + 1
+            new_frame_number = round(time_diff * fps_float) + 1
+            if new_frame_number != self.frame_number:
+                # If frame # has changed
+                self.frame_number = new_frame_number
 
-            # Calculate biggest and smallest possible frames
-            min_frame_number = round((clip.Start() * fps_float)) + 1
-            max_frame_number = round((clip.End() * fps_float)) + 1
+                # Calculate biggest and smallest possible frames
+                min_frame_number = round((clip.Start() * fps_float)) + 1
+                max_frame_number = round((clip.End() * fps_float)) + 1
 
-            # Adjust frame number if out of range
-            if self.frame_number < min_frame_number:
-                self.frame_number = min_frame_number
-            if self.frame_number > max_frame_number:
-                self.frame_number = max_frame_number
+                # Adjust frame number if out of range
+                if self.frame_number < min_frame_number:
+                    self.frame_number = min_frame_number
+                if self.frame_number > max_frame_number:
+                    self.frame_number = max_frame_number
 
-            log.debug("Update frame to %s" % self.frame_number)
+                log.debug("Update frame to %s" % self.frame_number)
 
-            # Update the model data
-            if reload_model:
-                self.update_model(get_app().window.txtPropertyFilter.text())
+                # Update the model data
+                if reload_model:
+                    self.update_model(get_app().window.txtPropertyFilter.text())
 
     def remove_keyframe(self, item):
         """Remove an existing keyframe (if any)"""
@@ -568,6 +571,7 @@ class PropertiesModel(updates.UpdateInterface):
             # Save changes
             if clip_updated:
                 # Save
+                c.data = clip_data
                 c.save()
 
                 # Update the preview

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -214,7 +214,7 @@ class Preferences(QDialog):
                     widget.setMinimum(float(param["min"]))
                     widget.setMaximum(float(param["max"]))
                     widget.setValue(float(param["value"]))
-                    widget.setSingleStep(1.0)
+                    widget.setSingleStep(param.get("step", 1.0))
                     widget.setToolTip(param["title"])
                     widget.valueChanged.connect(functools.partial(self.spinner_value_changed, param))
 
@@ -224,7 +224,7 @@ class Preferences(QDialog):
                     widget.setMinimum(int(param["min"]))
                     widget.setMaximum(int(param["max"]))
                     widget.setValue(int(param["value"]))
-                    widget.setSingleStep(1)
+                    widget.setSingleStep(param.get("step", 1))
                     widget.setToolTip(param["title"])
                     widget.valueChanged.connect(functools.partial(self.spinner_value_changed, param))
 
@@ -509,7 +509,9 @@ class Preferences(QDialog):
             openshot.Settings.Instance().DE_LIMIT_HEIGHT_MAX = int(str(value))
 
         # Apply cache settings (if needed)
-        if param["setting"] in ["cache-limit-mb", "cache-scale", "cache-quality"]:
+        if param["setting"] in ["cache-limit-mb", "cache-scale", "cache-quality", 
+                                "cache-ahead-percent", "cache-preroll-min-frames", 
+                                "cache-preroll-max-frames", "cache-max-frames"]:
             get_app().window.InitCacheSettings()
 
         # Check for restart

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -1618,6 +1618,21 @@
     <string>Edit Title</string>
    </property>
   </action>
+  <action name="actionClearAllCache">
+   <property name="icon">
+    <iconset theme="edit-clear" resource="../../../images/openshot.qrc">
+     <normaloff>:/icons/Humanity/actions/16/edit-clear.svg</normaloff>:/icons/Humanity/actions/16/edit-clear.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Clear All</string>
+   </property>
+   <property name="toolTip">
+    <string>Clear All</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+ESC</string>
+   </property>
+  </action>
   <action name="actionDuplicateTitle">
    <property name="icon">
     <iconset theme="edit-copy" resource="../../../images/openshot.qrc">

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -599,6 +599,10 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         # Ignore undo/redo history temporarily (to avoid a huge pile of undo/redo history)
         get_app().updates.ignore_history = True
 
+        # Disable video caching during drag operation (for performance reasons)
+        openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = False
+        log.debug('mousePressEvent: Stop caching frames on timeline')
+
     def mouseReleaseEvent(self, event):
         event.accept()
         """Capture mouse release event on video preview window"""
@@ -651,6 +655,10 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
         # Inform UpdateManager to accept updates, and only store our final update
         get_app().updates.ignore_history = False
+
+        # Enable video caching again
+        openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = True
+        log.debug('mouseReleaseEvent: Start caching frames on timeline')
 
         # Add final update to undo/redo history
         if self.original_clip_data:

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -449,7 +449,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
             # Add clear cache menu
             Cache_Menu = QMenu(_("Cache"), self)
-            Cache_Clear_All = Cache_Menu.addAction(self.window.actionClearAllCache)
+            Cache_Menu.addAction(self.window.actionClearAllCache)
             menu.addMenu(Cache_Menu)
 
             return menu.exec_(QCursor.pos())


### PR DESCRIPTION
This PR contains the UI components and improvements for better caching support in OpenShot, and is related to libopenshot PR: https://github.com/OpenShot/libopenshot/pull/847.

**TLDR:** 
Make playback smoother by improving caching during pause (and disabling caching during certain UI operations)

**UI Changes supported by this PR:**
 - Scrub timeline
    - disable caching thread until mouse-up
    - clear cache if seeking outside the cached range
 - Transform / Property Editor
    - disable caching thread until mouse-up
 - Fast Forward
    - cache every frame in the forward direction
 - Rewind
    - cache every frame in the reverse direction
    - KNOWN ISSUE: frames cached in reverse direction will contain "temporary" audio pops, use new context menu: **Playhead->Cache->Clear All** to fix
 - Playhead
    - Cache context menu -> Clear All
    - For use when cache contains audio pops or glitches - and the user wants to clear and rebuild cached frames
 - Load Project
    - pre-roll and cache frames when paused, right after opening a project
 - Pause
    - cache more aggressively - more frames cached on timeline (50% in front, 50% behind current playhead position)
    - NOTE: the cached frames to the left of the playhead position are cached during playback, and are not immediately available
 - Playback
    - cache less frames ahead - to conserve CPU for displaying frames rapidly

**Bug Fixes:**
 - Jump to Start / Jump to End toolbar buttons would not correctly update the frame # on the Property Editor - causing edits to affect the wrong frame #
 - Javascript Error when dragging the Playhead (or scrubbing the ruler) - regression from a previous accuracy improvement to `functions.js`
 - Fix a build-server error, caused by a soon-to-expire code signing cert
 - Fixed a bug causing empty cache objects to crash (or not render the cache progress on the timeline)