### PR TITLE
Prevent Crash in Object Detector and Tracker effects (due to child clip id)

### DIFF
--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -79,6 +79,7 @@ class TimelineSync(UpdateInterface):
             return
 
         # Disable video caching temporarily
+        caching_value = openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING
         openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = False
 
         try:
@@ -111,8 +112,8 @@ class TimelineSync(UpdateInterface):
             log.info("Error applying JSON to timeline object in libopenshot: %s. %s" %
                      (e, action.json(is_array=True)))
 
-        # Enable video caching
-        openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = True
+        # Resume video caching original value
+        openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = caching_value
 
     def MaxSizeChangedCB(self, new_size):
         """Callback for max sized change (i.e. max size of video widget)"""

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -208,7 +208,11 @@ class PropertiesModel(updates.UpdateInterface):
         # Create reference
         clip_data = c.data
         if object_id:
-            clip_data = c.data.get('objects').get(object_id)
+            objects = c.data.get('objects', {})
+            clip_data = objects.pop(object_id, {})
+            if not clip_data:
+                log.debug("No clip data found for this object id")
+                return
 
         if property_key in clip_data:  # Update clip attribute
             log_id = "{}/{}".format(clip_id, object_id) if object_id else clip_id
@@ -331,7 +335,11 @@ class PropertiesModel(updates.UpdateInterface):
                 # Create reference
                 clip_data = c.data
                 if object_id:
-                    clip_data = c.data.get('objects').get(object_id)
+                    objects = c.data.get('objects', {})
+                    clip_data = objects.pop(object_id, {})
+                    if not clip_data:
+                        log.debug("No clip data found for this object id")
+                        return
 
                 # Update clip attribute
                 if property_key in clip_data:

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -446,9 +446,11 @@ class PropertiesModel(updates.UpdateInterface):
         clip_id, item_type = item.data()
 
         # Get value (if any)
-        if item.text():
+        if item.text() or value:
             # Set and format value based on property type
-            if value is not None:
+            if value == "None":
+                new_value = ""
+            elif value is not None:
                 # Override value
                 new_value = value
             elif property_type == "string":

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -285,13 +285,17 @@ class PropertiesModel(updates.UpdateInterface):
                     has_waveform = True
 
             # Reduce # of clip properties we are saving (performance boost)
-            clip_data = {property_key: clip_data[property_key]}
-            if object_id:
-                clip_data = {'objects': {object_id: clip_data}}
+            if not object_id:
+                clip_data = {property_key: clip_data.get(property_key)}
+            else:
+                # If objects dict detected - don't reduce the # of objects
+                objects[object_id] = clip_data
+                clip_data = {'objects': objects}
 
             # Save changes
             if clip_updated:
                 # Save
+                c.data = clip_data
                 c.save()
 
                 # Update waveforms (if needed)
@@ -411,13 +415,17 @@ class PropertiesModel(updates.UpdateInterface):
                                 })
 
                 # Reduce # of clip properties we are saving (performance boost)
-                clip_data = {property_key: clip_data[property_key]}
-                if object_id:
-                    clip_data = {'objects': {object_id: clip_data}}
+                if not object_id:
+                    clip_data = {property_key: clip_data.get(property_key)}
+                else:
+                    # If objects dict detected - don't reduce the # of objects
+                    objects[object_id] = clip_data
+                    clip_data = {'objects': objects}
 
                 # Save changes
                 if clip_updated:
                     # Save
+                    c.data = clip_data
                     c.save()
 
                     # Update the preview

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -475,25 +475,26 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                     raw_properties_effect = json.loads(self.transforming_effect_object.PropertiesJSON(clip_frame_number))
                     # Get properties for the first object in dict. PropertiesJSON should return one object at the time
                     tmp = raw_properties_effect.get('objects')
-                    obj_id = list(tmp.keys())[0]
-                    raw_properties_effect = raw_properties_effect.get('objects').get(obj_id)
+                    if tmp:
+                        obj_id = list(tmp.keys())[0]
+                        raw_properties_effect = raw_properties_effect.get('objects').get(obj_id)
 
