### PR TITLE
Refresh final frame after Scrubbing

### DIFF
--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2674,6 +2674,11 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         # Enable video caching
         openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = True
 
+        # Refresh frame to ensure our last frame after scrubbing
+        # is the final frame shown. Due to some unknown reason, this
+        # is required for an accurate end to srubbing
+        QTimer.singleShot(50, self.window.refreshFrameSignal.emit)
+
     @pyqtSlot()
     def DisableCacheThread(self):
         log.debug('DisableCacheThread: Stop caching frames on timeline')


### PR DESCRIPTION
For some reason, after scrubbing a bunch of random frames on the Timeline, perhaps due to a race condition, the final frame in our video preview is not the final frame requested. This PR adds a "refresh frame" signal after scrubbing has completed, to ensure the final frame is correctly displayed. Seems to work fine.