### PR TITLE
Release 3.1.1 (minimum libopenshot 0.3.2)

### DIFF
--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -28,9 +28,9 @@
 import os
 from time import strftime
 
-VERSION = "3.1.0"
-MINIMUM_LIBOPENSHOT_VERSION = "0.3.1"
-DATE = "20230321000000"
+VERSION = "3.1.1"
+MINIMUM_LIBOPENSHOT_VERSION = "0.3.2"
+DATE = "20230417000000"
 NAME = "openshot-qt"
 PRODUCT_NAME = "OpenShot Video Editor"
 GPL_VERSION = "3"

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2545,26 +2545,17 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Is this a saved project?
         if not app.project.current_filepath:
-            # Not saved yet
-            self.setWindowTitle(
-                "%s %s [%s] - %s" % (
-                    save_indicator,
-                    _("Untitled Project"),
-                    profile,
-                    "OpenShot Video Editor",
-                    ))
+            # Not saved yet (use singleShot since this method can be invoked by our preview thread)
+            QTimer.singleShot(0, functools.partial(self.setWindowTitle,
+                "%s %s [%s] - %s" % (save_indicator, _("Untitled Project"), profile, "OpenShot Video Editor")))
         else:
             # Yes, project is saved
             # Get just the filename
             filename = os.path.basename(app.project.current_filepath)
             filename = os.path.splitext(filename)[0]
-            self.setWindowTitle(
-                "%s %s [%s] - %s" % (
-                    save_indicator,
-                    filename,
-                    profile,
-                    "OpenShot Video Editor",
-                    ))
+            # Use singleShot since this method can be invoked by our preview thread
+            QTimer.singleShot(0, functools.partial(self.setWindowTitle,
+                "%s %s [%s] - %s" % (save_indicator, filename, profile, "OpenShot Video Editor")))
 
     # Update undo and redo buttons enabled/disabled to available changes
     def updateStatusChanged(self, undo_status, redo_status):

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -45,7 +45,8 @@ class PreviewParent(QObject, UpdateInterface):
         """ This method is invoked by the UpdateManager each time a change happens (i.e UpdateInterface) """
 
         # Ignore changes that don't affect libopenshot
-        if len(action.key) >= 1 and action.key[0].lower() in ["files", "history", "markers", "layers", "scale", "profile"]:
+        if len(action.key) >= 1 and action.key[0].lower() in ["files", "history", "markers", "layers",
+                                                              "scale", "profile", "sample_rate"]:
             return
 
         try:

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -220,7 +220,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             return
 
         # Bail out if change unrelated to webview
-        if action.key and action.key[0] not in ["clips", "effects", "duration"]:
+        if action.key and action.key[0] not in ["clips", "effects", "duration", "layers", "markers"]:
             log.debug(f"Skipping unneeded webview update for '{action.key[0]}'")
             return
 

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -219,6 +219,11 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             log.error("Error duplicating UpdateAction", exc_info=1)
             return
 
+        # Bail out if change unrelated to webview
+        if action.key and action.key[0] not in ["clips", "effects"]:
+            log.debug(f"Skipping unneeded webview update for '{action.key[0]}'")
+            return
+
         # Send a JSON version of the UpdateAction to the timeline webview method: applyJsonDiff()
         if action.type == "load":
             # Set thumbnail server

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -220,7 +220,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             return
 
         # Bail out if change unrelated to webview
-        if action.key and action.key[0] not in ["clips", "effects"]:
+        if action.key and action.key[0] not in ["clips", "effects", "duration"]:
             log.debug(f"Skipping unneeded webview update for '{action.key[0]}'")
             return
 

--- a/xdg/org.openshot.OpenShot.appdata.xml
+++ b/xdg/org.openshot.OpenShot.appdata.xml
@@ -64,6 +64,7 @@
     <id>org.openshot.OpenShot.desktop</id>
   </provides>
   <releases>
+    <release version="3.1.1" date="2023-04-17"/>
     <release version="3.1.0" date="2023-03-21"/>
     <release version="3.0.0" date="2022-12-01"/>
     <release version="2.6.1" date="2021-09-04"/>


### PR DESCRIPTION
Release branch of OpenShot Video Editor 3.1.1

**Fixes:**
- Convert detected `sample_rate` to Integer from float
- Protect webview from unwanted libopenshot changes (it was redrawing things for no reason)
- Fixed huge freeze (on Windows) where our detected audio `sample_rate` would try and update the main UI thread from our preview thread, and freeze the UI if your sample rate differed from the OS audio device