### PR TITLE
Duplicate Profile Names can not be selected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,5 @@ jobs:
         pip3 install setuptools wheel sentry-sdk
         pip3 install cx_Freeze==6.1 distro defusedxml requests certifi chardet urllib3
 
-    - name: Build Python package
-      run: python3 freeze.py build
-
     - name: Test
       run: python3 ./src/tests/query_tests.py -platform minimal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
     defaults:
       run:
         shell: bash

--- a/src/profiles/00240x0160p0015_03-02
+++ b/src/profiles/00240x0160p0015_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 15 fps
+description=HQVGA 160p 15 fps [3:2]
 frame_rate_num=15
 frame_rate_den=1
 width=240

--- a/src/profiles/00240x0160p0015_03-02
+++ b/src/profiles/00240x0160p0015_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 15 fps [3:2]
+description=HQVGA 160p 15 fps - 240x160 | 3:2
 frame_rate_num=15
 frame_rate_den=1
 width=240

--- a/src/profiles/00240x0160p0024_03-02
+++ b/src/profiles/00240x0160p0024_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 24 fps [3:2]
+description=HQVGA 160p 24 fps - 240x160 | 3:2
 frame_rate_num=24
 frame_rate_den=1
 width=240

--- a/src/profiles/00240x0160p0024_03-02
+++ b/src/profiles/00240x0160p0024_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 24 fps
+description=HQVGA 160p 24 fps [3:2]
 frame_rate_num=24
 frame_rate_den=1
 width=240

--- a/src/profiles/00240x0160p0025_03-02
+++ b/src/profiles/00240x0160p0025_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 25 fps
+description=HQVGA 160p 25 fps [3:2]
 frame_rate_num=25
 frame_rate_den=1
 width=240

--- a/src/profiles/00240x0160p0025_03-02
+++ b/src/profiles/00240x0160p0025_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 25 fps [3:2]
+description=HQVGA 160p 25 fps - 240x160 | 3:2
 frame_rate_num=25
 frame_rate_den=1
 width=240

--- a/src/profiles/00240x0160p0030_03-02
+++ b/src/profiles/00240x0160p0030_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 30 fps
+description=HQVGA 160p 30 fps [3:2]
 frame_rate_num=30
 frame_rate_den=1
 width=240

--- a/src/profiles/00240x0160p0030_03-02
+++ b/src/profiles/00240x0160p0030_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 30 fps [3:2]
+description=HQVGA 160p 30 fps - 240x160 | 3:2
 frame_rate_num=30
 frame_rate_den=1
 width=240

--- a/src/profiles/00240x0160p0050_03-02
+++ b/src/profiles/00240x0160p0050_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 50 fps [3:2]
+description=HQVGA 160p 50 fps - 240x160 | 3:2
 frame_rate_num=50
 frame_rate_den=1
 width=240

--- a/src/profiles/00240x0160p0050_03-02
+++ b/src/profiles/00240x0160p0050_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 50 fps
+description=HQVGA 160p 50 fps [3:2]
 frame_rate_num=50
 frame_rate_den=1
 width=240

--- a/src/profiles/00240x0160p0060_03-02
+++ b/src/profiles/00240x0160p0060_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 60 fps
+description=HQVGA 160p 60 fps [3:2]
 frame_rate_num=60
 frame_rate_den=1
 width=240

--- a/src/profiles/00240x0160p0060_03-02
+++ b/src/profiles/00240x0160p0060_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 60 fps [3:2]
+description=HQVGA 160p 60 fps - 240x160 | 3:2
 frame_rate_num=60
 frame_rate_den=1
 width=240

--- a/src/profiles/00240x0160p2398_03-02
+++ b/src/profiles/00240x0160p2398_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 23.98 fps
+description=HQVGA 160p 23.98 fps [3:2]
 frame_rate_num=24000
 frame_rate_den=1001
 width=240

--- a/src/profiles/00240x0160p2398_03-02
+++ b/src/profiles/00240x0160p2398_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 23.98 fps [3:2]
+description=HQVGA 160p 23.98 fps - 240x160 | 3:2
 frame_rate_num=24000
 frame_rate_den=1001
 width=240

--- a/src/profiles/00240x0160p2997_03-02
+++ b/src/profiles/00240x0160p2997_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 29.97 fps
+description=HQVGA 160p 29.97 fps [3:2]
 frame_rate_num=30000
 frame_rate_den=1001
 width=240

--- a/src/profiles/00240x0160p2997_03-02
+++ b/src/profiles/00240x0160p2997_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 29.97 fps [3:2]
+description=HQVGA 160p 29.97 fps - 240x160 | 3:2
 frame_rate_num=30000
 frame_rate_den=1001
 width=240

--- a/src/profiles/00240x0160p5994_03-02
+++ b/src/profiles/00240x0160p5994_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 59.94 fps
+description=HQVGA 160p 59.94 fps [3:2]
 frame_rate_num=60000
 frame_rate_den=1001
 width=240

--- a/src/profiles/00240x0160p5994_03-02
+++ b/src/profiles/00240x0160p5994_03-02
@@ -1,4 +1,4 @@
-description=HQVGA 160p 59.94 fps [3:2]
+description=HQVGA 160p 59.94 fps - 240x160 | 3:2
 frame_rate_num=60000
 frame_rate_den=1001
 width=240

--- a/src/profiles/00256x0160p0015_16-10
+++ b/src/profiles/00256x0160p0015_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 15 fps
+description=HQVGA 160p 15 fps [16:10]
 frame_rate_num=15
 frame_rate_den=1
 width=256

--- a/src/profiles/00256x0160p0015_16-10
+++ b/src/profiles/00256x0160p0015_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 15 fps [16:10]
+description=HQVGA 160p 15 fps - 256x160 | 16:10
 frame_rate_num=15
 frame_rate_den=1
 width=256

--- a/src/profiles/00256x0160p0024_16-10
+++ b/src/profiles/00256x0160p0024_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 24 fps [16:10]
+description=HQVGA 160p 24 fps - 256x160 | 16:10
 frame_rate_num=24
 frame_rate_den=1
 width=256

--- a/src/profiles/00256x0160p0024_16-10
+++ b/src/profiles/00256x0160p0024_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 24 fps
+description=HQVGA 160p 24 fps [16:10]
 frame_rate_num=24
 frame_rate_den=1
 width=256

--- a/src/profiles/00256x0160p0025_16-10
+++ b/src/profiles/00256x0160p0025_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 25 fps [16:10]
+description=HQVGA 160p 25 fps - 256x160 | 16:10
 frame_rate_num=25
 frame_rate_den=1
 width=256

--- a/src/profiles/00256x0160p0025_16-10
+++ b/src/profiles/00256x0160p0025_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 25 fps
+description=HQVGA 160p 25 fps [16:10]
 frame_rate_num=25
 frame_rate_den=1
 width=256

--- a/src/profiles/00256x0160p0030_16-10
+++ b/src/profiles/00256x0160p0030_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 30 fps [16:10]
+description=HQVGA 160p 30 fps - 256x160 | 16:10
 frame_rate_num=30
 frame_rate_den=1
 width=256

--- a/src/profiles/00256x0160p0030_16-10
+++ b/src/profiles/00256x0160p0030_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 30 fps
+description=HQVGA 160p 30 fps [16:10]
 frame_rate_num=30
 frame_rate_den=1
 width=256

--- a/src/profiles/00256x0160p0050_16-10
+++ b/src/profiles/00256x0160p0050_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 50 fps [16:10]
+description=HQVGA 160p 50 fps - 256x160 | 16:10
 frame_rate_num=50
 frame_rate_den=1
 width=256

--- a/src/profiles/00256x0160p0050_16-10
+++ b/src/profiles/00256x0160p0050_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 50 fps
+description=HQVGA 160p 50 fps [16:10]
 frame_rate_num=50
 frame_rate_den=1
 width=256

--- a/src/profiles/00256x0160p0060_16-10
+++ b/src/profiles/00256x0160p0060_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 60 fps
+description=HQVGA 160p 60 fps [16:10]
 frame_rate_num=60
 frame_rate_den=1
 width=256

--- a/src/profiles/00256x0160p0060_16-10
+++ b/src/profiles/00256x0160p0060_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 60 fps [16:10]
+description=HQVGA 160p 60 fps - 256x160 | 16:10
 frame_rate_num=60
 frame_rate_den=1
 width=256

--- a/src/profiles/00256x0160p2398_16-10
+++ b/src/profiles/00256x0160p2398_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 23.98 fps
+description=HQVGA 160p 23.98 fps [16:10]
 frame_rate_num=24000
 frame_rate_den=1001
 width=256

--- a/src/profiles/00256x0160p2398_16-10
+++ b/src/profiles/00256x0160p2398_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 23.98 fps [16:10]
+description=HQVGA 160p 23.98 fps - 256x160 | 16:10
 frame_rate_num=24000
 frame_rate_den=1001
 width=256

--- a/src/profiles/00256x0160p2997_16-10
+++ b/src/profiles/00256x0160p2997_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 29.97 fps [16:10]
+description=HQVGA 160p 29.97 fps - 256x160 | 16:10
 frame_rate_num=30000
 frame_rate_den=1001
 width=256

--- a/src/profiles/00256x0160p2997_16-10
+++ b/src/profiles/00256x0160p2997_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 29.97 fps
+description=HQVGA 160p 29.97 fps [16:10]
 frame_rate_num=30000
 frame_rate_den=1001
 width=256

--- a/src/profiles/00256x0160p5994_16-10
+++ b/src/profiles/00256x0160p5994_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 59.94 fps [16:10]
+description=HQVGA 160p 59.94 fps - 256x160 | 16:10
 frame_rate_num=60000
 frame_rate_den=1001
 width=256

