### PR TITLE
"Recent Folder" Import File logic should Ignore Titles/Animated Titles

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -750,10 +750,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             _("Import Files...")
         )[0]
 
-        if len(qurl_list):
-            # If any files were imported,
-            # Use the folder of the LAST one as the new default path.
-            s.setDefaultPath(s.actionType.IMPORT, qurl_list[-1].toLocalFile())
         # Set cursor to waiting
         app.setOverrideCursor(QCursor(Qt.WaitCursor))
 

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -243,7 +243,8 @@ class FilesModel(QObject, updates.UpdateInterface):
         # Emit signal when model is updated
         self.ModelRefreshed.emit()
 
-    def add_files(self, files, image_seq_details=None, quiet=False, prevent_image_seq=False):
+    def add_files(self, files, image_seq_details=None, quiet=False,
+                  prevent_image_seq=False, prevent_recent_folder=False):
         # Access translations
         app = get_app()
         settings = app.get_settings()
@@ -343,7 +344,8 @@ class FilesModel(QObject, updates.UpdateInterface):
                 # Let the event loop run to update the status bar
                 get_app().processEvents()
                 # Update the recent import path
-                settings.setDefaultPath(settings.actionType.IMPORT, dir_path)
+                if not prevent_recent_folder:
+                    settings.setDefaultPath(settings.actionType.IMPORT, dir_path)
 
             except Exception as ex:
                 # Log exception

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -609,7 +609,7 @@ class TitleEditor(QDialog):
                 self.writeToFile(self.xmldoc)
 
                 # Add file to project
-                app.window.files_model.add_files(self.filename, prevent_image_seq=True)
+                app.window.files_model.add_files(self.filename, prevent_image_seq=True, prevent_recent_folder=True)
 
         # Close window
         super().accept()

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -330,7 +330,7 @@ class BlenderListView(QListView):
         log.info('RENDER FINISHED! Adding to project files: {}'.format(filename))
 
         # Add to project files
-        get_app().window.files_model.add_files(seq_params.get("path"), seq_params)
+        get_app().window.files_model.add_files(seq_params.get("path"), seq_params, prevent_recent_folder=True)
 
         # We're done here
         self.win.close()


### PR DESCRIPTION
Improving the "Recent Folder" Import File logic to ignore "Title Editor" and "Animated Title Editor" files, and only use recent paths of assets imported into OpenShot directly. It's confusing when a user creates a title, to all of a sudden have that `.openshot_qt/title` folder set as their default import folder.