-                    # Check if the tracked object is visible in this frame
-                    if raw_properties_effect.get('visible'):
-                        if raw_properties_effect.get('visible').get('value') == 1:
-                            # Get the selected bounding box values
-                            rotation = raw_properties_effect['rotation']['value']
-                            x1 = raw_properties_effect['x1']['value']
-                            y1 = raw_properties_effect['y1']['value']
-                            x2 = raw_properties_effect['x2']['value']
-                            y2 = raw_properties_effect['y2']['value']
-                            self.drawTransformHandler(
-                                painter,
-                                sx, sy,
-                                source_width, source_height,
-                                origin_x, origin_y,
-                                x1, y1, x2, y2,
-                                rotation)
+                        # Check if the tracked object is visible in this frame
+                        if raw_properties_effect.get('visible'):
+                            if raw_properties_effect.get('visible').get('value') == 1:
+                                # Get the selected bounding box values
+                                rotation = raw_properties_effect['rotation']['value']
+                                x1 = raw_properties_effect['x1']['value']
+                                y1 = raw_properties_effect['y1']['value']
+                                x2 = raw_properties_effect['x2']['value']
+                                y2 = raw_properties_effect['y2']['value']
+                                self.drawTransformHandler(
+                                    painter,
+                                    sx, sy,
+                                    source_width, source_height,
+                                    origin_x, origin_y,
+                                    x1, y1, x2, y2,
+                                    rotation)
             else:
                 self.drawTransformHandler(
                     painter,
@@ -1055,10 +1056,14 @@ class VideoWidget(QWidget, updates.UpdateInterface):
             if self.transforming_effect_object.info.has_tracked_object:
                 # Get properties of effect at current frame
                 raw_properties = json.loads(self.transforming_effect_object.PropertiesJSON(clip_frame_number))
+                objects = raw_properties.get('objects', {})
+                if not objects:
+                    return
+
                 # Get properties for the first object in dict.
                 # PropertiesJSON should return one object at the time
-                obj_id = list(raw_properties.get('objects').keys())[0]
-                raw_properties = raw_properties.get('objects').get(obj_id)
+                obj_id = list(objects.keys())[0]
+                raw_properties = objects.get(obj_id)
 
                 if not raw_properties.get('visible'):
                     self.mouse_position = event.pos()

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -381,7 +381,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
             # Set scale as STRETCH if the clip is attached to an object
             if (
-                    raw_properties.get('parentObjectId').get('memo') != 'None'
+                    raw_properties.get('parentObjectId').get('memo') != ''
                     and len(raw_properties.get('parentObjectId').get('memo')) > 0
             ):
                 scale = openshot.SCALE_STRETCH

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -205,12 +205,16 @@ class PropertiesTableView(QTableView):
             cursor_value = event.x() - value_column_x
             cursor_value_percent = cursor_value / self.columnWidth(1)
 
+            # Get data from selected item
             try:
                 cur_property = self.selected_label.data()
             except Exception:
-                # If item is deleted during this drag... an exception can occur
-                # Just ignore, since this is harmless
                 log.debug('Failed to access data on selected label widget')
+                return
+
+            if type(cur_property) != tuple:
+                log.debug('Failed to access valid data on current selected label widget')
+                return
 
             property_key = cur_property[0]
             property_name = cur_property[1]["name"]
@@ -439,7 +443,16 @@ class PropertiesTableView(QTableView):
                 self.menu_reset = False
 
             # Get data from selected item
-            cur_property = selected_label.data()
+            try:
+                cur_property = self.selected_label.data()
+            except Exception:
+                log.debug('Failed to access data on selected label widget')
+                return
+
+            if type(cur_property) != tuple:
+                log.debug('Failed to access valid data on current selected label widget')
+                return
+
             property_name = cur_property[1]["name"]
             self.property_type = cur_property[1]["type"]
             points = cur_property[1]["points"]

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -192,7 +192,8 @@ class PropertiesTableView(QTableView):
             self.selected_item = model.item(row, 1)
 
         # Is the user dragging on the value column
-        if self.selected_label and self.selected_item:
+        if self.selected_label and self.selected_item and \
+                self.selected_label.data() and type(self.selected_label.data()) == tuple:
             # Ignore undo/redo history temporarily (to avoid a huge pile of undo/redo history)
             get_app().updates.ignore_history = True
 
@@ -344,7 +345,7 @@ class PropertiesTableView(QTableView):
         selected_label = model.item(row, 0)
         self.selected_item = model.item(row, 1)
 
-        if selected_label:
+        if selected_label and selected_label.data() and type(selected_label.data()) == tuple:
             cur_property = selected_label.data()
             property_type = cur_property[1]["type"]
 
@@ -436,22 +437,13 @@ class PropertiesTableView(QTableView):
         _ = get_app()._tr
 
         # If item selected
-        if selected_label:
+        if selected_label and selected_label.data() and type(selected_label.data()) == tuple:
+            cur_property = selected_label.data()
+
             # Clear menu if models updated
             if self.menu_reset:
                 self.choices = []
                 self.menu_reset = False
-
-            # Get data from selected item
-            try:
-                cur_property = self.selected_label.data()
-            except Exception:
-                log.debug('Failed to access data on selected label widget')
-                return
-
-            if type(cur_property) != tuple:
-                log.debug('Failed to access valid data on current selected label widget')
-                return
 
             property_name = cur_property[1]["name"]
             self.property_type = cur_property[1]["type"]

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -486,10 +486,7 @@ class PropertiesTableView(QTableView):
                             if (clip_path == clip_instance_path):
                                 # Generate the clip icon to show in the selection menu
                                 clip_instance_icon = clip_index.data(Qt.DecorationRole)
-                        effect_choices = [{"name": "None",
-                                            "value": "None",
-                                            "selected": False,
-                                            "icon": QIcon()}]
+                        effect_choices = []
                         # Iterate through clip's effects
                         for effect_data in clip_instance_data["effects"]:
                             # Make sure the user can only set a parent effect of the same type as this effect
@@ -528,12 +525,12 @@ class PropertiesTableView(QTableView):
 
             # Handle property to set the Tracked Object's child clip
             if property_key == "child_clip_id" and not self.choices:
-                clip_choices = [{
+                self.choices.append({
                     "name": "None",
                     "value": "None",
                     "selected": False,
                     "icon": QIcon()
-                }]
+                })
                 # Instantiate the timeline
                 timeline_instance = get_app().window.timeline_sync.timeline
                 current_effect = timeline_instance.GetClipEffect(clip_id)
@@ -565,18 +562,8 @@ class PropertiesTableView(QTableView):
             # Handle clip attach options
             if property_key == "parentObjectId" and not self.choices:
                 # Add all Clips as choices - initialize with None
-                tracked_choices = [{
-                    "name": "None",
-                    "value": "None",
-                    "selected": False,
-                    "icon": QIcon()
-                }]
-                clip_choices = [{
-                    "name": "None",
-                    "value": "None",
-                    "selected": False,
-                    "icon": QIcon()
-                }]
+                tracked_choices = []
+                clip_choices = []
                 # Instantiate the timeline
                 timeline_instance = get_app().window.timeline_sync.timeline
                 # Loop through timeline's clips
@@ -630,6 +617,7 @@ class PropertiesTableView(QTableView):
                                               "value": tracked_objects,
                                               "selected": False,
                                               "icon": clip_instance_icon})