--- a/src/profiles/00256x0160p5994_16-10
+++ b/src/profiles/00256x0160p5994_16-10
@@ -1,4 +1,4 @@
-description=HQVGA 160p 59.94 fps
+description=HQVGA 160p 59.94 fps [16:10]
 frame_rate_num=60000
 frame_rate_den=1001
 width=256

--- a/src/profiles/00352x0576i0025_16-09
+++ b/src/profiles/00352x0576i0025_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps
+description=PAL SD Anamorphic 576i 25 fps [16:9]
 frame_rate_num=25
 frame_rate_den=1
 width=352

--- a/src/profiles/00352x0576i0025_16-09
+++ b/src/profiles/00352x0576i0025_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps [16:9]
+description=PAL SD Anamorphic 576i 25 fps - 352x576 | 16:9
 frame_rate_num=25
 frame_rate_den=1
 width=352

--- a/src/profiles/00352x0576p0025_16-09
+++ b/src/profiles/00352x0576p0025_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 25 fps [16:9]
+description=PAL SD Anamorphic 576p 25 fps - 352x576 | 16:9
 frame_rate_num=25
 frame_rate_den=1
 width=352

--- a/src/profiles/00352x0576p0025_16-09
+++ b/src/profiles/00352x0576p0025_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 25 fps
+description=PAL SD Anamorphic 576p 25 fps [16:9]
 frame_rate_num=25
 frame_rate_den=1
 width=352

--- a/src/profiles/00360x0240p0015_03-02
+++ b/src/profiles/00360x0240p0015_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 15 fps [3:2]
+description=WQVGA 240p 15 fps - 360x240 | 3:2
 frame_rate_num=15
 frame_rate_den=1
 width=360

--- a/src/profiles/00360x0240p0015_03-02
+++ b/src/profiles/00360x0240p0015_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 15 fps
+description=WQVGA 240p 15 fps [3:2]
 frame_rate_num=15
 frame_rate_den=1
 width=360

--- a/src/profiles/00360x0240p0024_03-02
+++ b/src/profiles/00360x0240p0024_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 24 fps [3:2]
+description=WQVGA 240p 24 fps - 360x240 | 3:2
 frame_rate_num=24
 frame_rate_den=1
 width=360

--- a/src/profiles/00360x0240p0024_03-02
+++ b/src/profiles/00360x0240p0024_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 24 fps
+description=WQVGA 240p 24 fps [3:2]
 frame_rate_num=24
 frame_rate_den=1
 width=360

--- a/src/profiles/00360x0240p0025_03-02
+++ b/src/profiles/00360x0240p0025_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 25 fps [3:2]
+description=WQVGA 240p 25 fps - 360x240 | 3:2
 frame_rate_num=25
 frame_rate_den=1
 width=360

--- a/src/profiles/00360x0240p0025_03-02
+++ b/src/profiles/00360x0240p0025_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 25 fps
+description=WQVGA 240p 25 fps [3:2]
 frame_rate_num=25
 frame_rate_den=1
 width=360

--- a/src/profiles/00360x0240p0030_03-02
+++ b/src/profiles/00360x0240p0030_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 30 fps
+description=WQVGA 240p 30 fps [3:2]
 frame_rate_num=30
 frame_rate_den=1
 width=360

--- a/src/profiles/00360x0240p0030_03-02
+++ b/src/profiles/00360x0240p0030_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 30 fps [3:2]
+description=WQVGA 240p 30 fps - 360x240 | 3:2
 frame_rate_num=30
 frame_rate_den=1
 width=360

--- a/src/profiles/00360x0240p0050_03-02
+++ b/src/profiles/00360x0240p0050_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 50 fps [3:2]
+description=WQVGA 240p 50 fps - 360x240 | 3:2
 frame_rate_num=50
 frame_rate_den=1
 width=360

--- a/src/profiles/00360x0240p0050_03-02
+++ b/src/profiles/00360x0240p0050_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 50 fps
+description=WQVGA 240p 50 fps [3:2]
 frame_rate_num=50
 frame_rate_den=1
 width=360

--- a/src/profiles/00360x0240p0060_03-02
+++ b/src/profiles/00360x0240p0060_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 60 fps
+description=WQVGA 240p 60 fps [3:2]
 frame_rate_num=60
 frame_rate_den=1
 width=360

--- a/src/profiles/00360x0240p0060_03-02
+++ b/src/profiles/00360x0240p0060_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 60 fps [3:2]
+description=WQVGA 240p 60 fps - 360x240 | 3:2
 frame_rate_num=60
 frame_rate_den=1
 width=360

--- a/src/profiles/00360x0240p2398_03-02
+++ b/src/profiles/00360x0240p2398_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 23.98 fps [3:2]
+description=WQVGA 240p 23.98 fps - 360x240 | 3:2
 frame_rate_num=24000
 frame_rate_den=1001
 width=360

--- a/src/profiles/00360x0240p2398_03-02
+++ b/src/profiles/00360x0240p2398_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 23.98 fps
+description=WQVGA 240p 23.98 fps [3:2]
 frame_rate_num=24000
 frame_rate_den=1001
 width=360

--- a/src/profiles/00360x0240p2997_03-02
+++ b/src/profiles/00360x0240p2997_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 29.97 fps
+description=WQVGA 240p 29.97 fps [3:2]
 frame_rate_num=30000
 frame_rate_den=1001
 width=360

--- a/src/profiles/00360x0240p2997_03-02
+++ b/src/profiles/00360x0240p2997_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 29.97 fps [3:2]
+description=WQVGA 240p 29.97 fps - 360x240 | 3:2
 frame_rate_num=30000
 frame_rate_den=1001
 width=360

--- a/src/profiles/00360x0240p5994_03-02
+++ b/src/profiles/00360x0240p5994_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 59.94 fps
+description=WQVGA 240p 59.94 fps [3:2]
 frame_rate_num=60000
 frame_rate_den=1001
 width=360

--- a/src/profiles/00360x0240p5994_03-02
+++ b/src/profiles/00360x0240p5994_03-02
@@ -1,4 +1,4 @@
-description=WQVGA 240p 59.94 fps [3:2]
+description=WQVGA 240p 59.94 fps - 360x240 | 3:2
 frame_rate_num=60000
 frame_rate_den=1001
 width=360

--- a/src/profiles/00384x0240p0015_16-10
+++ b/src/profiles/00384x0240p0015_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 15 fps
+description=WQVGA 240p 15 fps [16:10]
 frame_rate_num=15
 frame_rate_den=1
 width=384

--- a/src/profiles/00384x0240p0015_16-10
+++ b/src/profiles/00384x0240p0015_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 15 fps [16:10]
+description=WQVGA 240p 15 fps - 384x240 | 16:10
 frame_rate_num=15
 frame_rate_den=1
 width=384

--- a/src/profiles/00384x0240p0024_16-10
+++ b/src/profiles/00384x0240p0024_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 24 fps
+description=WQVGA 240p 24 fps [16:10]
 frame_rate_num=24
 frame_rate_den=1
 width=384

--- a/src/profiles/00384x0240p0024_16-10
+++ b/src/profiles/00384x0240p0024_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 24 fps [16:10]
+description=WQVGA 240p 24 fps - 384x240 | 16:10
 frame_rate_num=24
 frame_rate_den=1
 width=384

--- a/src/profiles/00384x0240p0025_16-10
+++ b/src/profiles/00384x0240p0025_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 25 fps [16:10]
+description=WQVGA 240p 25 fps - 384x240 | 16:10
 frame_rate_num=25
 frame_rate_den=1
 width=384

--- a/src/profiles/00384x0240p0025_16-10
+++ b/src/profiles/00384x0240p0025_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 25 fps
+description=WQVGA 240p 25 fps [16:10]
 frame_rate_num=25
 frame_rate_den=1
 width=384

--- a/src/profiles/00384x0240p0030_16-10
+++ b/src/profiles/00384x0240p0030_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 30 fps
+description=WQVGA 240p 30 fps [16:10]
 frame_rate_num=30
 frame_rate_den=1
 width=384

--- a/src/profiles/00384x0240p0030_16-10
+++ b/src/profiles/00384x0240p0030_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 30 fps [16:10]
+description=WQVGA 240p 30 fps - 384x240 | 16:10
 frame_rate_num=30
 frame_rate_den=1
 width=384

--- a/src/profiles/00384x0240p0050_16-10
+++ b/src/profiles/00384x0240p0050_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 50 fps [16:10]
+description=WQVGA 240p 50 fps - 384x240 | 16:10
 frame_rate_num=50
 frame_rate_den=1
 width=384

--- a/src/profiles/00384x0240p0050_16-10
+++ b/src/profiles/00384x0240p0050_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 50 fps
+description=WQVGA 240p 50 fps [16:10]
 frame_rate_num=50
 frame_rate_den=1
 width=384

--- a/src/profiles/00384x0240p0060_16-10
+++ b/src/profiles/00384x0240p0060_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 60 fps
+description=WQVGA 240p 60 fps [16:10]
 frame_rate_num=60
 frame_rate_den=1
 width=384

--- a/src/profiles/00384x0240p0060_16-10
+++ b/src/profiles/00384x0240p0060_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 60 fps [16:10]
+description=WQVGA 240p 60 fps - 384x240 | 16:10
 frame_rate_num=60
 frame_rate_den=1
 width=384

--- a/src/profiles/00384x0240p2398_16-10
+++ b/src/profiles/00384x0240p2398_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 23.98 fps
+description=WQVGA 240p 23.98 fps [16:10]
 frame_rate_num=24000
 frame_rate_den=1001
 width=384

