### PR TITLE
Support new image formats, with special "image handling" behavior

### DIFF
--- a/src/classes/image_types.py
+++ b/src/classes/image_types.py
@@ -29,17 +29,30 @@ def is_image(file_object):
     """Check a File object if the file extension is a known image format"""
     path = file_object["path"].lower()
     img_file_extensions = (
+        ".bmp",
+        ".dpx",
+        ".exr",
+        ".gif",
         ".jpg",
         ".jpeg",
-        ".png",
-        ".bmp",
-        ".svg",
-        ".thm",
-        ".gif",
-        ".bmp",
+        ".pam",
+        ".pbm",
+        ".pcx",
         ".pgm",
+        ".png",
+        ".pnm",
+        ".ppm",
+        ".psd",
+        ".sgi",
+        ".svg",
+        ".tga",
+        ".thm",
         ".tif",
         ".tiff",
+        ".webp",
+        ".xbm",
+        ".xpm",
+        ".xwd",
     )
     return path.endswith(img_file_extensions)
 


### PR DESCRIPTION
Support new image formats, with special "image handling" behavior. Previously these image formats were not support by libopenshot, and were imported as a 1 frame video.

Related to https://github.com/OpenShot/libopenshot/pull/863

**New formats include:**
- dxp
- exr
- pam
- pbm
- pcx
- pnm
- ppm
- psd
- sgi
- tga
- webp
- xbm
- xpm
- xwd