### PR TITLE
Delete clips / transitions with invalid or negative duration

### DIFF
--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -135,6 +135,9 @@ App.directive("tlClip", function ($timeout) {
               // prevent less than zero
               new_left = 0.0;
               new_position -= scope.clip.start;
+            } else if (new_left >= new_right) {
+              // prevent resizing past right edge
+              new_left = new_right;
             } else {
               new_position -= delta_time;
             }
@@ -145,6 +148,9 @@ App.directive("tlClip", function ($timeout) {
             if (new_right > scope.clip.duration) {
               // prevent greater than duration
               new_right = scope.clip.duration;
+            } else if (new_right < new_left) {
+              // Prevent resizing past left edge
+              new_right = new_left;
             }
           }
 


### PR DESCRIPTION
Delete clips / transitions with invalid or negative duration. For example, trim the left edge past the right edge, or the right edge past the left edge, and the item will now be deleted.

Previously, clips and transitions with a negative duration would just flicker and re-appear on the timeline, but are completely broken (no longer render on the timeline)