### PR TITLE
Fix Copy/Paste Shortcuts (when Timeline has focus)

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -3134,6 +3134,17 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         """Handle play-pause-toggle keypress"""
         get_app().window.PlayPauseToggleSignal.emit()
 
+    def copyAll(self):
+        """Handle Copy QShortcut (selected clips / transitions)"""
+        self.timeline.Copy_Triggered(-1, self.selected_clips, self.selected_transitions)
+
+    def pasteAll(self):
+        """Handle Paste QShortcut (at timeline position, same track as original clip)"""
+        fps = get_app().project.get("fps")
+        fps_float = float(fps["num"]) / float(fps["den"])
+        playhead_position = float(self.preview_thread.current_frame - 1) / fps_float
+        self.timeline.Paste_Triggered(9, float(playhead_position), -1, [], [])
+
     def eventFilter(self, obj, event):
         """Filter out certain QShortcuts - for example, arrow keys used
         in our files, transitions, effects, and emojis views."""
@@ -3443,3 +3454,5 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         QShortcut(app.window.getShortcutByName("playToggle1"), self, activated=self.playToggle, context=Qt.WindowShortcut)
         QShortcut(app.window.getShortcutByName("playToggle2"), self, activated=self.playToggle, context=Qt.WindowShortcut)
         QShortcut(app.window.getShortcutByName("playToggle3"), self, activated=self.playToggle, context=Qt.WindowShortcut)
+        QShortcut(app.window.getShortcutByName("copyAll"), self, activated=self.copyAll, context=Qt.WindowShortcut)
+        QShortcut(app.window.getShortcutByName("pasteAll"), self, activated=self.pasteAll, context=Qt.WindowShortcut)

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -1731,9 +1731,6 @@
    <property name="toolTip">
     <string>Insert Timestamp</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+C</string>
-   </property>
   </action>
   <action name="actionClearWaveformData">
    <property name="enabled">

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1596,8 +1596,7 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             elif action == MENU_COPY_KEYFRAMES_VOLUME:
                 self.copy_clipboard[clip_id]['volume'] = clip.data['volume']
             elif action == MENU_COPY_EFFECTS:
-                self.copy_clipboard[clip_id]['effects'] = [{k: (get_app().project.generate_id() if k == 'id' else v)
-                                                            for k, v in effect.items()} for effect in clip.data['effects']]
+                self.copy_clipboard[clip_id]['effects'] = clip.data['effects']
 
 
         # Loop through transition objects
@@ -1708,6 +1707,10 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 # Apply clipboard to clip (there should only be a single key in this dict)
                 for k, v in self.copy_clipboard[list(self.copy_clipboard)[0]].items():
                     if k != 'id':
+                        if k == 'effects':
+                            # Update effect IDs
+                            v = [{k: (get_app().project.generate_id() if k == 'id' else v)
+                                  for k, v in effect.items()} for effect in v]
                         # Overwrite clips properties (which are in the clipboard)
                         clip.data[k] = v
 

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1670,6 +1670,10 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 clip.type = 'insert'
                 clip.data.pop('id')
 
+                # Update effect IDs
+                clip.data['effects'] = [{k: (get_app().project.generate_id() if k == 'id' else v)
+                                         for k, v in effect.items()} for effect in clip.data['effects']]
+
                 # Adjust the position and track
                 clip.data['position'] += position_diff
                 clip.data['layer'] += layer_diff

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -1596,7 +1596,9 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             elif action == MENU_COPY_KEYFRAMES_VOLUME:
                 self.copy_clipboard[clip_id]['volume'] = clip.data['volume']
             elif action == MENU_COPY_EFFECTS:
-                self.copy_clipboard[clip_id]['effects'] = clip.data['effects']
+                self.copy_clipboard[clip_id]['effects'] = [{k: (get_app().project.generate_id() if k == 'id' else v)
+                                                            for k, v in effect.items()} for effect in clip.data['effects']]
+
 
         # Loop through transition objects
         for tran_id in tran_ids:


### PR DESCRIPTION
This is a temporary work-around, until our new Timeline widget is ready. But this fixes certain webview widgets from eating our Ctrl+C / Ctrl+V keypresses when the timeline is in focus.