### PR TITLE
Faster Serialization (Replace deepcopy with json)

### DIFF
--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -93,10 +93,10 @@ class JsonDataStore:
                     user_values[item["setting"].lower()] = item["value"]
 
             # Settings data
-            return copy.deepcopy(user_values.get(key, None))
+            return json.loads(json.dumps(user_values.get(key, None)))
         else:
             # Project data (i.e dictionary)
-            return copy.deepcopy(self._data.get(key, None))
+            return json.loads(json.dumps(self._data.get(key, None)))
 
     def set(self, key, value):
         """ Store value in key """

--- a/src/classes/metrics.py
+++ b/src/classes/metrics.py
@@ -32,7 +32,7 @@ import platform
 import threading
 import time
 import urllib.parse
-from copy import deepcopy
+import json
 
 from classes import info
 from classes import language
@@ -102,7 +102,7 @@ metric_queue = []
 
 def track_metric_screen(screen_name):
     """Track a GUI screen being shown"""
-    metric_params = deepcopy(params)
+    metric_params = json.loads(json.dumps(params))
     metric_params["t"] = "screenview"
     metric_params["cd"] = screen_name
     metric_params["cid"] = s.get("unique_install_id")
@@ -114,7 +114,7 @@ def track_metric_screen(screen_name):
 
 def track_metric_event(event_action, event_label, event_category="General", event_value=0):
     """Track a GUI screen being shown"""
-    metric_params = deepcopy(params)
+    metric_params = json.loads(json.dumps(params))
     metric_params["t"] = "event"
     metric_params["ec"] = event_category
     metric_params["ea"] = event_action
