### PR TITLE
Support for New Linux Build Server + Update AppImage Support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ linux-builder:
   except:
   - tags
   tags:
-    - linux-bionic
+    - linux-focal
 
 mac-builder:
   stage: build

--- a/freeze.py
+++ b/freeze.py
@@ -529,8 +529,7 @@ elif sys.platform == "linux":
                          "lib/libopenshot*",
                          "translations/",
                          "locales/",
-                         "libQt5WebKit.so.5",
-                         "libx264.so.152"]
+                         "libQt5WebKit.so.5"]
                 for path in paths:
                     full_path = os.path.join(build_path, frozen_path, path)
                     for remove_path in glob.glob(full_path):

--- a/freeze.py
+++ b/freeze.py
@@ -530,7 +530,7 @@ elif sys.platform == "linux":
                          "translations/",
                          "locales/",
                          "libQt5WebKit.so.5",
-                         "libx264-152.so"]
+                         "libx264.so.152"]
                 for path in paths:
                     full_path = os.path.join(build_path, frozen_path, path)
                     for remove_path in glob.glob(full_path):

--- a/freeze.py
+++ b/freeze.py
@@ -258,11 +258,12 @@ elif sys.platform == "linux":
             external_so_files.append((filename, os.path.relpath(filename, start=libopenshot_path)))
 
     # Add libresvg (if found)
-    resvg_path = "/usr/local/lib/libresvg.so"
+    resvg_path = "/usr/lib/libresvg.so"
     if os.path.exists(resvg_path):
         external_so_files.append((resvg_path, os.path.basename(resvg_path)))
 
     # Add QtWebEngineProcess (if found)