+                self.choices.append({"name": _("None"), "value": "None", "selected": False, "icon": None})
                 self.choices.append({"name": _("Tracked Objects"), "value": tracked_choices, "selected": False, "icon": None})
                 self.choices.append({"name": _("Clips"), "value": clip_choices, "selected": False, "icon": None})
 

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -500,7 +500,8 @@ class PropertiesTableView(QTableView):
                                                 "icon": clip_instance_icon})
 
                 self.choices.append({"name": _("None"), "value": "None", "selected": False, "icon": None})
-                self.choices.append({"name": _("Clips"), "value": clip_choices, "selected": False, "icon": None})
+                if clip_choices:
+                    self.choices.append({"name": _("Clips"), "value": clip_choices, "selected": False, "icon": None})
 
             # Handle selected object options (ObjectDetection effect)
             if property_key == "selected_object_index" and not self.choices:
@@ -519,7 +520,8 @@ class PropertiesTableView(QTableView):
                                 "selected": False,
                                 "icon": None
                             })
-                self.choices.append({"name": _("Detected Objects"), "value": object_index_choices, "selected": False, "icon": None})
+                if object_index_choices:
+                    self.choices.append({"name": _("Detected Objects"), "value": object_index_choices, "selected": False, "icon": None})
 
             # Handle clip attach options
             if property_key in ["parentObjectId", "child_clip_id"] and not self.choices:
