### PR TITLE
Fixing Inkscape/Blender launching in AppImage

### DIFF
--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -89,13 +89,12 @@ class TitleEditor(QDialog):
         # Track metrics
         track_metric_screen("title-screen")
 
+        # Get environment variables needed for launching a process without trying to load libraries
+        # from our frozen app bundle
         self.env = dict(os.environ)
-        if sys.platform == "linux" and os.path.exists('/lib/x86_64-linux-gnu/'):
-            # If on Linux, verify we have the following LD library path defined.
-            # This is needed for Inkscape to use the system libraries instead
-            # of our AppImage libraries
-            self.env['LD_LIBRARY_PATH'] = '/lib/x86_64-linux-gnu/'
-            log.debug(f'Appending system path before launching inkscape: {self.env.get("LD_LIBRARY_PATH")}')
+        if sys.platform == "linux":
+            self.env.pop('LD_LIBRARY_PATH', None)
+            log.debug('Removing custom LD_LIBRARY_PATH from environment variables when launching Inkscape')
 
         # Initialize variables
         self.template_name = ""

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -751,14 +751,13 @@ class Worker(QObject):
         self.version = None
         self.process = None
         self.canceled = False
+
+        # Get environment variables needed for launching a process without trying to load libraries
+        # from our frozen app bundle
         self.env = dict(os.environ)
-        if sys.platform == "linux" and os.path.exists('/lib/x86_64-linux-gnu/'):
-            # If on Linux, verify we have the following LD library path defined.
-            # This is needed for Blender to use the system libraries instead
-            # of our AppImage libraries (i.e. our libtiff.so.5 is missing symbols,
-            # compared to libtiff.so.5 on newer distros for some reason).
-            self.env['LD_LIBRARY_PATH'] = '/lib/x86_64-linux-gnu/'
-            log.debug(f'Appending system path before launching blender: {self.env.get("LD_LIBRARY_PATH")}')
+        if sys.platform == "linux":
+            self.env.pop('LD_LIBRARY_PATH', None)
+            log.debug('Removing custom LD_LIBRARY_PATH from environment variables when launching Blender')
 
         self.startupinfo = None
         if sys.platform == 'win32':

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -758,6 +758,7 @@ class Worker(QObject):
             # of our AppImage libraries (i.e. our libtiff.so.5 is missing symbols,
             # compared to libtiff.so.5 on newer distros for some reason).
             self.env['LD_LIBRARY_PATH'] = '/lib/x86_64-linux-gnu/'
+            log.debug(f'Appending system path before launching blender: {self.env.get("LD_LIBRARY_PATH")}')
 
         self.startupinfo = None
         if sys.platform == 'win32':


### PR DESCRIPTION
Fixing inkscape launching in AppImage on newer / different distros, use **system libraries** for missing libraries.