### PR TITLE
Remove $scope.$apply from right click directive

### DIFF
--- a/src/timeline/js/directives/misc.js
+++ b/src/timeline/js/directives/misc.js
@@ -33,10 +33,8 @@ App.directive("ngRightClick", function ($parse) {
   return function (scope, element, attrs) {
     var fn = $parse(attrs.ngRightClick);
     element.bind("contextmenu", function (event) {
-      scope.$apply(function () {
-        event.preventDefault();
-        fn(scope, {$event: event});
-      });
+      event.preventDefault();
+      fn(scope, {$event: event});
     });
   };
 });


### PR DESCRIPTION
Remove `$scope.$apply` from right click directive, to prevent double `$apply()` invokations when calling `ApplyJsonDiff()` from context menu.

Related to https://github.com/OpenShot/openshot-qt/pull/4971