### PR TITLE
Theme Manager refactor (prevent freezing on Windows)

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -153,7 +153,7 @@ class OpenShotApp(QApplication):
 
         # Instantiate Theme Manager (Singleton)
         from themes.manager import ThemeManager
-        ThemeManager(self)
+        self.theme_manager = ThemeManager(self)
 
     def show_environment(self, info, openshot):
         log = self.log
@@ -256,9 +256,8 @@ class OpenShotApp(QApplication):
         self.window = MainWindow()
 
         # Instantiate Theme Manager (Singleton)
-        from themes.manager import ThemeManager, ThemeName
-        theme_enum = ThemeName.find_by_name(self.settings.get("theme"))
-        theme = ThemeManager().apply_theme(theme_enum)
+        theme_name = self.settings.get("theme")
+        theme = self.theme_manager.apply_theme(theme_name)
 
         # Update theme in settings
         self.settings.set("theme", theme.name)

--- a/src/themes/base.py
+++ b/src/themes/base.py
@@ -34,7 +34,6 @@ from PyQt5.QtWidgets import QTabWidget, QWidget, QSizePolicy
 
 from classes import ui_util
 from classes.info import PATH
-from themes.manager import ThemeManager
 
 
 class BaseTheme:
@@ -150,25 +149,24 @@ class BaseTheme:
                 if button_stylesheet:
                     button.setStyleSheet(button_stylesheet)
 
-
     def apply_theme(self):
-        # Get initial style and palette
-        manager = ThemeManager()
-
         # Apply the stylesheet to the entire application
-        if manager.original_style:
-            self.app.setStyle(manager.original_style)
-        if manager.original_palette:
-            self.app.setPalette(manager.original_palette)
+        from classes import info
+        from classes.logger import log
+        from PyQt5.QtGui import QFont, QFontDatabase
+
+        if not self.app.theme_manager:
+            log.warning("ThemeManager not initialized yet. Skip applying a theme.")
+
+        if self.app.theme_manager.original_style:
+            self.app.setStyle(self.app.theme_manager.original_style)
+        if self.app.theme_manager.original_palette:
+            self.app.setPalette(self.app.theme_manager.original_palette)
         self.app.setStyleSheet(self.style_sheet)
 
         # Hide main window status bar
         if hasattr(self.app, "window") and hasattr(self.app.window, "statusBar"):
             self.app.window.statusBar.hide()
-
-        from classes import info
-        from classes.logger import log
-        from PyQt5.QtGui import QFont, QFontDatabase
 
         # Load embedded font
         font_path = os.path.join(info.IMAGES_PATH, "fonts", "Ubuntu-R.ttf")

--- a/src/themes/cosmic/theme.py
+++ b/src/themes/cosmic/theme.py
@@ -442,7 +442,7 @@ QWidget#aboutDialog QWidget#txtversion {
     background-color: #FABE0A;
 }
 
-.video_widget {
+QWidget#videoPreview {
     background-color: #141923;
 }
         """

--- a/src/themes/humanity/theme.py
+++ b/src/themes/humanity/theme.py
@@ -51,7 +51,7 @@ QComboBox::item {
     background-color: #ff0024;
 }
 
-.video_widget {
+QWidget#videoPreview {
     background-color: #191919;
 }
         """
@@ -94,7 +94,7 @@ QMainWindow::separator:hover {
     background-color: #ff0024;
 }
 
