### PR TITLE
Copy Keyframes to Include Shear X, Shear Y

### DIFF
--- a/src/language/OpenShot/OpenShot.pot
+++ b/src/language/OpenShot/OpenShot.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: OpenShot Video Editor (version: 3.1.1)\n"
+"Project-Id-Version: OpenShot Video Editor (version: 3.1.1-dev)\n"
 "Report-Msgid-Bugs-To: Jonathan Thomas <Jonathan.Oomph@gmail.com>\n"
-"POT-Creation-Date: 2024-02-19 16:59:32.986601\n"
+"POT-Creation-Date: 2024-03-27 14:15:51.138531\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Jonathan Thomas <Jonathan.Oomph@gmail.com>\n"
 "Language-Team: https://translations.launchpad.net/+groups/launchpad-translators\n"
@@ -175,9 +175,9 @@ msgstr ""
 
 #: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:465
 #: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:481
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:362
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:689
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:802
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:371
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:723
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:828
 msgid "Select a Color"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 #: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:216
 #: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:173
 #: /home/jonathan/apps/openshot-qt-git/src/windows/export_clips.py:168
-#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:76
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:78
 msgid "Cancel"
 msgstr ""
 
@@ -272,31 +272,31 @@ msgid "Image Sequence"
 msgstr ""
 
 #: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:175
-#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:141
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:143
 #: Settings for default-channellayout
 msgid "Mono (1 Channel)"
 msgstr ""
 
 #: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:176
-#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:142
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:144
 #: Settings for default-channellayout
 msgid "Stereo (2 Channel)"
 msgstr ""
 
 #: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:177
-#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:143
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:145
 #: Settings for default-channellayout
 msgid "Surround (3 Channel)"
 msgstr ""
 
 #: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:178
-#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:144
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:146
 #: Settings for default-channellayout
 msgid "Surround (5.1 Channel)"
 msgstr ""
 
 #: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:179
-#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:145
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:147
 #: Settings for default-channellayout
 msgid "Surround (7.1 Channel)"
 msgstr ""
@@ -312,7 +312,7 @@ msgid "MP4 (h.264)"
 msgstr ""
 
 #: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:446
-#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:159
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:161
 #: libopenshot (Clip Properties)
 msgid "No"
 msgstr ""
@@ -397,8 +397,8 @@ msgstr ""
 msgid "View Website"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:497
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:579
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:512
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:613
 #: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:480
 #: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:486
 #: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:498
@@ -406,30 +406,37 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:499
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:583
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:514
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:617
 msgid "Clips"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:519
-msgid "Detected Objects"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:520
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:540
+msgid "Tracked Classes"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:581
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:521
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:162
+msgid "Clear"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:523
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:615
 msgid "Tracked Objects"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:606
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:640
 msgid "Files"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:626
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:660
 #: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:296
 msgid "Transitions"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:635
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:234
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:669
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:235
 #: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:475
 #: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:755
 #: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:844
@@ -438,145 +445,145 @@ msgstr ""
 msgid "Track %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:653
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:687
 msgid "Ease (Default)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:654
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:688
 msgid "Ease In"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:655
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:689
 msgid "Ease Out"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:656
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:690
 msgid "Ease In/Out"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:658
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:692
 msgid "Ease In (Quad)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:659
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:693
 msgid "Ease In (Cubic)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:660
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:694
 msgid "Ease In (Quart)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:661
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:695
 msgid "Ease In (Quint)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:662
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:696
 msgid "Ease In (Sine)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:663
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:697
 msgid "Ease In (Expo)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:664
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:698
 msgid "Ease In (Circ)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:665
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:699
 msgid "Ease In (Back)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:667
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:701
 msgid "Ease Out (Quad)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:668
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:702
 msgid "Ease Out (Cubic)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:669
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:703
 msgid "Ease Out (Quart)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:670
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:704
 msgid "Ease Out (Quint)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:671
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:705
 msgid "Ease Out (Sine)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:672
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:706
 msgid "Ease Out (Expo)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:673
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:707
 msgid "Ease Out (Circ)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:674
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:708
 msgid "Ease Out (Back)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:676
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:710
 msgid "Ease In/Out (Quad)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:677
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:711
 msgid "Ease In/Out (Cubic)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:678
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:712
 msgid "Ease In/Out (Quart)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:679
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:713
 msgid "Ease In/Out (Quint)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:680
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:714
 msgid "Ease In/Out (Sine)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:681
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:715
 msgid "Ease In/Out (Expo)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:682
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:716
 msgid "Ease In/Out (Circ)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:683
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:717
 msgid "Ease In/Out (Back)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:694
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:728
 msgid "Bezier"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:699
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:733
 msgid "Linear"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:701
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:735
 msgid "Constant"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:706
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:740
 #: Settings for actionInsertKeyframe
 msgid "Insert Keyframe"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:708
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:742
 msgid "Remove Keyframe"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1004
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1031
 msgid "Selection:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1010
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1027
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1037
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1054
 msgid "No Selection"
 msgstr ""
 
