### PR TITLE
Migrate from altool to notarytool (for Mac Notarization)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ linux-builder:
     - ~/auto-update-sphinx "$CI_PROJECT_DIR/build" "$CI_COMMIT_REF_NAME"
     - python3 -u freeze.py build --git-branch=$CI_COMMIT_REF_NAME
     - for dir in "build/*/"; do /bin/sh ./installer/mangle-hw-libs.sh $(realpath "${dir}"); done 
-    - python3 -u installer/build_server.py "$SLACK_TOKEN" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "False" "$CI_COMMIT_REF_NAME"
+    - python3 -u installer/build_server.py "$SLACK_TOKEN" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "False" "$CI_COMMIT_REF_NAME" "$MAC_PASSWORD"
   when: always
   except:
   - tags
@@ -70,7 +70,7 @@ mac-builder:
     - echo -e "CI_PROJECT_NAME:$CI_PROJECT_NAME\nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME\nCI_COMMIT_SHA:$CI_COMMIT_SHA\nCI_JOB_ID:$CI_JOB_ID\nCI_PIPELINE_ID:$CI_PIPELINE_ID\nVERSION:$VERSION" > "build/install-x64/share/$CI_PROJECT_NAME.env"
     - git log $(git describe --tags --abbrev=0 @^)..@ --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"
     - python3 -u freeze.py bdist_mac --git-branch=$CI_COMMIT_REF_NAME --iconfile=installer/openshot.icns --custom-info-plist=installer/Info.plist --bundle-name="OpenShot Video Editor"
-    - python3 -u installer/build_server.py "$SLACK_TOKEN" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "False" "$CI_COMMIT_REF_NAME"
+    - python3 -u installer/build_server.py "$SLACK_TOKEN" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "False" "$CI_COMMIT_REF_NAME" "$MAC_PASSWORD"
   when: always
   except:
   - tags
@@ -107,7 +107,7 @@ windows-builder-x64:
     - $PREV_GIT_LABEL=(git describe --tags --abbrev=0 '@^')
     - git log "$PREV_GIT_LABEL..@" --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-x64/share/$CI_PROJECT_NAME.log"
     - python3 -u freeze.py build --git-branch=$CI_COMMIT_REF_NAME
-    - python3 -u installer/build_server.py "$SLACK_TOKEN" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "False" "$CI_COMMIT_REF_NAME"
+    - python3 -u installer/build_server.py "$SLACK_TOKEN" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "False" "$CI_COMMIT_REF_NAME" "$MAC_PASSWORD"
   when: always
   except:
   - tags
@@ -146,7 +146,7 @@ windows-builder-x86:
     - python3 -u freeze.py build --git-branch=$CI_COMMIT_REF_NAME
     - $EXE_PATH = "$CI_PROJECT_DIR\build\exe.mingw-" + $PY_ABI + "\openshot-qt.exe"
     - editbin /LARGEADDRESSAWARE "$EXE_PATH"
-    - python3 -u installer/build_server.py "$SLACK_TOKEN" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "True" "$CI_COMMIT_REF_NAME"
+    - python3 -u installer/build_server.py "$SLACK_TOKEN" "$WINDOWS_KEY" "$WINDOWS_PASSWORD" "$GITHUB_USER" "$GITHUB_PASS" "True" "$CI_COMMIT_REF_NAME" "$MAC_PASSWORD"
   when: always
   except:
   - tags

--- a/installer/build-mac-dmg.sh
+++ b/installer/build-mac-dmg.sh
@@ -3,6 +3,7 @@
 # XXX: These paths should be set using `brew prefix` commands,
 #      for future-proofing against upgrades
 PATH=/usr/local/Cellar/python@3.7/3.7.9_2/Frameworks/Python.framework/Versions/3.7/bin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/qt5/5.5/clang_64/bin:/opt/X11/bin
+MAC_NOTARIZE_PASSWORD=$1
 
 # Get Version
 VERSION=$(grep -E '^VERSION = "(.*)"' src/classes/info.py | awk '{print $3}' | tr -d '"')
@@ -67,10 +68,10 @@ codesign -s "OpenShot Studios, LLC" --force --entitlements "installer/openshot.e
 echo "Notarize DMG file (submit to Apple)"
 # No errors uploading '/Users/jonathan/builds/7d5103a1/0/OpenShot/openshot-qt/build/test.zip'.
 # RequestUUID = cc285719-823f-4f0b-8e71-2df4bbbdaf72
-notarize_output=$(xcrun notarytool submit --keychain-profile "NOTARIZE_AUTH_PROFILE" --wait "build/$OS_DMG_NAME")
+notarize_output=$(xcrun notarytool submit --apple-id "jonathan@openshot.org" --password "$MAC_NOTARIZE_PASSWORD" --wait "build/$OS_DMG_NAME")
 echo "$notarize_output"
 
-echo "Parse Notarize Output and get Notarization RequestUUID"
+echo "Parse Notarize Output and get Notarization ID & Status"
 pat='.*id: (.*)\n.*status: ([^'$'\n'']*)'
 [[ "$notarize_output" =~ $pat ]]
 REQUEST_UUID="${BASH_REMATCH[1]}"

--- a/installer/build-mac-dmg.sh
+++ b/installer/build-mac-dmg.sh
@@ -68,7 +68,7 @@ codesign -s "OpenShot Studios, LLC" --force --entitlements "installer/openshot.e
 echo "Notarize DMG file (submit to Apple)"
 # No errors uploading '/Users/jonathan/builds/7d5103a1/0/OpenShot/openshot-qt/build/test.zip'.
 # RequestUUID = cc285719-823f-4f0b-8e71-2df4bbbdaf72
-notarize_output=$(xcrun notarytool submit --apple-id "jonathan@openshot.org" --password "$MAC_NOTARIZE_PASSWORD" --wait "build/$OS_DMG_NAME")
+notarize_output=$(xcrun notarytool submit --apple-id "jonathan@openshot.org" --password "$MAC_NOTARIZE_PASSWORD" --team-id "C94ZNQ5JF3" --wait "build/$OS_DMG_NAME")
 echo "$notarize_output"
 
 echo "Parse Notarize Output and get Notarization ID & Status"

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -234,6 +234,10 @@ def main():
         if len(sys.argv) >= 8:
             git_branch_name = sys.argv[7]
 
+        mac_password = ""
+        if len(sys.argv) >= 9:
+            mac_password = sys.argv[8]
+
         # Start log
         output(
             "%s Build Log for %s (branch: %s)" % (
@@ -405,7 +409,7 @@ def main():
             app_image_success = False
 
             # Build app.bundle and create DMG
-            for line in run_command("bash installer/build-mac-dmg.sh"):
+            for line in run_command(f'bash installer/build-mac-dmg.sh "{mac_password}"'):
                 output(line)
                 if (
                         ("error".encode("UTF-8") in line


### PR DESCRIPTION
Since Apple has now blocked the old method of notarizing, our Mac builds have been broken for a little bit. This replaces the old notarize command with the new `notarytool` command, which is much easier to use in all honesty (i.e. --wait keyword). 