-.video_widget {
+QWidget#videoPreview {
     background-color: #dedede;
 }
         """

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1134,10 +1134,10 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         """Handle when playback is started"""
         # Set icon on Play button
         if self.initialized:
-            from themes.manager import ThemeManager
-            theme = ThemeManager().get_current_theme()
-            if theme:
-                theme.togglePlayIcon(True)
+            if get_app().theme_manager:
+                theme = get_app().theme_manager.get_current_theme()
+                if theme:
+                    theme.togglePlayIcon(True)
 
     def onPauseCallback(self):
         """Handle when playback is paused"""
@@ -1146,10 +1146,10 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Set icon on Pause button
         if self.initialized:
-            from themes.manager import ThemeManager
-            theme = ThemeManager().get_current_theme()
-            if theme:
-                theme.togglePlayIcon(False)
+            if get_app().theme_manager:
+                theme = get_app().theme_manager.get_current_theme()
+                if theme:
+                    theme.togglePlayIcon(False)
 
     def actionSaveFrame_trigger(self, checked=True):
         log.info("actionSaveFrame_trigger")
@@ -2992,19 +2992,22 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             # Add toolbar button for non-cosmic dusk themes
             # Cosmic dusk has a hidden toolbar button which is made visible
             # by the setVisible() call above this
-            from themes.manager import ThemeManager, ThemeName
-            theme = ThemeManager().get_current_theme()
-            if theme and theme.name != ThemeName.COSMIC.value:
-                # Add spacer and 'New Version Available' toolbar button (default hidden)
-                spacer = QWidget(self)
-                spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
-                self.toolBar.addWidget(spacer)
+            if get_app().theme_manager:
+                from themes.manager import ThemeName
+                theme = get_app().theme_manager.get_current_theme()
+                if theme and theme.name != ThemeName.COSMIC.value:
+                    # Add spacer and 'New Version Available' toolbar button (default hidden)
+                    spacer = QWidget(self)
+                    spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+                    self.toolBar.addWidget(spacer)
 
-                # Add update available button (with icon and text)
-                updateButton = QToolButton(self)
-                updateButton.setDefaultAction(self.actionUpdate)
-                updateButton.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
-                self.toolBar.addWidget(updateButton)
+                    # Add update available button (with icon and text)
+                    updateButton = QToolButton(self)
+                    updateButton.setDefaultAction(self.actionUpdate)
+                    updateButton.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+                    self.toolBar.addWidget(updateButton)
+            else:
+                log.warning("No ThemeManager loaded yet. Skip update available button.")
 
         # Initialize sentry exception tracing (now that we know the current version)
         from classes import sentry

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -566,9 +566,8 @@ class Preferences(QDialog):
 
         if param["setting"] == "theme":
             # Apply selected theme to UI
-            from themes.manager import ThemeManager, ThemeName
-            theme_enum = ThemeName.find_by_name(value)
-            ThemeManager().apply_theme(theme_enum)
+            if get_app().theme_manager:
+                get_app().theme_manager.apply_theme(value)
 
         # Check for restart
         self.check_for_restart(param)

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -330,17 +330,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
             True)
 
         # Get theme colors (if any)
-        # if get_app().theme_manager:
-        #     theme = get_app().theme_manager.get_current_theme()
-        #     if not theme:
-        #         log.warning("No theme loaded yet. Skip rendering video preview widget.")
-        #         return
-        #     background_color = theme.get_color(".video_widget", "background-color")
-        #     painter.fillRect(event.rect(), background_color)
-        # else:
-        #     log.warning("No ThemeManager loaded yet. Skip rendering video preview widget.")
-
-        background_color = QColor("#191919")
+        background_color = self.palette().color(self.backgroundRole())
         painter.fillRect(event.rect(), background_color)
 
         # Find centered viewport

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -44,7 +44,6 @@ from classes import openshot_rc  # noqa
 from classes.logger import log
 from classes.app import get_app
 from classes.query import Clip, Effect
-from themes.manager import ThemeManager
 
 
 class VideoWidget(QWidget, updates.UpdateInterface):
@@ -331,11 +330,15 @@ class VideoWidget(QWidget, updates.UpdateInterface):
             True)
 
         # Get theme colors (if any)
-        theme = ThemeManager().get_current_theme()
-        if not theme:
-            return
-        background_color = theme.get_color(".video_widget", "background-color")
-        painter.fillRect(event.rect(), background_color)
+        if get_app().theme_manager:
+            theme = get_app().theme_manager.get_current_theme()
+            if not theme:
+                log.warning("No theme loaded yet. Skip rendering video preview widget.")
+                return
+            background_color = theme.get_color(".video_widget", "background-color")
+            painter.fillRect(event.rect(), background_color)
+        else:
+            log.warning("No ThemeManager loaded yet. Skip rendering video preview widget.")
 
         # Find centered viewport
         viewport_rect = self.centeredViewport(self.width(), self.height())

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -330,15 +330,18 @@ class VideoWidget(QWidget, updates.UpdateInterface):
             True)
 
         # Get theme colors (if any)
-        if get_app().theme_manager:
-            theme = get_app().theme_manager.get_current_theme()
-            if not theme:
-                log.warning("No theme loaded yet. Skip rendering video preview widget.")
-                return
-            background_color = theme.get_color(".video_widget", "background-color")
-            painter.fillRect(event.rect(), background_color)
-        else:
-            log.warning("No ThemeManager loaded yet. Skip rendering video preview widget.")
+        # if get_app().theme_manager:
+        #     theme = get_app().theme_manager.get_current_theme()
+        #     if not theme:
+        #         log.warning("No theme loaded yet. Skip rendering video preview widget.")
+        #         return
+        #     background_color = theme.get_color(".video_widget", "background-color")
+        #     painter.fillRect(event.rect(), background_color)
+        # else:
+        #     log.warning("No ThemeManager loaded yet. Skip rendering video preview widget.")
+
+        background_color = QColor("#191919")
+        painter.fillRect(event.rect(), background_color)
 
         # Find centered viewport
         viewport_rect = self.centeredViewport(self.width(), self.height())

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -49,7 +49,6 @@ from classes.query import Clip, Effect, Transition
 
 from windows.models.properties_model import PropertiesModel
 from windows.color_picker import ColorPicker
-from themes.manager import ThemeManager
 from .menu import StyledContextMenu
 
 import openshot
@@ -109,11 +108,15 @@ class PropertyDelegate(QItemDelegate):
             value_percent = 0.0
 
         # Get theme colors
-        theme = ThemeManager().get_current_theme()
-        if not theme:
-            return
-        foreground_color = theme.get_color(".property_value", "foreground-color")
-        background_color = theme.get_color(".property_value", "background-color")
+        if get_app().theme_manager:
+            theme = get_app().theme_manager.get_current_theme()
+            if not theme:
+                log.warning("No theme loaded yet. Skip rendering properties widget.")
+                return
+            foreground_color = theme.get_color(".property_value", "foreground-color")
+            background_color = theme.get_color(".property_value", "background-color")
+        else:
+            log.warning("No ThemeManager loaded yet. Skip rendering properties widget.")
 
         # set background color
         painter.setPen(QPen(Qt.NoPen))

--- a/src/windows/views/zoom_slider.py
+++ b/src/windows/views/zoom_slider.py
@@ -38,7 +38,7 @@ import openshot  # Python module for libopenshot (required video editing module 
 from classes import updates
 from classes.app import get_app
 from classes.query import Clip, Track, Transition, Marker
-from themes.manager import ThemeManager
+from classes.logger import log
 
 
 class ZoomSlider(QWidget, updates.UpdateInterface):
@@ -108,10 +108,14 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
         event.accept()
 
         # Get theme colors
-        theme = ThemeManager().get_current_theme()
-        if not theme:
-            return
-        playhead_color = theme.get_color(".zoom_slider_playhead", "background-color")
+        if get_app().theme_manager:
+            theme = get_app().theme_manager.get_current_theme()
+            if not theme:
+                log.warning("No theme loaded yet. Skip rendering zoom slider widget.")
+                return
+            playhead_color = theme.get_color(".zoom_slider_playhead", "background-color")
+        else:
+            log.warning("No ThemeManager loaded yet. Skip rendering zoom slider widget.")
 
         # Paint timeline preview on QWidget
         painter = QPainter(self)


### PR DESCRIPTION
This is a refactor of the ThemeManager, making it more thread-safe and less likely to freeze certain versions of Windows. This limits the # of times ThemeManager is imported, and maintains a single reference to the manager instance. It also removes ThemeManager access from the video widget paint method, which was directly responsible for the crash / freeze in certain versions of Windows.

The freeze would manifest itself as an issue with `oleaut32.dll` in a debugger, which was the last line logged when the freeze would occur. While I never fully found the root cause of the freeze, removing ThemeManager from the video preview widget paint method seems to resolved the issue for testers.

Closes #5549