### PR TITLE
Memory Clean-up, Safer Shutdown, and Cache Improvements

### DIFF
--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -29,7 +29,7 @@ import os
 from time import strftime
 
 VERSION = "2.6.1-dev"
-MINIMUM_LIBOPENSHOT_VERSION = "0.2.7"
+MINIMUM_LIBOPENSHOT_VERSION = "0.2.8"
 DATE = "20210904000000"
 NAME = "openshot-qt"
 PRODUCT_NAME = "OpenShot Video Editor"

--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -80,6 +80,9 @@ class TimelineSync(UpdateInterface):
         # Pass the change to the libopenshot timeline
         try:
             if action.type == "load":
+                # Clear any existing clips & effects (free memory)
+                self.timeline.Clear()
+
                 # This JSON is initially loaded to libopenshot to update the timeline
                 self.timeline.SetJson(action.json(only_value=True))
                 self.timeline.Open()  # Re-Open the Timeline reader

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -264,7 +264,7 @@
   {
     "min": 0,
     "max": 1024,
-    "value": 2,
+    "value": 30,
     "title": "Cache Pre-roll: Min Frames",
     "type": "spinner-int",
     "category": "Cache",
@@ -273,7 +273,7 @@
   {
     "min": 0,
     "max": 1024,
-    "value": 8,
+    "value": 30,
     "title": "Cache Pre-roll: Max Frames",
     "type": "spinner-int",
     "category": "Cache",

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -264,7 +264,7 @@
   {
     "min": 0,
     "max": 1024,
-    "value": 30,
+    "value": 24,
     "title": "Cache Pre-roll: Min Frames",
     "type": "spinner-int",
     "category": "Cache",
@@ -273,7 +273,7 @@
   {
     "min": 0,
     "max": 1024,
-    "value": 30,
+    "value": 48,
     "title": "Cache Pre-roll: Max Frames",
     "type": "spinner-int",
     "category": "Cache",
@@ -283,7 +283,7 @@
     "min": 0.0,
     "max": 1.0,
     "step": 0.1,
-    "value": 0.75,
+    "value": 0.7,
     "title": "Cache Ahead (Percent)",
     "type": "spinner",
     "category": "Cache",
@@ -301,7 +301,7 @@
   {
     "min": 0,
     "max": 9999999,
-    "value": 1024,
+    "value": 512,
     "title": "Cache Limit (MB)",
     "type": "spinner-int",
     "category": "Cache",

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -184,10 +184,14 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.videoPreview = None
         self.preview_parent.Stop()
 
-        # Close Timeline
+        # Clean-up Timeline
         if self.timeline_sync and self.timeline_sync.timeline:
+            # Clear all clips & close all readers
+            self.timeline_sync.timeline.Clear()
+
+            # Close & delete timeline
             self.timeline_sync.timeline.Close()
-            self.timeline_sync.timeline = None
+            del self.timeline_sync.timeline
 
         # Destroy lock file
         self.destroy_lock_file()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2498,6 +2498,10 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 self.selected_effects.remove(item_id)
 
         if not self.selected_clips:
+            # Clear properties view (if no other clips are selected)
+            if self.propertyTableView:
+                self.propertyTableView.loadProperties.emit("", "")
+
             # Clear transform (if no other clips are selected)
             self.TransformSignal.emit("")
 

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -297,13 +297,13 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Clear any previous thumbnails
         self.clear_temporary_files()
 
+        # Reset selections
+        self.clearSelections()
+
         # clear data and start new project
         app.project.load("")
         app.updates.reset()
         self.updateStatusChanged(False, False)
-
-        # Reset selections
-        self.clearSelections()
 
         # Refresh files views
         self.refreshFilesSignal.emit()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -294,11 +294,21 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 # User canceled prompt
                 return
 
-        # Clear any previous thumbnails
-        self.clear_temporary_files()
+        # Disable video caching
+        openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = False
+
+        # Stop preview thread
+        self.SpeedSignal.emit(0)
+        self.PauseSignal.emit()
 
         # Reset selections
         self.clearSelections()
+
+        # Process all events
+        QCoreApplication.processEvents()
+
+        # Clear any previous thumbnails
+        self.clear_temporary_files()
 
         # clear data and start new project
         app.project.load("")
@@ -317,6 +327,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Update max size (for fast previews)
         self.MaxSizeChanged.emit(self.videoPreview.size())
+
+        # Enable video caching
+        openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = True
 
     def actionAnimatedTitle_trigger(self):
         # show dialog
@@ -468,9 +481,17 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             # Ignore the request
             return
 
+        # Disable video caching
+        openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = False
+
         # Stop preview thread
         self.SpeedSignal.emit(0)
         self.PauseSignal.emit()
+
+        # Reset selections
+        self.clearSelections()
+
+        # Process all events
         QCoreApplication.processEvents()
 
         # Do we have unsaved changes?
@@ -506,9 +527,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 app.updates.reset()
                 app.updates.load_history(app.project)
 
-                # Reset selections
-                self.clearSelections()
-
                 # Refresh files views
                 self.refreshFilesSignal.emit()
 
@@ -539,6 +557,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         except Exception as ex:
             log.error("Couldn't open project %s.", file_path, exc_info=1)
             QMessageBox.warning(self, _("Error Opening Project"), str(ex))
+
+        # Enable video caching
+        openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = True
 
         # Restore normal cursor
         app.restoreOverrideCursor()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1024,8 +1024,24 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def actionJumpStart_trigger(self, checked=True):
         log.debug("actionJumpStart_trigger")
 
+        # Get current player speed/direction
+        player = self.preview_thread.player
+        current_speed = player.Speed()
+
+        # Switch speed back to forward (and then pause)
+        # This will allow video caching to start working in the forward direction
+        self.SpeedSignal.emit(1)
+        self.SpeedSignal.emit(0)
+
         # Seek to the 1st frame
         self.SeekSignal.emit(1)
+
+        # If playing, continue playing
+        if current_speed >= 0:
+            self.SpeedSignal.emit(current_speed)
+        else:
+            # If reversing, pause video
+            self.PauseSignal.emit()
 
     def actionJumpEnd_trigger(self, checked=True):
         log.debug("actionJumpEnd_trigger")

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -165,6 +165,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Track end of session
         track_metric_session(False)
 
+        # Disable video caching
+        openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = False
+
         # Stop threads
         self.StopSignal.emit()
 

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -1283,6 +1283,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         if self.transforming_clip and not clip_id:
             # Clear transform
             self.transforming_clip = None
+            self.transforming_clip_object = None
             need_refresh = True
 
         # Get new clip for transform
@@ -1291,6 +1292,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
             self.transforming_clip_object = win.timeline_sync.timeline.GetClip(clip_id)
             if self.transforming_clip and self.transforming_clip_object:
                 self.transforming_effect = None
+                self.transforming_effect_object = None
                 need_refresh = True
 
         # Update the preview and reselct current frame in properties
@@ -1308,7 +1310,9 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         if self.transforming_effect and not effect_id:
             # Clear transform
             self.transforming_effect = None
+            self.transforming_effect_object = None
             self.transforming_clip = None
+            self.transforming_clip_object = None
             need_refresh = True
 
         # Get new clip for transform


### PR DESCRIPTION
- Fixed caching direction on "Jump to Start" during a rewind operation
- Updating default cache settings (24 min pre-roll, 48 max pre-roll, 300 max frames, 512 MB memory cache)
- Protect against accessing deleted clips (property window, preview widget, new/open dialogs, etc...)
- Disabling video cache during shutdown