@@ -654,481 +661,485 @@ msgid ""
 "this button to export your timeline as a single video file."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:506
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:507
 msgid "Slice All"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:507
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1009
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2732
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:508
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1013
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2741
 msgid "Keep Both Sides"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:511
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1012
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2735
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:512
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1016
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2744
 msgid "Keep Left Side"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:515
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1015
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2738
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:516
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1019
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2747
 msgid "Keep Right Side"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:522
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:523
 #: Settings Category for Cache
 msgid "Cache"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:566
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:655
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2707
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:567
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:659
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2716
 #: Settings for pasteAll
 msgid "Paste"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:607
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:612
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2674
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2679
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:608
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:613
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2683
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2688
 #: Settings for copyAll
 msgid "Copy"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:613
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:614
 #: libopenshot (Clip Properties)
 msgid "Clip"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:617
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2684
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:618
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2693
 msgid "Keyframes"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:618
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2685
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:619
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2694
 msgid "All"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:622
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:623
 #: libopenshot (Clip Properties)
 msgid "Alpha"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:625
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:626
 #: libopenshot (Clip Properties)
 msgid "Scale"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:628
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:629
+msgid "Shear"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:632
 #: libopenshot (Clip Properties)
 msgid "Rotation"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:631
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:635
 #: Settings Category for Location
 msgid "Location"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:634
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:858
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:638
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:862
 #: libopenshot (Clip Properties)
 msgid "Time"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:637
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:907
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:641
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:911
 #: effect_init (Effect parameter for Example) Settings volume
 msgid "Volume"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:642
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:646
 #: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:350
 msgid "Effects"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:662
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2714
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:666
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2723
 msgid "Align"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:663
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2715
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:667
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2724
 #: libopenshot (Clip Properties)
 msgid "Left"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:665
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2717
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:669
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2726
 #: libopenshot (Clip Properties)
 msgid "Right"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:672
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:676
 #: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:240
 msgid "Fade"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:673
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:677
 msgid "No Fade"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:677
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:723
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:912
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:681
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:727
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:916
 msgid "Start of Clip"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:678
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:724
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:913
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:682
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:728
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:917
 msgid "End of Clip"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:679
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:725
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:914
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:683
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:729
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:918
 msgid "Entire Clip"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:684
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:919
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:688
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:923
 msgid "Fade In (Fast)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:687
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:922
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:691
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:926
 msgid "Fade In (Slow)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:692
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:927
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:696
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:931
 msgid "Fade Out (Fast)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:695
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:930
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:699
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:934
 msgid "Fade Out (Slow)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:700
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:935
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:704
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:939
 msgid "Fade In and Out (Fast)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:703
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:938
-msgid "Fade In and Out (Slow)"
 msgstr ""
 
 #: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:707
 #: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:942
