### PR TITLE
Calculate z-index for clips and transitions (selected items use larger z-index)

### DIFF
--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -83,7 +83,7 @@
 				</div>
 				
 				<!-- CLIPS -->
-				<div ng-hide tl-clip ng-repeat="clip in project.clips" id="clip_{{clip.id}}" ng-click="selectClip(clip.id, true, $event)" ng-right-click="showClipMenu(clip.id, $event)" class="clip droppable" ng-class="getClipStyle(clip)" style="width:{{(clip.end - clip.start) * pixelsPerSecond}}px; left:{{clip.position * pixelsPerSecond}}px; top:{{getTrackTop(clip.layer)}}px;z-index:{{1000 + $index}};">
+				<div ng-hide tl-clip ng-repeat="clip in project.clips" id="clip_{{clip.id}}" ng-click="selectClip(clip.id, true, $event)" ng-right-click="showClipMenu(clip.id, $event)" class="clip droppable" ng-class="getClipStyle(clip)" style="width:{{(clip.end - clip.start) * pixelsPerSecond}}px; left:{{clip.position * pixelsPerSecond}}px; top:{{getTrackTop(clip.layer)}}px;z-index:{{getZindex(clip, 1000, $index)}};">
 					<div class="clip_top">
 						<div tl-clip-menu class="menu clip_menu" ng-if="!enable_razor" ng-mousedown="showClipMenu(clip.id, $event)" tooltip-enable="!enable_razor" tooltip="{{clip.title}}" tooltip-placement="bottom" tooltip-popup-delay="400"></div>
 
@@ -118,7 +118,7 @@
 				</div>
 
 				<!-- TRANSITIONS -->
-				<div ng-hide tl-transition ng-repeat="transition in project.effects" id="transition_{{transition.id}}" ng-click="selectTransition(transition.id, true, $event)" ng-right-click="showTransitionMenu(transition.id, $event)" class="transition droppable" ng-class="getClipStyle(transition)" style="width:{{ (transition.end - transition.start) * pixelsPerSecond}}px; left:{{transition.position * pixelsPerSecond}}px; top:{{getTrackTop(transition.layer)}}px;z-index:{{5000 + $index}};">
+				<div ng-hide tl-transition ng-repeat="transition in project.effects" id="transition_{{transition.id}}" ng-click="selectTransition(transition.id, true, $event)" ng-right-click="showTransitionMenu(transition.id, $event)" class="transition droppable" ng-class="getClipStyle(transition)" style="width:{{ (transition.end - transition.start) * pixelsPerSecond}}px; left:{{transition.position * pixelsPerSecond}}px; top:{{getTrackTop(transition.layer)}}px;z-index:{{getZindex(transition, 5000, $index)}};">
 					<div class="transition_top">
 						<div tl-clip-menu class="transition_menu" ng-if="!enable_razor" ng-mousedown="showTransitionMenu(transition.id, $event)"></div>
 

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -1322,6 +1322,21 @@ App.controller("TimelineCtrl", function ($scope) {
     return style;
   };
 
+  // Determine which z-index to assign for a clip / transition.
+  // Selected items z-index should be larger than unselected items.
+  // The index is passed in, and represents the current position
+  // in the render loop (1, 2, 3, etc...)
+  $scope.getZindex = function (item, starting_index, index) {
+    let unselected_zindex = starting_index;
+    let selected_zindex = starting_index + 1000;
+
+    if (item.selected) {
+      return selected_zindex + index;
+    } else {
+      return unselected_zindex + index;
+    }
+  };
+
   $scope.markerPath = function(marker) {
     var dir = "media/images/markers";
     var marker_file;


### PR DESCRIPTION
Calculate z-index for clips and transitions on the timeline, and ensure selected z-indexes are higher than unselected ones, to allow a selected clip to be easily resized/trimmed. This makes editing clips/transitions that are snapped together much easier to grab the edge of the selected item.