### PR TITLE
Verify ALL selections on Undo, and clear property window (if selection is invalid)

### DIFF
--- a/src/classes/updates.py
+++ b/src/classes/updates.py
@@ -303,16 +303,11 @@ class UpdateManager:
             # Get reverse of last action and perform it
             reverse = self.get_reverse_action(last_action)
 
-            # Remove selections for deleted items (if any)
-            if reverse.type == "delete" and len(reverse.key) == 2 and reverse.key[0] == "clips":
-                # unselect deleted clip
-                get_app().window.clearSelections()
-            elif reverse.type == "delete" and len(reverse.key) == 2 and reverse.key[0] == "effects":
-                # unselect deleted effect
-                get_app().window.clearSelections()
-
             # Perform next undo action
             self.dispatch_action(reverse)
+
+            # Verify selections are still valid objects
+            get_app().window.verifySelections()
 
     def redo(self):
         """ Redo the last UpdateAction (and notify all listeners and watchers).

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2627,8 +2627,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             elif item_type == "effect" and item_id in self.selected_effects:
                 self.selected_effects.remove(item_id)
 
-        if not self.selected_clips:
-            # Clear properties view (if no other clips are selected)
+        if not self.selected_clips and not self.selected_effects and not self.selected_transitions:
+            # Clear properties view (if no other items are selected)
             if self.propertyTableView:
                 self.propertyTableView.loadProperties.emit("", "")
 
@@ -2930,6 +2930,20 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Clear selection in properties view
         if self.propertyTableView:
             self.propertyTableView.loadProperties.emit("", "")
+
+    def verifySelections(self):
+        """Clear any invalid selections"""
+        for clip_id in self.selected_clips:
+            if not Clip.get(id=clip_id):
+                self.removeSelection(clip_id, "clip")
+
+        for tran_id in self.selected_transitions:
+            if not Transition.get(id=tran_id):
+                self.removeSelection(tran_id, "transition")
+
+        for effect_id in self.selected_effects:
+            if not Effect.get(id=effect_id):
+                self.removeSelection(effect_id, "effect")
 
     def foundCurrentVersion(self, version):
         """Handle the callback for detecting the current version on openshot.org"""


### PR DESCRIPTION
Verify ALL selections on Undo, and clear property window (if selection is invalid). For example, if you drop an effect on a clip, select the effect (which makes the Properties dock visible), and then UNDO until the effect is no longer valid, the property window was remaining on the screen, even though the effect was deleted.
![OpenShot-Empty-Properties](https://github.com/OpenShot/openshot-qt/assets/5551883/b8aee3ab-21f8-4eb2-9915-13d044b1c2ff)

