### PR TITLE
Cache Fragmentation Fixes (Preferences & Profile Dialogs)

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -865,6 +865,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.refreshFrameSignal.emit()
 
     def actionPreferences_trigger(self, checked=True):
+        log.debug("Showing preferences dialog")
+
         # Stop preview thread
         self.SpeedSignal.emit(0)
         self.PauseSignal.emit()
@@ -1156,8 +1158,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.cache_object.Clear()
         self.timeline_sync.timeline.SetCache(old_cache_object)
         self.cache_object = old_cache_object
-        old_cache_object = None
-        new_cache_object = None
 
     def renumber_all_layers(self, insert_at=None, stride=1000000):
         """Renumber all of the project's layers to be equidistant (in
@@ -1784,11 +1784,10 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def actionProfile_trigger(self):
         # Show dialog
         from windows.profile import Profile
-        log.debug("Showing preferences dialog")
+        log.debug("Showing profile dialog")
         win = Profile()
         # Run the dialog event loop - blocking interaction on this window during this time
         win.exec_()
-        log.debug("Preferences dialog closed")
 
     def actionSplitClip_trigger(self):
         log.debug("actionSplitClip_trigger")

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -76,6 +76,9 @@ class Preferences(QDialog):
         # Track metrics
         track_metric_screen("preferences-screen")
 
+        # Disable video caching
+        openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = False
+
         # Load all user values
         self.params = {}
         for item in self.settings_data:
@@ -639,6 +642,9 @@ class Preferences(QDialog):
         self.reject()
 
     def reject(self):
+        # Enable video caching
+        openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = True
+
         # Prompt user to restart openshot (if needed)
         if self.requires_restart:
             msg = QMessageBox()


### PR DESCRIPTION
Cache can become fragmented when the Preferences or Profile dialogs are opened during the video cache building, since both of those dialogs can adjust the cache.

- Disable video caching on Preferences and Profile windows.
- Re-enable video caching when exiting Preferences and Profile windows
- Exiting Profile dialog will refresh current frame (even if changing FPS)
- Changing Caching settings in Preferences will never fragment cache