### PR TITLE
Delay Showing Main Windows (until after Theme is applied)

### DIFF
--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -273,9 +273,6 @@ class OpenShotApp(QApplication):
         # Connect our exit signals
         self.aboutToQuit.connect(self.cleanup)
 
-        # Process any queued events
-        QApplication.processEvents()
-
         # Show main window
         self.window.show()
 

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -273,6 +273,12 @@ class OpenShotApp(QApplication):
         # Connect our exit signals
         self.aboutToQuit.connect(self.cleanup)
 
+        # Process any queued events
+        QApplication.processEvents()
+
+        # Show main window
+        self.window.show()
+
         args = self.args
         if len(args) < 2:
             # Recover backup file (this can't happen until after the Main Window has completely loaded)

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -255,13 +255,6 @@ class OpenShotApp(QApplication):
         log.debug("Creating main interface window")
         self.window = MainWindow()
 
-        # Instantiate Theme Manager (Singleton)
-        theme_name = self.settings.get("theme")
-        theme = self.theme_manager.apply_theme(theme_name)
-
-        # Update theme in settings
-        self.settings.set("theme", theme.name)
-
         # Check for gui launch failures
         if self.mode == "quit":
             self.window.close()

--- a/src/themes/base.py
+++ b/src/themes/base.py
@@ -83,9 +83,9 @@ class BaseTheme:
                         if child.objectName().startswith("dock") and child.objectName().endswith("Contents"):
                             # Set content margins on QDock* widget
                             child.setContentsMargins(*content_margins)
-                        if child.layout() and layout_margins:
-                            # Set content margins on the QDock Layout (which has additional margins)
-                            child.layout().setContentsMargins(*layout_margins)
+                            if child.layout() and layout_margins:
+                                # Set content margins on the QDock Layout (which has additional margins)
+                                child.layout().setContentsMargins(*layout_margins)
 
     def set_toolbar_buttons(self, toolbar, icon_size=24, settings=None):
         """Iterate through toolbar button settings, and apply them to each button.

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -3487,15 +3487,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Apply saved window geometry/state from settings
         if self.saved_geometry:
-            try:
-                QTimer.singleShot(0, functools.partial(self.restoreGeometry, self.saved_geometry))
-            except Exception as e:
-                log.error(f"Error restoring window geometry: {e}")
+            self.restoreGeometry(self.saved_geometry)
         if self.saved_state:
-            try:
-                QTimer.singleShot(0, functools.partial(self.restoreState, self.saved_state))
-            except Exception as e:
-                log.error(f"Error restoring window state: {e}")
+            self.restoreState(self.saved_state)
 
         # Save settings
         s.save()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -3485,6 +3485,11 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Create tutorial manager
         self.tutorial_manager = TutorialManager(self)
 
+        # Apply theme
+        theme_name = s.get("theme")
+        theme = get_app().theme_manager.apply_theme(theme_name)
+        s.set("theme", theme.name)
+
         # Apply saved window geometry/state from settings
         if self.saved_geometry:
             self.restoreGeometry(self.saved_geometry)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -3494,7 +3494,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         if self.saved_geometry:
             self.restoreGeometry(self.saved_geometry)
         if self.saved_state:
-            self.restoreState(self.saved_state)
+            QTimer.singleShot(0, functools.partial(self.restoreState, self.saved_state))
 
         # Save settings
         s.save()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -3482,21 +3482,18 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.toolBar.topLevelChanged.connect(
             functools.partial(self.freezeMainToolBar, None))
 
-        # Show window
-        self.show()
-
         # Create tutorial manager
         self.tutorial_manager = TutorialManager(self)
 
         # Apply saved window geometry/state from settings
         if self.saved_geometry:
             try:
-                QTimer.singleShot(100, functools.partial(self.restoreGeometry, self.saved_geometry))
+                QTimer.singleShot(0, functools.partial(self.restoreGeometry, self.saved_geometry))
             except Exception as e:
                 log.error(f"Error restoring window geometry: {e}")
         if self.saved_state:
             try:
-                QTimer.singleShot(100, functools.partial(self.restoreState, self.saved_state))
+                QTimer.singleShot(0, functools.partial(self.restoreState, self.saved_state))
             except Exception as e:
                 log.error(f"Error restoring window state: {e}")
 


### PR DESCRIPTION
Delay the showing of the main window until all themes are applied fully. This prevents the "popping" / rapid changing of the theme engine, which first clears any theme, and then applies the selected theme. In other words, this makes the initial launch of OpenShot smoother.