+msgid "Fade In and Out (Slow)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:711
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:946
 msgid "Fade In (Entire Clip)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:710
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:945
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:714
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:949
 msgid "Fade Out (Entire Clip)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:718
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:722
 msgid "Animate"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:719
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:723
 msgid "No Animation"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:730
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:734
 #: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:307
 msgid "Zoom"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:731
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:735
 msgid "Zoom In (50% to 100%)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:734
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:738
 msgid "Zoom In (75% to 100%)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:737
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:741
 msgid "Zoom In (100% to 150%)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:740
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:744
 msgid "Zoom Out (100% to 75%)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:743
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:747
 msgid "Zoom Out (100% to 50%)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:746
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:750
 msgid "Zoom Out (150% to 100%)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:752
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:756
 msgid "Center to Edge"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:753
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:757
 msgid "Center to Top"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:756
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:760
 msgid "Center to Left"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:759
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:763
 msgid "Center to Right"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:762
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:766
 msgid "Center to Bottom"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:768
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:772
 msgid "Edge to Center"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:769
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:773
 msgid "Top to Center"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:772
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:776
 msgid "Left to Center"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:775
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:779
 msgid "Right to Center"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:778
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:782
 msgid "Bottom to Center"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:784
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:788
 msgid "Edge to Edge"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:785
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:789
 msgid "Top to Bottom"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:788
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:792
 msgid "Left to Right"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:791
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:795
 msgid "Right to Left"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:794
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:798
 msgid "Bottom to Top"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:801
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:805
 #: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:487
 #: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:499
 msgid "Random"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:811
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:815
 msgid "Rotate"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:812
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:816
 msgid "No Rotation"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:816
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:820
 msgid "Rotate 90 (Right)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:819
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:823
 msgid "Rotate 90 (Left)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:822
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:826
 msgid "Rotate 180 (Flip)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:828
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:832
 msgid "Layout"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:829
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:833
 msgid "Reset Layout"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:833
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:837
 msgid "1/4 Size - Center"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:836
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:840
 msgid "1/4 Size - Top Left"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:839
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:843
 msgid "1/4 Size - Top Right"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:842
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:846
 msgid "1/4 Size - Bottom Left"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:845
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:849
 msgid "1/4 Size - Bottom Right"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:849
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:853
 msgid "Show All (Maintain Ratio)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:852
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:856
 msgid "Show All (Distort)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:859
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:863
 msgid "Reset Time"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:863
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:867
 msgid "Normal"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:864
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:868
 msgid "Fast"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:865
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:869
 msgid "Slow"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:870
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:874
 msgid "Forward"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:871
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:875
 msgid "Backward"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:889
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:893
 msgid "Freeze"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:890
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:894
 msgid "Freeze && Zoom"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:896
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:900
 msgid "{} seconds"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:908
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:912
 msgid "Reset Volume"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:951
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:955
 msgid "Level 100%"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:954
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:958
 msgid "Level 90%"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:957
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:961
 msgid "Level 80%"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:960
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:964
 msgid "Level 70%"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:963
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:967
 msgid "Level 60%"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:966
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:970
 msgid "Level 50%"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:969
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:973
 msgid "Level 40%"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:972
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:976
 msgid "Level 30%"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:975
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:979
 msgid "Level 20%"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:978
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:982
 msgid "Level 10%"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:981
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:985
 msgid "Level 0%"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:989
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:993
 msgid "Separate Audio"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:990
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:994
 msgid "Single Clip (all channels)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:993
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:997
 msgid "Multiple Clips (each channel)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1008
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2731
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1012
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2740
 msgid "Slice"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1028
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1032
 msgid "Display"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1029
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1033
 msgid "Show Waveform"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1031
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1035
 msgid "Show Thumbnail"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1191
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1195
 msgid "(all channels)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1237
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:1241
 #, python-format
 msgid "(channel %s)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2680
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2689
 #: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:341
 msgid "Transition"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2689
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2698
 #: libopenshot (Clip Properties)
 msgid "Brightness"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2692
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2701
 #: libopenshot (Clip Properties)
 msgid "Contrast"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2744
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/webview.py:2753
 msgid "Reverse Transition"
 msgstr ""
 
@@ -1268,13 +1279,13 @@ msgstr ""
 msgid "True"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:924
-#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:951
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:933
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:958
 msgid "Property"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:924
-#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:951
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:933
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:958
 msgid "Value"
 msgstr ""
 
@@ -1545,7 +1556,7 @@ msgstr ""
 #: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2803
 #: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2821
 #: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2831
-#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3285
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3299
 #: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:441
 msgid "Filter"
 msgstr ""
