### PR TITLE
Removing default folder from Windows Installer/Uninstaller name

### DIFF
--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -25,7 +25,7 @@
 ; Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={code:GetAppId|4BB0DCDC-BC24-49EC-8937-72956C33A470}
-AppName={code:GetDefaultDirName|OpenShot Video Editor}
+AppName=OpenShot Video Editor
 AppVersion={#VERSION}
 VersionInfoVersion={#VERSION}
 AppPublisher={#MyAppPublisher}


### PR DESCRIPTION
The OpenShot Windows installers accidentally changed the name of the app from "OpenShot Video Editor" to "C:\Program Files\OpenShot Video Editor". This is visible in the Installer and the Uninstaller (Add / Remove Programs)