### PR TITLE
Move protobuf data files to Project Folder

### DIFF
--- a/installer/build-mac-dmg.sh
+++ b/installer/build-mac-dmg.sh
@@ -101,8 +101,8 @@ while [ "$(( $(date +%s) - 3600 ))" -lt "$START" ]; do
       fi
     fi
 
-    # Wait a few seconds
-    sleep 60
+    # Wait a few seconds (otherwise the stapler can sometimes fail to find the ticket)
+    sleep 180
 done
 
 echo "Staple Notarization Ticket to DMG"

--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -39,7 +39,7 @@ from classes import info
 from classes.app import get_app
 
 # Compiled path regex
-path_regex = re.compile(r'"(image|path)"\s*:\s*"(.*)"')
+path_regex = re.compile(r'"(image|path|protobuf_data_path)"\s*:\s*"(.*)"')
 path_context = {}
 
 


### PR DESCRIPTION
Move protobuf data files (i.e. OpenCV effects that store data in protobuf file format) to the project folder, and store them as relative paths. Make protobuf files behave the same as BLENDER and TITLE and THUMBNAIL files. 