+    # /usr/lib/x86_64-linux-gnu/
     web_process_path = ARCHLIB + "qt5/libexec/QtWebEngineProcess"
     if os.path.exists(web_process_path):
         external_so_files.append(
@@ -287,7 +288,7 @@ elif sys.platform == "linux":
 
     # Manually add BABL extensions (used in ChromaKey effect) - these are loaded at runtime,
     # and thus cx_freeze is not able to detect them
-    babl_ext_path = "/usr/local/lib/babl-0.1"
+    babl_ext_path = ARCHLIB + "babl-0.1/"
     for filename in find_files(babl_ext_path, ["*.so"]):
         src_files.append((filename, os.path.join("lib", "babl-ext", os.path.relpath(filename, start=babl_ext_path))))
 
@@ -305,7 +306,7 @@ elif sys.platform == "linux":
     pyqt5_mod_files = []
     from importlib import import_module
     for submod in ['Qt', 'QtSvg', 'QtWidgets', 'QtCore', 'QtGui', 'QtDBus']:
-        mod_name  = "PyQt5.{}".format(submod)
+        mod_name = "PyQt5.{}".format(submod)
         mod = import_module(mod_name)
         pyqt5_mod_files.append(inspect.getfile(mod))
     # Optional additions
@@ -320,7 +321,6 @@ elif sys.platform == "linux":
             pyqt5_mod_files.append(inspect.getfile(mod))
         except ImportError as ex:
             log.warning("Skipping {}: {}".format(mod_name, ex))
-
 
     lib_list = pyqt5_mod_files
     for lib_name in [
@@ -339,6 +339,7 @@ elif sys.platform == "linux":
 
         # Loop through each line of output (which outputs dependencies - one per line)
         for line in depends:
+            log.info("ldd raw line: %s" % line)
             lineparts = line.split("=>")
             libname = lineparts[0].strip()
 
@@ -356,6 +357,8 @@ elif sys.platform == "linux":
             # And ignore paths that start with /lib
             libpath = libdetailsparts[0].strip()
             libpath_file = os.path.basename(libpath)
+            log.info("libpath: %s, libpath_file: %s" % (libpath, libpath_file))
+
             if (libpath
                 and os.path.exists(libpath)
                 and not libpath.startswith("/lib")
@@ -403,6 +406,8 @@ elif sys.platform == "linux":
                 external_so_files.append((libpath, libpath_file))
                 # Any other lib deps that fail to meet the inclusion
                 # criteria above will be silently skipped over
+
+    log.info("external_so_files: %s" % str(external_so_files))
 
     # Append all source files
     src_files.append((os.path.join(PATH, "installer", "qt.conf"), "qt.conf"))

--- a/freeze.py
+++ b/freeze.py
@@ -363,6 +363,7 @@ elif sys.platform == "linux":
                 and os.path.exists(libpath)
                 and "libnvidia-glcore.so" not in libpath
                 and libpath_file not in [
+                    "libdl.so.2",
                     "librt.so.1",
                     "libpthread.so.0",
                     "libc.so.6",

--- a/freeze.py
+++ b/freeze.py
@@ -363,6 +363,7 @@ elif sys.platform == "linux":
                 and os.path.exists(libpath)
                 and "libnvidia-glcore.so" not in libpath
                 and libpath_file not in [
+                    "libpthread.so.0",
                     "libc.so.6",
                     "libstdc++.so.6",
                     "libGL.so.1",

--- a/freeze.py
+++ b/freeze.py
@@ -529,7 +529,8 @@ elif sys.platform == "linux":
                          "lib/libopenshot*",
                          "translations/",
                          "locales/",
-                         "libQt5WebKit.so.5"]
+                         "libQt5WebKit.so.5",
+                         "libx264-152.so"]
                 for path in paths:
                     full_path = os.path.join(build_path, frozen_path, path)
                     for remove_path in glob.glob(full_path):

--- a/freeze.py
+++ b/freeze.py
@@ -407,8 +407,9 @@ elif sys.platform == "linux":
                     "libselinux.so.1",
                     ]:
                 external_so_files.append((libpath, libpath_file))
-                # Any other lib deps that fail to meet the inclusion
-                # criteria above will be silently skipped over
+            else:
+                log.info("Skipping external library: %s" % libpath)
+
 
     log.info("external_so_files: %s" % str(external_so_files))
 

--- a/freeze.py
+++ b/freeze.py
@@ -357,7 +357,10 @@ elif sys.platform == "linux":
             # And ignore paths that start with /lib
             libpath = libdetailsparts[0].strip()
             libpath_file = os.path.basename(libpath)
-            log.info("libpath: %s, libpath_file: %s" % (libpath, libpath_file))
+            log.info("libpath: %s, libpath_file: %s, exists: %s, not lib: %s" % (libpath,
+                                                                                 libpath_file,
+                                                                                 os.path.exists(libpath),
+                                                                                 not libpath.startswith("/lib")))
 
             if (libpath
                 and os.path.exists(libpath)

--- a/freeze.py
+++ b/freeze.py
@@ -363,6 +363,7 @@ elif sys.platform == "linux":
                 and os.path.exists(libpath)
                 and "libnvidia-glcore.so" not in libpath
                 and libpath_file not in [
+                    "libc.so.6",
                     "libstdc++.so.6",
                     "libGL.so.1",
                     "libxcb.so.1",

--- a/freeze.py
+++ b/freeze.py
@@ -357,14 +357,10 @@ elif sys.platform == "linux":
             # And ignore paths that start with /lib
             libpath = libdetailsparts[0].strip()
             libpath_file = os.path.basename(libpath)
-            log.info("libpath: %s, libpath_file: %s, exists: %s, not lib: %s" % (libpath,
-                                                                                 libpath_file,
-                                                                                 os.path.exists(libpath),
-                                                                                 not libpath.startswith("/lib")))
+            log.info("libpath: %s, libpath_file: %s" % (libpath, libpath_file))
 
             if (libpath
                 and os.path.exists(libpath)
-                and not libpath.startswith("/lib")
                 and "libnvidia-glcore.so" not in libpath
                 and libpath_file not in [
                     "libstdc++.so.6",

--- a/freeze.py
+++ b/freeze.py
@@ -363,6 +363,7 @@ elif sys.platform == "linux":
                 and os.path.exists(libpath)
                 and "libnvidia-glcore.so" not in libpath
                 and libpath_file not in [
+                    "librt.so.1",
                     "libpthread.so.0",
                     "libc.so.6",
                     "libstdc++.so.6",

--- a/freeze.py
+++ b/freeze.py
@@ -470,7 +470,7 @@ build_exe_options["excludes"] = ["distutils",
                                  "pydoc_data",
                                  "pycparser",
                                  "pkg_resources"]
-if sys.platform != "win32":
+if sys.platform != "darwin":
     build_exe_options["excludes"].append("sentry_sdk.integrations.django")
 
 # Set options

--- a/freeze.py
+++ b/freeze.py
@@ -410,9 +410,6 @@ elif sys.platform == "linux":
             else:
                 log.info("Skipping external library: %s" % libpath)
 
-
-    log.info("external_so_files: %s" % str(external_so_files))
-
     # Append all source files
     src_files.append((os.path.join(PATH, "installer", "qt.conf"), "qt.conf"))
     for filename in find_files("openshot_qt", ["*"]):

--- a/freeze.py
+++ b/freeze.py
@@ -263,7 +263,6 @@ elif sys.platform == "linux":
         external_so_files.append((resvg_path, os.path.basename(resvg_path)))
 
     # Add QtWebEngineProcess (if found)
-    # /usr/lib/x86_64-linux-gnu/
     web_process_path = ARCHLIB + "qt5/libexec/QtWebEngineProcess"
     if os.path.exists(web_process_path):
         external_so_files.append(

--- a/freeze.py
+++ b/freeze.py
@@ -470,7 +470,7 @@ build_exe_options["excludes"] = ["distutils",
                                  "pydoc_data",
                                  "pycparser",
                                  "pkg_resources"]
-if sys.platform != "darwin":
+if sys.platform == "darwin":
     build_exe_options["excludes"].append("sentry_sdk.integrations.django")
 
 # Set options

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -365,7 +365,8 @@ def main():
             # Copy modified .desktop file to usr/share/applciations
             dest = os.path.join(app_dir_path, "usr", "share", "applications")
             os.makedirs(dest, exist_ok=True)
-            shutil.copyfile(desk_out, os.path.join(app_dir_path, "usr", "share", "applications"))
+            shutil.copyfile(os.path.join(app_dir_path, "org.openshot.OpenShot.desktop"),
+                            os.path.join(app_dir_path, "usr", "share", "applications", "org.openshot.OpenShot.desktop"))
 
             # Rename executable launcher script
             launcher_path = os.path.join(app_dir_path, "usr", "bin", "openshot-qt-launch")

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -355,6 +355,8 @@ def main():
                 for line in inf:
                     if line.startswith("Exec="):
                         outf.write("Exec=openshot-qt-launch.wrapper %F\n")
+                    elif line.startswith("Icon="):
+                        outf.write("Icon=appimagekit-openshot-qt\n")
                     else:
                         outf.write(line)
 

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -355,8 +355,6 @@ def main():
                 for line in inf:
                     if line.startswith("Exec="):
                         outf.write("Exec=openshot-qt-launch.wrapper %F\n")
-                    elif line.startswith("Icon="):
-                        outf.write("Icon=appimagekit-openshot-qt\n")
                     else:
                         outf.write(line)
 

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -365,7 +365,7 @@ def main():
             # Copy modified .desktop file to usr/share/applciations
             dest = os.path.join(app_dir_path, "usr", "share", "applications")
             os.makedirs(dest, exist_ok=True)
-            shutil.copytree(desk_out, os.path.join(app_dir_path, "usr", "share", "applications"))
+            shutil.copyfile(desk_out, os.path.join(app_dir_path, "usr", "share", "applications"))
 
             # Rename executable launcher script
             launcher_path = os.path.join(app_dir_path, "usr", "bin", "openshot-qt-launch")

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -344,6 +344,16 @@ def main():
             shutil.copyfile(os.path.join(PATH, "xdg", "org.openshot.OpenShot.xml"),
                             os.path.join(dest, "openshot-qt.xml"))
 
+            # Install AppStream XML metadata
+            dest = os.path.join(app_dir_path, "usr", "share", "metainfo")
+            os.makedirs(dest, exist_ok=True)
+
+            desk_in = os.path.join(PATH, "xdg", "org.openshot.OpenShot.appdata.xml")
+            desk_out = os.path.join(dest, "openshot-qt.appdata.xml")
+            with open(desk_in, "r") as inf, open(desk_out, "w") as outf:
+                for line in inf:
+                    outf.write(line.replace("org.openshot.OpenShot", "openshot-qt"))
+
             # Copy the entire frozen app
             shutil.copytree(os.path.join(PATH, "build", exe_dir),
                             os.path.join(app_dir_path, "usr", "bin"))

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -362,12 +362,16 @@ def main():
                         outf.write("Exec=openshot-qt-launch %F\n")
                     else:
                         outf.write(line)
+            # Copy modified .desktop file to usr/share/applciations
+            dest = os.path.join(app_dir_path, "usr", "share", "applications")
+            os.makedirs(dest, exist_ok=True)
+            shutil.copytree(desk_out, os.path.join(app_dir_path, "usr", "share", "applications"))
 
-            # Copy desktop integration wrapper (prompts users to install shortcut)
+            # Rename executable launcher script
             launcher_path = os.path.join(app_dir_path, "usr", "bin", "openshot-qt-launch")
             os.rename(os.path.join(app_dir_path, "usr", "bin", "launch-linux.sh"), launcher_path)
 
-            # Create AppRun.64 file (the real one)
+            # Create AppRun file
             app_run_path = os.path.join(app_dir_path, "AppRun")
             shutil.copyfile("/home/ubuntu/apps/AppImageKit/AppRun", app_run_path)
 

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -386,6 +386,7 @@ def main():
                 '/home/ubuntu/apps/AppImageKit/appimagetool-x86_64.AppImage',
                 '"%s"' % app_dir_path,
                 '"%s"' % app_build_path,
+                '--no-appstream'
             ])):
                 output(line)
             app_image_success = os.path.exists(app_build_path)

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -340,7 +340,6 @@ def main():
             # Install MIME handler
             dest = os.path.join(app_dir_path, "usr", "share", "mime", "packages")
             os.makedirs(dest, exist_ok=True)
-
             shutil.copyfile(os.path.join(PATH, "xdg", "org.openshot.OpenShot.xml"),
                             os.path.join(dest, "openshot-qt.xml"))
 
@@ -349,14 +348,10 @@ def main():
             os.makedirs(dest, exist_ok=True)
 
             desk_in = os.path.join(PATH, "xdg", "org.openshot.OpenShot.appdata.xml")
-            desk_out = os.path.join(dest, "org.openshot.OpenShot.appdata.xml")
+            desk_out = os.path.join(dest, "openshot-qt.appdata.xml")
             with open(desk_in, "r") as inf, open(desk_out, "w") as outf:
                 for line in inf:
-                    if "launchable" in line:
-                        outf.write(line.replace("org.openshot.OpenShot", "openshot-qt"))
-                    else:
-                        outf.write(line)
-
+                    outf.write(line.replace("org.openshot.OpenShot", "openshot-qt"))
 
             # Copy the entire frozen app
             shutil.copytree(os.path.join(PATH, "build", exe_dir),

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -366,7 +366,7 @@ def main():
             dest = os.path.join(app_dir_path, "usr", "share", "applications")
             os.makedirs(dest, exist_ok=True)
             shutil.copyfile(os.path.join(app_dir_path, "org.openshot.OpenShot.desktop"),
-                            os.path.join(app_dir_path, "usr", "share", "applications", "org.openshot.OpenShot.desktop"))
+                            os.path.join(dest, "org.openshot.OpenShot.desktop"))
 
             # Rename executable launcher script
             launcher_path = os.path.join(app_dir_path, "usr", "bin", "openshot-qt-launch")

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -341,17 +341,13 @@ def main():
             dest = os.path.join(app_dir_path, "usr", "share", "mime", "packages")
             os.makedirs(dest, exist_ok=True)
             shutil.copyfile(os.path.join(PATH, "xdg", "org.openshot.OpenShot.xml"),
-                            os.path.join(dest, "openshot-qt.xml"))
+                            os.path.join(dest, "org.openshot.OpenShot.xml"))
 
             # Install AppStream XML metadata
             dest = os.path.join(app_dir_path, "usr", "share", "metainfo")
             os.makedirs(dest, exist_ok=True)
-
-            desk_in = os.path.join(PATH, "xdg", "org.openshot.OpenShot.appdata.xml")
-            desk_out = os.path.join(dest, "openshot-qt.appdata.xml")
-            with open(desk_in, "r") as inf, open(desk_out, "w") as outf:
-                for line in inf:
-                    outf.write(line.replace("org.openshot.OpenShot", "openshot-qt"))
+            shutil.copyfile(os.path.join(PATH, "xdg", "org.openshot.OpenShot.appdata.xml"),
+                            os.path.join(dest, "org.openshot.OpenShot.appdata.xml"))
 
             # Copy the entire frozen app
             shutil.copytree(os.path.join(PATH, "build", exe_dir),
@@ -359,7 +355,7 @@ def main():
 
             # Copy .desktop file, replacing Exec= commandline
             desk_in = os.path.join(PATH, "xdg", "org.openshot.OpenShot.desktop")
-            desk_out = os.path.join(app_dir_path, "openshot-qt.desktop")
+            desk_out = os.path.join(app_dir_path, "org.openshot.OpenShot.desktop")
             with open(desk_in, "r") as inf, open(desk_out, "w") as outf:
                 for line in inf:
                     if line.startswith("Exec="):
@@ -385,8 +381,7 @@ def main():
             for line in run_command(" ".join([
                 '/home/ubuntu/apps/AppImageKit/appimagetool-x86_64.AppImage',
                 '"%s"' % app_dir_path,
-                '"%s"' % app_build_path,
-                '--no-appstream'
+                '"%s"' % app_build_path
             ])):
                 output(line)
             app_image_success = os.path.exists(app_build_path)

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -349,10 +349,14 @@ def main():
             os.makedirs(dest, exist_ok=True)
 
             desk_in = os.path.join(PATH, "xdg", "org.openshot.OpenShot.appdata.xml")
-            desk_out = os.path.join(dest, "openshot-qt.appdata.xml")
+            desk_out = os.path.join(dest, "org.openshot.OpenShot.appdata.xml")
             with open(desk_in, "r") as inf, open(desk_out, "w") as outf:
                 for line in inf:
-                    outf.write(line.replace("org.openshot.OpenShot", "openshot-qt"))
+                    if "launchable" in line:
+                        outf.write(line.replace("org.openshot.OpenShot", "openshot-qt"))
+                    else:
+                        outf.write(line)
+
 
             # Copy the entire frozen app
             shutil.copytree(os.path.join(PATH, "build", exe_dir),

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -387,7 +387,7 @@ def main():
             # Was the AppImage creation successful
             if not app_image_success or errors_detected:
                 # AppImage failed
-                error("AppImageKit Error: AppImageAssistant did not output the AppImage file")
+                error("AppImageKit Error: appimagetool did not output the AppImage file")
                 needs_upload = False
 
                 # Delete build (since something failed)

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -377,7 +377,7 @@ def main():
             # Create AppImage (OpenShot-%s-x86_64.AppImage)
             app_image_success = False
             for line in run_command(" ".join([
-                '/home/ubuntu/apps/AppImageKit/AppImageAssistant',
+                '/home/ubuntu/apps/AppImageKit/appimagetool-x86_64.AppImage',
                 '"%s"' % app_dir_path,
                 '"%s"' % app_build_path,
             ])):

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -354,15 +354,13 @@ def main():
             with open(desk_in, "r") as inf, open(desk_out, "w") as outf:
                 for line in inf:
                     if line.startswith("Exec="):
-                        outf.write("Exec=openshot-qt-launch.wrapper %F\n")
+                        outf.write("Exec=openshot-qt-launch %F\n")
                     else:
                         outf.write(line)
 
             # Copy desktop integration wrapper (prompts users to install shortcut)
             launcher_path = os.path.join(app_dir_path, "usr", "bin", "openshot-qt-launch")
             os.rename(os.path.join(app_dir_path, "usr", "bin", "launch-linux.sh"), launcher_path)
-            desktop_wrapper = os.path.join(app_dir_path, "usr", "bin", "openshot-qt-launch.wrapper")
-            shutil.copyfile("/home/ubuntu/apps/AppImageKit/desktopintegration", desktop_wrapper)
 
             # Create AppRun.64 file (the real one)
             app_run_path = os.path.join(app_dir_path, "AppRun")
@@ -371,7 +369,6 @@ def main():
             # Add execute bit to file mode for AppRun and scripts
             st = os.stat(app_run_path)
             os.chmod(app_run_path, st.st_mode | stat.S_IEXEC)
-            os.chmod(desktop_wrapper, st.st_mode | stat.S_IEXEC)
             os.chmod(launcher_path, st.st_mode | stat.S_IEXEC)
 
             # Create AppImage (OpenShot-%s-x86_64.AppImage)

--- a/installer/launch-linux.sh
+++ b/installer/launch-linux.sh
@@ -1,30 +1,5 @@
 #!/bin/bash
 
-# Query the current display DPI
-#   Fix the AppImage devicePixelRatio and scale the UI correctly
-#   for High DPI displays. Ignore this logic if QT_SCREEN_SCALE_FACTORS
-#   is already defined as an environment. The format is a
-#   semicolon-separated list of scale factors in the same order as
-#   QGuiApplication::screens().
-if [[ -z "${QT_SCREEN_SCALE_FACTORS}" ]]; then
-
-  regex="^.*resolution:\s*([0-9]*)x"
-  while read line; do
-    # Loop through display results, looking for regex matches
-    [[ $line =~ $regex ]]
-    if [[ -n "${BASH_REMATCH[1]}" ]]; then
-      # Found a DPI results match
-      SCALE_FACTOR=$(bc <<<"scale=2;${BASH_REMATCH[1]}/92")
-      SCREENS+="${SCALE_FACTOR}"
-      echo "Detected scale factor: ${SCALE_FACTOR}"
-      SCREENS+=";"
-    fi
-  done <<< $(xdpyinfo | grep resolution)
-
-  echo "Setting QT_SCREEN_SCALE_FACTORS='${SCREENS}'"
-  export QT_SCREEN_SCALE_FACTORS="${SCREENS}"
-fi
-
 # Add the current folder the library path
 HERE=$(dirname "$(realpath "$0")")
 export LD_LIBRARY_PATH="${HERE}"

--- a/src/launch.py
+++ b/src/launch.py
@@ -46,7 +46,7 @@ import argparse
 
 try:
     # This needs to be imported before PyQt5
-    # To prevent some issues on Linux: wrapping/forcing older libc versions
+    # To prevent some issues on AppImage build: wrapping/forcing older glibc versions
     import openshot
 except ImportError:
     pass

--- a/src/launch.py
+++ b/src/launch.py
@@ -44,6 +44,13 @@ import sys
 import os
 import argparse
 
+try:
+    # This needs to be imported before PyQt5
+    # To prevent some issues on Linux: wrapping/forcing older libc versions
+    import openshot
+except ImportError:
+    pass
+
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QApplication
 

--- a/xdg/org.openshot.OpenShot.appdata.xml
+++ b/xdg/org.openshot.OpenShot.appdata.xml
@@ -24,12 +24,12 @@
         <li><em>Advanced clips</em> (including trimming, alpha, scaling, location, rotation, and shearing)</li>
         <li><em>Real-time preview</em> (multi-threaded, and optimized for performance)</li>
         <li><em>Simple &amp; advanced views</em> (or customize your own unique view)</li>
-        <li><em>Powerful, curve-based Keyframe animations</em> (<cite>linear</cite>, <cite>Bézier</cite>, and <cite>constant</cite> interpolation)</li>
+        <li><em>Powerful, curve-based Keyframe animations</em> (linear, Bézier, and constant interpolation)</li>
         <li><em>Compositing, image overlays, watermarks, &amp; transparency</em></li>
         <li><em>Unlimited tracks / layers</em> (support for complex projects)</li>
         <li><em>Video transitions, masks, &amp; wipes</em> (grayscale images and animated masks)</li>
         <li><em>Video &amp; audio effects</em> (including brightness, gamma, hue, chroma key / blue screen, and more)</li>
-        <li><em>Image sequences &amp; 2D animations</em> (<cite>001.png</cite>, <cite>002.png</cite>, <cite>003.png</cite>, etc…)</li>
+        <li><em>Image sequences &amp; 2D animations</em> (001.png, 002.png, 003.png, etc…)</li>
         <li><em>Blender 3D integration</em> (animated 3D title templates)</li>
         <li><em>Vector file support &amp; editing</em> (SVG / scalable vector graphics used for titles and credits)</li>
         <li><em>Audio mixing, waveform, &amp; editing</em></li>

--- a/xdg/org.openshot.OpenShot.appdata.xml
+++ b/xdg/org.openshot.OpenShot.appdata.xml
@@ -42,7 +42,6 @@
         <li><em>Import &amp; export</em> (EDL and Final Cut Pro formats, supports most video editors)</li>
         <li><em>Customizable keyboard shortcuts</em></li>
         <li><em>Translations</em> (available in 100+ languages)</li>
-        <li><em>Community support</em> (https://openshot.org/forum/)</li>
     </ul>
   </description>
   <url type="donation">https://www.openshot.org/donate/</url>
@@ -62,7 +61,6 @@
   </content_rating>
   <provides>
     <binary>openshot-qt</binary>
-    <id>org.openshot.OpenShot</id>
   </provides>
   <releases>
     <release version="2.6.1" date="2021-09-04"/>

--- a/xdg/org.openshot.OpenShot.appdata.xml
+++ b/xdg/org.openshot.OpenShot.appdata.xml
@@ -61,6 +61,7 @@
   </content_rating>
   <provides>
     <binary>openshot-qt</binary>
+    <id>org.openshot.OpenShot.desktop</id>
   </provides>
   <releases>
     <release version="2.6.1" date="2021-09-04"/>

--- a/xdg/org.openshot.OpenShot.appdata.xml
+++ b/xdg/org.openshot.OpenShot.appdata.xml
@@ -13,36 +13,36 @@
         and Windows. OpenShot can create stunning videos, films, and animations with an easy-to-use interface
         and rich set of features.
     </p>
-      <p><em>Features include:</em></p>
+        <p><em>Features include:</em></p>
     <ul>
-        <li><p><em>Free &amp; open-source</em> (licensed under GPLv3)</p></li>
-        <li><p><em>Cross-platform</em> (Linux, OS X, Chrome OS, and Windows)</p></li>
-        <li><p><em>Easy-to-use user interface</em> (designed for beginners, built-in tutorial)</p></li>
-        <li><p><em>Supports most video, audio, &amp; image formats</em> (based on FFmpeg)</p></li>
-        <li><p><em>Includes popular video profiles &amp; presets</em> (over 70+ profiles, including YouTube HD)</p></li>
-        <li><p><em>Advanced timeline</em> (including drag and drop, scrolling, panning, zooming, and snapping)</p></li>
-        <li><p><em>Advanced clips</em> (including trimming, alpha, scaling, location, rotation, and shearing)</p></li>
-        <li><p><em>Real-time preview</em> (multi-threaded, and optimized for performance)</p></li>
-        <li><p><em>Simple &amp; advanced views</em> (or customize your own unique view)</p></li>
-        <li><p><em>Powerful, curve-based Keyframe animations</em> (<cite>linear</cite>, <cite>Bézier</cite>, and <cite>constant</cite> interpolation)</p></li>
-        <li><p><em>Compositing, image overlays, watermarks, &amp; transparency</em></p></li>
-        <li><p><em>Unlimited tracks / layers</em> (support for complex projects)</p></li>
-        <li><p><em>Video transitions, masks, &amp; wipes</em> (grayscale images and animated masks)</p></li>
-        <li><p><em>Video &amp; audio effects</em> (including brightness, gamma, hue, chroma key / blue screen, and more)</p></li>
-        <li><p><em>Image sequences &amp; 2D animations</em> (<cite>001.png</cite>, <cite>002.png</cite>, <cite>003.png</cite>, etc…)</p></li>
-        <li><p><em>Blender 3D integration</em> (animated 3D title templates)</p></li>
-        <li><p><em>Vector file support &amp; editing</em> (SVG / scalable vector graphics used for titles and credits)</p></li>
-        <li><p><em>Audio mixing, waveform, &amp; editing</em></p></li>
-        <li><p><em>Emojis</em> (open-source stickers &amp; artwork included)</p></li>
-        <li><p><em>Frame accuracy</em> (step through each frame of video)</p></li>
-        <li><p><em>Time mapping &amp; speed changes</em> (slow/fast, forward/backward)</p></li>
-        <li><p><em>Advanced AI</em> (motion tracking, object detection, &amp; stabilization effects)</p></li>
-        <li><p><em>Credits &amp; captions</em> (scrolling and animated)</p></li>
-        <li><p><em>Hardware accelerated</em> (encoding &amp; decoding supports NVIDIA, AMD, Intel and more)</p></li>
-        <li><p><em>Import &amp; export</em> (EDL and Final Cut Pro formats, supports most video editors)</p></li>
-        <li><p><em>Customizable keyboard shortcuts</em></p></li>
-        <li><p><em>Translations</em> (available in 100+ languages)</p></li>
-        <li><p><em>Community support</em> (https://openshot.org/forum/)</p></li>
+        <li><em>Free &amp; open-source</em> (licensed under GPLv3)</li>
+        <li><em>Cross-platform</em> (Linux, OS X, Chrome OS, and Windows)</li>
+        <li><em>Easy-to-use user interface</em> (designed for beginners, built-in tutorial)</li>
+        <li><em>Supports most video, audio, &amp; image formats</em> (based on FFmpeg)</li>
+        <li><em>Includes popular video profiles &amp; presets</em> (over 70+ profiles, including YouTube HD)</li>
+        <li><em>Advanced timeline</em> (including drag and drop, scrolling, panning, zooming, and snapping)</li>
+        <li><em>Advanced clips</em> (including trimming, alpha, scaling, location, rotation, and shearing)</li>
+        <li><em>Real-time preview</em> (multi-threaded, and optimized for performance)</li>
+        <li><em>Simple &amp; advanced views</em> (or customize your own unique view)</li>
+        <li><em>Powerful, curve-based Keyframe animations</em> (<cite>linear</cite>, <cite>Bézier</cite>, and <cite>constant</cite> interpolation)</li>
+        <li><em>Compositing, image overlays, watermarks, &amp; transparency</em></li>
+        <li><em>Unlimited tracks / layers</em> (support for complex projects)</li>
+        <li><em>Video transitions, masks, &amp; wipes</em> (grayscale images and animated masks)</li>
+        <li><em>Video &amp; audio effects</em> (including brightness, gamma, hue, chroma key / blue screen, and more)</li>
+        <li><em>Image sequences &amp; 2D animations</em> (<cite>001.png</cite>, <cite>002.png</cite>, <cite>003.png</cite>, etc…)</li>
+        <li><em>Blender 3D integration</em> (animated 3D title templates)</li>
+        <li><em>Vector file support &amp; editing</em> (SVG / scalable vector graphics used for titles and credits)</li>
+        <li><em>Audio mixing, waveform, &amp; editing</em></li>
+        <li><em>Emojis</em> (open-source stickers &amp; artwork included)</li>
+        <li><em>Frame accuracy</em> (step through each frame of video)</li>
+        <li><em>Time mapping &amp; speed changes</em> (slow/fast, forward/backward)</li>
+        <li><em>Advanced AI</em> (motion tracking, object detection, &amp; stabilization effects)</li>
+        <li><em>Credits &amp; captions</em> (scrolling and animated)</li>
+        <li><em>Hardware accelerated</em> (encoding &amp; decoding supports NVIDIA, AMD, Intel and more)</li>
+        <li><em>Import &amp; export</em> (EDL and Final Cut Pro formats, supports most video editors)</li>
+        <li><em>Customizable keyboard shortcuts</em></li>
+        <li><em>Translations</em> (available in 100+ languages)</li>
+        <li><em>Community support</em> (https://openshot.org/forum/)</li>
     </ul>
   </description>
   <url type="donation">https://www.openshot.org/donate/</url>

--- a/xdg/org.openshot.OpenShot.appdata.xml
+++ b/xdg/org.openshot.OpenShot.appdata.xml
@@ -31,16 +31,13 @@
       </ul>
     </p>
   </description>
-  <provides>
-    <binary>openshot-qt</binary>
-  </provides>
-  <url type="donation">https://www.openshot.org/donate</url>
-  <url type="help">https://www.openshot.org/user-guide</url>
-  <url type="homepage">https://www.openshot.org</url>
-  <url type="bugtracker">https://github.com/OpenShot/openshot-qt/issues</url>
+  <url type="donation">https://www.openshot.org/donate/</url>
+  <url type="help">https://www.openshot.org/user-guide/</url>
+  <url type="homepage">https://www.openshot.org/</url>
+  <url type="bugtracker">https://www.openshot.org/issues/new/</url>
   <screenshots>
     <screenshot type="default">
-      <image  height="637" width="975">https://www.openshot.org/static/img/gallery/ui-example.jpg</image>
+      <image height="637" width="975">https://www.openshot.org/static/img/gallery/ui-example.jpg</image>
     </screenshot>
     <screenshot>
       <image height="555" width="780">https://www.openshot.org/static/img/gallery/title-editor.jpg</image>

--- a/xdg/org.openshot.OpenShot.appdata.xml
+++ b/xdg/org.openshot.OpenShot.appdata.xml
@@ -62,7 +62,7 @@
   </content_rating>
   <provides>
     <binary>openshot-qt</binary>
-    <id>openshot-qt</id>
+    <id>org.openshot.OpenShot</id>
   </provides>
   <releases>
     <release version="2.6.1" date="2021-09-04"/>

--- a/xdg/org.openshot.OpenShot.appdata.xml
+++ b/xdg/org.openshot.OpenShot.appdata.xml
@@ -9,25 +9,41 @@
   <summary>An easy to use, quick to learn, and surprisingly powerful video editor</summary>
   <description>
     <p>
-      OpenShot Video Editor is a free, open-source, non-linear video editor. It
-      can create and edit videos and movies using many popular video, audio,
-      image formats. Create videos for YouTube, Flickr, Vimeo, Metacafe, iPod,
-      Xbox, and more!
+        OpenShot Video Editor is an award-winning, open-source video editor, available on Linux, Mac, Chrome OS,
+        and Windows. OpenShot can create stunning videos, films, and animations with an easy-to-use interface
+        and rich set of features.
     </p>
-    <p>
-      Features include:
-      <ul>
-          <li>Multiple tracks (layers)</li>
-          <li>Compositing, image overlays, and watermarks</li>
-          <li>Audio mixing and editing</li>
-          <li>Support for image sequences (rotoscoping)</li>
-          <li>Key-frame animation</li>
-          <li>Video effects (chroma-key)</li>
-          <li>Transitions (lumas and masks)</li>
-          <li>Titles with integrated editor and templates</li>
-          <li>3D animation (titles and effects)</li>
-      </ul>
-    </p>
+      <p><em>Features include:</em></p>
+    <ul>
+        <li><p><em>Free &amp; open-source</em> (licensed under GPLv3)</p></li>
+        <li><p><em>Cross-platform</em> (Linux, OS X, Chrome OS, and Windows)</p></li>
+        <li><p><em>Easy-to-use user interface</em> (designed for beginners, built-in tutorial)</p></li>
+        <li><p><em>Supports most video, audio, &amp; image formats</em> (based on FFmpeg)</p></li>
+        <li><p><em>Includes popular video profiles &amp; presets</em> (over 70+ profiles, including YouTube HD)</p></li>
+        <li><p><em>Advanced timeline</em> (including drag and drop, scrolling, panning, zooming, and snapping)</p></li>
+        <li><p><em>Advanced clips</em> (including trimming, alpha, scaling, location, rotation, and shearing)</p></li>
+        <li><p><em>Real-time preview</em> (multi-threaded, and optimized for performance)</p></li>
+        <li><p><em>Simple &amp; advanced views</em> (or customize your own unique view)</p></li>
+        <li><p><em>Powerful, curve-based Keyframe animations</em> (<cite>linear</cite>, <cite>Bézier</cite>, and <cite>constant</cite> interpolation)</p></li>
+        <li><p><em>Compositing, image overlays, watermarks, &amp; transparency</em></p></li>
+        <li><p><em>Unlimited tracks / layers</em> (support for complex projects)</p></li>
+        <li><p><em>Video transitions, masks, &amp; wipes</em> (grayscale images and animated masks)</p></li>
+        <li><p><em>Video &amp; audio effects</em> (including brightness, gamma, hue, chroma key / blue screen, and more)</p></li>
+        <li><p><em>Image sequences &amp; 2D animations</em> (<cite>001.png</cite>, <cite>002.png</cite>, <cite>003.png</cite>, etc…)</p></li>
+        <li><p><em>Blender 3D integration</em> (animated 3D title templates)</p></li>
+        <li><p><em>Vector file support &amp; editing</em> (SVG / scalable vector graphics used for titles and credits)</p></li>
+        <li><p><em>Audio mixing, waveform, &amp; editing</em></p></li>
+        <li><p><em>Emojis</em> (open-source stickers &amp; artwork included)</p></li>
+        <li><p><em>Frame accuracy</em> (step through each frame of video)</p></li>
+        <li><p><em>Time mapping &amp; speed changes</em> (slow/fast, forward/backward)</p></li>
+        <li><p><em>Advanced AI</em> (motion tracking, object detection, &amp; stabilization effects)</p></li>
+        <li><p><em>Credits &amp; captions</em> (scrolling and animated)</p></li>
+        <li><p><em>Hardware accelerated</em> (encoding &amp; decoding supports NVIDIA, AMD, Intel and more)</p></li>
+        <li><p><em>Import &amp; export</em> (EDL and Final Cut Pro formats, supports most video editors)</p></li>
+        <li><p><em>Customizable keyboard shortcuts</em></p></li>
+        <li><p><em>Translations</em> (available in 100+ languages)</p></li>
+        <li><p><em>Community support</em> (https://openshot.org/forum/)</p></li>
+    </ul>
   </description>
   <url type="donation">https://www.openshot.org/donate/</url>
   <url type="help">https://www.openshot.org/user-guide/</url>

--- a/xdg/org.openshot.OpenShot.appdata.xml
+++ b/xdg/org.openshot.OpenShot.appdata.xml
@@ -6,9 +6,7 @@
   <project_license>GPL-3.0-or-later</project_license>
   <name>OpenShot Video Editor</name>
   <developer_name>OpenShot Studios, LLC</developer_name>
-  <summary>
-    An easy to use, quick to learn, and surprisingly powerful video editor
-  </summary>
+  <summary>An easy to use, quick to learn, and surprisingly powerful video editor</summary>
   <description>
     <p>
       OpenShot Video Editor is a free, open-source, non-linear video editor. It
@@ -19,15 +17,15 @@
     <p>
       Features include:
       <ul>
-      <li>Multiple tracks (layers)</li>
-      <li>Compositing, image overlays, and watermarks</li>
-      <li>Audio mixing and editing</li>
-      <li>Support for image sequences (rotoscoping)</li>
-      <li>Key-frame animation</li>
-      <li>Video effects (chroma-key)</li>
-      <li>Transitions (lumas and masks)</li>
-      <li>Titles with integrated editor and templates</li>
-      <li>3D animation (titles and effects)</li>
+          <li>Multiple tracks (layers)</li>
+          <li>Compositing, image overlays, and watermarks</li>
+          <li>Audio mixing and editing</li>
+          <li>Support for image sequences (rotoscoping)</li>
+          <li>Key-frame animation</li>
+          <li>Video effects (chroma-key)</li>
+          <li>Transitions (lumas and masks)</li>
+          <li>Titles with integrated editor and templates</li>
+          <li>3D animation (titles and effects)</li>
       </ul>
     </p>
   </description>


### PR DESCRIPTION
Related to: https://github.com/OpenShot/libopenshot-audio/pull/146 and https://github.com/OpenShot/libopenshot/pull/878

Adding support for a new Linux build server (Ubuntu 20.04), which has updated dependencies, but also a newer glibc version. This only affects our **AppImage** builds.

**Pros:** 
- Newer FFmpeg 
- Newer Qt
- Newer SVG / ReSVG
- Newer AppImage Format
- New AppStream XML Verification / AppImageLauncher support


**Cons:**
- Older distros (older than April 2020) will likely be incompatible due to glibc. However, we did add some glibc wrapping for OpenShot related executables - although I think more work is needed in this area (i.e. cx_Freeze, Qt, FFmpeg, and other dependencies which are not compiled, but still packaged). However, older Debian-based distros can still install our PPA and get daily updates: https://www.openshot.org/ppa/)