--- a/src/profiles/00384x0240p2398_16-10
+++ b/src/profiles/00384x0240p2398_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 23.98 fps [16:10]
+description=WQVGA 240p 23.98 fps - 384x240 | 16:10
 frame_rate_num=24000
 frame_rate_den=1001
 width=384

--- a/src/profiles/00384x0240p2997_16-10
+++ b/src/profiles/00384x0240p2997_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 29.97 fps [16:10]
+description=WQVGA 240p 29.97 fps - 384x240 | 16:10
 frame_rate_num=30000
 frame_rate_den=1001
 width=384

--- a/src/profiles/00384x0240p2997_16-10
+++ b/src/profiles/00384x0240p2997_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 29.97 fps
+description=WQVGA 240p 29.97 fps [16:10]
 frame_rate_num=30000
 frame_rate_den=1001
 width=384

--- a/src/profiles/00384x0240p5994_16-10
+++ b/src/profiles/00384x0240p5994_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 59.94 fps
+description=WQVGA 240p 59.94 fps [16:10]
 frame_rate_num=60000
 frame_rate_den=1001
 width=384

--- a/src/profiles/00384x0240p5994_16-10
+++ b/src/profiles/00384x0240p5994_16-10
@@ -1,4 +1,4 @@
-description=WQVGA 240p 59.94 fps [16:10]
+description=WQVGA 240p 59.94 fps - 384x240 | 16:10
 frame_rate_num=60000
 frame_rate_den=1001
 width=384

--- a/src/profiles/00400x0240p0015_05-03
+++ b/src/profiles/00400x0240p0015_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 15 fps
+description=WQVGA 240p 15 fps [5:3]
 frame_rate_num=15
 frame_rate_den=1
 width=400

--- a/src/profiles/00400x0240p0015_05-03
+++ b/src/profiles/00400x0240p0015_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 15 fps [5:3]
+description=WQVGA 240p 15 fps - 400x240 | 5:3
 frame_rate_num=15
 frame_rate_den=1
 width=400

--- a/src/profiles/00400x0240p0024_05-03
+++ b/src/profiles/00400x0240p0024_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 24 fps
+description=WQVGA 240p 24 fps [5:3]
 frame_rate_num=24
 frame_rate_den=1
 width=400

--- a/src/profiles/00400x0240p0024_05-03
+++ b/src/profiles/00400x0240p0024_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 24 fps [5:3]
+description=WQVGA 240p 24 fps - 400x240 | 5:3
 frame_rate_num=24
 frame_rate_den=1
 width=400

--- a/src/profiles/00400x0240p0025_05-03
+++ b/src/profiles/00400x0240p0025_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 25 fps
+description=WQVGA 240p 25 fps [5:3]
 frame_rate_num=25
 frame_rate_den=1
 width=400

--- a/src/profiles/00400x0240p0025_05-03
+++ b/src/profiles/00400x0240p0025_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 25 fps [5:3]
+description=WQVGA 240p 25 fps - 400x240 | 5:3
 frame_rate_num=25
 frame_rate_den=1
 width=400

--- a/src/profiles/00400x0240p0030_05-03
+++ b/src/profiles/00400x0240p0030_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 30 fps [5:3]
+description=WQVGA 240p 30 fps - 400x240 | 5:3
 frame_rate_num=30
 frame_rate_den=1
 width=400

--- a/src/profiles/00400x0240p0030_05-03
+++ b/src/profiles/00400x0240p0030_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 30 fps
+description=WQVGA 240p 30 fps [5:3]
 frame_rate_num=30
 frame_rate_den=1
 width=400

--- a/src/profiles/00400x0240p0050_05-03
+++ b/src/profiles/00400x0240p0050_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 50 fps
+description=WQVGA 240p 50 fps [5:3]
 frame_rate_num=50
 frame_rate_den=1
 width=400

--- a/src/profiles/00400x0240p0050_05-03
+++ b/src/profiles/00400x0240p0050_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 50 fps [5:3]
+description=WQVGA 240p 50 fps - 400x240 | 5:3
 frame_rate_num=50
 frame_rate_den=1
 width=400

--- a/src/profiles/00400x0240p0060_05-03
+++ b/src/profiles/00400x0240p0060_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 60 fps [5:3]
+description=WQVGA 240p 60 fps - 400x240 | 5:3
 frame_rate_num=60
 frame_rate_den=1
 width=400

--- a/src/profiles/00400x0240p0060_05-03
+++ b/src/profiles/00400x0240p0060_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 60 fps
+description=WQVGA 240p 60 fps [5:3]
 frame_rate_num=60
 frame_rate_den=1
 width=400

--- a/src/profiles/00400x0240p2398_05-03
+++ b/src/profiles/00400x0240p2398_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 23.98 fps [5:3]
+description=WQVGA 240p 23.98 fps - 400x240 | 5:3
 frame_rate_num=24000
 frame_rate_den=1001
 width=400

--- a/src/profiles/00400x0240p2398_05-03
+++ b/src/profiles/00400x0240p2398_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 23.98 fps
+description=WQVGA 240p 23.98 fps [5:3]
 frame_rate_num=24000
 frame_rate_den=1001
 width=400

--- a/src/profiles/00400x0240p2997_05-03
+++ b/src/profiles/00400x0240p2997_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 29.97 fps [5:3]
+description=WQVGA 240p 29.97 fps - 400x240 | 5:3
 frame_rate_num=30000
 frame_rate_den=1001
 width=400

--- a/src/profiles/00400x0240p2997_05-03
+++ b/src/profiles/00400x0240p2997_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 29.97 fps
+description=WQVGA 240p 29.97 fps [5:3]
 frame_rate_num=30000
 frame_rate_den=1001
 width=400

--- a/src/profiles/00400x0240p5994_05-03
+++ b/src/profiles/00400x0240p5994_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 59.94 fps
+description=WQVGA 240p 59.94 fps [5:3]
 frame_rate_num=60000
 frame_rate_den=1001
 width=400

--- a/src/profiles/00400x0240p5994_05-03
+++ b/src/profiles/00400x0240p5994_05-03
@@ -1,4 +1,4 @@
-description=WQVGA 240p 59.94 fps [5:3]
+description=WQVGA 240p 59.94 fps - 400x240 | 5:3
 frame_rate_num=60000
 frame_rate_den=1001
 width=400

--- a/src/profiles/00480x0480i0030_04-03
+++ b/src/profiles/00480x0480i0030_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 30 fps [4:3]
+description=NTSC SD Anamorphic 480i 30 fps - 480x480 | 4:3
 frame_rate_num=30
 frame_rate_den=1
 width=480

--- a/src/profiles/00480x0480i0030_04-03
+++ b/src/profiles/00480x0480i0030_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 30 fps
+description=NTSC SD Anamorphic 480i 30 fps [4:3]
 frame_rate_num=30
 frame_rate_den=1
 width=480

--- a/src/profiles/00480x0480i2398_04-03
+++ b/src/profiles/00480x0480i2398_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 23.98 fps [4:3]
+description=NTSC SD Anamorphic 480i 23.98 fps - 480x480 | 4:3
 frame_rate_num=24000
 frame_rate_den=1001
 width=480

--- a/src/profiles/00480x0480i2398_04-03
+++ b/src/profiles/00480x0480i2398_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 23.98 fps
+description=NTSC SD Anamorphic 480i 23.98 fps [4:3]
 frame_rate_num=24000
 frame_rate_den=1001
 width=480

--- a/src/profiles/00480x0480i2398_16-09
+++ b/src/profiles/00480x0480i2398_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 23.98 fps
+description=NTSC SD Anamorphic 480i 23.98 fps [16:9]
 frame_rate_num=24000
 frame_rate_den=1001
 width=480

--- a/src/profiles/00480x0480i2398_16-09
+++ b/src/profiles/00480x0480i2398_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 23.98 fps [16:9]
+description=NTSC SD Anamorphic 480i 23.98 fps - 480x480 | 16:9
 frame_rate_num=24000
 frame_rate_den=1001
 width=480

--- a/src/profiles/00480x0480i2997_04-03
+++ b/src/profiles/00480x0480i2997_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 29.97 fps [4:3]
+description=NTSC SD Anamorphic 480i 29.97 fps - 480x480 | 4:3
 frame_rate_num=30000
 frame_rate_den=1001
 width=480

--- a/src/profiles/00480x0480i2997_04-03
+++ b/src/profiles/00480x0480i2997_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 29.97 fps
+description=NTSC SD Anamorphic 480i 29.97 fps [4:3]
 frame_rate_num=30000
 frame_rate_den=1001
 width=480

--- a/src/profiles/00480x0480i2997_16-09
+++ b/src/profiles/00480x0480i2997_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 29.97 fps [16:9]
+description=NTSC SD Anamorphic 480i 29.97 fps - 480x480 | 16:9
 frame_rate_num=30000
 frame_rate_den=1001
 width=480

--- a/src/profiles/00480x0480i2997_16-09
+++ b/src/profiles/00480x0480i2997_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 29.97 fps
+description=NTSC SD Anamorphic 480i 29.97 fps [16:9]
 frame_rate_num=30000
 frame_rate_den=1001
 width=480

--- a/src/profiles/00480x0576i0025_04-03
+++ b/src/profiles/00480x0576i0025_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps
+description=PAL SD Anamorphic 576i 25 fps [4:3]
 frame_rate_num=25
 frame_rate_den=1
 width=480

--- a/src/profiles/00480x0576i0025_04-03
+++ b/src/profiles/00480x0576i0025_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps [4:3]
+description=PAL SD Anamorphic 576i 25 fps - 480x576 | 4:3
 frame_rate_num=25
 frame_rate_den=1
 width=480

