### PR TITLE
Remove `libm.so.6` from AppImage

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -387,6 +387,7 @@ elif sys.platform == "linux":
                     #"libpango-1.0.so.0",
                     #"libpangocairo-1.0.so.0",
                     #"libpangoft2-1.0.so.0",
+                    "libm.so.6",
                     "libdrm.so.2",
                     "libfreetype.so.6",
                     "libfontconfig.so.1",


### PR DESCRIPTION
Experimental change to AppImage to fix the GLIB error which has become more common on newer distros when attempting to run the OpenShot AppImage.

![OpenShot-Error-GLIB](https://github.com/OpenShot/openshot-qt/assets/5551883/0fee5ca8-182c-42cc-9711-41a2d3ac352f)

**Testing Results:**

- Ubuntu 20.04.6 LTS == SUCCESS
- Ubuntu 22.04 == SUCCESS
- Fedora 37 == SUCCESS
- Manjaro 22 == SUCCESS (Newer GLIB)
- Fedora 39 == SUCCESS (Newer GLIB)

resolves #5300