### PR TITLE
Fix regression which broke Undo & Redo

### DIFF
--- a/src/classes/metrics.py
+++ b/src/classes/metrics.py
@@ -41,7 +41,8 @@ from classes.logger import log
 
 import openshot
 
-from PyQt5.QtCore import QT_VERSION_STR, PYQT_VERSION_STR
+from PyQt5.QtCore import QTimer, QT_VERSION_STR, PYQT_VERSION_STR
+from functools import partial
 
 try:
     import distro
@@ -106,9 +107,7 @@ def track_metric_screen(screen_name):
     metric_params["t"] = "screenview"
     metric_params["cd"] = screen_name
     metric_params["cid"] = s.get("unique_install_id")
-
-    t = threading.Thread(target=send_metric, args=[metric_params], daemon=True)
-    t.start()
+    QTimer.singleShot(0, partial(send_metric, metric_params))
 
 
 def track_metric_event(event_action, event_label, event_category="General", event_value=0):
@@ -120,9 +119,7 @@ def track_metric_event(event_action, event_label, event_category="General", even
     metric_params["el"] = event_label
     metric_params["ev"] = event_value
     metric_params["cid"] = s.get("unique_install_id")
-
-    t = threading.Thread(target=send_metric, args=[metric_params], daemon=True)
-    t.start()
+    QTimer.singleShot(0, partial(send_metric, metric_params))
 
 
 def track_metric_error(error_name, is_fatal=False):
@@ -133,9 +130,7 @@ def track_metric_error(error_name, is_fatal=False):
     metric_params["exf"] = 0
     if is_fatal:
         metric_params["exf"] = 1
-
-    t = threading.Thread(target=send_metric, args=[metric_params], daemon=True)
-    t.start()
+    QTimer.singleShot(0, partial(send_metric, metric_params))
 
 
 def track_metric_session(is_start=True):
@@ -148,9 +143,7 @@ def track_metric_session(is_start=True):
     if not is_start:
         metric_params["sc"] = "end"
         metric_params["cd"] = "close-app"
-
-    t = threading.Thread(target=send_metric, args=[metric_params], daemon=True)
-    t.start()
+    QTimer.singleShot(0, partial(send_metric, metric_params))
 
 
 def send_metric(params):

--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -32,6 +32,8 @@ import openshot  # Python module for libopenshot (required video editing module 
 from classes.updates import UpdateInterface
 from classes.logger import log
 from classes.app import get_app
+from PyQt5.QtCore import QTimer
+from functools import partial
 
 
 class TimelineSync(UpdateInterface):
@@ -79,6 +81,7 @@ class TimelineSync(UpdateInterface):
             try:
                 if update_action.type == "load":
                     # Clear any existing clips & effects (free memory)
+                    self.timeline.Close()
                     self.timeline.Clear()
 
                     # This JSON is initially loaded to libopenshot to update the timeline
@@ -108,8 +111,7 @@ class TimelineSync(UpdateInterface):
             return
 
         # Pass the change to the libopenshot timeline in a separate thread (to not block main thread)
-        t = threading.Thread(target=send_changes_to_libopenshot, args=[action], daemon=True)
-        t.start()
+        QTimer.singleShot(0, partial(send_changes_to_libopenshot, action))
 
     def MaxSizeChangedCB(self, new_size):
         """Callback for max sized change (i.e. max size of video widget)"""

--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -290,11 +290,11 @@ class UpdateManager:
             if reverse.type == "delete" and len(reverse.key) == 2 and reverse.key[0] == "clips":
                 # unselect deleted clip
                 item_id = reverse.key[1].get("id")
-                get_app().window.removeSelection(item_id, "clip")
+                get_app().window.clearSelections()
             elif reverse.type == "delete" and len(reverse.key) == 2 and reverse.key[0] == "effects":
                 # unselect deleted effect
                 item_id = reverse.key[1].get("id")
-                get_app().window.removeSelection(item_id, "effect")
+                get_app().window.clearSelections()
 
             # Perform next undo action
             self.dispatch_action(reverse)

--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -28,7 +28,7 @@
  """
 
 from classes.logger import log
-import copy
+from classes.app import get_app
 import json
 
 
@@ -55,12 +55,17 @@ class UpdateAction:
     """A data structure representing a single update manager action,
     including any necessary data to reverse the action."""
 
-    def __init__(self, type=None, key=[], values=None, partial_update=False):
+    def __init__(self, type=None, key=[], values=None, partial_update=False, old_values=None):
         self.type = type  # insert, update, or delete
         self.key = key  # list which contains the path to the item, for example: ["clips",{"id":"123"}]
         self.values = values
-        self.old_values = None
+        self.old_values = old_values
         self.partial_update = partial_update
+
+    def copy(self):
+        """Create and return a copy of UpdateAction - with no references to the original"""
+        # Serialize as JSON string, then load JSON string and cast back into UpdateAction
+        return UpdateAction(**json.loads(json.dumps(self, default=lambda o: o.__dict__)))
 
     def set_old_values(self, old_vals):
         self.old_values = old_vals
@@ -264,8 +269,8 @@ class UpdateManager:
 
         # On updates, just swap the old and new values data
         # Swap old and new values
-        reverse.old_values = action.values
-        reverse.values = action.old_values
+        reverse.old_values = json.loads(json.dumps(action.values))
+        reverse.values = json.loads(json.dumps(action.old_values))
 
         return reverse
 
@@ -274,20 +279,32 @@ class UpdateManager:
 
         if len(self.actionHistory) > 0:
             # Get last action from history (remove)
-            last_action = json.loads(json.dumps(self.actionHistory.pop()))
+            last_action = self.actionHistory.pop().copy()
 
             self.redoHistory.append(last_action)
             self.pending_action = None
             # Get reverse of last action and perform it
-            reverse_action = self.get_reverse_action(last_action)
-            self.dispatch_action(reverse_action)
+            reverse = self.get_reverse_action(last_action)
+
+            # Remove selections for deleted items (if any)
+            if reverse.type == "delete" and len(reverse.key) == 2 and reverse.key[0] == "clips":
+                # unselect deleted clip
+                item_id = reverse.key[1].get("id")
+                get_app().window.removeSelection(item_id, "clip")
+            elif reverse.type == "delete" and len(reverse.key) == 2 and reverse.key[0] == "effects":
+                # unselect deleted effect
+                item_id = reverse.key[1].get("id")
+                get_app().window.removeSelection(item_id, "effect")
+
+            # Perform next undo action
+            self.dispatch_action(reverse)
 
     def redo(self):
         """ Redo the last UpdateAction (and notify all listeners and watchers) """
 
         if len(self.redoHistory) > 0:
             # Get last undone action off redo history (remove)
-            next_action = json.loads(json.dumps(self.redoHistory.pop()))
+            next_action = self.redoHistory.pop().copy()
 
             # Remove ID from insert (if found)
             if next_action.type == "insert" and isinstance(next_action.key[-1], dict) and "id" in next_action.key[-1]:

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -190,10 +190,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Clean-up Timeline
         if self.timeline_sync and self.timeline_sync.timeline:
             # Clear all clips & close all readers
-            self.timeline_sync.timeline.Clear()
-
-            # Close & delete timeline
             self.timeline_sync.timeline.Close()
+            self.timeline_sync.timeline.Clear()
             del self.timeline_sync.timeline
 
         # Destroy lock file

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2824,6 +2824,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.selected_tracks = []
         self.selected_effects = []
 
+        # Clear transform
+        self.TransformSignal.emit("")
+
         # Clear selection in properties view
         if self.propertyTableView:
             self.propertyTableView.loadProperties.emit("", "")

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -1302,7 +1302,6 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         # Update the preview and reselect current frame in properties
         if need_refresh:
             win.refreshFrameSignal.emit()
-            win.propertyTableView.select_frame(win.preview_thread.player.Position())
 
     def keyFrameTransformTriggered(self, effect_id, clip_id):
         """Handle the key frame transform signal when it's emitted"""

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -203,8 +203,13 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
     # This method is invoked by the UpdateManager each time a change happens (i.e UpdateInterface)
     def changed(self, action):
-        # Remove unused action attribute (old_values)
-        action.old_values = {}
+        try:
+            # Duplicate UpdateAction, and remove unused action attribute (old_values)
+            action = action.copy()
+            action.old_values = {}
+        except:
+            log.error("Error duplicating UpdateAction", exc_info=1)
+            return
 
         # Send a JSON version of the UpdateAction to the timeline webview method: applyJsonDiff()
         if action.type == "load":


### PR DESCRIPTION
Fix regression which broke undo/redo - this adds a helper copy() function for UpdateAction objects, to easily and safely copy them. Also, remove selections for clips/effect which get deleted in the undo()/redo() functions.