### PR TITLE
Restore geometry and window state (on Windows High DPI monitors)

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -3493,7 +3493,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Apply saved window geometry/state from settings
         if self.saved_geometry:
             self.restoreGeometry(self.saved_geometry)
+            QTimer.singleShot(0, functools.partial(self.restoreGeometry, self.saved_geometry))
         if self.saved_state:
+            self.restoreState(self.saved_state)
             QTimer.singleShot(0, functools.partial(self.restoreState, self.saved_state))
 
         # Save settings


### PR DESCRIPTION
Restore geometry and window state twice (once on creation of main windows, and once after window is shown). This fixes an issue where on Windows, Qt does not yet know about the scaling pixel ratio until the window is shown, causing the geometry to get HUGE, due to the window size increasing on each launch of OpenShot. But on other OSes (Linux, Mac), it seems to work on window creation just fine.