### PR TITLE
Fix Blender Animated Titles for <= 24 FPS Projects

### DIFF
--- a/src/blender/scripts/blinds.py.in
+++ b/src/blender/scripts/blinds.py.in
@@ -142,8 +142,8 @@ bpy.context.scene.render.resolution_y = params["resolution_y"]
 bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/blur.py.in
+++ b/src/blender/scripts/blur.py.in
@@ -139,8 +139,8 @@ bpy.context.scene.render.resolution_y = params["resolution_y"]
 bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/colors.py.in
+++ b/src/blender/scripts/colors.py.in
@@ -192,8 +192,8 @@ render.resolution_y = params["resolution_y"]
 render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 render.frame_map_old = 1
 render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/dissolve.py.in
+++ b/src/blender/scripts/dissolve.py.in
@@ -291,8 +291,8 @@ render.resolution_percentage = params["resolution_percentage"]
 bpy.ops.ptcache.free_bake_all()
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 render.frame_map_old = 1
 render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/earth.py.in
+++ b/src/blender/scripts/earth.py.in
@@ -338,8 +338,8 @@ render.resolution_y = params["resolution_y"]
 render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 render.frame_map_old = 1
 render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/explode.py.in
+++ b/src/blender/scripts/explode.py.in
@@ -239,8 +239,8 @@ render.resolution_percentage = params["resolution_percentage"]
 bpy.ops.ptcache.free_bake_all()
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 render.frame_map_old = 1
 render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/fly_by_1.py.in
+++ b/src/blender/scripts/fly_by_1.py.in
@@ -133,8 +133,8 @@ bpy.context.scene.render.resolution_y = params["resolution_y"]
 bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/fly_by_two_titles.py.in
+++ b/src/blender/scripts/fly_by_two_titles.py.in
@@ -142,8 +142,8 @@ bpy.context.scene.render.resolution_y = params["resolution_y"]
 bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/glare.py.in
+++ b/src/blender/scripts/glare.py.in
@@ -137,8 +137,8 @@ bpy.context.scene.render.resolution_y = params["resolution_y"]
 bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/glass_slider.py.in
+++ b/src/blender/scripts/glass_slider.py.in
@@ -164,8 +164,8 @@ bpy.context.scene.render.resolution_y = params["resolution_y"]
 bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/lens_flare.py.in
+++ b/src/blender/scripts/lens_flare.py.in
@@ -110,13 +110,13 @@ bpy.data.materials["Material.001"].node_tree.nodes[1].inputs["Alpha"].default_va
 glare_node = bpy.data.scenes[0].node_tree.nodes["Glare"]
 glare_node.color_modulation = params["glare1_color"]
 glare_node.glare_type = params["glare1_type"]
-glare_node.streaks = params["glare1_streaks"]
+glare_node.streaks = round(params["glare1_streaks"])
 glare_node.angle_offset = params["glare1_angle"]
 
 glare_node = bpy.data.scenes[0].node_tree.nodes["Glare.001"]
 glare_node.color_modulation = params["glare2_color"]
 glare_node.glare_type = params["glare2_type"]
-glare_node.streaks = params["glare2_streaks"]
+glare_node.streaks = round(params["glare2_streaks"])
 glare_node.angle_offset = params["glare2_angle"]
 
 # Set the render options.  It is important that these are set

--- a/src/blender/scripts/lens_flare.py.in
+++ b/src/blender/scripts/lens_flare.py.in
@@ -134,8 +134,8 @@ bpy.context.scene.render.resolution_y = params["resolution_y"]
 bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/magic_wand.py.in
+++ b/src/blender/scripts/magic_wand.py.in
@@ -146,8 +146,8 @@ bpy.data.worlds["World"].color = params["horizon_color"]
 bpy.ops.ptcache.free_bake_all()
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 render.frame_map_old = 1
 render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/neon_curves.py.in
+++ b/src/blender/scripts/neon_curves.py.in
@@ -151,8 +151,8 @@ bpy.context.scene.render.resolution_y = params["resolution_y"]
 bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/picture_frames_4.py.in
+++ b/src/blender/scripts/picture_frames_4.py.in
@@ -168,8 +168,8 @@ bpy.context.scene.render.resolution_y = params["resolution_y"]
 bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/rotate_360.py.in
+++ b/src/blender/scripts/rotate_360.py.in
@@ -133,8 +133,8 @@ bpy.context.scene.render.resolution_y = params["resolution_y"]
 bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/slide_left_to_right.py.in
+++ b/src/blender/scripts/slide_left_to_right.py.in
@@ -133,8 +133,8 @@ bpy.context.scene.render.resolution_y = params["resolution_y"]
 bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/snow.py.in
+++ b/src/blender/scripts/snow.py.in
@@ -107,8 +107,8 @@ bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 bpy.ops.ptcache.free_bake_all()
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/spacemovie_intro.py.in
+++ b/src/blender/scripts/spacemovie_intro.py.in
@@ -119,8 +119,8 @@ bpy.context.scene.render.resolution_y = params["resolution_y"]
 bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/wireframe_text.py.in
+++ b/src/blender/scripts/wireframe_text.py.in
@@ -143,8 +143,8 @@ bpy.context.scene.render.resolution_y = params["resolution_y"]
 bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 

--- a/src/blender/scripts/zoom_clapboard.py.in
+++ b/src/blender/scripts/zoom_clapboard.py.in
@@ -135,8 +135,8 @@ bpy.context.scene.render.resolution_y = params["resolution_y"]
 bpy.context.scene.render.resolution_percentage = params["resolution_percentage"]
 
 # Animation Speed (use Blender's time remapping to slow or speed up animation)
-length_multiplier = int(params["length_multiplier"])  # time remapping multiplier
-new_length = int(params["end_frame"]) * length_multiplier  # new length (in frames)
+length_multiplier = round(params["length_multiplier"])  # time remapping multiplier
+new_length = round(params["end_frame"]) * length_multiplier  # new length (in frames)
 bpy.context.scene.render.frame_map_old = 1
 bpy.context.scene.render.frame_map_new = length_multiplier
 


### PR DESCRIPTION
Rounding length multiplier for all animated title scripts - to allow for <= 24 FPS, without truncating to 0. Currently, if you select a 24 FPS profile and try and generate a Blender Animated Title, it will only export a single frame.