--- a/src/profiles/00480x0576i0025_16-09
+++ b/src/profiles/00480x0576i0025_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps
+description=PAL SD Anamorphic 576i 25 fps [16:9]
 frame_rate_num=25
 frame_rate_den=1
 width=480

--- a/src/profiles/00480x0576i0025_16-09
+++ b/src/profiles/00480x0576i0025_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps [16:9]
+description=PAL SD Anamorphic 576i 25 fps - 480x576 | 16:9
 frame_rate_num=25
 frame_rate_den=1
 width=480

--- a/src/profiles/00480x0576p0025_04-03
+++ b/src/profiles/00480x0576p0025_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 25 fps [4:3]
+description=PAL SD Anamorphic 576p 25 fps - 480x576 | 4:3
 frame_rate_num=25
 frame_rate_den=1
 width=480

--- a/src/profiles/00480x0576p0025_04-03
+++ b/src/profiles/00480x0576p0025_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 25 fps
+description=PAL SD Anamorphic 576p 25 fps [4:3]
 frame_rate_num=25
 frame_rate_den=1
 width=480

--- a/src/profiles/00480x0576p0025_16-09
+++ b/src/profiles/00480x0576p0025_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 25 fps
+description=PAL SD Anamorphic 576p 25 fps [16:9]
 frame_rate_num=25
 frame_rate_den=1
 width=480

--- a/src/profiles/00480x0576p0025_16-09
+++ b/src/profiles/00480x0576p0025_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 25 fps [16:9]
+description=PAL SD Anamorphic 576p 25 fps - 480x576 | 16:9
 frame_rate_num=25
 frame_rate_den=1
 width=480

--- a/src/profiles/00528x0480i0025_04-03
+++ b/src/profiles/00528x0480i0025_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480i 25 fps
+description=NTSC SD 3/4 Anamorphic 480i 25 fps [4:3]
 frame_rate_num=25
 frame_rate_den=1
 width=528

--- a/src/profiles/00528x0480i0025_04-03
+++ b/src/profiles/00528x0480i0025_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480i 25 fps [4:3]
+description=NTSC SD 3/4 Anamorphic 480i 25 fps - 528x480 | 4:3
 frame_rate_num=25
 frame_rate_den=1
 width=528

--- a/src/profiles/00528x0480i2997_04-03
+++ b/src/profiles/00528x0480i2997_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480i 29.97 fps
+description=NTSC SD 3/4 Anamorphic 480i 29.97 fps [4:3]
 frame_rate_num=30000
 frame_rate_den=1001
 width=528

--- a/src/profiles/00528x0480i2997_04-03
+++ b/src/profiles/00528x0480i2997_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480i 29.97 fps [4:3]
+description=NTSC SD 3/4 Anamorphic 480i 29.97 fps - 528x480 | 4:3
 frame_rate_num=30000
 frame_rate_den=1001
 width=528

--- a/src/profiles/00528x0480p0025_04-03
+++ b/src/profiles/00528x0480p0025_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480p 25 fps
+description=NTSC SD 3/4 Anamorphic 480p 25 fps [4:3]
 frame_rate_num=25
 frame_rate_den=1
 width=528

--- a/src/profiles/00528x0480p0025_04-03
+++ b/src/profiles/00528x0480p0025_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480p 25 fps [4:3]
+description=NTSC SD 3/4 Anamorphic 480p 25 fps - 528x480 | 4:3
 frame_rate_num=25
 frame_rate_den=1
 width=528

--- a/src/profiles/00528x0480p2398_04-03
+++ b/src/profiles/00528x0480p2398_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480p 23.98 fps [4:3]
+description=NTSC SD 3/4 Anamorphic 480p 23.98 fps - 528x480 | 4:3
 frame_rate_num=24000
 frame_rate_den=1001
 width=528

--- a/src/profiles/00528x0480p2398_04-03
+++ b/src/profiles/00528x0480p2398_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480p 23.98 fps
+description=NTSC SD 3/4 Anamorphic 480p 23.98 fps [4:3]
 frame_rate_num=24000
 frame_rate_den=1001
 width=528

--- a/src/profiles/00544x0480i0025_04-03
+++ b/src/profiles/00544x0480i0025_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480i 25 fps
+description=NTSC SD 3/4 Anamorphic 480i 25 fps [4:3]
 frame_rate_num=25
 frame_rate_den=1
 width=544

--- a/src/profiles/00544x0480i0025_04-03
+++ b/src/profiles/00544x0480i0025_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480i 25 fps [4:3]
+description=NTSC SD 3/4 Anamorphic 480i 25 fps - 544x480 | 4:3
 frame_rate_num=25
 frame_rate_den=1
 width=544

--- a/src/profiles/00544x0480i2997_04-03
+++ b/src/profiles/00544x0480i2997_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480i 29.97 fps
+description=NTSC SD 3/4 Anamorphic 480i 29.97 fps [4:3]
 frame_rate_num=30000
 frame_rate_den=1001
 width=544

--- a/src/profiles/00544x0480i2997_04-03
+++ b/src/profiles/00544x0480i2997_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480i 29.97 fps [4:3]
+description=NTSC SD 3/4 Anamorphic 480i 29.97 fps - 544x480 | 4:3
 frame_rate_num=30000
 frame_rate_den=1001
 width=544

--- a/src/profiles/00544x0480p0025_04-03
+++ b/src/profiles/00544x0480p0025_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480p 25 fps [4:3]
+description=NTSC SD 3/4 Anamorphic 480p 25 fps - 544x480 | 4:3
 frame_rate_num=25
 frame_rate_den=1
 width=544

--- a/src/profiles/00544x0480p0025_04-03
+++ b/src/profiles/00544x0480p0025_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480p 25 fps
+description=NTSC SD 3/4 Anamorphic 480p 25 fps [4:3]
 frame_rate_num=25
 frame_rate_den=1
 width=544

--- a/src/profiles/00544x0480p2398_04-03
+++ b/src/profiles/00544x0480p2398_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480p 23.98 fps
+description=NTSC SD 3/4 Anamorphic 480p 23.98 fps [4:3]
 frame_rate_num=24000
 frame_rate_den=1001
 width=544

--- a/src/profiles/00544x0480p2398_04-03
+++ b/src/profiles/00544x0480p2398_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD 3/4 Anamorphic 480p 23.98 fps [4:3]
+description=NTSC SD 3/4 Anamorphic 480p 23.98 fps - 544x480 | 4:3
 frame_rate_num=24000
 frame_rate_den=1001
 width=544

--- a/src/profiles/00544x0576i0025_04-03
+++ b/src/profiles/00544x0576i0025_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps
+description=PAL SD Anamorphic 576i 25 fps [4:3]
 frame_rate_num=25
 frame_rate_den=1
 width=544

--- a/src/profiles/00544x0576i0025_04-03
+++ b/src/profiles/00544x0576i0025_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps [4:3]
+description=PAL SD Anamorphic 576i 25 fps - 544x576 | 4:3
 frame_rate_num=25
 frame_rate_den=1
 width=544

--- a/src/profiles/00544x0576i0025_16-09
+++ b/src/profiles/00544x0576i0025_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps [16:9]
+description=PAL SD Anamorphic 576i 25 fps - 544x576 | 16:9
 frame_rate_num=25
 frame_rate_den=1
 width=544

--- a/src/profiles/00544x0576i0025_16-09
+++ b/src/profiles/00544x0576i0025_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps
+description=PAL SD Anamorphic 576i 25 fps [16:9]
 frame_rate_num=25
 frame_rate_den=1
 width=544

--- a/src/profiles/00544x0576p0025_04-03
+++ b/src/profiles/00544x0576p0025_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 25 fps
+description=PAL SD Anamorphic 576p 25 fps [4:3]
 frame_rate_num=25
 frame_rate_den=1
 width=544

--- a/src/profiles/00544x0576p0025_04-03
+++ b/src/profiles/00544x0576p0025_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 25 fps [4:3]
+description=PAL SD Anamorphic 576p 25 fps - 544x576 | 4:3
 frame_rate_num=25
 frame_rate_den=1
 width=544

--- a/src/profiles/00544x0576p0025_16-09
+++ b/src/profiles/00544x0576p0025_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 25 fps [16:9]
+description=PAL SD Anamorphic 576p 25 fps - 544x576 | 16:9
 frame_rate_num=25
 frame_rate_den=1
 width=544

--- a/src/profiles/00544x0576p0025_16-09
+++ b/src/profiles/00544x0576p0025_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 25 fps
+description=PAL SD Anamorphic 576p 25 fps [16:9]
 frame_rate_num=25
 frame_rate_den=1
 width=544

--- a/src/profiles/00704x0480i0025_04-03
+++ b/src/profiles/00704x0480i0025_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 25 fps
+description=NTSC SD Anamorphic 480i 25 fps [4:3]
 frame_rate_num=25
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480i0025_04-03
+++ b/src/profiles/00704x0480i0025_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 25 fps [4:3]
+description=NTSC SD Anamorphic 480i 25 fps - 704x480 | 4:3
 frame_rate_num=25
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480i0025_16-09
+++ b/src/profiles/00704x0480i0025_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 25 fps [16:9]
+description=NTSC SD Anamorphic 480i 25 fps - 704x480 | 16:9
 frame_rate_num=25
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480i0025_16-09
+++ b/src/profiles/00704x0480i0025_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 25 fps
+description=NTSC SD Anamorphic 480i 25 fps [16:9]
 frame_rate_num=25
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480i0030_04-03
+++ b/src/profiles/00704x0480i0030_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 30 fps
+description=NTSC SD Anamorphic 480i 30 fps [4:3]
 frame_rate_num=30
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480i0030_04-03
+++ b/src/profiles/00704x0480i0030_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 30 fps [4:3]
+description=NTSC SD Anamorphic 480i 30 fps - 704x480 | 4:3
 frame_rate_num=30
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480i0030_16-09
+++ b/src/profiles/00704x0480i0030_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 30 fps [16:9]
+description=NTSC SD Anamorphic 480i 30 fps - 704x480 | 16:9
 frame_rate_num=30
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480i0030_16-09
+++ b/src/profiles/00704x0480i0030_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 30 fps
+description=NTSC SD Anamorphic 480i 30 fps [16:9]
 frame_rate_num=30
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480i2997_16-09
+++ b/src/profiles/00704x0480i2997_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 29.97 fps
+description=NTSC SD Anamorphic 480i 29.97 fps [16:9]
 frame_rate_num=30000
 frame_rate_den=1001
 width=704

