### PR TITLE
Fixing the resolution of China Video Disc (CVD)

### DIFF
--- a/src/profiles/cvd_ntsc
+++ b/src/profiles/cvd_ntsc
@@ -1,8 +1,8 @@
 description=CVD NTSC
 frame_rate_num=30000
 frame_rate_den=1001
-width=352
-height=480
+width=480
+height=352
 progressive=0
 sample_aspect_num=20
 sample_aspect_den=11

--- a/src/profiles/cvd_pal
+++ b/src/profiles/cvd_pal
@@ -1,8 +1,8 @@
 description=CVD PAL
 frame_rate_num=25
 frame_rate_den=1
-width=352
-height=576
+width=576
+height=352
 progressive=0
 sample_aspect_num=59
 sample_aspect_den=27


### PR DESCRIPTION
Fixing the resolution of China Video Disc (CVD), which is described as a **horizontal** format - but most websites list the resolution backwards for some reason.

NTSC: `480x352`
PAL: `576x352`