@@ -129,7 +129,7 @@ def track_metric_event(event_action, event_label, event_category="General", even
 
 def track_metric_error(error_name, is_fatal=False):
     """Track an error has occurred"""
-    metric_params = deepcopy(params)
+    metric_params = json.loads(json.dumps(params))
     metric_params["t"] = "exception"
     metric_params["exd"] = error_name
     metric_params["exf"] = 0
@@ -143,7 +143,7 @@ def track_metric_error(error_name, is_fatal=False):
 
 def track_metric_session(is_start=True):
     """Track a GUI screen being shown"""
-    metric_params = deepcopy(params)
+    metric_params = json.loads(json.dumps(params))
     metric_params["t"] = "screenview"
     metric_params["sc"] = "start"
     metric_params["cd"] = "launch-app"

--- a/src/classes/metrics.py
+++ b/src/classes/metrics.py
@@ -107,8 +107,7 @@ def track_metric_screen(screen_name):
     metric_params["cd"] = screen_name
     metric_params["cid"] = s.get("unique_install_id")
 
-    t = threading.Thread(target=send_metric, args=[metric_params])
-    t.daemon = True
+    t = threading.Thread(target=send_metric, args=[metric_params], daemon=True)
     t.start()
 
 
@@ -122,8 +121,7 @@ def track_metric_event(event_action, event_label, event_category="General", even
     metric_params["ev"] = event_value
     metric_params["cid"] = s.get("unique_install_id")
 
-    t = threading.Thread(target=send_metric, args=[metric_params])
-    t.daemon = True
+    t = threading.Thread(target=send_metric, args=[metric_params], daemon=True)
     t.start()
 
 
@@ -136,8 +134,7 @@ def track_metric_error(error_name, is_fatal=False):
     if is_fatal:
         metric_params["exf"] = 1
 
-    t = threading.Thread(target=send_metric, args=[metric_params])
-    t.daemon = True
+    t = threading.Thread(target=send_metric, args=[metric_params], daemon=True)
     t.start()
 
 
@@ -152,8 +149,7 @@ def track_metric_session(is_start=True):
         metric_params["sc"] = "end"
         metric_params["cd"] = "close-app"
 
-    t = threading.Thread(target=send_metric, args=[metric_params])
-    t.daemon = True
+    t = threading.Thread(target=send_metric, args=[metric_params], daemon=True)
     t.start()
 
 

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -229,7 +229,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
 
         # After processing each key, we've found object and parent, return former value/s on update
-        ret = copy.deepcopy(obj)
+        ret = json.loads(json.dumps(obj))
 
         # Apply the correct action to the found item
         if remove:
@@ -400,7 +400,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         # Create a scaler instance
         scaler = KeyframeScaler(factor=scale_factor)
         # Create copy of active project data and scale
-        scaled = scaler(copy.deepcopy(self._data))
+        scaled = scaler(json.loads(json.dumps(self._data)))
         return scaled
 
     def read_legacy_project_file(self, file_path):
@@ -482,7 +482,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                             failed_files.append(item.name)
 
                 # Delete all tracks
-                track_list = copy.deepcopy(Track.filter())
+                track_list = json.loads(json.dumps(Track.filter()))
                 for track in track_list:
                     track.delete()
 

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -482,7 +482,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                             failed_files.append(item.name)
 
                 # Delete all tracks
-                track_list = json.loads(json.dumps(Track.filter()))
+                track_list = Track.filter()
                 for track in track_list:
                     track.delete()
 

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -149,7 +149,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
     def _set(self, key, values=None, add=False, partial_update=False, remove=False):
         """ Store setting, but adding isn't allowed. All possible settings must be in default settings file. """
 
-        log.info(
+        log.debug(
             "_set key: %s values: %s add: %s partial: %s remove: %s",
             key, values, add, partial_update, remove)
         parent, my_key = None, ""

--- a/src/classes/query.py
+++ b/src/classes/query.py
@@ -27,6 +27,7 @@
 
 import os
 import copy
+import json
 
 from classes import info
 from classes.app import get_app
@@ -54,15 +55,15 @@ class QueryObject:
             self.id = get_app().project.generate_id()
 
             # save id in data (if attribute found)
-            self.data["id"] = copy.deepcopy(self.id)
+            self.data["id"] = json.loads(json.dumps(self.id))
 
             # Set key (if needed)
             if not self.key:
-                self.key = copy.deepcopy(OBJECT_TYPE.object_key)
+                self.key = json.loads(json.dumps(OBJECT_TYPE.object_key))
                 self.key.append({"id": self.id})
 
             # Insert into project data
-            get_app().updates.insert(copy.deepcopy(OBJECT_TYPE.object_key), copy.deepcopy(self.data))
+            get_app().updates.insert(json.loads(json.dumps(OBJECT_TYPE.object_key)), json.loads(json.dumps(self.data)))
 
             # Mark record as 'update' now... so another call to this method won't insert it again
             self.type = "update"
@@ -125,7 +126,7 @@ class QueryObject:
                 object = OBJECT_TYPE()
                 object.id = child["id"]
                 object.key = [OBJECT_TYPE.object_name, {"id": object.id}]
-                object.data = copy.deepcopy(child)  # copy of object
+                object.data = json.loads(json.dumps(child))  # copy of object
                 object.type = "update"
                 matching_objects.append(object)
 

--- a/src/classes/query.py
+++ b/src/classes/query.py
@@ -125,7 +125,7 @@ class QueryObject:
                 object = OBJECT_TYPE()
                 object.id = child["id"]
                 object.key = [OBJECT_TYPE.object_name, {"id": object.id}]
-                object.data = copy.deepcopy(child)  # copy of object
+                object.data = child
                 object.type = "update"
                 matching_objects.append(object)
 

--- a/src/classes/query.py
+++ b/src/classes/query.py
@@ -125,7 +125,7 @@ class QueryObject:
                 object = OBJECT_TYPE()
                 object.id = child["id"]
                 object.key = [OBJECT_TYPE.object_name, {"id": object.id}]
-                object.data = child
+                object.data = copy.deepcopy(child)  # copy of object
                 object.type = "update"
                 matching_objects.append(object)
 

--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -107,8 +107,7 @@ class TimelineSync(UpdateInterface):
             return
 
         # Pass the change to the libopenshot timeline in a separate thread (to not block main thread)
-        t = threading.Thread(target=send_changes_to_libopenshot, args=[action])
-        t.daemon = True
+        t = threading.Thread(target=send_changes_to_libopenshot, args=[action], daemon=True)
         t.start()
 
     def MaxSizeChangedCB(self, new_size):

--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -103,7 +103,8 @@ class TimelineSync(UpdateInterface):
                          (e, update_action.json(is_array=True)))
 
         # Ignore changes that don't affect libopenshot
-        if len(action.key) >= 1 and action.key[0].lower() in ["files", "history", "markers", "layers", "scale", "profile"]:
+        if len(action.key) >= 1 and action.key[0].lower() in ["files", "history", "markers",
+                                                              "layers", "scale", "profile", "duration"]:
             return
 
         # Pass the change to the libopenshot timeline in a separate thread (to not block main thread)

--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -25,6 +25,7 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
+import threading
 import time
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 
@@ -73,35 +74,42 @@ class TimelineSync(UpdateInterface):
     def changed(self, action):
         """ This method is invoked by the UpdateManager each time a change happens (i.e UpdateInterface) """
 
+        def send_changes_to_libopenshot(update_action):
+            """Send changes to libopenshot in a separate thread"""
+            try:
+                if update_action.type == "load":
+                    # Clear any existing clips & effects (free memory)
+                    self.timeline.Clear()
+
+                    # This JSON is initially loaded to libopenshot to update the timeline
+                    self.timeline.SetJson(update_action.json(only_value=True))
+                    self.timeline.Open()  # Re-Open the Timeline reader
+
+                    # The timeline's profile changed, so update all clips
+                    self.timeline.ApplyMapperToClips()
+
+                    # Always seek back to frame 1
+                    self.window.SeekSignal.emit(1)
+
+                    # Refresh current frame (since the entire timeline was updated)
+                    self.window.refreshFrameSignal.emit()
+
+                else:
+                    # This JSON DIFF is passed to libopenshot to update the timeline
+                    self.timeline.ApplyJsonDiff(update_action.json(is_array=True))
+
+            except Exception as e:
+                log.info("Error applying JSON to timeline object in libopenshot: %s. %s" %
+                         (e, update_action.json(is_array=True)))
+
         # Ignore changes that don't affect libopenshot
         if len(action.key) >= 1 and action.key[0].lower() in ["files", "history", "markers", "layers", "scale", "profile"]:
             return
 
-        # Pass the change to the libopenshot timeline
-        try:
-            if action.type == "load":
-                # Clear any existing clips & effects (free memory)
-                self.timeline.Clear()
-
-                # This JSON is initially loaded to libopenshot to update the timeline
-                self.timeline.SetJson(action.json(only_value=True))
-                self.timeline.Open()  # Re-Open the Timeline reader
-
-                # The timeline's profile changed, so update all clips
-                self.timeline.ApplyMapperToClips()
-
-                # Always seek back to frame 1
-                self.window.SeekSignal.emit(1)
-
-                # Refresh current frame (since the entire timeline was updated)
-                self.window.refreshFrameSignal.emit()
-
-            else:
-                # This JSON DIFF is passed to libopenshot to update the timeline
-                self.timeline.ApplyJsonDiff(action.json(is_array=True))
-
-        except Exception as e:
-            log.info("Error applying JSON to timeline object in libopenshot: %s. %s" % (e, action.json(is_array=True)))
+        # Pass the change to the libopenshot timeline in a separate thread (to not block main thread)
+        t = threading.Thread(target=send_changes_to_libopenshot, args=[action])
+        t.daemon = True
+        t.start()
 
     def MaxSizeChangedCB(self, new_size):
         """Callback for max sized change (i.e. max size of video widget)"""

--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -70,13 +70,13 @@ class UpdateAction:
 
         # Build the dictionary to be serialized
         if only_value:
-            data_dict = copy.deepcopy(self.values)
+            data_dict = json.loads(json.dumps(self.values))
         else:
             data_dict = {"type": self.type,
                          "key": self.key,
-                         "value": copy.deepcopy(self.values),
+                         "value": json.loads(json.dumps(self.values)),
                          "partial": self.partial_update,
-                         "old_values": copy.deepcopy(self.old_values)}
+                         "old_values": json.loads(json.dumps(self.old_values))}
 
             # Always remove 'history' key (if found). This prevents nested "history"
             # attributes when a project dict is loaded.
@@ -274,7 +274,7 @@ class UpdateManager:
 
         if len(self.actionHistory) > 0:
             # Get last action from history (remove)
-            last_action = copy.deepcopy(self.actionHistory.pop())
+            last_action = json.loads(json.dumps(self.actionHistory.pop()))
 
             self.redoHistory.append(last_action)
             self.pending_action = None
@@ -287,7 +287,7 @@ class UpdateManager:
 
         if len(self.redoHistory) > 0:
             # Get last undone action off redo history (remove)
-            next_action = copy.deepcopy(self.redoHistory.pop())
+            next_action = json.loads(json.dumps(self.redoHistory.pop()))
 
             # Remove ID from insert (if found)
             if next_action.type == "insert" and isinstance(next_action.key[-1], dict) and "id" in next_action.key[-1]:

--- a/src/classes/version.py
+++ b/src/classes/version.py
@@ -34,8 +34,7 @@ from classes.logger import log
 
 def get_current_Version():
     """Get the current version """
-    t = threading.Thread(target=get_version_from_http)
-    t.daemon = True
+    t = threading.Thread(target=get_version_from_http, daemon=True)
     t.start()
 
 def get_version_from_http():

--- a/src/classes/waveform.py
+++ b/src/classes/waveform.py
@@ -47,9 +47,7 @@ def get_audio_data(files: dict):
         clip_list = files[file_id]
 
         log.info("Clip loaded, start thread")
-        t = threading.Thread(target=get_waveform_thread,
-                             args=[file_id, clip_list])
-        t.daemon = True
+        t = threading.Thread(target=get_waveform_thread, args=[file_id, clip_list], daemon=True)
         t.start()
 
 

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2471,7 +2471,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             log.debug('addSelection: item_type: {}, clear_existing: {}'.format(
                 item_type, clear_existing))
         else:
-            log.info('addSelection: item_id: {}, item_type: {}, clear_existing: {}'.format(
+            log.debug('addSelection: item_id: {}, item_type: {}, clear_existing: {}'.format(
                 item_id, item_type, clear_existing))
 
         s = get_app().get_settings()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -31,9 +31,9 @@ import os
 import shutil
 import webbrowser
 import functools
-from copy import deepcopy
 from time import sleep
 from uuid import uuid4
+import json
 
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 from PyQt5.QtCore import (
@@ -1848,7 +1848,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                          if l.get("lock", False)]
 
         # Loop through selected clips
-        for clip_id in deepcopy(self.selected_clips):
+        for clip_id in json.loads(json.dumps(self.selected_clips)):
             # Find matching file
             clips = Clip.filter(id=clip_id)
             clips = list(filter(lambda x: x.data.get("layer") not in locked_tracks, clips))
@@ -1873,7 +1873,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         log.debug('actionRemoveEffect_trigger')
 
         # Loop through selected clips
-        for effect_id in deepcopy(self.selected_effects):
+        for effect_id in json.loads(json.dumps(self.selected_effects)):
             log.info("effect id: %s" % effect_id)
 
             # Find matching file
@@ -1912,7 +1912,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                          if l.get("lock", False)]
 
         # Loop through selected clips
-        for tran_id in deepcopy(self.selected_transitions):
+        for tran_id in json.loads(json.dumps(self.selected_transitions)):
             # Find matching file
             transitions = Transition.filter(id=tran_id)
             transitions = list(filter(lambda x: x.data.get("layer") not in locked_tracks, transitions))

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -275,7 +275,7 @@ class PlayerWorker(QObject):
         # Mark frame number for processing (if parent is done initializing)
         self.Seek(self.player.Position())
 
-        log.info("player Position(): %s", self.player.Position())
+        log.debug("player Position(): %s", self.player.Position())
 
     def LoadFile(self, path=None):
         """ Load a media file into the video player """

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -1295,7 +1295,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                 self.transforming_effect_object = None
                 need_refresh = True
 
-        # Update the preview and reselct current frame in properties
+        # Update the preview and reselect current frame in properties
         if need_refresh:
             win.refreshFrameSignal.emit()
             win.propertyTableView.select_frame(win.preview_thread.player.Position())

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -544,7 +544,7 @@ Blender Path: {}
         # prepare string to inject
         user_params = "\n#BEGIN INJECTING PARAMS\n"
 
-        param_data = copy.deepcopy(self.params)
+        param_data = json.loads(json.dumps(self.params))
         param_data.update(self.get_project_params(is_preview))
 
         param_serialization = json.dumps(param_data)

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1900,8 +1900,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         fps = get_app().project.get("fps")
         fps_num = float(fps["num"])
         fps_den = float(fps["den"])
-        fps_float = fps_num / fps_den
-        frame_duration = fps_den / fps_num
 
         # Get locked tracks from project
         locked_layers = [
@@ -1968,10 +1966,10 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 right_clip.save()
 
                 # Save changes again (with new thumbnail)
-                self.update_clip_data(right_clip.data, only_basic_props=False, ignore_reader=True)
+                self.update_clip_data(right_clip.data, only_basic_props=True, ignore_reader=True)
 
             # Save changes
-            self.update_clip_data(clip.data, only_basic_props=False, ignore_reader=True)
+            self.update_clip_data(clip.data, only_basic_props=True, ignore_reader=True)
 
         # Start or restart timer to redraw audio waveforms
         self.redraw_audio_timer.start()

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -29,7 +29,6 @@
 
 import os
 import time
-from copy import deepcopy
 from functools import partial
 from random import uniform
 from operator import itemgetter
@@ -205,7 +204,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
     # This method is invoked by the UpdateManager each time a change happens (i.e UpdateInterface)
     def changed(self, action):
         # Remove unused action attribute (old_values)
-        action = deepcopy(action)
         action.old_values = {}
 
         # Send a JSON version of the UpdateAction to the timeline webview method: applyJsonDiff()
@@ -2500,7 +2498,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 continue
 
             # Loop through brightness keyframes
-            tran_data_copy = deepcopy(tran.data)
+            tran_data_copy = json.loads(json.dumps(tran.data))
             new_index = len(tran.data["brightness"]["Points"])
             for point in tran.data["brightness"]["Points"]:
                 new_index -= 1


### PR DESCRIPTION
After profiling OpenShot with CProfile, the deepcopy calls to our internal project data structures is painfully inefficient. Replacing with `json.loads(json.dumps())`, which appears to be much lighter and requires far less CPU. Also, moving a slow call to `Timeline::ApplyJsonDiff` to it's own thread, to not block our main thread.