--- a/src/profiles/00704x0480i2997_16-09
+++ b/src/profiles/00704x0480i2997_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 29.97 fps [16:9]
+description=NTSC SD Anamorphic 480i 29.97 fps - 704x480 | 16:9
 frame_rate_num=30000
 frame_rate_den=1001
 width=704

--- a/src/profiles/00704x0480p0024_04-03
+++ b/src/profiles/00704x0480p0024_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 24 fps
+description=NTSC SD Anamorphic 480p 24 fps [4:3]
 frame_rate_num=24
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0024_04-03
+++ b/src/profiles/00704x0480p0024_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 24 fps [4:3]
+description=NTSC SD Anamorphic 480p 24 fps - 704x480 | 4:3
 frame_rate_num=24
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0024_16-09
+++ b/src/profiles/00704x0480p0024_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 24 fps [16:9]
+description=NTSC SD Anamorphic 480p 24 fps - 704x480 | 16:9
 frame_rate_num=24
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0024_16-09
+++ b/src/profiles/00704x0480p0024_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 24 fps
+description=NTSC SD Anamorphic 480p 24 fps [16:9]
 frame_rate_num=24
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0025_16-09
+++ b/src/profiles/00704x0480p0025_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 25 fps
+description=NTSC SD Anamorphic 480p 25 fps [16:9]
 frame_rate_num=25
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0025_16-09
+++ b/src/profiles/00704x0480p0025_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 25 fps [16:9]
+description=NTSC SD Anamorphic 480p 25 fps - 704x480 | 16:9
 frame_rate_num=25
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0030_04-03
+++ b/src/profiles/00704x0480p0030_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 30 fps [4:3]
+description=NTSC SD Anamorphic 480p 30 fps - 704x480 | 4:3
 frame_rate_num=30
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0030_04-03
+++ b/src/profiles/00704x0480p0030_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 30 fps
+description=NTSC SD Anamorphic 480p 30 fps [4:3]
 frame_rate_num=30
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0030_16-09
+++ b/src/profiles/00704x0480p0030_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 30 fps
+description=NTSC SD Anamorphic 480p 30 fps [16:9]
 frame_rate_num=30
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0030_16-09
+++ b/src/profiles/00704x0480p0030_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 30 fps [16:9]
+description=NTSC SD Anamorphic 480p 30 fps - 704x480 | 16:9
 frame_rate_num=30
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0050_04-03
+++ b/src/profiles/00704x0480p0050_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 50 fps [4:3]
+description=NTSC SD Anamorphic 480p 50 fps - 704x480 | 4:3
 frame_rate_num=50
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0050_04-03
+++ b/src/profiles/00704x0480p0050_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 50 fps
+description=NTSC SD Anamorphic 480p 50 fps [4:3]
 frame_rate_num=50
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0050_16-09
+++ b/src/profiles/00704x0480p0050_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 50 fps
+description=NTSC SD Anamorphic 480p 50 fps [16:9]
 frame_rate_num=50
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0050_16-09
+++ b/src/profiles/00704x0480p0050_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 50 fps [16:9]
+description=NTSC SD Anamorphic 480p 50 fps - 704x480 | 16:9
 frame_rate_num=50
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0060_04-03
+++ b/src/profiles/00704x0480p0060_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 60 fps
+description=NTSC SD Anamorphic 480p 60 fps [4:3]
 frame_rate_num=60
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0060_04-03
+++ b/src/profiles/00704x0480p0060_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 60 fps [4:3]
+description=NTSC SD Anamorphic 480p 60 fps - 704x480 | 4:3
 frame_rate_num=60
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0060_16-09
+++ b/src/profiles/00704x0480p0060_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 60 fps [16:9]
+description=NTSC SD Anamorphic 480p 60 fps - 704x480 | 16:9
 frame_rate_num=60
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p0060_16-09
+++ b/src/profiles/00704x0480p0060_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 60 fps
+description=NTSC SD Anamorphic 480p 60 fps [16:9]
 frame_rate_num=60
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0480p2398_04-03
+++ b/src/profiles/00704x0480p2398_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 23.98 fps [4:3]
+description=NTSC SD Anamorphic 480p 23.98 fps - 704x480 | 4:3
 frame_rate_num=24000
 frame_rate_den=1001
 width=704

--- a/src/profiles/00704x0480p2398_04-03
+++ b/src/profiles/00704x0480p2398_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 23.98 fps
+description=NTSC SD Anamorphic 480p 23.98 fps [4:3]
 frame_rate_num=24000
 frame_rate_den=1001
 width=704

--- a/src/profiles/00704x0480p2398_16-09
+++ b/src/profiles/00704x0480p2398_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 23.98 fps
+description=NTSC SD Anamorphic 480p 23.98 fps [16:9]
 frame_rate_num=24000
 frame_rate_den=1001
 width=704

--- a/src/profiles/00704x0480p2398_16-09
+++ b/src/profiles/00704x0480p2398_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 23.98 fps [16:9]
+description=NTSC SD Anamorphic 480p 23.98 fps - 704x480 | 16:9
 frame_rate_num=24000
 frame_rate_den=1001
 width=704

--- a/src/profiles/00704x0480p2997_16-09
+++ b/src/profiles/00704x0480p2997_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 29.97 fps [16:9]
+description=NTSC SD Anamorphic 480p 29.97 fps - 704x480 | 16:9
 frame_rate_num=30000
 frame_rate_den=1001
 width=704

--- a/src/profiles/00704x0480p2997_16-09
+++ b/src/profiles/00704x0480p2997_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 29.97 fps
+description=NTSC SD Anamorphic 480p 29.97 fps [16:9]
 frame_rate_num=30000
 frame_rate_den=1001
 width=704

--- a/src/profiles/00704x0480p5994_04-03
+++ b/src/profiles/00704x0480p5994_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 59.94 fps
+description=NTSC SD Anamorphic 480p 59.94 fps [4:3]
 frame_rate_num=60000
 frame_rate_den=1001
 width=704

--- a/src/profiles/00704x0480p5994_04-03
+++ b/src/profiles/00704x0480p5994_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 59.94 fps [4:3]
+description=NTSC SD Anamorphic 480p 59.94 fps - 704x480 | 4:3
 frame_rate_num=60000
 frame_rate_den=1001
 width=704

--- a/src/profiles/00704x0480p5994_16-09
+++ b/src/profiles/00704x0480p5994_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 59.94 fps [16:9]
+description=NTSC SD Anamorphic 480p 59.94 fps - 704x480 | 16:9
 frame_rate_num=60000
 frame_rate_den=1001
 width=704

--- a/src/profiles/00704x0480p5994_16-09
+++ b/src/profiles/00704x0480p5994_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 59.94 fps
+description=NTSC SD Anamorphic 480p 59.94 fps [16:9]
 frame_rate_num=60000
 frame_rate_den=1001
 width=704

--- a/src/profiles/00704x0576i0025_04-03
+++ b/src/profiles/00704x0576i0025_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps
+description=PAL SD Anamorphic 576i 25 fps [4:3]
 frame_rate_num=25
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0576i0025_04-03
+++ b/src/profiles/00704x0576i0025_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps [4:3]
+description=PAL SD Anamorphic 576i 25 fps - 704x576 | 4:3
 frame_rate_num=25
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0576i0025_16-09
+++ b/src/profiles/00704x0576i0025_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps
+description=PAL SD Anamorphic 576i 25 fps [16:9]
 frame_rate_num=25
 frame_rate_den=1
 width=704

--- a/src/profiles/00704x0576i0025_16-09
+++ b/src/profiles/00704x0576i0025_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps [16:9]
+description=PAL SD Anamorphic 576i 25 fps - 704x576 | 16:9
 frame_rate_num=25
 frame_rate_den=1
 width=704

