### PR TITLE
Integrate New AudioWaveformer Class (for generating fast, graph-friendly audio datasets)

### DIFF
--- a/src/classes/waveform.py
+++ b/src/classes/waveform.py
@@ -83,17 +83,26 @@ def get_waveform_thread(file_id, clip_list):
         # Show waiting cursor
         get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
 
-        # Loop through audio samples, and create a list of amplitudes
+        # Extract audio waveform data (for all channels)
+        # Use max RMS (root mean squared) value for each sample
+        # NOTE: we also have the average RMS value calculated, although we do
+        # not use it yet - it's commented out below
         waveformer = openshot.AudioWaveformer(temp_clip.Reader())
-        file_audio_data = waveformer.ExtractSamples(0, SAMPLES_PER_SECOND, True)
+        file_audio_data = waveformer.ExtractSamples(-1, SAMPLES_PER_SECOND, True)
+        samples_vectors = file_audio_data.vectors()
+        max_samples_vector = samples_vectors[0]  # max sample value dataset
+        rms_samples_vector = samples_vectors[1]  # average RMS sample value dataset
+
+        # Clear data
+        file_audio_data.clear()
 
         # Update file with audio data
-        get_app().window.timeline.fileAudioDataReady.emit(file.id, {"ui": {"audio_data": file_audio_data}})
+        get_app().window.timeline.fileAudioDataReady.emit(file.id, {"ui": {"audio_data": max_samples_vector}})
 
         # Restore cursor
         get_app().restoreOverrideCursor()
 
-        return file_audio_data
+        return max_samples_vector
 
     # Get file query object
     file = File.get(id=file_id)

--- a/src/classes/waveform.py
+++ b/src/classes/waveform.py
@@ -132,7 +132,7 @@ def get_waveform_thread(file_id, clip_list):
         clip = Clip.get(id=clip_id)
 
         # Check for channel mapping and filters
-        channel_filter = clip.data.get("channel_filter", {}).get("Points", [])[0].get("co", {}).get("Y", -1)
+        channel_filter = int(clip.data.get("channel_filter", {}).get("Points", [])[0].get("co", {}).get("Y", -1))
         if channel_filter != -1:
             # Some kind of filtering is happening, so we need to re-generate waveform data for this clip
             file_audio_data = getAudioData(file, channel_filter)

--- a/src/classes/waveform.py
+++ b/src/classes/waveform.py
@@ -86,7 +86,7 @@ def get_waveform_thread(file_id, clip_list):
         # Extract audio waveform data (for all channels)
         # Use max RMS (root mean squared) value for each sample
         # NOTE: we also have the average RMS value calculated, although we do
-        # not use it yet - it's commented out below
+        # not use it yet
         waveformer = openshot.AudioWaveformer(temp_clip.Reader())
         file_audio_data = waveformer.ExtractSamples(channel, SAMPLES_PER_SECOND, True)
         samples_vectors = file_audio_data.vectors()

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -1451,6 +1451,10 @@ App.controller("TimelineCtrl", function ($scope) {
         $scope.updateLayerIndex();
       }
     }
+
+    // Apply all changes
+    $scope.$apply();
+
     // return true
     return true;
   };
@@ -1485,6 +1489,9 @@ App.controller("TimelineCtrl", function ($scope) {
 
     // Update playhead position and time readout (reset to zero)
     $scope.movePlayhead(0.0);
+
+    // Apply all changes
+    $scope.$apply();
 
     // return true
     return true;

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1156,7 +1156,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                     clip.data.pop('id')
 
                 # Generate waveform for new clip
-                log.info("Generate waveform for split audio track clip id: %s" % clip.id)
+                log.info("Generate waveform for split audio track clip ids: %s" % str(separate_clip_ids))
                 self.Show_Waveform_Triggered(separate_clip_ids)
 
         for clip_id in clip_ids:

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1111,6 +1111,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 channels = int(clip.data["reader"]["channels"])
 
                 # Loop through each channel
+                separate_clip_ids = []
                 for channel in range(0, channels):
                     log.debug("Adding clip for channel %s" % channel)
 
@@ -1147,15 +1148,16 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
                     # Save changes
                     clip.save()
-
-                    # Generate waveform for new clip
-                    log.info("Generate waveform for split audio track clip id: %s" % clip.id)
-                    self.Show_Waveform_Triggered([clip.id])
+                    separate_clip_ids.append(clip.id)
 
                     # Remove the ID property from the clip (so next time, it will create a new clip)
                     clip.id = None
                     clip.type = 'insert'
                     clip.data.pop('id')
+
+                # Generate waveform for new clip
+                log.info("Generate waveform for split audio track clip id: %s" % clip.id)
+                self.Show_Waveform_Triggered(separate_clip_ids)
 
         for clip_id in clip_ids:
 

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2215,6 +2215,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         # Get FPS from project
         fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
+        clips_with_waveforms = []
 
         # Loop through each selected clip
         for clip_id in clip_ids:
@@ -2224,6 +2225,10 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             if not clip:
                 # Invalid clip, skip to next item
                 continue
+
+            # Add any clips with waveforms to a list
+            if clip.data.get("ui", {}).get("audio_data", []):
+                clips_with_waveforms.append(clip.id)
 
             # Keep original 'end' and 'duration'
             if "original_data" not in clip.data:
@@ -2408,6 +2413,9 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
 
             # Save changes
             self.update_clip_data(clip.data, only_basic_props=False, ignore_reader=True)
+
+        # Update waveforms of all clips that have them
+        self.Show_Waveform_Triggered(clips_with_waveforms)
 
     def round_to_multiple(self, number, multiple):
         """Round this to the closest multiple of a given #"""


### PR DESCRIPTION
Use Root Mean Square to calculate both the "average" and "max" samples per period. Integrate new class from libopenshot. This PR is related to https://github.com/OpenShot/libopenshot/pull/868. Instead of iterating via Python, over all our Frames and building Python lists of audio samples... we call a C++ function and retrieve the data directly from libopenshot. This also fixes some bugs in our applying of Clip Keyframes (time and volume) to our file audio data set.