### PR TITLE
Blender 3.3.1 Support

### DIFF
--- a/src/blender/scripts/explode.py.in
+++ b/src/blender/scripts/explode.py.in
@@ -207,7 +207,7 @@ else:
     font = bpy.data.fonts["Bfont"]
 
 createExplodeTxt(
-    params["title"], params["particle_number"], params["extrude"],
+    params["title"], int(params["particle_number"]), params["extrude"],
     params["bevel_depth"], params["spacemode"], params["text_size"],
     params["width"], font, int(params["ground_on_off"]),
 )

--- a/src/blender/scripts/magic_wand.py.in
+++ b/src/blender/scripts/magic_wand.py.in
@@ -119,7 +119,7 @@ bpy.data.scenes["Scene"].node_tree.nodes["Glare"].glare_type = params["glare_typ
 
 # Change particle settings
 psettings = bpy.data.particles["ParticleSettings"]
-psettings.count = params["particles_count"]
+psettings.count = int(params["particles_count"])
 psettings.lifetime = params["particles_lifetime"]
 psettings.effector_weights.gravity = params["particles_gravity"]
 psettings.object_align_factor = (

--- a/src/blender/scripts/picture_frames_4.py.in
+++ b/src/blender/scripts/picture_frames_4.py.in
@@ -111,7 +111,7 @@ if len(picture1) > 1:
         bpy.data.materials["Material.001"].node_tree.nodes[2].image.source = 'MOVIE'
         bpy.data.materials["Material.001"].node_tree.nodes[2].image.filepath = picture1[0]
         bpy.data.materials["Material.001"].node_tree.nodes[2].image_user.use_cyclic = True
-        bpy.data.materials["Material.001"].node_tree.nodes[2].image_user.frame_duration = 230.0
+        bpy.data.materials["Material.001"].node_tree.nodes[2].image_user.frame_duration = 230
 
 if len(picture2) > 1:
     bpy.data.objects["Plane.002"].scale.y = -picture2_scale[0]
@@ -124,7 +124,7 @@ if len(picture2) > 1:
         bpy.data.materials["Material.002"].node_tree.nodes[2].image.source = 'MOVIE'
         bpy.data.materials["Material.002"].node_tree.nodes[2].image.filepath = picture2[0]
         bpy.data.materials["Material.002"].node_tree.nodes[2].image_user.use_cyclic = True
-        bpy.data.materials["Material.002"].node_tree.nodes[2].image_user.frame_duration = 230.0
+        bpy.data.materials["Material.002"].node_tree.nodes[2].image_user.frame_duration = 230
 
 if len(picture3) > 1:
     bpy.data.objects["Plane.003"].scale.y = -picture3_scale[0]
@@ -137,7 +137,7 @@ if len(picture3) > 1:
         bpy.data.materials["Material.003"].node_tree.nodes[2].image.source = 'MOVIE'
         bpy.data.materials["Material.003"].node_tree.nodes[2].image.filepath = picture3[0]
         bpy.data.materials["Material.003"].node_tree.nodes[2].image_user.use_cyclic = True
-        bpy.data.materials["Material.003"].node_tree.nodes[2].image_user.frame_duration = 230.0
+        bpy.data.materials["Material.003"].node_tree.nodes[2].image_user.frame_duration = 230
 
 if len(picture4) > 1:
     bpy.data.objects["Plane.004"].scale.y = -picture4_scale[0]
@@ -150,7 +150,7 @@ if len(picture4) > 1:
         bpy.data.materials["Material.004"].node_tree.nodes[2].image.source = 'MOVIE'
         bpy.data.materials["Material.004"].node_tree.nodes[2].image.filepath = picture4[0]
         bpy.data.materials["Material.004"].node_tree.nodes[2].image_user.use_cyclic = True
-        bpy.data.materials["Material.004"].node_tree.nodes[2].image_user.frame_duration = 230.0
+        bpy.data.materials["Material.004"].node_tree.nodes[2].image_user.frame_duration = 230
 
 # Set the render options.  It is important that these are set
 # to the same values as the current OpenShot project.  These

--- a/src/blender/scripts/snow.py.in
+++ b/src/blender/scripts/snow.py.in
@@ -82,7 +82,7 @@ bpy.data.objects["Wand"].particle_systems[0].settings.particle_size = params["si
 
 # Change particle settings
 particle_object = bpy.data.particles[0]
-particle_object.count = params["particles_count"]
+particle_object.count = int(params["particles_count"])
 
 # Change Scene settings
 scene_object = bpy.data.scenes[0]


### PR DESCRIPTION
Fixing 4 broken Animated Titles with Blender 3.3.1 (these have been broken for a few versions, I think). All 4 broken titles were due to a `float`, when Blender was expecting an `int`.

- Picture Frame
- Magic Wand
- Snow
- Exploding Text