### PR TITLE
Fixing the detection of max timeline length (during playback)

### DIFF
--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -202,6 +202,12 @@ class UpdateManager:
         # Notify watchers of new history state
         self.update_watchers()
 
+    def disconnect_listener(self, listener):
+        """Remove a listener from the update manager"""
+        if listener in self.updateListeners:
+            log.info("Remove listener from UpdateManager: %s" % str(listener))
+            self.updateListeners.remove(listener)
+
     def add_listener(self, listener, index=-1):
         """ Add a new listener (which will invoke the changed(action) method
         each time an UpdateAction is available). """

--- a/src/windows/cutting.py
+++ b/src/windows/cutting.py
@@ -50,7 +50,7 @@ class Cutting(QDialog):
     previewFrameSignal = pyqtSignal(int)
     refreshFrameSignal = pyqtSignal()
     LoadFileSignal = pyqtSignal(str)
-    PlaySignal = pyqtSignal(int)
+    PlaySignal = pyqtSignal()
     PauseSignal = pyqtSignal()
     SeekSignal = pyqtSignal(int)
     SpeedSignal = pyqtSignal(float)
@@ -149,7 +149,7 @@ class Cutting(QDialog):
         self.initialized = False
         self.transforming_clip = False
         self.preview_parent = PreviewParent()
-        self.preview_parent.Init(self, self.r, self.videoPreview)
+        self.preview_parent.Init(self, self.r, self.videoPreview, self.video_length)
         self.preview_thread = self.preview_parent.worker
 
         # Set slider constraints
@@ -212,7 +212,7 @@ class Cutting(QDialog):
         if self.btnPlay.isChecked():
             log.info('play (icon to pause)')
             ui_util.setup_icon(self, self.btnPlay, "actionPlay", "media-playback-pause")
-            self.preview_thread.Play(self.video_length)
+            self.preview_thread.Play()
         else:
             log.info('pause (icon to play)')
             ui_util.setup_icon(self, self.btnPlay, "actionPlay", "media-playback-start")  # to default
@@ -363,12 +363,10 @@ class Cutting(QDialog):
         log.debug('closeEvent')
 
         # Stop playback
-        self.preview_parent.worker.Stop()
-
-        # Stop preview thread (and wait for it to end)
-        self.preview_parent.worker.kill()
-        self.preview_parent.background.exit()
-        self.preview_parent.background.wait(5000)
+        get_app().updates.disconnect_listener(self.videoPreview)
+        self.videoPreview.deleteLater()
+        self.videoPreview = None
+        self.preview_parent.Stop()
 
         # Close readers
         self.r.Close()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -92,7 +92,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     refreshTransitionsSignal = pyqtSignal()
     refreshEffectsSignal = pyqtSignal()
     LoadFileSignal = pyqtSignal(str)
-    PlaySignal = pyqtSignal(int)
+    PlaySignal = pyqtSignal()
     PauseSignal = pyqtSignal()
     StopSignal = pyqtSignal()
     SeekSignal = pyqtSignal(int)
@@ -180,8 +180,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Stop preview thread (and wait for it to end)
         self.preview_thread.player.CloseAudioDevice()
         self.preview_thread.kill()
-        self.preview_parent.background.exit()
-        self.preview_parent.background.wait(5000)
+        self.videoPreview.deleteLater()
+        self.videoPreview = None
+        self.preview_parent.Stop()
 
         # Close Timeline
         if self.timeline_sync and self.timeline_sync.timeline:
@@ -962,7 +963,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             # Start playback
             if self.should_play():
                 max_frame = get_app().window.timeline_sync.timeline.GetMaxFrame()
-                self.PlaySignal.emit(max_frame)
+                self.PlaySignal.emit()
         else:
             # Pause playback
             self.PauseSignal.emit()

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -53,7 +53,7 @@ class SelectRegion(QDialog):
     previewFrameSignal = pyqtSignal(int)
     refreshFrameSignal = pyqtSignal()
     LoadFileSignal = pyqtSignal(str)
-    PlaySignal = pyqtSignal(int)
+    PlaySignal = pyqtSignal()
     PauseSignal = pyqtSignal()
     SeekSignal = pyqtSignal(int)
     SpeedSignal = pyqtSignal(float)
@@ -153,7 +153,7 @@ class SelectRegion(QDialog):
         self.initialized = False
         self.transforming_clip = False
         self.preview_parent = PreviewParent()
-        self.preview_parent.Init(self, self.r, self.videoPreview)
+        self.preview_parent.Init(self, self.r, self.videoPreview, self.video_length)
         self.preview_thread = self.preview_parent.worker
 
         # Set slider constraints
@@ -215,7 +215,7 @@ class SelectRegion(QDialog):
         if self.btnPlay.isChecked():
             log.info('play (icon to pause)')
             ui_util.setup_icon(self, self.btnPlay, "actionPlay", "media-playback-pause")
-            self.preview_thread.Play(self.video_length)
+            self.preview_thread.Play()
         else:
             log.info('pause (icon to play)')
             ui_util.setup_icon(self, self.btnPlay, "actionPlay", "media-playback-start")  # to default
@@ -246,12 +246,7 @@ class SelectRegion(QDialog):
         log.info('shutdownPlayer')
 
         # Stop playback
-        self.preview_parent.worker.Stop()
-
-        # Stop preview thread (and wait for it to end)
-        self.preview_parent.worker.kill()
-        self.preview_parent.background.exit()
-        self.preview_parent.background.wait(5000)
+        self.preview_parent.Stop()
 
         # Close readers
         self.clip.Close()


### PR DESCRIPTION
Fixing the detection of max timeline length. Any change to the project data (i.e. a clip moving for example) will re-calculate the max frame/max length of the timeline, so our playback stops at the correct moment. Also, improved the clean-up code on our video preview widget and preview thread, so we don't accumulate unneeded project data watchers.