### PR TITLE
Experimental freeze changes to include libthai.so (Slackware 15)

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -391,7 +391,7 @@ elif sys.platform == "linux":
                     "libfreetype.so.6",
                     "libfontconfig.so.1",
                     "libharfbuzz.so.0",
-                    "libthai.so.0",
+                    #"libthai.so.0",
                     ]
                ) or libpath_file in [
                     "libgcrypt.so.11",


### PR DESCRIPTION
Experimental freeze changes, to include libthai, required for some font rasterizing - needed by Slackware distro in AppImage.

Closes #5060, #5007 