### PR TITLE
Time Remapping - Invalid `End` frame #

### DIFF
--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2461,7 +2461,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 clip.data['time'] = {"Points": [p_object]}
 
                 # Get the ending frame
-                end_of_clip = round(float(clip.data["end"]) * fps_float) + 1
+                end_of_clip = round(float(clip.data["end"]) * fps_float)
 
                 # Determine the beginning and ending of this animation
                 start_animation = round(float(clip.data["start"]) * fps_float) + 1

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -2460,8 +2460,8 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 p_object = json.loads(p.Json())
                 clip.data['time'] = {"Points": [p_object]}
 
-                # Get the ending frame
-                end_of_clip = round(float(clip.data["end"]) * fps_float)
+                # Get the ending frame (do not round)
+                end_of_clip = int(float(clip.data["end"]) * fps_float)
 
                 # Determine the beginning and ending of this animation
                 start_animation = round(float(clip.data["start"]) * fps_float) + 1


### PR DESCRIPTION
When using the "Time" context menu to reverse or change the speed of a clip, we were calculating the "End" frame # incorrectly, resulting in occasionally duplicating the last or first frame #.