### PR TITLE
Windows Installer (AppID + App DisplayName)

### DIFF
--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -24,7 +24,7 @@
 ; NOTE: The value of AppId uniquely identifies this application.
 ; Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-AppId={code:GetAppId|{{4BB0DCDC-BC24-49EC-8937-72956C33A470}
+AppId={code:GetAppId|{{4BB0DCDC-BC24-49EC-8937-72956C33A470}}
 AppName=OpenShot Video Editor
 AppVersion={#VERSION}
 VersionInfoVersion={#VERSION}

--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -138,6 +138,8 @@ Root: HKLM; Subkey: "Software\Classes\.osp"; ValueType: string; ValueName: ""; V
 Root: HKLM; Subkey: "Software\Classes\OpenShotProject"; ValueType: string; ValueName: ""; ValueData: "{#MyAppProjectFileDesc}"; Flags: uninsdeletekey; Tasks: fileassoc
 ; Launcher association for data files of type OpenShotProject
 Root: HKLM; Subkey: "Software\Classes\OpenShotProject\shell\open\command"; ValueType: string;  ValueName: ""; ValueData: """{app}\{#MyAppExeName}"" ""%1"""; Tasks: fileassoc
+; Clean-up old, incorrect AppID Uninstaller (used in 2.6.1-dev builds)
+Root: HKLM; Subkey: "Software\Microsoft\Windows\CurrentVersion\Uninstall\4BB0DCDC-BC24-49EC-8937-72956C33A470_is1"; ValueName: ""; ValueType: none; Flags: deletevalue;
 
 [Files]
 ; Add all frozen files from cx_Freeze build

--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -139,7 +139,7 @@ Root: HKLM; Subkey: "Software\Classes\OpenShotProject"; ValueType: string; Value
 ; Launcher association for data files of type OpenShotProject
 Root: HKLM; Subkey: "Software\Classes\OpenShotProject\shell\open\command"; ValueType: string;  ValueName: ""; ValueData: """{app}\{#MyAppExeName}"" ""%1"""; Tasks: fileassoc
 ; Clean-up old, incorrect AppID Uninstaller (used in 2.6.1-dev builds)
-Root: HKLM; Subkey: "Software\Microsoft\Windows\CurrentVersion\Uninstall\4BB0DCDC-BC24-49EC-8937-72956C33A470_is1"; ValueName: ""; ValueType: none; Flags: deletekey;
+Root: HKLM; Subkey: "Software\Microsoft\Windows\CurrentVersion\Uninstall\4BB0DCDC-BC24-49EC-8937-72956C33A470_is1"; ValueName: ""; Flags: deletekey;
 
 [Files]
 ; Add all frozen files from cx_Freeze build

--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -139,7 +139,7 @@ Root: HKLM; Subkey: "Software\Classes\OpenShotProject"; ValueType: string; Value
 ; Launcher association for data files of type OpenShotProject
 Root: HKLM; Subkey: "Software\Classes\OpenShotProject\shell\open\command"; ValueType: string;  ValueName: ""; ValueData: """{app}\{#MyAppExeName}"" ""%1"""; Tasks: fileassoc
 ; Clean-up old, incorrect AppID Uninstaller (used in 2.6.1-dev builds)
-Root: HKLM; Subkey: "Software\Microsoft\Windows\CurrentVersion\Uninstall\4BB0DCDC-BC24-49EC-8937-72956C33A470_is1"; ValueName: ""; ValueType: none; Flags: deletevalue;
+Root: HKLM; Subkey: "Software\Microsoft\Windows\CurrentVersion\Uninstall\4BB0DCDC-BC24-49EC-8937-72956C33A470_is1"; ValueName: ""; ValueType: none; Flags: deletekey;
 
 [Files]
 ; Add all frozen files from cx_Freeze build

--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -24,7 +24,7 @@
 ; NOTE: The value of AppId uniquely identifies this application.
 ; Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-AppId={code:GetAppId|{4BB0DCDC-BC24-49EC-8937-72956C33A470}
+AppId={code:GetAppId|{{4BB0DCDC-BC24-49EC-8937-72956C33A470}
 AppName=OpenShot Video Editor
 AppVersion={#VERSION}
 VersionInfoVersion={#VERSION}

--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -24,7 +24,7 @@
 ; NOTE: The value of AppId uniquely identifies this application.
 ; Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-AppId={code:GetAppId|4BB0DCDC-BC24-49EC-8937-72956C33A470}
+AppId={{code:GetAppId|4BB0DCDC-BC24-49EC-8937-72956C33A470}
 AppName=OpenShot Video Editor
 AppVersion={#VERSION}
 VersionInfoVersion={#VERSION}

--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -52,6 +52,10 @@ SignedUninstallerDir=..\build\
 PrivilegesRequiredOverridesAllowed=commandline
 AllowNoIcons=yes
 
+[Messages]
+; Format DisplayName shown on Add/Remove Programs
+NameAndVersion=%1 %2
+
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "afrikaans"; MessagesFile: "compiler:Languages\Afrikaans.isl"

--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -27,6 +27,7 @@
 AppId={code:GetAppId|{{4BB0DCDC-BC24-49EC-8937-72956C33A470}}
 AppName=OpenShot Video Editor
 AppVersion={#VERSION}
+AppVerName={#MyAppName} {#VERSION}
 VersionInfoVersion={#VERSION}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyPublisherURL}
@@ -51,10 +52,6 @@ SignedUninstaller=yes
 SignedUninstallerDir=..\build\
 PrivilegesRequiredOverridesAllowed=commandline
 AllowNoIcons=yes
-
-[Messages]
-; Format DisplayName shown on Add/Remove Programs
-NameAndVersion=%1 %2
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -24,7 +24,7 @@
 ; NOTE: The value of AppId uniquely identifies this application.
 ; Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-AppId={{code:GetAppId|4BB0DCDC-BC24-49EC-8937-72956C33A470}
+AppId={code:GetAppId|{4BB0DCDC-BC24-49EC-8937-72956C33A470}
 AppName=OpenShot Video Editor
 AppVersion={#VERSION}
 VersionInfoVersion={#VERSION}


### PR DESCRIPTION
Fix our 3.0.0 release candidate Windows installer to use the same AppID in the registry as our previous stable builds (`2.5.1`, `2.6.0`, and `2.6.1`). This prevents multiple entries in the `Add / Remove Programs` screen.