@@ -535,6 +537,7 @@ class PropertiesTableView(QTableView):
                     parent_clip_id = clip_id
                     if item_type == "effect":
                         parent_clip_id = Effect.get(id=clip_id).parent.get("id")
+                        log.debug(f"Lookup parent clip ID for effect: '{clip_id}' = '{parent_clip_id}'")
 
                     # Avoid attach a clip to it's own object
                     if clip_instance_id != parent_clip_id:
@@ -580,7 +583,6 @@ class PropertiesTableView(QTableView):
                                                             "value": str(object_id),
                                                             "selected": False,
                                                             "icon": QIcon(tracked_object_icon)})
-                        if tracked_objects:
                             tracked_choices.append({"name": clip_instance_data["title"],
                                                   "value": tracked_objects,
                                                   "selected": False,
@@ -588,7 +590,8 @@ class PropertiesTableView(QTableView):
                 self.choices.append({"name": _("None"), "value": "None", "selected": False, "icon": None})
                 if property_key == "parentObjectId" and tracked_choices:
                     self.choices.append({"name": _("Tracked Objects"), "value": tracked_choices, "selected": False, "icon": None})
-                self.choices.append({"name": _("Clips"), "value": clip_choices, "selected": False, "icon": None})
+                if clip_choices:
+                    self.choices.append({"name": _("Clips"), "value": clip_choices, "selected": False, "icon": None})
 
             # Handle reader type values
             if self.property_type == "reader" and not self.choices:
@@ -610,7 +613,8 @@ class PropertiesTableView(QTableView):
                                          })
 
                 # Add root file choice
-                self.choices.append({"name": _("Files"), "value": file_choices, "selected": False, icon: None})
+                if file_choices:
+                    self.choices.append({"name": _("Files"), "value": file_choices, "selected": False, icon: None})
 
                 # Add all transitions
                 trans_choices = []
@@ -717,6 +721,7 @@ class PropertiesTableView(QTableView):
                 menu.popup(event.globalPos())
 
             # Menu for choices
+            log.debug(f"Context menu choices: {self.choices}")
             if not self.choices:
                 return
             for choice in self.choices:
@@ -761,6 +766,7 @@ class PropertiesTableView(QTableView):
                         Choice_Action.triggered.connect(self.Choice_Action_Triggered)
 
             # Show choice menuk
+            log.debug(f"Display context menu: {menu.children()}")
             menu.popup(event.globalPos())
 
     def Bezier_Action_Triggered(self, preset=[]):


### PR DESCRIPTION
There have been many bad recent regressions which have broken our Object Detector and Tracker effects - mostly related to optimizations before we save project JSON - accidentally deleting some bits that are important, such as our "tracked" objects, among other Property window errors (missing or invalid child clip ids or parent ids), etc...

This PR fixes all of this, and protects the code much better against missing or invalid IDs.