--- a/src/profiles/00720x0480i0024_04-03
+++ b/src/profiles/00720x0480i0024_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 24 fps
+description=NTSC SD Anamorphic 480i 24 fps [4:3]
 frame_rate_num=24
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0024_04-03
+++ b/src/profiles/00720x0480i0024_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 24 fps [4:3]
+description=NTSC SD Anamorphic 480i 24 fps - 720x480 | 4:3
 frame_rate_num=24
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0024_16-09
+++ b/src/profiles/00720x0480i0024_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 24 fps [16:9]
+description=NTSC SD Anamorphic 480i 24 fps - 720x480 | 16:9
 frame_rate_num=24
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0024_16-09
+++ b/src/profiles/00720x0480i0024_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 24 fps
+description=NTSC SD Anamorphic 480i 24 fps [16:9]
 frame_rate_num=24
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0025_04-03
+++ b/src/profiles/00720x0480i0025_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 25 fps
+description=NTSC SD Anamorphic 480i 25 fps [4:3]
 frame_rate_num=25
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0025_04-03
+++ b/src/profiles/00720x0480i0025_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 25 fps [4:3]
+description=NTSC SD Anamorphic 480i 25 fps - 720x480 | 4:3
 frame_rate_num=25
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0025_16-09
+++ b/src/profiles/00720x0480i0025_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 25 fps [16:9]
+description=NTSC SD Anamorphic 480i 25 fps - 720x480 | 16:9
 frame_rate_num=25
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0025_16-09
+++ b/src/profiles/00720x0480i0025_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 25 fps
+description=NTSC SD Anamorphic 480i 25 fps [16:9]
 frame_rate_num=25
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0030_04-03
+++ b/src/profiles/00720x0480i0030_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 30 fps [4:3]
+description=NTSC SD Anamorphic 480i 30 fps - 720x480 | 4:3
 frame_rate_num=30
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0030_04-03
+++ b/src/profiles/00720x0480i0030_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 30 fps
+description=NTSC SD Anamorphic 480i 30 fps [4:3]
 frame_rate_num=30
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0030_16-09
+++ b/src/profiles/00720x0480i0030_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 30 fps
+description=NTSC SD Anamorphic 480i 30 fps [16:9]
 frame_rate_num=30
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0030_16-09
+++ b/src/profiles/00720x0480i0030_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 30 fps [16:9]
+description=NTSC SD Anamorphic 480i 30 fps - 720x480 | 16:9
 frame_rate_num=30
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0060_04-03
+++ b/src/profiles/00720x0480i0060_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 60 fps [4:3]
+description=NTSC SD Anamorphic 480i 60 fps - 720x480 | 4:3
 frame_rate_num=60
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0060_04-03
+++ b/src/profiles/00720x0480i0060_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 60 fps
+description=NTSC SD Anamorphic 480i 60 fps [4:3]
 frame_rate_num=60
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0060_16-09
+++ b/src/profiles/00720x0480i0060_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 60 fps [16:9]
+description=NTSC SD Anamorphic 480i 60 fps - 720x480 | 16:9
 frame_rate_num=60
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i0060_16-09
+++ b/src/profiles/00720x0480i0060_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 60 fps
+description=NTSC SD Anamorphic 480i 60 fps [16:9]
 frame_rate_num=60
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480i2398_04-03
+++ b/src/profiles/00720x0480i2398_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 23.98 fps [4:3]
+description=NTSC SD Anamorphic 480i 23.98 fps - 720x480 | 4:3
 frame_rate_num=24000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480i2398_04-03
+++ b/src/profiles/00720x0480i2398_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 23.98 fps
+description=NTSC SD Anamorphic 480i 23.98 fps [4:3]
 frame_rate_num=24000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480i2398_16-09
+++ b/src/profiles/00720x0480i2398_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 23.98 fps
+description=NTSC SD Anamorphic 480i 23.98 fps [16:9]
 frame_rate_num=24000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480i2398_16-09
+++ b/src/profiles/00720x0480i2398_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 23.98 fps [16:9]
+description=NTSC SD Anamorphic 480i 23.98 fps - 720x480 | 16:9
 frame_rate_num=24000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480i2997_04-03
+++ b/src/profiles/00720x0480i2997_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 29.97 fps [4:3]
+description=NTSC SD Anamorphic 480i 29.97 fps - 720x480 | 4:3
 frame_rate_num=30000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480i2997_04-03
+++ b/src/profiles/00720x0480i2997_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 29.97 fps
+description=NTSC SD Anamorphic 480i 29.97 fps [4:3]
 frame_rate_num=30000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480i5994_04-03
+++ b/src/profiles/00720x0480i5994_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 59.94 fps [4:3]
+description=NTSC SD Anamorphic 480i 59.94 fps - 720x480 | 4:3
 frame_rate_num=60000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480i5994_04-03
+++ b/src/profiles/00720x0480i5994_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 59.94 fps
+description=NTSC SD Anamorphic 480i 59.94 fps [4:3]
 frame_rate_num=60000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480i5994_16-09
+++ b/src/profiles/00720x0480i5994_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 59.94 fps [16:9]
+description=NTSC SD Anamorphic 480i 59.94 fps - 720x480 | 16:9
 frame_rate_num=60000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480i5994_16-09
+++ b/src/profiles/00720x0480i5994_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480i 59.94 fps
+description=NTSC SD Anamorphic 480i 59.94 fps [16:9]
 frame_rate_num=60000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p0015_03-02
+++ b/src/profiles/00720x0480p0015_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 15 fps [3:2]
+description=WVGA 480p 15 fps - 720x480 | 3:2
 frame_rate_num=15
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0015_03-02
+++ b/src/profiles/00720x0480p0015_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 15 fps
+description=WVGA 480p 15 fps [3:2]
 frame_rate_num=15
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0024_03-02
+++ b/src/profiles/00720x0480p0024_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 24 fps
+description=WVGA 480p 24 fps [3:2]
 frame_rate_num=24
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0024_03-02
+++ b/src/profiles/00720x0480p0024_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 24 fps [3:2]
+description=WVGA 480p 24 fps - 720x480 | 3:2
 frame_rate_num=24
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0024_04-03
+++ b/src/profiles/00720x0480p0024_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 24 fps [4:3]
+description=NTSC SD Anamorphic 480p 24 fps - 720x480 | 4:3
 frame_rate_num=24
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0024_04-03
+++ b/src/profiles/00720x0480p0024_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 24 fps
+description=NTSC SD Anamorphic 480p 24 fps [4:3]
 frame_rate_num=24
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0024_16-09
+++ b/src/profiles/00720x0480p0024_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 24 fps [16:9]
+description=NTSC SD Anamorphic 480p 24 fps - 720x480 | 16:9
 frame_rate_num=24
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0024_16-09
+++ b/src/profiles/00720x0480p0024_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 24 fps
+description=NTSC SD Anamorphic 480p 24 fps [16:9]
 frame_rate_num=24
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0025_03-02
+++ b/src/profiles/00720x0480p0025_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 25 fps
+description=WVGA 480p 25 fps [3:2]
 frame_rate_num=25
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0025_03-02
+++ b/src/profiles/00720x0480p0025_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 25 fps [3:2]
+description=WVGA 480p 25 fps - 720x480 | 3:2
 frame_rate_num=25
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0025_04-03
+++ b/src/profiles/00720x0480p0025_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 25 fps [4:3]
+description=NTSC SD Anamorphic 480p 25 fps - 720x480 | 4:3
 frame_rate_num=25
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0025_04-03
+++ b/src/profiles/00720x0480p0025_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 25 fps
+description=NTSC SD Anamorphic 480p 25 fps [4:3]
 frame_rate_num=25
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0025_16-09
+++ b/src/profiles/00720x0480p0025_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 25 fps [16:9]
+description=NTSC SD Anamorphic 480p 25 fps - 720x480 | 16:9
 frame_rate_num=25
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0025_16-09
+++ b/src/profiles/00720x0480p0025_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 25 fps
+description=NTSC SD Anamorphic 480p 25 fps [16:9]
 frame_rate_num=25
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0030_03-02
+++ b/src/profiles/00720x0480p0030_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 30 fps [3:2]
+description=WVGA 480p 30 fps - 720x480 | 3:2
 frame_rate_num=30
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0030_03-02
+++ b/src/profiles/00720x0480p0030_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 30 fps
+description=WVGA 480p 30 fps [3:2]
 frame_rate_num=30
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0030_04-03
+++ b/src/profiles/00720x0480p0030_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 30 fps
+description=NTSC SD Anamorphic 480p 30 fps [4:3]
 frame_rate_num=30
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0030_04-03
+++ b/src/profiles/00720x0480p0030_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 30 fps [4:3]
+description=NTSC SD Anamorphic 480p 30 fps - 720x480 | 4:3
 frame_rate_num=30
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0030_16-09
+++ b/src/profiles/00720x0480p0030_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 30 fps
+description=NTSC SD Anamorphic 480p 30 fps [16:9]
 frame_rate_num=30
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0030_16-09
+++ b/src/profiles/00720x0480p0030_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 30 fps [16:9]
+description=NTSC SD Anamorphic 480p 30 fps - 720x480 | 16:9
 frame_rate_num=30
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0050_03-02
+++ b/src/profiles/00720x0480p0050_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 50 fps [3:2]
+description=WVGA 480p 50 fps - 720x480 | 3:2
 frame_rate_num=50
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0050_03-02
+++ b/src/profiles/00720x0480p0050_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 50 fps
+description=WVGA 480p 50 fps [3:2]
 frame_rate_num=50
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0050_04-03
+++ b/src/profiles/00720x0480p0050_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 50 fps
+description=NTSC SD Anamorphic 480p 50 fps [4:3]
 frame_rate_num=50
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0050_04-03
+++ b/src/profiles/00720x0480p0050_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 50 fps [4:3]
+description=NTSC SD Anamorphic 480p 50 fps - 720x480 | 4:3
 frame_rate_num=50
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0050_16-09
+++ b/src/profiles/00720x0480p0050_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 50 fps [16:9]
+description=NTSC SD Anamorphic 480p 50 fps - 720x480 | 16:9
 frame_rate_num=50
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0050_16-09
+++ b/src/profiles/00720x0480p0050_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 50 fps
+description=NTSC SD Anamorphic 480p 50 fps [16:9]
 frame_rate_num=50
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0060_03-02
+++ b/src/profiles/00720x0480p0060_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 60 fps
+description=WVGA 480p 60 fps [3:2]
 frame_rate_num=60
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0060_03-02
+++ b/src/profiles/00720x0480p0060_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 60 fps [3:2]
+description=WVGA 480p 60 fps - 720x480 | 3:2
 frame_rate_num=60
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0060_04-03
+++ b/src/profiles/00720x0480p0060_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 60 fps [4:3]
+description=NTSC SD Anamorphic 480p 60 fps - 720x480 | 4:3
 frame_rate_num=60
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0060_04-03
+++ b/src/profiles/00720x0480p0060_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 60 fps
+description=NTSC SD Anamorphic 480p 60 fps [4:3]
 frame_rate_num=60
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0060_16-09
+++ b/src/profiles/00720x0480p0060_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 60 fps [16:9]
+description=NTSC SD Anamorphic 480p 60 fps - 720x480 | 16:9
 frame_rate_num=60
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p0060_16-09
+++ b/src/profiles/00720x0480p0060_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 60 fps
+description=NTSC SD Anamorphic 480p 60 fps [16:9]
 frame_rate_num=60
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0480p2398_03-02
+++ b/src/profiles/00720x0480p2398_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 23.98 fps [3:2]
+description=WVGA 480p 23.98 fps - 720x480 | 3:2
 frame_rate_num=24000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p2398_03-02
