### PR TITLE
`Edit Title` does not update thumbnails on timeline

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -396,7 +396,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             c.save()
 
             # Emit thumbnail update signal (to update timeline thumb image)
-            self.ThumbnailUpdated.emit(c.id)
+            self.ThumbnailUpdated.emit(c.id, 1)
 
         # Update preview
         self.refreshFrameSignal.emit()


### PR DESCRIPTION
Fix for editing a title and trying to update a thumbnail on the timeline - was missing a required arg. This error was caught in Sentry.