### PR TITLE
Removing `sphinx_markdown_builder` dependency from Docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,7 +34,7 @@ from classes import info
 # ones.
 extensions = [
     'sphinx.ext.extlinks',
-    'sphinx_markdown_builder'
+    #'sphinx_markdown_builder' (pip3 install sphinx_markdown_builder)
 ]
 
 try:


### PR DESCRIPTION
Removing `sphinx_markdown_builder` pip dependency from our documentation, since it is not easy to package for Linux and breaks our current Debian packaging. I will leave it commented out for now, if anyone wants to manually experiment with it. I personally use it for generating markdown of the OpenShot User Guide, to chunk / embed into a Vector DB for our AI Support Bot.