+++ b/src/profiles/00720x0480p2398_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 23.98 fps
+description=WVGA 480p 23.98 fps [3:2]
 frame_rate_num=24000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p2398_04-03
+++ b/src/profiles/00720x0480p2398_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 23.98 fps [4:3]
+description=NTSC SD Anamorphic 480p 23.98 fps - 720x480 | 4:3
 frame_rate_num=24000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p2398_04-03
+++ b/src/profiles/00720x0480p2398_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 23.98 fps
+description=NTSC SD Anamorphic 480p 23.98 fps [4:3]
 frame_rate_num=24000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p2398_16-09
+++ b/src/profiles/00720x0480p2398_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 23.98 fps [16:9]
+description=NTSC SD Anamorphic 480p 23.98 fps - 720x480 | 16:9
 frame_rate_num=24000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p2398_16-09
+++ b/src/profiles/00720x0480p2398_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 23.98 fps
+description=NTSC SD Anamorphic 480p 23.98 fps [16:9]
 frame_rate_num=24000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p2997_03-02
+++ b/src/profiles/00720x0480p2997_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 29.97 fps
+description=WVGA 480p 29.97 fps [3:2]
 frame_rate_num=30000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p2997_03-02
+++ b/src/profiles/00720x0480p2997_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 29.97 fps [3:2]
+description=WVGA 480p 29.97 fps - 720x480 | 3:2
 frame_rate_num=30000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p2997_04-03
+++ b/src/profiles/00720x0480p2997_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 29.97 fps
+description=NTSC SD Anamorphic 480p 29.97 fps [4:3]
 frame_rate_num=30000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p2997_04-03
+++ b/src/profiles/00720x0480p2997_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 29.97 fps [4:3]
+description=NTSC SD Anamorphic 480p 29.97 fps - 720x480 | 4:3
 frame_rate_num=30000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p5994_03-02
+++ b/src/profiles/00720x0480p5994_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 59.94 fps [3:2]
+description=WVGA 480p 59.94 fps - 720x480 | 3:2
 frame_rate_num=60000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p5994_03-02
+++ b/src/profiles/00720x0480p5994_03-02
@@ -1,4 +1,4 @@
-description=WVGA 480p 59.94 fps
+description=WVGA 480p 59.94 fps [3:2]
 frame_rate_num=60000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p5994_04-03
+++ b/src/profiles/00720x0480p5994_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 59.94 fps [4:3]
+description=NTSC SD Anamorphic 480p 59.94 fps - 720x480 | 4:3
 frame_rate_num=60000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p5994_04-03
+++ b/src/profiles/00720x0480p5994_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 59.94 fps
+description=NTSC SD Anamorphic 480p 59.94 fps [4:3]
 frame_rate_num=60000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p5994_16-09
+++ b/src/profiles/00720x0480p5994_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 59.94 fps
+description=NTSC SD Anamorphic 480p 59.94 fps [16:9]
 frame_rate_num=60000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0480p5994_16-09
+++ b/src/profiles/00720x0480p5994_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 480p 59.94 fps [16:9]
+description=NTSC SD Anamorphic 480p 59.94 fps - 720x480 | 16:9
 frame_rate_num=60000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0486i2997_04-03
+++ b/src/profiles/00720x0486i2997_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 486i 29.97 fps
+description=NTSC SD Anamorphic 486i 29.97 fps [4:3]
 frame_rate_num=30000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0486i2997_04-03
+++ b/src/profiles/00720x0486i2997_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 486i 29.97 fps [4:3]
+description=NTSC SD Anamorphic 486i 29.97 fps - 720x486 | 4:3
 frame_rate_num=30000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0486i2997_16-09
+++ b/src/profiles/00720x0486i2997_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 486i 29.97 fps
+description=NTSC SD Anamorphic 486i 29.97 fps [16:9]
 frame_rate_num=30000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0486i2997_16-09
+++ b/src/profiles/00720x0486i2997_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 486i 29.97 fps [16:9]
+description=NTSC SD Anamorphic 486i 29.97 fps - 720x486 | 16:9
 frame_rate_num=30000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0486p2398_04-03
+++ b/src/profiles/00720x0486p2398_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 486p 23.98 fps
+description=NTSC SD Anamorphic 486p 23.98 fps [4:3]
 frame_rate_num=24000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0486p2398_04-03
+++ b/src/profiles/00720x0486p2398_04-03
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 486p 23.98 fps [4:3]
+description=NTSC SD Anamorphic 486p 23.98 fps - 720x486 | 4:3
 frame_rate_num=24000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0486p2398_16-09
+++ b/src/profiles/00720x0486p2398_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 486p 23.98 fps [16:9]
+description=NTSC SD Anamorphic 486p 23.98 fps - 720x486 | 16:9
 frame_rate_num=24000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0486p2398_16-09
+++ b/src/profiles/00720x0486p2398_16-09
@@ -1,4 +1,4 @@
-description=NTSC SD Anamorphic 486p 23.98 fps
+description=NTSC SD Anamorphic 486p 23.98 fps [16:9]
 frame_rate_num=24000
 frame_rate_den=1001
 width=720

--- a/src/profiles/00720x0576i0025_04-03
+++ b/src/profiles/00720x0576i0025_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps
+description=PAL SD Anamorphic 576i 25 fps [4:3]
 frame_rate_num=25
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0576i0025_04-03
+++ b/src/profiles/00720x0576i0025_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576i 25 fps [4:3]
+description=PAL SD Anamorphic 576i 25 fps - 720x576 | 4:3
 frame_rate_num=25
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0576p0025_04-03
+++ b/src/profiles/00720x0576p0025_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 25 fps
+description=PAL SD Anamorphic 576p 25 fps [4:3]
 frame_rate_num=25
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0576p0025_04-03
+++ b/src/profiles/00720x0576p0025_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 25 fps [4:3]
+description=PAL SD Anamorphic 576p 25 fps - 720x576 | 4:3
 frame_rate_num=25
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0576p0050_04-03
+++ b/src/profiles/00720x0576p0050_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 50 fps
+description=PAL SD Anamorphic 576p 50 fps [4:3]
 frame_rate_num=50
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0576p0050_04-03
+++ b/src/profiles/00720x0576p0050_04-03
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 50 fps [4:3]
+description=PAL SD Anamorphic 576p 50 fps - 720x576 | 4:3
 frame_rate_num=50
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0576p0050_16-09
+++ b/src/profiles/00720x0576p0050_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 50 fps [16:9]
+description=PAL SD Anamorphic 576p 50 fps - 720x576 | 16:9
 frame_rate_num=50
 frame_rate_den=1
 width=720

--- a/src/profiles/00720x0576p0050_16-09
+++ b/src/profiles/00720x0576p0050_16-09
@@ -1,4 +1,4 @@
-description=PAL SD Anamorphic 576p 50 fps
+description=PAL SD Anamorphic 576p 50 fps [16:9]
 frame_rate_num=50
 frame_rate_den=1
 width=720

--- a/src/profiles/00768x0480p0015_16-10
+++ b/src/profiles/00768x0480p0015_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 15 fps [16:10]
+description=WVGA 480p 15 fps - 768x480 | 16:10
 frame_rate_num=15
 frame_rate_den=1
 width=768

--- a/src/profiles/00768x0480p0015_16-10
+++ b/src/profiles/00768x0480p0015_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 15 fps
+description=WVGA 480p 15 fps [16:10]
 frame_rate_num=15
 frame_rate_den=1
 width=768

--- a/src/profiles/00768x0480p0024_16-10
+++ b/src/profiles/00768x0480p0024_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 24 fps [16:10]
+description=WVGA 480p 24 fps - 768x480 | 16:10
 frame_rate_num=24
 frame_rate_den=1
 width=768

--- a/src/profiles/00768x0480p0024_16-10
+++ b/src/profiles/00768x0480p0024_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 24 fps
+description=WVGA 480p 24 fps [16:10]
 frame_rate_num=24
 frame_rate_den=1
 width=768

--- a/src/profiles/00768x0480p0025_16-10
+++ b/src/profiles/00768x0480p0025_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 25 fps
+description=WVGA 480p 25 fps [16:10]
 frame_rate_num=25
 frame_rate_den=1
 width=768

--- a/src/profiles/00768x0480p0025_16-10
+++ b/src/profiles/00768x0480p0025_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 25 fps [16:10]
+description=WVGA 480p 25 fps - 768x480 | 16:10
 frame_rate_num=25
 frame_rate_den=1
 width=768

