### PR TITLE
Improve user-guide embedded javascript (resize iFrame, external link targets)

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,2 +1,22 @@
 {% extends "!layout.html" %}
 {% set css_files = css_files + ["_static/tablefix.css"] %}
+{%- block footer %}
+  <script>
+    $( document ).ready(function() {
+        console.log( "OpenShot Documentation page ready" );
+        const height = document.body.scrollHeight;
+        const href = location.href;
+        if (window.parent) {
+            location.href.includes('index.html')
+            window.parent.postMessage(
+                {height, href}
+            );
+        }
+    });
+
+    <!-- Adds target=_blank to external links -->
+    $(document).ready(function () {
+      $('a[href^="http://"], a[href^="https://"]').not('a[class*=internal]').attr('target', '_blank');
+    });
+  </script>
+{% endblock %}


### PR DESCRIPTION
Improve user guide embedded javascript, to communicate back to openshot.org/user-guide correctly. Since we are hosting these docs on a cdn, this is the only secure way to resize the contents of these docs inside an iframe. Also, making external links use target _blank