### PR TITLE
Protecting timeline args from non-Integer values

### DIFF
--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -50,8 +50,8 @@ class TimelineSync(UpdateInterface):
         channel_layout = project.get("channel_layout")
 
         # Create an instance of a libopenshot Timeline object
-        self.timeline = openshot.Timeline(width, height, openshot.Fraction(fps["num"], fps["den"]), sample_rate, channels,
-                                          channel_layout)
+        self.timeline = openshot.Timeline(width, height, openshot.Fraction(fps["num"], fps["den"]),
+                                          sample_rate, channels, channel_layout)
         self.timeline.info.channel_layout = channel_layout
         self.timeline.info.has_audio = True
         self.timeline.info.has_video = True

--- a/src/windows/cutting.py
+++ b/src/windows/cutting.py
@@ -92,7 +92,7 @@ class Cutting(QDialog):
         self.fps = float(self.fps_num) / float(self.fps_den)
         self.width = int(file.data['width'])
         self.height = int(file.data['height'])
-        self.sample_rate = get_app().project.get("sample_rate")
+        self.sample_rate = int(get_app().project.get("sample_rate"))
         self.channels = int(file.data['channels'])
         self.channel_layout = int(file.data['channel_layout'])
 

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -110,12 +110,12 @@ class Export(QDialog):
         project_timeline.ClearAllCache()
 
         # Get the original timeline settings
-        width = project_timeline.info.width
-        height = project_timeline.info.height
+        width = int(project_timeline.info.width)
+        height = int(project_timeline.info.height)
         fps = project_timeline.info.fps
-        sample_rate = project_timeline.info.sample_rate
-        channels = project_timeline.info.channels
-        channel_layout = project_timeline.info.channel_layout
+        sample_rate = int(project_timeline.info.sample_rate)
+        channels = int(project_timeline.info.channels)
+        channel_layout = int(project_timeline.info.channel_layout)
 
         # Create new "export" openshot.Timeline object
         self.timeline = openshot.Timeline(

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -323,14 +323,16 @@ class PlayerWorker(QObject):
 
             # Get some settings from the project
             fps = project.get("fps")
-            width = project.get("width")
-            height = project.get("height")
-            sample_rate = project.get("sample_rate")
-            channels = project.get("channels")
-            channel_layout = project.get("channel_layout")
+            width = int(project.get("width"))
+            height = int(project.get("height"))
+            sample_rate = int(project.get("sample_rate"))
+            channels = int(project.get("channels"))
+            channel_layout = int(project.get("channel_layout"))
 
             # Create an instance of a libopenshot Timeline object
-            self.clip_reader = openshot.Timeline(width, height, openshot.Fraction(fps["num"], fps["den"]), sample_rate, channels, channel_layout)
+            self.clip_reader = openshot.Timeline(width, height,
+                                                 openshot.Fraction(fps["num"], fps["den"]),
+                                                 sample_rate, channels, channel_layout)
             self.clip_reader.info.channel_layout = channel_layout
             self.clip_reader.info.has_audio = True
             self.clip_reader.info.has_video = True

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -94,15 +94,15 @@ class SelectRegion(QDialog):
         self.file_path = file.absolute_path()
 
         c_info = clip.Reader().info
-        self.fps = c_info.fps.ToInt() #float(self.fps_num) / float(self.fps_den)
-        self.fps_num = self.fps #int(file.data['fps']['num'])
-        self.fps_den = 1 #int(file.data['fps']['den'])
-        self.width = c_info.width #int(file.data['width'])
-        self.height = c_info.height #int(file.data['height'])
-        self.sample_rate = c_info.sample_rate #int(file.data['sample_rate'])
-        self.channels = c_info.channels #int(file.data['channels'])
-        self.channel_layout = c_info.channel_layout #int(file.data['channel_layout'])
-        self.video_length = int(self.clip.Duration() * self.fps) + 1 #int(file.data['video_length'])
+        self.fps = c_info.fps.ToInt()
+        self.fps_num = c_info.fps.num
+        self.fps_den = c_info.fps.den
+        self.width = c_info.width
+        self.height = c_info.height
+        self.sample_rate = int(c_info.sample_rate)
+        self.channels = int(c_info.channels)
+        self.channel_layout = int(c_info.channel_layout)
+        self.video_length = int(self.clip.Duration() * self.fps) + 1
 
         # Apply effects to region frames
         for effect in clip.Effects():
@@ -125,7 +125,9 @@ class SelectRegion(QDialog):
         self.viewport_rect = self.videoPreview.centeredViewport(self.width, self.height)
 
         # Create an instance of a libopenshot Timeline object
-        self.r = openshot.Timeline(self.viewport_rect.width(), self.viewport_rect.height(), openshot.Fraction(self.fps_num, self.fps_den), self.sample_rate, self.channels, self.channel_layout)
+        self.r = openshot.Timeline(self.viewport_rect.width(), self.viewport_rect.height(),
+                                   openshot.Fraction(self.fps_num, self.fps_den),
+                                   self.sample_rate, self.channels, self.channel_layout)
         self.r.info.channel_layout = self.channel_layout
         self.r.SetMaxSize(self.viewport_rect.width(), self.viewport_rect.height())
 


### PR DESCRIPTION
Protecting timeline args from non-Integer values. Detected on Sentry: OPENSHOT-245G. Occasionally Sentry reports a float sample rate, which breaks our Timeline() constructor