### PR TITLE
Improved Captions + File Properties Improvements

### DIFF
--- a/src/classes/thumbnail.py
+++ b/src/classes/thumbnail.py
@@ -30,6 +30,7 @@ import re
 import openshot
 import socket
 import time
+from requests import get
 from threading import Thread
 from classes import info
 from classes.query import File
@@ -45,6 +46,30 @@ from socketserver import ThreadingMixIn
 #  http://127.0.0.1:33723/thumbnails/9ATJTBQ71V/1/
 #  http://127.0.0.1:33723/thumbnails/9ATJTBQ71V/1
 REGEX_THUMBNAIL_URL = re.compile(r"/thumbnails/(?P<file_id>.+?)/(?P<file_frame>\d+)/*(?P<only_path>path)?/*(?P<no_cache>no-cache)?")
+
+
+def GetThumbPath(file_id, thumbnail_frame, clear_cache=False):
+    """Get thumbnail path by invoking HTTP thumbnail request"""
+
+    # Clear thumb cache (if requested)
+    thumb_cache = ""
+    if clear_cache:
+        thumb_cache = "no-cache/"
+
+    # Connect to thumbnail server and get image
+    thumb_server_details = get_app().window.http_server_thread.server_address
+    thumb_address = "http://%s:%s/thumbnails/%s/%s/path/%s" % (
+        thumb_server_details[0],
+        thumb_server_details[1],
+        file_id,
+        thumbnail_frame,
+        thumb_cache)
+    r = get(thumb_address)
+    if r.ok:
+        # Update thumbnail path to real one
+        return r.text
+    else:
+        return ''
 
 
 def GenerateThumbnail(file_path, thumb_path, thumbnail_frame, width, height, mask, overlay):

--- a/src/windows/add_to_timeline.py
+++ b/src/windows/add_to_timeline.py
@@ -194,22 +194,12 @@ class AddToTimeline(QDialog):
             new_clip["layer"] = track_num
             new_clip["file_id"] = file.id
             new_clip["title"] = filename
+            new_clip["reader"] = file.data
 
             # Skip any clips that are missing a 'reader' attribute
             # TODO: Determine why this even happens, as it shouldn't be possible
             if not new_clip.get("reader"):
                 continue  # Skip to next file
-
-            # Overwrite frame rate (incase the user changed it in the File Properties)
-            file_properties_fps = float(file.data["fps"]["num"]) / float(file.data["fps"]["den"])
-            file_fps = float(new_clip["reader"]["fps"]["num"]) / float(new_clip["reader"]["fps"]["den"])
-            fps_diff = file_fps / file_properties_fps
-            new_clip["reader"]["fps"]["num"] = file.data["fps"]["num"]
-            new_clip["reader"]["fps"]["den"] = file.data["fps"]["den"]
-            # Scale duration / length / and end properties
-            new_clip["reader"]["duration"] *= fps_diff
-            new_clip["end"] *= fps_diff
-            new_clip["duration"] *= fps_diff
 
             # Check for optional start and end attributes
             start_time = 0

--- a/src/windows/add_to_timeline.py
+++ b/src/windows/add_to_timeline.py
@@ -217,6 +217,8 @@ class AddToTimeline(QDialog):
             if file.data["media_type"] == "image":
                 end_time = image_length
                 new_clip["end"] = end_time
+            else:
+                new_clip["end"] = end_time
 
             # Adjust Fade of Clips (if no transition is chosen)
             if not transition_path:

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -888,9 +888,6 @@ class Export(QDialog):
         # Mark project file as unsaved
         get_app().project.has_unsaved_changes = True
 
-        # Set MaxSize (so we don't have any downsampling)
-        self.timeline.SetMaxSize(video_settings.get("width"), video_settings.get("height"))
-
         # Set lossless cache settings (temporarily)
         export_cache_object = openshot.CacheMemory(500)
         self.timeline.SetCache(export_cache_object)
@@ -903,8 +900,11 @@ class Export(QDialog):
             # Load the "export" Timeline reader with the JSON from the real timeline
             self.timeline.SetJson(json.dumps(rescaled_app_data))
 
-            # Re-update the timeline FPS again (since the timeline just got clobbered)
-            self.updateFrameRate()
+        # Re-update the timeline FPS again (since the timeline just got clobbered)
+        self.updateFrameRate()
+
+        # Set MaxSize (so we don't have any downsampling)
+        self.timeline.SetMaxSize(video_settings.get("width"), video_settings.get("height"))
 
         # Apply mappers to timeline readers
         self.timeline.ApplyMapperToClips()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -106,7 +106,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     MaxSizeChanged = pyqtSignal(object)
     InsertKeyframe = pyqtSignal(object)
     OpenProjectSignal = pyqtSignal(str)
