### PR TITLE
Fix AppImage for Fedora 37 compatibility

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -387,11 +387,9 @@ elif sys.platform == "linux":
                     #"libpango-1.0.so.0",
                     #"libpangocairo-1.0.so.0",
                     #"libpangoft2-1.0.so.0",
-
                     "libdrm.so.2",
                     "libfreetype.so.6",
                     "libfontconfig.so.1",
-                    "libcairo.so.2",
                     "libharfbuzz.so.0",
                     "libthai.so.0",
                     ]


### PR DESCRIPTION
Adding libcairo.so.2 back to AppImage, for Fedora 37 compatibility.

Closes #5028 

I've successfully tested this change on:
- Fedora 37
- Ubuntu 22.04
- Ubuntu 20.04
- Manjaro 21
- CentOS 8 (fails launching AppImage - but apparently it fails on our stable release of 3.0 also - glibc version too old)