### PR TITLE
Fix transition direction (overlapping clips)

### DIFF
--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -388,15 +388,20 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         # For example, the left side of a clip, or the right side, so we can determine
         # which direction the wipe should be moving in
         is_forward_direction = True
+        diff_from_edge = 9999
         for intersecting_clip in Clip.filter(intersect=position, layer=layer):
-            log.debug(f"Intersecting Clip: {intersecting_clip}")
             diff_from_start = abs(intersecting_clip.data.get("position", 0.0) - position)
             diff_from_end = abs((intersecting_clip.data.get("position", 0.0) + \
                                 (intersecting_clip.data.get("end", 0.0) - intersecting_clip.data.get("start", 0.0))) \
                                 - position)
-            if diff_from_end < diff_from_start:
-                is_forward_direction = False
-        log.debug(f"Is transition moving a forward direction? {is_forward_direction}")
+            smallest_diff = min(diff_from_start, diff_from_end)
+            if smallest_diff < diff_from_edge:
+                diff_from_edge = smallest_diff
+                if diff_from_end < diff_from_start:
+                    is_forward_direction = False
+                else:
+                    is_forward_direction = True
+        log.debug(f"Is transition moving in a forward direction? {is_forward_direction}")
 
         # Determine existing brightness and contrast ranges (if any)
         brightness_range = []

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -382,12 +382,13 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
         fps_float = float(fps["num"]) / float(fps["den"])
         duration = existing_item.data["end"] - existing_item.data["start"]
         position = transition_data["position"]
+        layer = transition_data["layer"]
 
         # Determine if transition is intersecting a clip
         # For example, the left side of a clip, or the right side, so we can determine
         # which direction the wipe should be moving in
         is_forward_direction = True
-        for intersecting_clip in Clip.filter(intersect=position):
+        for intersecting_clip in Clip.filter(intersect=position, layer=layer):
             log.debug(f"Intersecting Clip: {intersecting_clip}")
             diff_from_start = abs(intersecting_clip.data.get("position", 0.0) - position)
             diff_from_end = abs((intersecting_clip.data.get("position", 0.0) + \


### PR DESCRIPTION
When clips are overlapping (i.e. auto created transitions), replacing or moving those did not work correctly, and often, the direction would be set incorrectly... causing the 2nd clips to fade out, and then snap back to visible.