### PR TITLE
fix issue with parsing relative filepath

### DIFF
--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -39,7 +39,7 @@ from classes import info
 from classes.app import get_app
 
 # Compiled path regex
-path_regex = re.compile(r'"(image|path|protobuf_data_path)"\s*:\s*"(.*)"')
+path_regex = re.compile(r'"(image|path|protobuf_data_path)"\s*:\s*"(.*?)"')
 path_context = {}
 
 


### PR DESCRIPTION
Conversion of asset path from relative to absolute does not work, as the used regexp is selecting the entire json data. Proposed change is to select the minimum string which fits the pattern. 