### PR TITLE
Copy Effects Between Clips (bug fix)

### DIFF
--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1596,8 +1596,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             elif action == MENU_COPY_KEYFRAMES_VOLUME:
                 self.copy_clipboard[clip_id]['volume'] = clip.data['volume']
             elif action == MENU_COPY_EFFECTS:
-                self.copy_clipboard[clip_id]['effects'] = [{k: (get_app().project.generate_id() if k == 'id' else v)
-                                                            for k, v in effect.items()} for effect in clip.data['effects']]
+                self.copy_clipboard[clip_id]['effects'] = clip.data['effects']
 
 
         # Loop through transition objects
@@ -1708,6 +1707,10 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 # Apply clipboard to clip (there should only be a single key in this dict)
                 for k, v in self.copy_clipboard[list(self.copy_clipboard)[0]].items():
                     if k != 'id':
+                        if k == 'effects':
+                            # Update effect IDs
+                            v = [{k: (get_app().project.generate_id() if k == 'id' else v)
+                                  for k, v in effect.items()} for effect in v]
                         # Overwrite clips properties (which are in the clipboard)
                         clip.data[k] = v
 

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1670,6 +1670,10 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 clip.type = 'insert'
                 clip.data.pop('id')
 
+                # Update effect IDs
+                clip.data['effects'] = [{k: (get_app().project.generate_id() if k == 'id' else v)
+                                         for k, v in effect.items()} for effect in clip.data['effects']]
+
                 # Adjust the position and track
                 clip.data['position'] += position_diff
                 clip.data['layer'] += layer_diff

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1596,7 +1596,9 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             elif action == MENU_COPY_KEYFRAMES_VOLUME:
                 self.copy_clipboard[clip_id]['volume'] = clip.data['volume']
             elif action == MENU_COPY_EFFECTS:
-                self.copy_clipboard[clip_id]['effects'] = clip.data['effects']
+                self.copy_clipboard[clip_id]['effects'] = [{k: (get_app().project.generate_id() if k == 'id' else v)
+                                                            for k, v in effect.items()} for effect in clip.data['effects']]
+
 
         # Loop through transition objects
         for tran_id in tran_ids:


### PR DESCRIPTION
Fixing bug when copying effects from 1 clip to another clip. We were copying the "id" from the first clip, instead of generating a new one. The created all sorts of chaos, and linked the 2 effects together incorrectly.