### PR TITLE
Reduce verbosity for Sentry (on a few methods)

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -149,7 +149,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
     def _set(self, key, values=None, add=False, partial_update=False, remove=False):
         """ Store setting, but adding isn't allowed. All possible settings must be in default settings file. """
 
-        log.info(
+        log.debug(
             "_set key: %s values: %s add: %s partial: %s remove: %s",
             key, values, add, partial_update, remove)
         parent, my_key = None, ""

--- a/src/classes/query.py
+++ b/src/classes/query.py
@@ -125,7 +125,7 @@ class QueryObject:
                 object = OBJECT_TYPE()
                 object.id = child["id"]
                 object.key = [OBJECT_TYPE.object_name, {"id": object.id}]
-                object.data = copy.deepcopy(child)  # copy of object
+                object.data = child
                 object.type = "update"
                 matching_objects.append(object)
 

--- a/src/classes/query.py
+++ b/src/classes/query.py
@@ -125,7 +125,7 @@ class QueryObject:
                 object = OBJECT_TYPE()
                 object.id = child["id"]
                 object.key = [OBJECT_TYPE.object_name, {"id": object.id}]
-                object.data = child
+                object.data = copy.deepcopy(child)  # copy of object
                 object.type = "update"
                 matching_objects.append(object)
 

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2471,7 +2471,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             log.debug('addSelection: item_type: {}, clear_existing: {}'.format(
                 item_type, clear_existing))
         else:
-            log.info('addSelection: item_id: {}, item_type: {}, clear_existing: {}'.format(
+            log.debug('addSelection: item_id: {}, item_type: {}, clear_existing: {}'.format(
                 item_id, item_type, clear_existing))
 
         s = get_app().get_settings()

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -275,7 +275,7 @@ class PlayerWorker(QObject):
         # Mark frame number for processing (if parent is done initializing)
         self.Seek(self.player.Position())
 
-        log.info("player Position(): %s", self.player.Position())
+        log.debug("player Position(): %s", self.player.Position())
 
     def LoadFile(self, path=None):
         """ Load a media file into the video player """

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -1295,7 +1295,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                 self.transforming_effect_object = None
                 need_refresh = True
 
-        # Update the preview and reselct current frame in properties
+        # Update the preview and reselect current frame in properties
         if need_refresh:
             win.refreshFrameSignal.emit()
             win.propertyTableView.select_frame(win.preview_thread.player.Position())


### PR DESCRIPTION
Related to https://github.com/OpenShot/libopenshot/pull/861

This is a minor change, but reducing the verbosity of a few logging calls, and removing a copy.deepcopy() call around all query object data, which is unneeded and slows down openshot-qt.