### PR TITLE
Detect font (and style: italics and bold) in Title Editor

### DIFF
--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -28,7 +28,7 @@
 import os
 from time import strftime
 
-VERSION = "3.2.1"
+VERSION = "3.2.1-dev"
 MINIMUM_LIBOPENSHOT_VERSION = "0.3.3"
 DATE = "20240709000000"
 NAME = "openshot-qt"


### PR DESCRIPTION
Correctly detect font family, italics, bold, and font-size when editing previous titles, so the font selector defaults correctly, and the font's don't revert back to the default font.