### PR TITLE
Freeze BABL extensions for all 3 OSes

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -231,7 +231,9 @@ if sys.platform == "win32":
     MSYSTEM = os.getenv('MSYSTEM', "MINGW64").lower()
     babl_ext_path = "c:/msys64/%s/lib/babl-0.1/" % MSYSTEM
     for filename in find_files(babl_ext_path, ["*.dll"]):
-        src_files.append((filename, os.path.join("lib", "babl-extensions", os.path.relpath(filename, start=babl_ext_path))))
+        if os.path.split(filename)[1] not in ["libbabl-0.1-0.dll", "libgcc_s_seh-1.dll",
+                                              "liblcms2-2.dll", "libwinpthread-1.dll", "msvcrt.dll"]:
+            src_files.append((filename, os.path.join("lib", "babl-ext", os.path.relpath(filename, start=babl_ext_path))))
 
     # Append all source files
     src_files.append((os.path.join(PATH, "installer", "qt.conf"), "qt.conf"))

--- a/freeze.py
+++ b/freeze.py
@@ -529,14 +529,12 @@ elif sys.platform == "win32":
             if frozen_path.startswith("exe"):
                 paths = ["lib/babl-ext/libbabl-0.1-0.*",
                          "lib/babl-ext/libgcc_s_seh-1.*",
-                         "lib/babl-ext/liblcms2-2.*"
-                         "lib/babl-ext/libwinpthread-1.*"
+                         "lib/babl-ext/liblcms2-2.*",
+                         "lib/babl-ext/libwinpthread-1.*",
                          "lib/babl-ext/msvcrt.*"]
                 for path in paths:
                     full_path = os.path.join(build_path, frozen_path, path)
-                    log.info("Inspecting unneeded path: %s" % full_path)
                     for remove_path in glob.glob(full_path):
-                        log.info("Inspecting removal path: %s" % remove_path)
                         if os.path.isfile(remove_path):
                             log.info("Removing unneeded file: %s" % remove_path)
                             os.unlink(remove_path)

--- a/freeze.py
+++ b/freeze.py
@@ -280,6 +280,12 @@ elif sys.platform == "linux":
     for filename in find_files(nss_path, ["*"]):
         external_so_files.append((filename, os.path.basename(filename)))
 
+    # Manually add BABL extensions (used in ChromaKey effect) - these are loaded at runtime,
+    # and thus cx_freeze is not able to detect them
+    babl_ext_path = "/usr/local/lib/babl-0.1"
+    for filename in find_files(babl_ext_path, ["*.so"]):
+        src_files.append((filename, os.path.join("lib", "babl-ext", os.path.relpath(filename, start=babl_ext_path))))
+
     # Append Linux ICON file
     iconFile += ".svg"
     src_files.append((os.path.join(PATH, "xdg", iconFile), iconFile))
@@ -420,6 +426,12 @@ elif sys.platform == "darwin":
     external_so_files.append((web_process_path, os.path.basename(web_process_path)))
     external_so_files.append((web_core_path, os.path.basename(web_core_path)))
 
+    # Manually add BABL extensions (used in ChromaKey effect) - these are loaded at runtime,
+    # and thus cx_freeze is not able to detect them
+    babl_ext_path = "/usr/local/lib/babl-0.1"
+    for filename in find_files(babl_ext_path, ["*.dylib"]):
+        src_files.append((filename, os.path.join("lib", "babl-ext", os.path.relpath(filename, start=babl_ext_path))))
+
     # Add QtWebEngineProcess Resources & Local
     for filename in find_files(os.path.join(qt_webengine_path, "Resources"), ["*"]):
         external_so_files.append((filename, os.path.relpath(filename, start=os.path.join(qt_webengine_path, "Resources"))))
@@ -522,19 +534,18 @@ elif sys.platform == "linux":
                             log.info("Removing unneeded folder: %s" % remove_path)
                             rmtree(remove_path)
 
-elif sys.platform == "win32":
-    # Windows issues with frozen folder
-    # We need to remove some excess folders/files that are unneeded bloat
-    for frozen_path in os.listdir(build_path):
-            if frozen_path.startswith("exe"):
-                paths = ["lib/babl-ext/libbabl-0.1-0.*",
-                         "lib/babl-ext/libgcc_s_seh-1.*",
-                         "lib/babl-ext/liblcms2-2.*",
-                         "lib/babl-ext/libwinpthread-1.*",
-                         "lib/babl-ext/msvcrt.*"]
-                for path in paths:
-                    full_path = os.path.join(build_path, frozen_path, path)
-                    for remove_path in glob.glob(full_path):
-                        if os.path.isfile(remove_path):
-                            log.info("Removing unneeded file: %s" % remove_path)
-                            os.unlink(remove_path)
+# We need to remove some excess folders/files that are unneeded bloat
+# All 3 OSes
+for frozen_path in os.listdir(build_path):
+        if frozen_path.startswith("exe"):
+            paths = ["lib/babl-ext/libbabl-0.1-0.*",
+                     "lib/babl-ext/libgcc_s_seh-1.*",
+                     "lib/babl-ext/liblcms2-2.*",
+                     "lib/babl-ext/libwinpthread-1.*",
+                     "lib/babl-ext/msvcrt.*"]
+            for path in paths:
+                full_path = os.path.join(build_path, frozen_path, path)
+                for remove_path in glob.glob(full_path):
+                    if os.path.isfile(remove_path):
+                        log.info("Removing unneeded file: %s" % remove_path)
+                        os.unlink(remove_path)

