### PR TITLE
Windows Installer Update (custom translation strings)

### DIFF
--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -117,7 +117,7 @@ Name: "lithuanian"; MessagesFile: "compiler:Languages\Lithuanian.isl"
 Name: "icelandic"; MessagesFile: "compiler:Languages\Icelandic.isl"
 Name: "slovak"; MessagesFile: "compiler:Languages\Slovak.isl"
 
-[CustomStrings]
+[CustomMessages]
 english.FirewallException=Add an exception to the Windows Firewall for optionally sending anonymized usage and error information.
 italian.FirewallException=Aggiungi un'eccezione a Windows Firewall per l'invio facoltativo di informazioni anonime sull'uso/errori dell'applicazione.
 

--- a/installer/windows-installer.iss
+++ b/installer/windows-installer.iss
@@ -117,10 +117,14 @@ Name: "lithuanian"; MessagesFile: "compiler:Languages\Lithuanian.isl"
 Name: "icelandic"; MessagesFile: "compiler:Languages\Icelandic.isl"
 Name: "slovak"; MessagesFile: "compiler:Languages\Slovak.isl"
 
+[CustomStrings]
+english.FirewallException=Add an exception to the Windows Firewall for optionally sending anonymized usage and error information.
+italian.FirewallException=Aggiungi un'eccezione a Windows Firewall per l'invio facoltativo di informazioni anonime sull'uso/errori dell'applicazione.
+
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked; Check: not PortableCheck;
 Name: "fileassoc"; Description: "{cm:AssocFileExtension,{#MyAppName},.osp}"; GroupDescription: "{cm:AdditionalIcons}"; Check: not PortableCheck;
-Name: "firewall"; Description: "Add an exception to the Windows Firewall for optionally sending anonymized usage and error information."; GroupDescription: "{cm:AdditionalIcons}"; Check: not PortableCheck;
+Name: "firewall"; Description: "{cm:FirewallException}"; GroupDescription: "{cm:AdditionalIcons}"; Check: not PortableCheck;
 
 [InstallDelete]
 ; Remove previous installed versions of OpenShot


### PR DESCRIPTION
Adding the firewall exception in English and Italian - as manual translation strings in ISS installer.

Related PR:
https://github.com/OpenShot/openshot-qt/pull/5204