### PR TITLE
WIP: Large refactor of UpdateAction (for grouped undo/redo actions)

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -146,12 +146,12 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         """Prevent calling JsonDataStore set() method. It is not allowed in ProjectDataStore, as changes come from UpdateManager."""
         raise RuntimeError("ProjectDataStore.set() is not allowed. Changes must route through UpdateManager.")
 
-    def _set(self, key, values=None, add=False, partial_update=False, remove=False):
+    def _set(self, key, values=None, add=False, remove=False):
         """ Store setting, but adding isn't allowed. All possible settings must be in default settings file. """
 
         log.debug(
-            "_set key: %s values: %s add: %s partial: %s remove: %s",
-            key, values, add, partial_update, remove)
+            "_set key: %s, values: %s, add: %s, remove: %s",
+            key, values, add, remove)
         parent, my_key = None, ""
 
         # Verify key is valid type
@@ -1003,7 +1003,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
         elif action.type == "update":
             # Update existing item
-            old_vals = self._set(action.key, action.values, partial_update=action.partial_update)
+            old_vals = self._set(action.key, action.values)
             action.set_old_values(old_vals)  # Save previous values to reverse this action
             self.has_unsaved_changes = True
 

--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -56,9 +56,9 @@ class UpdateAction:
     """A data structure representing a single update manager action,
     including any necessary data to reverse the action."""
 
-    def __init__(self, type=None, key=[], values=None, old_values=None, transaction=None):
+    def __init__(self, type=None, key=None, values=None, old_values=None, transaction=None):
         self.type = type  # insert, update, or delete