--- a/freeze.py
+++ b/freeze.py
@@ -231,7 +231,7 @@ if sys.platform == "win32":
     MSYSTEM = os.getenv('MSYSTEM', "MINGW64").lower()
     babl_ext_path = "c:/msys64/%s/lib/babl-0.1/" % MSYSTEM
     for filename in find_files(babl_ext_path, ["*.dll"]):
-        src_files.append((filename, os.path.join("babl-extensions", os.path.relpath(filename, start=babl_ext_path))))
+        src_files.append((filename, os.path.join("lib", "babl-extensions", os.path.relpath(filename, start=babl_ext_path))))
 
     # Append all source files
     src_files.append((os.path.join(PATH, "installer", "qt.conf"), "qt.conf"))

--- a/freeze.py
+++ b/freeze.py
@@ -226,6 +226,13 @@ if sys.platform == "win32":
     for filename in find_files(zmq_path, ["*"]):
         src_files.append((filename, os.path.join("lib", "zmq", os.path.relpath(filename, start=zmq_path))))
 
+    # Manually add BABL extensions (used in ChromaKey effect) - these are loaded at runtime,
+    # and thus cx_freeze is not able to detect them
+    MSYSTEM = os.getenv('MSYSTEM', "MINGW64").lower()
+    babl_ext_path = "c:/msys64/%s/lib/babl-0.1/" % MSYSTEM
+    for filename in find_files(babl_ext_path, ["*.dll"]):
+        src_files.append((filename, os.path.join("babl-extensions", os.path.relpath(filename, start=babl_ext_path))))
+
     # Append all source files
     src_files.append((os.path.join(PATH, "installer", "qt.conf"), "qt.conf"))
     for filename in find_files("openshot_qt", ["*"]):

--- a/freeze.py
+++ b/freeze.py
@@ -527,17 +527,16 @@ elif sys.platform == "win32":
     # We need to remove some excess folders/files that are unneeded bloat
     for frozen_path in os.listdir(build_path):
             if frozen_path.startswith("exe"):
-                paths = ["lib/babl-ext/libbabl-0.1-0.dll",
-                         "lib/babl-ext/libgcc_s_seh-1.dll",
-                         "lib/babl-ext/liblcms2-2.dll"
-                         "lib/babl-ext/libwinpthread-1.dll"
-                         "lib/babl-ext/msvcrt.dll"]
+                paths = ["lib/babl-ext/libbabl-0.1-0.*",
+                         "lib/babl-ext/libgcc_s_seh-1.*",
+                         "lib/babl-ext/liblcms2-2.*"
+                         "lib/babl-ext/libwinpthread-1.*"
+                         "lib/babl-ext/msvcrt.*"]
                 for path in paths:
                     full_path = os.path.join(build_path, frozen_path, path)
+                    log.info("Inspecting unneeded path: %s" % full_path)
                     for remove_path in glob.glob(full_path):
+                        log.info("Inspecting removal path: %s" % remove_path)
                         if os.path.isfile(remove_path):
                             log.info("Removing unneeded file: %s" % remove_path)
                             os.unlink(remove_path)
-                        elif os.path.isdir(remove_path):
-                            log.info("Removing unneeded folder: %s" % remove_path)
-                            rmtree(remove_path)

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -138,7 +138,7 @@ class OpenShotApp(QApplication):
         openshot.Settings.Instance().PATH_OPENSHOT_INSTALL = info.PATH
 
         # Set BABL extensions path (for windows)
-        babl_ext_path = os.path.join(info.PATH, "lib", "babl-extensions")
+        babl_ext_path = os.path.join(info.PATH, "lib", "babl-ext")
         log.info(f"checking babl_ext_path: {babl_ext_path}")
         if sys.platform == "win32" and os.path.exists(babl_ext_path):
             os.environ["BABL_PATH"] = babl_ext_path

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -137,6 +137,13 @@ class OpenShotApp(QApplication):
         # Set location of OpenShot program (for libopenshot)
         openshot.Settings.Instance().PATH_OPENSHOT_INSTALL = info.PATH
 
+        # Set BABL extensions path (for windows)
+        babl_ext_path = os.path.join(info.PATH, "lib", "babl-extensions")
+        log.info(f"checking babl_ext_path: {babl_ext_path}")
+        if sys.platform == "win32" and os.path.exists(babl_ext_path):
+            os.environ["BABL_PATH"] = babl_ext_path
+            log.info(f"setting BABL_PATH: {babl_ext_path}")
+
         # Check to disable sentry
         if self.mode == "unittest" or not self.settings.get('send_metrics'):
             sentry.disable_tracing()

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -140,7 +140,7 @@ class OpenShotApp(QApplication):
         # Set BABL extensions path (for windows)
         babl_ext_path = os.path.join(info.PATH, "lib", "babl-ext")
         log.info(f"checking babl_ext_path: {babl_ext_path}")
-        if sys.platform == "win32" and os.path.exists(babl_ext_path):
+        if os.path.exists(babl_ext_path):
             os.environ["BABL_PATH"] = babl_ext_path
             log.info(f"setting BABL_PATH: {babl_ext_path}")
 


### PR DESCRIPTION
All 3 OSes (in official installers) are missing the BABL extensions, used by our ChromaKey effect to use different color algorithms - for color distance. We need to both include these missing libraries (DLL, SO, and DYLIB which are loaded at runtime), and set the `BABL_PATH` environment variable when launching OpenShot on Windows - so we load the correct folder.