@@ -1554,22 +1565,22 @@ msgstr ""
 msgid "Caption Toolbar"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2947
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2961
 #: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1537
 #: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1540
 msgid "Update Available"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2948
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2962
 #, python-format
 msgid "Update Available: <b>%s</b>"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3242
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3256
 msgid "Error starting local HTTP server"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3243
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3257
 msgid "Failed multiple attempts to start server:"
 msgstr ""
 
@@ -1676,20 +1687,20 @@ msgstr ""
 msgid "Exporting"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:74
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:76
 msgid "Update"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:140
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:142
 msgid "Unknown"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:158
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:160
 #: libopenshot (Clip Properties)
 msgid "Yes"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:219
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:221
 #, python-format
 msgid "Locate media file: %s"
 msgstr ""
@@ -3317,10 +3328,6 @@ msgstr ""
 
 #: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:150
 msgid "Optional"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:162
-msgid "Clear"
 msgstr ""
 
 #: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:175

--- a/src/windows/views/webview.py
+++ b/src/windows/views/webview.py
@@ -135,8 +135,9 @@ MENU_COPY_KEYFRAMES_ROTATE = 4
 MENU_COPY_KEYFRAMES_LOCATION = 5
 MENU_COPY_KEYFRAMES_TIME = 6
 MENU_COPY_KEYFRAMES_VOLUME = 7
-MENU_COPY_EFFECTS = 8
-MENU_PASTE = 9
+MENU_COPY_KEYFRAMES_SHEAR = 8
+MENU_COPY_EFFECTS = 9
+MENU_PASTE = 10
 
 MENU_COPY_TRANSITION = 10
 MENU_COPY_KEYFRAMES_BRIGHTNESS = 11
@@ -625,6 +626,9 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
             Copy_Keyframes_Scale = Keyframe_Menu.addAction(_("Scale"))
             Copy_Keyframes_Scale.triggered.connect(partial(
                 self.Copy_Triggered, MENU_COPY_KEYFRAMES_SCALE, [clip_id], []))
+            Copy_Keyframes_Shear = Keyframe_Menu.addAction(_("Shear"))
+            Copy_Keyframes_Shear.triggered.connect(partial(
+                self.Copy_Triggered, MENU_COPY_KEYFRAMES_SHEAR, [clip_id], []))
             Copy_Keyframes_Rotate = Keyframe_Menu.addAction(_("Rotation"))
             Copy_Keyframes_Rotate.triggered.connect(partial(
                 self.Copy_Triggered, MENU_COPY_KEYFRAMES_ROTATE, [clip_id], []))
@@ -1573,6 +1577,8 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 self.copy_clipboard[clip_id]['gravity'] = clip.data['gravity']
                 self.copy_clipboard[clip_id]['scale_x'] = clip.data['scale_x']
                 self.copy_clipboard[clip_id]['scale_y'] = clip.data['scale_y']
+                self.copy_clipboard[clip_id]['shear_x'] = clip.data['shear_x']
+                self.copy_clipboard[clip_id]['shear_y'] = clip.data['shear_y']
                 self.copy_clipboard[clip_id]['rotation'] = clip.data['rotation']
                 self.copy_clipboard[clip_id]['location_x'] = clip.data['location_x']
                 self.copy_clipboard[clip_id]['location_y'] = clip.data['location_y']
@@ -1584,6 +1590,9 @@ class TimelineWebView(updates.UpdateInterface, WebViewClass):
                 self.copy_clipboard[clip_id]['gravity'] = clip.data['gravity']
                 self.copy_clipboard[clip_id]['scale_x'] = clip.data['scale_x']
                 self.copy_clipboard[clip_id]['scale_y'] = clip.data['scale_y']
+            elif action == MENU_COPY_KEYFRAMES_SHEAR:
+                self.copy_clipboard[clip_id]['shear_x'] = clip.data['shear_x']
+                self.copy_clipboard[clip_id]['shear_y'] = clip.data['shear_y']
             elif action == MENU_COPY_KEYFRAMES_ROTATE:
                 self.copy_clipboard[clip_id]['gravity'] = clip.data['gravity']
                 self.copy_clipboard[clip_id]['rotation'] = clip.data['rotation']


### PR DESCRIPTION
For some reason, Shear X and Shear Y keyframes were not preset in the Copy/Paste Keyframes menu. This PR fixes this.