### PR TITLE
Refactor Audio Devices (auto update preferences to match system device)

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -3223,11 +3223,20 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         else:
             lib_settings.HW_EN_DEVICE_SET = 0
 
-        # Set audio playback settings
-        if s.get("playback-audio-device"):
-            lib_settings.PLAYBACK_AUDIO_DEVICE_NAME = str(s.get("playback-audio-device"))
-        else:
-            lib_settings.PLAYBACK_AUDIO_DEVICE_NAME = ""
+        # Set audio device settings (used for playback of audio)
+        # - OLD settings only includes device name (i.e. "PulseAudio Sound Server")
+        # - NEW settings include both device name and type (double pipe delimited)
+        #   (i.e. "PulseAudio Sound Server||ALSA")
+        playback_device_value = s.get("playback-audio-device") or ""
+        playback_device_parts = playback_device_value.split("||")
+        playback_device_name = playback_device_parts[0]
+        playback_device_type = ""
+        if len(playback_device_parts) == 2:
+            # This might be empty for older settings, which only included the device name
+            playback_device_type = playback_device_parts[1]
+        # Set libopenshot settings
+        lib_settings.PLAYBACK_AUDIO_DEVICE_NAME = playback_device_name
+        lib_settings.PLAYBACK_AUDIO_DEVICE_TYPE = playback_device_type
 
         # Set scaling mode to lower quality scaling (for faster previews)
         lib_settings.HIGH_QUALITY_SCALING = False

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -280,10 +280,12 @@ class Preferences(QDialog):
                         # Loop through audio devices
                         value_list.append({"name": "Default", "value": ""})
                         for audio_device in get_app().window.preview_thread.player.GetAudioDeviceNames():
+                            # Text:  Type first, then device name  (i.e. "ALSA: PulseAudio Sound Server")
+                            # Value: Name first, ||, then device type  (i.e. "PulseAudio Sound Server||ALSA")
                             value_list.append({
                                 "name": "%s: %s" % (audio_device[1], audio_device[0]),
-                                "value": audio_device[0],
-                                })
+                                "value": "%s||%s" % (audio_device[0], audio_device[1])
+                            })
 
                     # Overwrite value list (for language dropdown)
                     if param["setting"] == "default-language":


### PR DESCRIPTION
Related to https://github.com/OpenShot/libopenshot/pull/882

- Refactor of "playback-audio-device" setting to hold both the device…name and type: for example "PulseAudio Sound Server||ALSA"
- Refactor of Preferences to store the value of both the name and type of audio devices
- Refactor of preview thread to detect default audio device and sample rate, and compare to current Preference values.. if different, update OpenShot preferences to match the actual audio device opened, and actual sample rate supported.