--- a/src/profiles/00768x0480p0030_16-10
+++ b/src/profiles/00768x0480p0030_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 30 fps
+description=WVGA 480p 30 fps [16:10]
 frame_rate_num=30
 frame_rate_den=1
 width=768

--- a/src/profiles/00768x0480p0030_16-10
+++ b/src/profiles/00768x0480p0030_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 30 fps [16:10]
+description=WVGA 480p 30 fps - 768x480 | 16:10
 frame_rate_num=30
 frame_rate_den=1
 width=768

--- a/src/profiles/00768x0480p0050_16-10
+++ b/src/profiles/00768x0480p0050_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 50 fps [16:10]
+description=WVGA 480p 50 fps - 768x480 | 16:10
 frame_rate_num=50
 frame_rate_den=1
 width=768

--- a/src/profiles/00768x0480p0050_16-10
+++ b/src/profiles/00768x0480p0050_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 50 fps
+description=WVGA 480p 50 fps [16:10]
 frame_rate_num=50
 frame_rate_den=1
 width=768

--- a/src/profiles/00768x0480p0060_16-10
+++ b/src/profiles/00768x0480p0060_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 60 fps
+description=WVGA 480p 60 fps [16:10]
 frame_rate_num=60
 frame_rate_den=1
 width=768

--- a/src/profiles/00768x0480p0060_16-10
+++ b/src/profiles/00768x0480p0060_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 60 fps [16:10]
+description=WVGA 480p 60 fps - 768x480 | 16:10
 frame_rate_num=60
 frame_rate_den=1
 width=768

--- a/src/profiles/00768x0480p2398_16-10
+++ b/src/profiles/00768x0480p2398_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 23.98 fps [16:10]
+description=WVGA 480p 23.98 fps - 768x480 | 16:10
 frame_rate_num=24000
 frame_rate_den=1001
 width=768

--- a/src/profiles/00768x0480p2398_16-10
+++ b/src/profiles/00768x0480p2398_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 23.98 fps
+description=WVGA 480p 23.98 fps [16:10]
 frame_rate_num=24000
 frame_rate_den=1001
 width=768

--- a/src/profiles/00768x0480p2997_16-10
+++ b/src/profiles/00768x0480p2997_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 29.97 fps [16:10]
+description=WVGA 480p 29.97 fps - 768x480 | 16:10
 frame_rate_num=30000
 frame_rate_den=1001
 width=768

--- a/src/profiles/00768x0480p2997_16-10
+++ b/src/profiles/00768x0480p2997_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 29.97 fps
+description=WVGA 480p 29.97 fps [16:10]
 frame_rate_num=30000
 frame_rate_den=1001
 width=768

--- a/src/profiles/00768x0480p5994_16-10
+++ b/src/profiles/00768x0480p5994_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 59.94 fps
+description=WVGA 480p 59.94 fps [16:10]
 frame_rate_num=60000
 frame_rate_den=1001
 width=768

--- a/src/profiles/00768x0480p5994_16-10
+++ b/src/profiles/00768x0480p5994_16-10
@@ -1,4 +1,4 @@
-description=WVGA 480p 59.94 fps [16:10]
+description=WVGA 480p 59.94 fps - 768x480 | 16:10
 frame_rate_num=60000
 frame_rate_den=1001
 width=768

--- a/src/profiles/00800x0480p0015_05-03
+++ b/src/profiles/00800x0480p0015_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 15 fps
+description=WVGA 480p 15 fps [5:3]
 frame_rate_num=15
 frame_rate_den=1
 width=800

--- a/src/profiles/00800x0480p0015_05-03
+++ b/src/profiles/00800x0480p0015_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 15 fps [5:3]
+description=WVGA 480p 15 fps - 800x480 | 5:3
 frame_rate_num=15
 frame_rate_den=1
 width=800

--- a/src/profiles/00800x0480p0024_05-03
+++ b/src/profiles/00800x0480p0024_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 24 fps [5:3]
+description=WVGA 480p 24 fps - 800x480 | 5:3
 frame_rate_num=24
 frame_rate_den=1
 width=800

--- a/src/profiles/00800x0480p0024_05-03
+++ b/src/profiles/00800x0480p0024_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 24 fps
+description=WVGA 480p 24 fps [5:3]
 frame_rate_num=24
 frame_rate_den=1
 width=800

--- a/src/profiles/00800x0480p0025_05-03
+++ b/src/profiles/00800x0480p0025_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 25 fps
+description=WVGA 480p 25 fps [5:3]
 frame_rate_num=25
 frame_rate_den=1
 width=800

--- a/src/profiles/00800x0480p0025_05-03
+++ b/src/profiles/00800x0480p0025_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 25 fps [5:3]
+description=WVGA 480p 25 fps - 800x480 | 5:3
 frame_rate_num=25
 frame_rate_den=1
 width=800

--- a/src/profiles/00800x0480p0030_05-03
+++ b/src/profiles/00800x0480p0030_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 30 fps [5:3]
+description=WVGA 480p 30 fps - 800x480 | 5:3
 frame_rate_num=30
 frame_rate_den=1
 width=800

--- a/src/profiles/00800x0480p0030_05-03
+++ b/src/profiles/00800x0480p0030_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 30 fps
+description=WVGA 480p 30 fps [5:3]
 frame_rate_num=30
 frame_rate_den=1
 width=800

--- a/src/profiles/00800x0480p0050_05-03
+++ b/src/profiles/00800x0480p0050_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 50 fps [5:3]
+description=WVGA 480p 50 fps - 800x480 | 5:3
 frame_rate_num=50
 frame_rate_den=1
 width=800

--- a/src/profiles/00800x0480p0050_05-03
+++ b/src/profiles/00800x0480p0050_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 50 fps
+description=WVGA 480p 50 fps [5:3]
 frame_rate_num=50
 frame_rate_den=1
 width=800

--- a/src/profiles/00800x0480p0060_05-03
+++ b/src/profiles/00800x0480p0060_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 60 fps [5:3]
+description=WVGA 480p 60 fps - 800x480 | 5:3
 frame_rate_num=60
 frame_rate_den=1
 width=800

--- a/src/profiles/00800x0480p0060_05-03
+++ b/src/profiles/00800x0480p0060_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 60 fps
+description=WVGA 480p 60 fps [5:3]
 frame_rate_num=60
 frame_rate_den=1
 width=800

--- a/src/profiles/00800x0480p2398_05-03
+++ b/src/profiles/00800x0480p2398_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 23.98 fps [5:3]
+description=WVGA 480p 23.98 fps - 800x480 | 5:3
 frame_rate_num=24000
 frame_rate_den=1001
 width=800

--- a/src/profiles/00800x0480p2398_05-03
+++ b/src/profiles/00800x0480p2398_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 23.98 fps
+description=WVGA 480p 23.98 fps [5:3]
 frame_rate_num=24000
 frame_rate_den=1001
 width=800

--- a/src/profiles/00800x0480p2997_05-03
+++ b/src/profiles/00800x0480p2997_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 29.97 fps [5:3]
+description=WVGA 480p 29.97 fps - 800x480 | 5:3
 frame_rate_num=30000
 frame_rate_den=1001
 width=800

--- a/src/profiles/00800x0480p2997_05-03
+++ b/src/profiles/00800x0480p2997_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 29.97 fps
+description=WVGA 480p 29.97 fps [5:3]
 frame_rate_num=30000
 frame_rate_den=1001
 width=800

--- a/src/profiles/00800x0480p5994_05-03
+++ b/src/profiles/00800x0480p5994_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 59.94 fps
+description=WVGA 480p 59.94 fps [5:3]
 frame_rate_num=60000
 frame_rate_den=1001
 width=800

--- a/src/profiles/00800x0480p5994_05-03
+++ b/src/profiles/00800x0480p5994_05-03
@@ -1,4 +1,4 @@
-description=WVGA 480p 59.94 fps [5:3]
+description=WVGA 480p 59.94 fps - 800x480 | 5:3
 frame_rate_num=60000
 frame_rate_den=1001
 width=800

--- a/src/profiles/definitions/manage.py
+++ b/src/profiles/definitions/manage.py
@@ -321,7 +321,7 @@ display_aspect_den={profile.info.display_ratio.den}"""
                 profile_path = os.path.join(PROFILE_PATH, key)
                 profile = openshot.Profile(profile_path)
                 # Create unique name (since more than 2 profiles use the same name)
-                unique_profile_name = f'{profile_name} [{profile.info.display_ratio.num}:{profile.info.display_ratio.den}]'
+                unique_profile_name = f'{profile_name} - {profile.info.width}x{profile.info.height} | {profile.info.display_ratio.num}:{profile.info.display_ratio.den}'
                 print(f'Updating name for uniqueness: {unique_profile_name} in profile: {profile.Key()}')
 
                 # Write file with description updated for uniqueness

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -196,6 +196,8 @@ class Export(QDialog):
         for profile_folder in [info.USER_PROFILES_PATH, info.PROFILES_PATH]:
             for file in reversed(sorted(os.listdir(profile_folder))):
                 profile_path = os.path.join(profile_folder, file)
+                if os.path.isdir(profile_path):
+                    continue
                 try:
                     # Load Profile
                     profile = openshot.Profile(profile_path)


### PR DESCRIPTION
Fix duplicate profile names, including a unique name for those with duplicates. For example, their are many similar profiles that go by a common name, for example `PAL SD Anamorphic 576i 25 fps` has both a `4:3` and a `16:9` ratio version. These profiles must have a unique name for OpenShot to function correctly. 

Also, adding a "Search Profile" button for our Preferences (when updating the default profile):
![Default-Profile-OpenShot](https://user-images.githubusercontent.com/5551883/231595020-654089f0-49e4-4a5e-af6a-377a839e2691.png)
