### PR TITLE
Fix broken windows builds - soon to expire cert (build server script)

### DIFF
--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -576,7 +576,7 @@ def main():
             # Sign MSI
             for line in run_command(key_sign_command):
                 output(line)
-                if line:
+                if line and "will expire" not in line.decode('UTF-8'):
                     key_sign_success = False
                     key_sign_output = line
 


### PR DESCRIPTION
Updating build server script for Windows to not fail due to a soon-to-expire signing certificate