-    ThumbnailUpdated = pyqtSignal(str)
+    ThumbnailUpdated = pyqtSignal(str, int)
     FileUpdated = pyqtSignal(str)
     CaptionTextUpdated = pyqtSignal(str, object)
     CaptionTextLoaded = pyqtSignal(str, object)
@@ -2162,18 +2162,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Run the dialog event loop - blocking interaction on this window during that time
         result = win.exec_()
         if result == QDialog.Accepted:
-
-            # BRUTE FORCE approach: go through all clips and update file data
-            clips = Clip.filter(file_id=f.id)
-            for c in clips:
-                # update clip
-                c.data["reader"] = f.data
-                c.data["duration"] = f.data["duration"]
-                c.save()
-
-                # Emit thumbnail update signal (to update timeline thumb image)
-                self.ThumbnailUpdated.emit(c.id)
-
             log.info('File Properties Finished')
         else:
             log.info('File Properties Cancelled')

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1839,6 +1839,23 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 "num": profile.info.pixel_ratio.num,
                 "den": profile.info.pixel_ratio.den,
                 })
+
+            # Update size of audio-only files
+            # Used by our video transform handles (if waveforms are visible)
+            for file in File.filter():
+                # Check for audio-only files
+                if file.data.get("has_audio") and not file.data.get("has_video"):
+                    # Audio-only file should match the current project size and FPS
+                    file.data["width"] = proj.get("width")
+                    file.data["height"] = proj.get("height")
+                    file.save()
+
+                    # Change all related clips
+                    for clip in Clip.filter(file_id=file.id):
+                        clip.data["reader"] = file.data
+                        clip.save()
+
+            # Clear transaction id
             get_app().updates.transaction_id = None
 
             # Rescale all keyframes and reload project

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -295,6 +295,13 @@ class FilesModel(QObject, updates.UpdateInterface):
                 # Determine media type
                 file_data["media_type"] = get_media_type(file_data)
 
+                # Check for audio-only files
+                if file_data.get("has_audio") and not file_data.get("has_video"):
+                    # Audio-only file should match the current project size and FPS
+                    project = get_app().project
+                    file_data["width"] = project.get("width")
+                    file_data["height"] = project.get("height")
+
                 # Save new file to the project data
                 new_file = File()
                 new_file.data = file_data

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2984,6 +2984,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             new_clip = json.loads(c.Json())
             new_clip["file_id"] = file.id
             new_clip["title"] = filename
+            new_clip["reader"] = file.data
 
             # Skip any clips that are missing a 'reader' attribute
             if not new_clip.get("reader"):
@@ -3003,17 +3004,6 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             new_clip["duration"] = new_clip["reader"]["duration"]
             if file.data["media_type"] == "image":
                 new_clip["end"] = get_app().get_settings().get("default-image-length")  # default to 8 seconds
-
-            # Overwrite frame rate (incase the user changed it in the File Properties)
-            file_properties_fps = float(file.data["fps"]["num"]) / float(file.data["fps"]["den"])
-            file_fps = float(new_clip["reader"]["fps"]["num"]) / float(new_clip["reader"]["fps"]["den"])
-            fps_diff = file_fps / file_properties_fps
-            new_clip["reader"]["fps"]["num"] = file.data["fps"]["num"]
-            new_clip["reader"]["fps"]["den"] = file.data["fps"]["den"]
-            # Scale duration / length / and end properties
-            new_clip["reader"]["duration"] *= fps_diff
-            new_clip["end"] *= fps_diff
-            new_clip["duration"] *= fps_diff
 
             # Add clip to timeline
             self.update_clip_data(new_clip, only_basic_props=False, transaction_id=tid)


### PR DESCRIPTION
Related to libopenshot PR: https://github.com/OpenShot/libopenshot/pull/899

- Default the video size of audio-only Files/Clips to use the current Project size. When selecting the clip in the Preview/Transform window, it should draw a blue line around the entire frame, and not a fixed, hard-coded 720x480 rectangle
- Large refactor when adding Clips to timeline (`Add to Timeline` or `Drag n Drop`) - to re-use existing File object, including any customized `start`, `end`, or `FPS` changes.
- Fixed a bug on Export, which would stretch certain Clips if you render a horizontal project using a vertical profile.
- Large refactor to `File Properties` dialog, to correctly replace a File (browse button) or a FPS change to an image sequence - and replace the file details on all related clips (including a transaction for undo/redo as a single click). This also fixes a bug with the related clips not generating new thumbnails.