### PR TITLE
Translate Preferences Dropdowns

### DIFF
--- a/src/settings/_default.project
+++ b/src/settings/_default.project
@@ -22,7 +22,7 @@
   "effects": [],
   "files": [],
   "duration": 300,
-  "scale": 15,
+  "scale": 15.0,
   "tick_pixels": 100,
   "playhead_position": 0,
   "profile": "HD 720p 30 fps",

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -360,6 +360,10 @@ class Preferences(QDialog):
                         v = value_item["value"]
                         i = value_item.get("icon", None)
 
+                        # Translate dropdown item (if needed)
+                        if param.get("translate_values"):
+                            k = _(value_item["name"])
+
                         # Override icons for certain values
                         # TODO: Find a more elegant way to do this
                         icon = None
@@ -509,8 +513,8 @@ class Preferences(QDialog):
             openshot.Settings.Instance().DE_LIMIT_HEIGHT_MAX = int(str(value))
 
         # Apply cache settings (if needed)
-        if param["setting"] in ["cache-limit-mb", "cache-scale", "cache-quality", 
-                                "cache-ahead-percent", "cache-preroll-min-frames", 
+        if param["setting"] in ["cache-limit-mb", "cache-scale", "cache-quality",
+                                "cache-ahead-percent", "cache-preroll-min-frames",
                                 "cache-preroll-max-frames", "cache-max-frames"]:
             get_app().window.InitCacheSettings()
 

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2829,7 +2829,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         self.redraw_audio_timer.start()
 
         # Only update scale if different
-        current_scale = get_app().project.get("scale")
+        current_scale = float(get_app().project.get("scale"))
 
         # Save current zoom
         if newScale != current_scale:

--- a/src/windows/views/zoom_slider.py
+++ b/src/windows/views/zoom_slider.py
@@ -533,6 +533,6 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
         # Timer to use a delay before sending MaxSizeChanged signals (so we don't spam libopenshot)
         self.delayed_size = None
         self.delayed_resize_timer = QTimer(self)
-        self.delayed_resize_timer.setInterval(200)
+        self.delayed_resize_timer.setInterval(100)
         self.delayed_resize_timer.setSingleShot(True)
         self.delayed_resize_timer.timeout.connect(self.delayed_resize_callback)


### PR DESCRIPTION
Fix a mistake which causes certain dropdowns in the OpenShot preferences to be left untranslated. Also, fix a small bug on launch of OpenShot, which occasionally causes a "has_changes" * save asterisk, due to a race condition of the initial screen resizing, and the loading of the default blank project.