-        self.key = key  # list which contains the path to the item, for example: ["clips",{"id":"123"}]
+        self.key = key or []  # list which contains the path to the item, for example: ["clips",{"id":"123"}]
         self.values = values
         self.old_values = old_values
         self.transaction = transaction

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -724,57 +724,71 @@ App.controller("TimelineCtrl", function ($scope) {
 // Show clip context menu
   $scope.showClipMenu = function (clip_id, event) {
     if ($scope.Qt && !$scope.enable_razor) {
-      timeline.qt_log("DEBUG", "$scope.showClipMenu");
-      $scope.selectClip(clip_id, false, event);
-      timeline.ShowClipMenu(clip_id);
+      setTimeout(function() {
+        timeline.qt_log("DEBUG", "$scope.showClipMenu");
+        $scope.selectClip(clip_id, false, event);
+        timeline.ShowClipMenu(clip_id);
+      });
     }
   };
 
 // Show clip context menu
   $scope.showEffectMenu = function (effect_id) {
     if ($scope.Qt && !$scope.enable_razor) {
-      timeline.qt_log("DEBUG", "$scope.showEffectMenu");
-      timeline.ShowEffectMenu(effect_id);
+      setTimeout(function() {
+        timeline.qt_log("DEBUG", "$scope.showEffectMenu");
+        timeline.ShowEffectMenu(effect_id);
+      });
     }
   };
 
 // Show transition context menu
   $scope.showTransitionMenu = function (tran_id, event) {
     if ($scope.Qt && !$scope.enable_razor) {
-      timeline.qt_log("DEBUG", "$scope.showTransitionMenu");
-      $scope.selectTransition(tran_id, false, event);
-      timeline.ShowTransitionMenu(tran_id);
+      setTimeout(function() {
+        timeline.qt_log("DEBUG", "$scope.showTransitionMenu");
+        $scope.selectTransition(tran_id, false, event);
+        timeline.ShowTransitionMenu(tran_id);
+      });
     }
   };
 
 // Show track context menu
   $scope.showTrackMenu = function (layer_id) {
     if ($scope.Qt && !$scope.enable_razor) {
-      timeline.qt_log("DEBUG", "$scope.showTrackMenu");
-      timeline.ShowTrackMenu(layer_id);
+      setTimeout(function() {
+        timeline.qt_log("DEBUG", "$scope.showTrackMenu");
+        timeline.ShowTrackMenu(layer_id);
+      });
     }
   };
 
 // Show marker context menu
   $scope.showMarkerMenu = function (marker_id) {
     if ($scope.Qt && !$scope.enable_razor) {
-      timeline.qt_log("DEBUG", "$scope.showMarkerMenu");
-      timeline.ShowMarkerMenu(marker_id);
+      setTimeout(function() {
+        timeline.qt_log("DEBUG", "$scope.showMarkerMenu");
+        timeline.ShowMarkerMenu(marker_id);
+      });
     }
   };
 
   // Show playhead context menu
   $scope.showPlayheadMenu = function (position) {
     if ($scope.Qt && !$scope.enable_razor) {
-      timeline.qt_log("DEBUG", "$scope.showPlayheadMenu");
-      timeline.ShowPlayheadMenu(position);
+      setTimeout(function() {
+        timeline.qt_log("DEBUG", "$scope.showPlayheadMenu");
+        timeline.ShowPlayheadMenu(position);
+      });
     }
   };
 
   // Show timeline context menu
   $scope.showTimelineMenu = function (e, layer_number) {
     if ($scope.Qt && !$scope.enable_razor) {
-      timeline.ShowTimelineMenu($scope.getJavaScriptPosition(e.pageX, null).position, layer_number);
+      setTimeout(function() {
+        timeline.ShowTimelineMenu($scope.getJavaScriptPosition(e.pageX, null).position, layer_number);
+      });
     }
   };
 
@@ -873,10 +887,10 @@ App.controller("TimelineCtrl", function ($scope) {
 
     // update clip in Qt (very important =)
     if (item_type === "clip") {
-      timeline.update_clip_data(JSON.stringify(item_object), true, true, false);
+      timeline.update_clip_data(JSON.stringify(item_object), true, true, false, null);
     }
     else if (item_type === "transition") {
-      timeline.update_transition_data(JSON.stringify(item_object), true, false);
+      timeline.update_transition_data(JSON.stringify(item_object), true, false, null);
     }
 
     // Resize timeline if it's too small to contain all clips

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -859,7 +859,7 @@ App.controller("TimelineCtrl", function ($scope) {
   };
 
   // Get JSON of most recent item (used by Qt)
-  $scope.updateRecentItemJSON = function (item_type, item_id) {
+  $scope.updateRecentItemJSON = function (item_type, item_id, item_tid) {
 
     // Find item in JSON
     var item_object = null;
@@ -887,10 +887,10 @@ App.controller("TimelineCtrl", function ($scope) {
 
     // update clip in Qt (very important =)
     if (item_type === "clip") {
-      timeline.update_clip_data(JSON.stringify(item_object), true, true, false, null);
+      timeline.update_clip_data(JSON.stringify(item_object), true, true, false, item_tid);
     }
     else if (item_type === "transition") {
-      timeline.update_transition_data(JSON.stringify(item_object), true, false, null);
+      timeline.update_transition_data(JSON.stringify(item_object), true, false, item_tid);
     }
 
     // Resize timeline if it's too small to contain all clips

--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -173,7 +173,7 @@ App.directive("tlClip", function ($timeout) {
 
           // update clip in Qt (very important =)
           if (scope.Qt) {
-            timeline.update_clip_data(JSON.stringify(scope.clip), true, true, false);
+            timeline.update_clip_data(JSON.stringify(scope.clip), true, true, false, null);
           }
 
           //resize the audio canvas to match the new clip width

--- a/src/timeline/js/directives/track.js
+++ b/src/timeline/js/directives/track.js
@@ -70,7 +70,7 @@ App.directive("tlTrack", function ($timeout) {
           var selected_item_count = ui_selected.length;
 
           // Get uuid to group all these updates as a single transaction
-          var tid = timeline.get_uuid()
+          var tid = timeline.get_uuid();
 
           // with each dragged clip, find out which track they landed on
           // Loop through each selected item, and remove the selection if multiple items are selected
@@ -127,7 +127,7 @@ App.directive("tlTrack", function ($timeout) {
             if (drop_track_num !== -1) {
 
               // find the item in the json data
-              item_data = null;
+              let item_data = null;
               if (item_type === "clip") {
                 item_data = findElement(scope.project.clips, "id", item_num);
               } else if (item_type === "transition") {

--- a/src/timeline/js/directives/track.js
+++ b/src/timeline/js/directives/track.js
@@ -69,6 +69,9 @@ App.directive("tlTrack", function ($timeout) {
           var ui_selected = $(".ui-selected");
           var selected_item_count = ui_selected.length;
 
+          // Get uuid to group all these updates as a single transaction
+          var tid = timeline.get_uuid()
+
           // with each dragged clip, find out which track they landed on
           // Loop through each selected item, and remove the selection if multiple items are selected
           // If only 1 item is selected, leave it selected
@@ -156,9 +159,9 @@ App.directive("tlTrack", function ($timeout) {
 
               // update clip in Qt (very important =)
               if (scope.Qt && item_type === "clip") {
-                timeline.update_clip_data(JSON.stringify(item_data), true, true, !needs_refresh);
+                timeline.update_clip_data(JSON.stringify(item_data), true, true, !needs_refresh, tid);
               } else if (scope.Qt && item_type === "transition") {
-                timeline.update_transition_data(JSON.stringify(item_data), true, !needs_refresh);
+                timeline.update_transition_data(JSON.stringify(item_data), true, !needs_refresh, tid);
               }
 
 

--- a/src/timeline/js/directives/transition.js
+++ b/src/timeline/js/directives/transition.js
@@ -145,7 +145,7 @@ App.directive("tlTransition", function () {
 
           // update transition in Qt (very important =)
           if (scope.Qt) {
-            timeline.update_transition_data(JSON.stringify(scope.transition), true, false);
+            timeline.update_transition_data(JSON.stringify(scope.transition), true, false, null);
           }
 
           dragLoc = null;

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1832,10 +1832,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         log.debug("actionRemove_from_Project_trigger")
 
         # Transaction id to group all deletes together
-        tid = str(uuid.uuid4())
-
-        # Set transaction id (if any)
-        get_app().updates.transaction_id = tid
+        get_app().updates.transaction_id = str(uuid.uuid4())
 
         # Loop through selected files
         for f in self.selected_files():
@@ -1965,10 +1962,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         _ = get_app()._tr
 
         # Transaction id to group all deletes together
-        tid = str(uuid.uuid4())
-
-        # Set transaction id (if any)
-        get_app().updates.transaction_id = tid
+        get_app().updates.transaction_id = str(uuid.uuid4())
 
         track_id = self.selected_tracks[0]
         max_track_number = len(get_app().project.get("layers"))
@@ -1983,13 +1977,13 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             QMessageBox.warning(self, _("Error Removing Track"), _("You must keep at least 1 track"))
             return
 
-        # Revove all clips on this track first
+        # Remove all clips on this track first
         for clip in Clip.filter(layer=selected_track_number):
             # Clear selected clips
             self.removeSelection(clip.id, "clip")
             clip.delete()
 
-        # Revove all transitions on this track first
+        # Remove all transitions on this track first
         for trans in Transition.filter(layer=selected_track_number):
             self.removeSelection(trans.id, "transition")
             trans.delete()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -34,6 +34,7 @@ import functools
 from time import sleep
 from uuid import uuid4
 import json
+import uuid
 
 import openshot  # Python module for libopenshot (required video editing module installed separately)
 from PyQt5.QtCore import (
@@ -1824,6 +1825,12 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     def actionRemove_from_Project_trigger(self):
         log.debug("actionRemove_from_Project_trigger")
 
+        # Transaction id to group all deletes together
+        tid = str(uuid.uuid4())
+
+        # Set transaction id (if any)
+        get_app().updates.transaction_id = tid
+
         # Loop through selected files
         for f in self.selected_files():
             if not f:
@@ -1841,6 +1848,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             # Remove file (after clips are deleted)
             f.delete()
 
+        # Clear transaction id
+        get_app().updates.transaction_id = None
+
         # Refresh preview
         get_app().window.refreshFrameSignal.emit()
 
@@ -1850,6 +1860,12 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         locked_tracks = [l.get("number")
                          for l in get_app().project.get('layers')
                          if l.get("lock", False)]
+
+        # Transaction id to group all deletes together
+        tid = str(uuid.uuid4())
+
+        # Set transaction id (if any)
+        get_app().updates.transaction_id = tid
 
         # Loop through selected clips
         for clip_id in json.loads(json.dumps(self.selected_clips)):
@@ -1862,6 +1878,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
                 # Remove clip
                 c.delete()
+
+        # Clear transaction id
+        get_app().updates.transaction_id = None
 
         # Refresh preview
         get_app().window.refreshFrameSignal.emit()
@@ -1915,6 +1934,12 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                          for l in get_app().project.get('layers')
                          if l.get("lock", False)]
 
+        # Transaction id to group all deletes together
+        tid = str(uuid.uuid4())
+
+        # Set transaction id (if any)
+        get_app().updates.transaction_id = tid
+
         # Loop through selected clips
         for tran_id in json.loads(json.dumps(self.selected_transitions)):
             # Find matching file
@@ -1927,6 +1952,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 # Remove transition
                 t.delete()
 
+        # Clear transaction id
+        get_app().updates.transaction_id = None
+
         # Refresh preview
         self.refreshFrameSignal.emit()
 
@@ -1935,6 +1963,12 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Get translation function
         _ = get_app()._tr
+
+        # Transaction id to group all deletes together
+        tid = str(uuid.uuid4())
+
+        # Set transaction id (if any)
+        get_app().updates.transaction_id = tid
 
         track_id = self.selected_tracks[0]
         max_track_number = len(get_app().project.get("layers"))
@@ -1953,15 +1987,18 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         for clip in Clip.filter(layer=selected_track_number):
             # Clear selected clips
             self.removeSelection(clip.id, "clip")
-
             clip.delete()
 
         # Revove all transitions on this track first
         for trans in Transition.filter(layer=selected_track_number):
+            self.removeSelection(trans.id, "transition")
             trans.delete()
 
         # Remove track
         selected_track.delete()
+
+        # Clear transaction id
+        get_app().updates.transaction_id = None
 
         # Clear selected track
         self.selected_tracks = []

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -431,6 +431,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         """Clear audio data from current project"""
         files = File.filter()
 
+        # Transaction id to group all deletes together
+        get_app().updates.transaction_id = str(uuid.uuid4())
+
         for file in files:
             if "audio_data" in file.data.get("ui", {}):
                 file_path = file.data.get("path")
@@ -444,6 +447,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 log.debug("Clip %s has audio data. Deleting it." % clip.id)
                 del clip.data["ui"]["audio_data"]
                 clip.save()
+
+        # Clear transaction id
+        get_app().updates.transaction_id = None
 
         get_app().window.actionClearWaveformData.setEnabled(False)
 

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1642,8 +1642,14 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 key.matches(self.getShortcutByName("deleteItem")) == QKeySequence.ExactMatch,
                 key.matches(self.getShortcutByName("deleteItem1")) == QKeySequence.ExactMatch,
                 ]):
+            # Set delete transaction id
+            tid = str(uuid.uuid4())
+            get_app().updates.transaction_id = tid
             # Delete selected clip / transition
             self.actionRemoveClip.trigger()
+
+            # Set delete transaction id (again)
+            get_app().updates.transaction_id = tid
             self.actionRemoveTransition.trigger()
 
         # Menu shortcuts
@@ -1861,11 +1867,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                          for l in get_app().project.get('layers')
                          if l.get("lock", False)]
 
-        # Transaction id to group all deletes together
-        tid = str(uuid.uuid4())
-
-        # Set transaction id (if any)
-        get_app().updates.transaction_id = tid
+        # Set transaction id (if not already set)
+        get_app().updates.transaction_id = get_app().updates.transaction_id or str(uuid.uuid4())
 
         # Loop through selected clips
         for clip_id in json.loads(json.dumps(self.selected_clips)):
@@ -1934,11 +1937,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                          for l in get_app().project.get('layers')
                          if l.get("lock", False)]
 
-        # Transaction id to group all deletes together
-        tid = str(uuid.uuid4())
-
-        # Set transaction id (if any)
-        get_app().updates.transaction_id = tid
+        # Set transaction id (if not already set)
+        get_app().updates.transaction_id = get_app().updates.transaction_id or str(uuid.uuid4())
 
         # Loop through selected clips
         for tran_id in json.loads(json.dumps(self.selected_transitions)):


### PR DESCRIPTION
Large refactor of UpdateAction (for grouping undo/redo actions)

- Removing `partial_update` property (never used it)
- Adding `UpdateAction.transaction`, a uuid that can be either unique or shared amongst undo/redo actions
- Integrated shared transaction id into the following tasks:
  - Multi-select moves (clip/transitions)
  - Slice multiple items (razor, slice)
  - Multi-select file delete
  - Multi-select clip & transition delete
  - Track insert causing reorder of clips
  - `Edit->Clear->Clear Waveform`
  - `Display->Show Waveform`
  - Adding new clips / transitions to the timeline
- Context menus on timeline now use `setTimeout` - to prevent double `$apply`