### PR TITLE
Prevent Gaps when Editing / Exporting / Changing Profiles

### DIFF
--- a/doc/profiles.rst
+++ b/doc/profiles.rst
@@ -61,6 +61,19 @@ Choose Profile Dialog
 4   Accept Profile      Click the :guilabel:`OK` button to switch to the selected profile.
 ==  ==================  ============
 
+Converting Profiles
+-------------------
+When switching profiles (or exporting to a different profile), OpenShot will do it's best to convert all clip,
+transition, and keyframe data to the new framerate (FPS). Certain properties, such as `position`, `start`, `end`, and `keyframes`
+will be updated to match the new framerate precision. For example, if moving from 30 FPS to 25 FPS, these properties will be changed
+from increments of 1/30 seconds to increments of 1/25 seconds. In order to preserve the overall timing accuracy of the
+timeline, OpenShot will match the `position` and `start` trim as closely as possible, and any tiny gaps (1-3 frames big)
+caused due to rounding or precision changes, will be resolved automatically by adjusting the `end` trim. This should
+result in a seamless conversion for most video projects (with no noticeable black gaps between clips).
+
+However, the destructive nature of this conversion is why we recommend always editing in your target profile, or at least your
+target FPS, in order to avoid converting between profiles as much as possible.
+
 Export Profile
 --------------
 

--- a/src/classes/convert_framerate.py
+++ b/src/classes/convert_framerate.py
@@ -1,0 +1,83 @@
+"""
+ @file
+ @brief This file converts project data from one FPS to a new FPS (adjusting precisions, trims, and positions)
+ @author Jonathan Thomas <jonathan@openshot.org>
+
+ @section LICENSE
+
+ Copyright (c) 2008-2024 OpenShot Studios, LLC
+ (http://www.openshotstudios.com). This file is part of
+ OpenShot Video Editor (http://www.openshot.org), an open-source project
+ dedicated to delivering high quality video editing and animation solutions
+ to the world.
+
+ OpenShot Video Editor is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenShot Video Editor is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
+ """
+
+
+def remove_gaps(clips, new_profile):
+    project_fps_num = new_profile.info.fps.num
+    project_fps_den = new_profile.info.fps.den
+    FRAME_DURATION = project_fps_den / project_fps_num  # Duration of one frame
+
+    # Define a tolerance in frames (e.g., 1 to 3 frames)
+    max_gap_tolerance = 3 * FRAME_DURATION
+    min_gap_tolerance = 1 / 10000  # Tiny tolerance for floating-point drift
+
+    def snap_to_new_fps_grid(time_in_seconds):
+        # Snap the time to the nearest frame boundary based on the FPS grid
+        return round(time_in_seconds / FRAME_DURATION) * FRAME_DURATION
+
+    # Sort clips by position to ensure we handle them in order
+    clips.sort(key=lambda x: x['position'])
+
+    # Iterate over the clips and adjust tiny gaps (by modifying the "end" attribute)
+    for i in range(1, len(clips)):
+        current_clip = clips[i]
+        previous_clip = clips[i - 1]
+
+        # Calculate the right edge of the previous clip
+        previous_clip_right_edge = snap_to_new_fps_grid(previous_clip['position'] + (previous_clip['end'] - previous_clip['start']))
+
+        # Calculate the gap between the current clip's position and the end of the previous clip
+        gap = current_clip['position'] - previous_clip_right_edge
+
+        # Fix tiny gaps or overlaps within the tolerance range (1-3 frames) by adjusting the "end" of the previous clip
+        if min_gap_tolerance < abs(gap) < max_gap_tolerance:
+            # Adjust the "end" of the previous clip to fill the gap
+            previous_clip['end'] += gap  # Extend the end trim by the gap size
+
+        # Ensure that the adjusted "end" is snapped to the grid
+        previous_clip['end'] = snap_to_new_fps_grid(previous_clip['end'])
+
+    return clips
+
+def change_profile(clips, new_profile):
+    """Adjust all clip-like objects to use project FPS precision, adjusting 'end' trim
+    (if needed) to close any tiny (1 to 3 frame) gaps."""
+    project_fps_num = new_profile.info.fps.num
+    project_fps_den = new_profile.info.fps.den
+
+    def snap_to_new_fps_grid(time_in_seconds):
+        frame_time = project_fps_den / project_fps_num
+        return round(time_in_seconds / frame_time) * frame_time
+
+    for clip in clips:
+        # Update position, start, and end to the new profile's FPS grid
+        clip['position'] = snap_to_new_fps_grid(clip['position'])
+        clip['start'] = snap_to_new_fps_grid(clip['start'])
+        clip['end'] = snap_to_new_fps_grid(clip['end'])
+
+    # After snapping to the new grid, remove gaps by adjusting the "end" attribute
+    return remove_gaps(clips, new_profile)

--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -67,18 +67,6 @@ class JsonDataStore:
         # Regular expression used to detect lost slashes, when repairing data
         self.slash_repair_re = re.compile(r'(["/][.]+)(/u[0-9a-fA-F]{4})')
 
-        # Connection to Qt main window, used in recovery alerts
-        app = get_app()
-        if app:
-            self.app = app
-
-        if app and app._tr:
-            self._ = app._tr
-        else:
-            def fn(arg):
-                return arg
-            self._ = fn
-
     def get(self, key):
         """ Get copied value of a given key in data store """
         key = key.lower()
@@ -376,6 +364,8 @@ class JsonDataStore:
 
     def make_repair_backup(self, file_path, jsondata, backup_dir=None):
         """ Make a backup copy of an OSP file before performing recovery """
+        app = get_app()
+        _ = app._tr
 
         if backup_dir:
             backup_base = os.path.join(backup_dir, os.path.basename(file_path))
@@ -398,10 +388,8 @@ class JsonDataStore:
             with open(backup_file, "w") as fout:
                 fout.write(jsondata)
 
-            if hasattr(self.app, "window") and hasattr(self.app.window, "statusBar"):
-                self.app.window.statusBar.showMessage(
-                    self._("Saved backup file {}").format(backup_file), 5000
-                )
+            if hasattr(app, "window") and hasattr(app.window, "statusBar"):
+                app.window.statusBar.showMessage(_("Saved backup file {}").format(backup_file), 5000)
             log.info("Backed up {} as {}".format(file_path, backup_file))
         except (PermissionError, FileExistsError) as ex:
             # Couldn't write to backup file! Try alternate location

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -394,6 +394,14 @@
     "setting": "show_finished_window"
   },
   {
+    "value": true,
+    "title": "Auto-Transition (overlap clips)",
+    "type": "bool",
+    "restart": false,
+    "category": "General",
+    "setting": "automatic_transitions"
+  },
+  {
     "max": 4,
     "title": "Hardware Decoder Mode",
     "category": "Performance",

--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -81,6 +81,7 @@
 			<div id="track-container" tl-track tl-multi-selectable style="width: {{getTimelineWidth(0) - 6}}px; padding-bottom: 2px;">
 				<!-- TRACKS -->
 				<div ng-repeat="layer in project.layers.slice().reverse()" id="track_{{layer.number}}" ng-right-click="showTimelineMenu($event, layer.number)"  class="{{getTrackStyle(layer.lock)}}" style="width:{{getTimelineWidth(0) - 6}}px;">
+					<div class="banding-overlay"></div>
 				</div>
 				
 				<!-- CLIPS -->

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -90,7 +90,7 @@ App.controller("TimelineCtrl", function ($scope) {
   // Move the playhead to a specific time
   $scope.movePlayhead = function (position_seconds) {
     // Update internal scope (in seconds)
-    $scope.project.playhead_position = position_seconds;
+    $scope.project.playhead_position = snapToFPSGridTime($scope, position_seconds);
     $scope.playheadTime = secondsToTime(position_seconds, $scope.project.fps.num, $scope.project.fps.den);
 
     // Use JQuery to move playhead (for performance reasons) - scope.apply is too expensive here
@@ -904,8 +904,9 @@ App.controller("TimelineCtrl", function ($scope) {
       // Bail out if no id found
       return;
     }
-    // Get position of item
-    var clip_position = parseFloat(bounding_box.left) / parseFloat($scope.pixelsPerSecond);
+
+    // Get position of item (snapped to FPS grid)
+    var clip_position = snapToFPSGridTime($scope, pixelToTime($scope, parseFloat(bounding_box.left)));
 
     // Get the nearest track
     var layer_num = 0;

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -1515,6 +1515,9 @@ $scope.updateLayerIndex = function () {
     // Update playhead position and time readout (reset to zero)
     $scope.movePlayhead(0.0);
 
+    // Force ruler to redraw
+    $scope.project.scale += 1/100000
+
     // Apply all changes
     $scope.$apply();
 

--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -161,11 +161,11 @@ App.directive("tlClip", function ($timeout) {
           scope.$apply(function () {
             // Apply clip scope changes
             if (scope.clip.end !== new_right) {
-              scope.clip.end = new_right;
+              scope.clip.end = snapToFPSGridTime(scope, new_right);
             }
             if (scope.clip.start !== new_left) {
-              scope.clip.start = new_left;
-              scope.clip.position = new_position;
+              scope.clip.start = snapToFPSGridTime(scope, new_left);
+              scope.clip.position = snapToFPSGridTime(scope, new_position);
             }
             // Resize timeline if it's too small to contain all clips
             scope.resizeTimeline();

--- a/src/timeline/js/directives/playhead.js
+++ b/src/timeline/js/directives/playhead.js
@@ -70,7 +70,7 @@ App.directive("tlPlayhead", function () {
           }
 
           // Move playhead
-          let playhead_seconds = new_position / scope.pixelsPerSecond;
+          let playhead_seconds = snapToFPSGridTime(scope, pixelToTime(scope, new_position));
           scope.movePlayhead(playhead_seconds);
           scope.previewFrame(playhead_seconds);
         }

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -158,10 +158,15 @@ App.directive("tlRuler", function ($timeout) {
       element.on("mousedown", function (e) {
         // Get playhead position
         var playhead_left = e.pageX - element.offset().left;
-        var playhead_seconds = playhead_left / scope.pixelsPerSecond;
+        var playhead_seconds = snapToFPSGridTime(scope, pixelToTime(scope, playhead_left));
 
         // Immediately preview frame (don't wait for animated playhead)
         scope.previewFrame(playhead_seconds);
+
+        if (playhead_seconds == scope.project.playhead_position) {
+          // No animation (playhead didn't move)
+          return;
+        }
 
         // Animate to new position (and then update scope)
         scope.playhead_animating = true;

--- a/src/timeline/js/directives/ruler.js
+++ b/src/timeline/js/directives/ruler.js
@@ -217,6 +217,78 @@ App.directive("tlRuler", function ($timeout) {
       });
 
       /**
+       * Draw frame precision alternating banding on each track (when zoomed in)
+       */
+      function updateTrackBackground() {
+          const fps = scope.project.fps.num / scope.project.fps.den;
+          const pixelsPerFrame = scope.pixelsPerSecond / fps;
+          const fpt = framesPerTick(scope.pixelsPerSecond, scope.project.fps.num, scope.project.fps.den);
+
+          // Calculate the time start and end positions
+          let timeStart = scope.scrollLeft / scope.pixelsPerSecond;
+          let timeEnd = (scope.scrollLeft + $("body").width()) / scope.pixelsPerSecond;
+
+          // Align the start time based on frames per tick
+          timeStart -= fpt > fps ? (timeStart % (fpt / Math.round(fps))) : (timeStart % 2);
+          timeEnd -= timeEnd % 1 - 1;
+
+          const startFrame = timeStart * Math.round(fps);
+          const endFrame = timeEnd * Math.round(fps);
+
+          if (fpt <= 2.0) {
+              $('.track').each(function() {
+                  const $bandingContainer = $(this).find('.banding-overlay').empty();
+                  const trackHeight = $(this).innerHeight();
+                  let frame = startFrame;
+                  let isDarkBand = true;
+
+                  while (frame <= endFrame) {
+                      const pos = (frame / fps) * scope.pixelsPerSecond;
+
+                      if (fpt === 1.0) {
+                          // When fpt == 1, alternate entire ticks as dark or transparent
+                          if (isDarkBand) {
+                              $bandingContainer.append($('<div></div>').css({
+                                  'position': 'absolute',
+                                  'left': `${pos}px`,
+                                  'width': `${pixelsPerFrame}px`,  // Full frame width for one frame
+                                  'height': '100%',
+                                  'background-color': 'rgba(0, 0, 0, 0.1)'
+                              }));
+                          }
+                          isDarkBand = !isDarkBand;  // Alternate bands
+                      } else if (fpt === 2.0) {
+                          // When fpt == 2, create two alternating dark bands per tick
+                          const bandWidth = pixelsPerFrame * fpt;
+                          $bandingContainer.append($('<div></div>').css({
+                              'position': 'absolute',
+                              'left': `${pos}px`,
+                              'width': `${bandWidth / 2}px`,  // Dark band width is half of the tick
+                              'height': '100%',
+                              'background-color': 'rgba(0, 0, 0, 0.1)'
+                          }));
+                      }
+                      frame += fpt;  // Move to the next frame
+                  }
+
+                  // Set container CSS for banding overlay
+                  $bandingContainer.css({
+                      'position': 'absolute',
+                      'top': '0',
+                      'left': '0',
+                      'height': `${trackHeight}px`,
+                      'width': '100%',
+                      'z-index': '1',
+                      'pointer-events': 'none'
+                  });
+              });
+          } else {
+              // Clear bands when not zoomed in enough
+              $('.track').find('.banding-overlay').empty();
+          }
+      }
+
+      /**
        * Draw times on the ruler
        * Always starts on a second
        * Draws to the right edge of the screen
@@ -266,11 +338,12 @@ App.directive("tlRuler", function ($timeout) {
             ruler.append(timeSpan);
           }
           ruler.append(tickSpan);
-
           frame += fpt;
         }
-        return;
-      };
+
+        // Add alternating banding to indicate frame boundaries (when zoomed in)
+        updateTrackBackground();
+      }
 
       scope.$watch("project.scale + project.duration + scrollLeft + element.width()", function (val) {
         $timeout(function () {

--- a/src/timeline/js/directives/track.js
+++ b/src/timeline/js/directives/track.js
@@ -118,12 +118,16 @@ App.directive("tlTrack", function ($timeout) {
                 position_diff = (item_left / scope.pixelsPerSecond) - item_data.position;
               }
 
-              // change the clip's track and position in the json data
               scope.$apply(function () {
-                //set track
+                //set track and position
                 item_data.layer = drop_track.number;
                 item_data.position += position_diff;
-                item_data.position = (Math.round((item_data.position * scope.project.fps.num) / scope.project.fps.den) * scope.project.fps.den ) / scope.project.fps.num;
+              });
+              scope.$apply(function () {
+                // Snap to FPS grid (must be done separately so Angular will actually refresh
+                // when extreme zooms are used (i.e. you drag a clip a partial frame, this causes it
+                // to jump back to it's original position correctly).
+                item_data.position = snapToFPSGridTime(scope, item_data.position);
               });
 
               // Resize timeline if it's too small to contain all clips
@@ -141,8 +145,6 @@ App.directive("tlTrack", function ($timeout) {
               } else if (scope.Qt && item_type === "transition") {
                 timeline.update_transition_data(JSON.stringify(item_data), true, !needs_refresh, tid);
               }
-
-
             }
           });
 

--- a/src/timeline/js/functions.js
+++ b/src/timeline/js/functions.js
@@ -327,9 +327,21 @@ function moveBoundingBox(scope, previous_x, previous_y, x_offset, y_offset, left
   bounding_box.top += y_offset;
   bounding_box.bottom += y_offset;
 
+  // Snap bounding box to FPS grid (ensure we don't land between frames)
+  const fps_num = scope.project.fps.num;
+  const fps_den = scope.project.fps.den;
+
+  // Function to snap position to nearest frame boundary
+  function snapToFPSGrid(position) {
+    return (Math.round((position * fps_num) / fps_den) * fps_den) / fps_num;
+  }
+
+  // Snap left and right bounding box positions to the FPS grid
+  bounding_box.left = snapToFPSGrid(bounding_box.left);
+  bounding_box.right = snapToFPSGrid(bounding_box.right);
+
   // Find closest nearby object, if any (for snapping)
-  var results = scope.getNearbyPosition([bounding_box.left, bounding_box.right],
-    10.0, bounding_box.selected_ids);
+  var results = scope.getNearbyPosition([bounding_box.left, bounding_box.right], 10.0, bounding_box.selected_ids);
   var nearby_offset = results[0];
   var snapline_position = results[1];
 
@@ -396,6 +408,7 @@ function moveBoundingBox(scope, previous_x, previous_y, x_offset, y_offset, left
 
   return {"position": snapping_result, "x_offset": x_offset, "y_offset": y_offset};
 }
+
 
 /**
  * Primes are used for factoring.

--- a/src/timeline/js/functions.js
+++ b/src/timeline/js/functions.js
@@ -305,6 +305,23 @@ function setBoundingBox(scope, item, item_type="clip") {
   }
 }
 
+// Convert pixel positions to time (in seconds)
+function pixelToTime(scope, pixelPosition) {
+    return pixelPosition / scope.pixelsPerSecond;  // Convert from pixel to time
+}
+
+// Function to snap time (in seconds) to the nearest frame boundary based on FPS
+function snapToFPSGridTime(scope, timePosition) {
+    const fps_num = scope.project.fps.num;
+    const fps_den = scope.project.fps.den;
+
+    // Frames per second (including fractional frame rates like 29.97)
+    const fps = fps_num / fps_den;
+
+    // Snap time to the nearest frame boundary (frames = time * fps)
+    return Math.round(timePosition * fps) / fps;
+}
+
 // Move bounding box (apply snapping and constraints)
 function moveBoundingBox(scope, previous_x, previous_y, x_offset, y_offset, left, top, item_type="clip", cursor_offset= {top: 0}) {
   let scrolling_tracks = $("#scrolling_tracks");
@@ -326,19 +343,6 @@ function moveBoundingBox(scope, previous_x, previous_y, x_offset, y_offset, left
   bounding_box.right += x_offset;
   bounding_box.top += y_offset;
   bounding_box.bottom += y_offset;
-
-  // Snap bounding box to FPS grid (ensure we don't land between frames)
-  const fps_num = scope.project.fps.num;
-  const fps_den = scope.project.fps.den;
-
-  // Function to snap position to nearest frame boundary
-  function snapToFPSGrid(position) {
-    return (Math.round((position * fps_num) / fps_den) * fps_den) / fps_num;
-  }
-
-  // Snap left and right bounding box positions to the FPS grid
-  bounding_box.left = snapToFPSGrid(bounding_box.left);
-  bounding_box.right = snapToFPSGrid(bounding_box.right);
 
   // Find closest nearby object, if any (for snapping)
   var results = scope.getNearbyPosition([bounding_box.left, bounding_box.right], 10.0, bounding_box.selected_ids);

--- a/src/timeline/media/css/main.css
+++ b/src/timeline/media/css/main.css
@@ -193,6 +193,33 @@ img {
   border-top-right-radius: 8px;
   border-bottom-right-radius: 8px;
   box-shadow: 0 0 10px #000;
+  position: relative;
+  z-index: 1;
+}
+
+.banding-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.banding-overlay div {
+  position: absolute;
+  height: 100%;
+}
+
+.track.banding-overlay::before {
+  content: '';
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  pointer-events: none;
 }
 
 /* Playhead */

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1572,7 +1572,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         closest_position = None
         for marker_position in sorted(all_marker_positions):
             # Is marker smaller than position?
-            if marker_position < current_position and (abs(marker_position - current_position) > 0.1):
+            if marker_position < current_position and (abs(marker_position - current_position) > 0.001):
                 # Is marker larger than previous marker
                 if closest_position and marker_position > closest_position:
                     # Set a new closest marker
@@ -1604,7 +1604,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         closest_position = None
         for marker_position in sorted(all_marker_positions):
             # Is marker smaller than position?
-            if marker_position > current_position and (abs(marker_position - current_position) > 0.1):
+            if marker_position > current_position and (abs(marker_position - current_position) > 0.001):
                 # Is marker larger than previous marker
                 if closest_position and marker_position < closest_position:
                     # Set a new closest marker

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2615,7 +2615,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     # Update undo and redo buttons enabled/disabled to available changes
     def updateStatusChanged(self, undo_status, redo_status):
-        log.info('updateStatusChanged')
         self.actionUndo.setEnabled(undo_status)
         self.actionRedo.setEnabled(redo_status)
         self.actionClearHistory.setEnabled(undo_status | redo_status)

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1903,21 +1903,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
             # Update timeline settings
             get_app().updates.transaction_id = tid
-            get_app().updates.update(["profile"], profile.info.description)
-            get_app().updates.update(["width"], profile.info.width)
-            get_app().updates.update(["height"], profile.info.height)
-            get_app().updates.update(["fps"], {
-                "num": profile.info.fps.num,
-                "den": profile.info.fps.den,
-                })
-            get_app().updates.update(["display_ratio"], {
-                "num": profile.info.display_ratio.num,
-                "den": profile.info.display_ratio.den,
-                })
-            get_app().updates.update(["pixel_ratio"], {
-                "num": profile.info.pixel_ratio.num,
-                "den": profile.info.pixel_ratio.den,
-                })
 
             # Update size of audio-only files
             # Used by our video transform handles (if waveforms are visible)
@@ -1939,14 +1924,14 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
             # Rescale all keyframes and reload project
             if fps_factor != 1.0:
-                # Get a copy of rescaled project data (this does not modify the active project... yet)
-                rescaled_app_data = proj.rescale_keyframes(fps_factor)
+                # Rescale keyframes (if FPS changed)
+                proj.rescale_keyframes(fps_factor)
 
-                # Apply rescaled data to active project
-                proj._data = rescaled_app_data
+                # Apply new profile (and any FPS precision updates)
+                proj.apply_profile(profile)
 
                 # Distribute all project data through update manager
-                get_app().updates.load(rescaled_app_data, reset_history=False)
+                get_app().updates.load(proj._data, reset_history=False)
 
             # Force ApplyMapperToClips to apply these changes
             self.timeline_sync.timeline.ApplyMapperToClips()

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -611,6 +611,16 @@ class PropertiesModel(updates.UpdateInterface):
                     clip_updated = True
                     try:
                         clip_data[property_key] = float(new_value)
+
+                        # Fix precision issues with time properties by snapping to FPS grid
+                        if property_key in ['position', 'start', 'end']:
+                            fps_num = get_app().project.get("fps").get("num")
+                            fps_den = get_app().project.get("fps").get("den")
+                            frame_duration = fps_den / fps_num
+
+                            # Snap the value to the nearest frame
+                            clip_data[property_key] = round(clip_data[property_key] / frame_duration) * frame_duration
+
                     except Exception:
                         log.warn('Invalid Float value passed to property', exc_info=1)
 

--- a/src/windows/views/timeline.py
+++ b/src/windows/views/timeline.py
@@ -240,6 +240,9 @@ class TimelineView(updates.UpdateInterface, ViewClass):
     # Add missing transition
     @pyqtSlot(str)
     def add_missing_transition(self, transition_json):
+        if not get_app().get_settings().get("automatic_transitions"):
+            log.debug("Skipping auto transition (disabled in settings)")
+            return
 
         transition_details = json.loads(transition_json)
 

--- a/src/windows/views/zoom_slider.py
+++ b/src/windows/views/zoom_slider.py
@@ -239,15 +239,38 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
         self.mouse_position = event.pos().x()
         self.scrollbar_position_previous = self.scrollbar_position
 
+        # Check if click is outside the current selection (scroll bar rect)
+        if not self.scroll_bar_rect.contains(event.pos()):
+            self.selection_start_pos = event.pos().x()
+            self.selection_dragging = True
+        else:
+            self.selection_dragging = False
+
     def mouseReleaseEvent(self, event):
         """Capture mouse release event"""
         event.accept()
 
+        # Handle the case where no dragging occurred (single click)
+        if not self.mouse_dragging and self.selection_dragging:
+            # Center the scroll region at the click position
+            click_pos = event.pos().x() / self.width()
+            selection_width = self.scrollbar_position[1] - self.scrollbar_position[0]
+            half_width = selection_width / 2
+            new_left_pos = max(0.0, click_pos - half_width)
+            new_right_pos = min(1.0, click_pos + half_width)
+            self.scrollbar_position = [new_left_pos, new_right_pos, self.scrollbar_position[2],
+                                       self.scrollbar_position[3]]
+            self.delayed_resize_timer.start()
+            self.update()
+
+        # Finalize drag selection
         self.mouse_pressed = False
         self.mouse_dragging = False
+        self.selection_dragging = False
         self.left_handle_dragging = False
         self.right_handle_dragging = False
         self.scroll_bar_dragging = False
+        self.update()
 
     def set_handle_limits(self, left_handle, right_handle, is_left=False):
         """Set min/max limits on the bounds of the handles (to prevent invalid values)"""
@@ -280,7 +303,8 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
         elif mouse_pos > self.width():
             mouse_pos = self.width()
 
-        # Set cursor
+        # Set cursor (based on current mouse position)
+        drag_threshold = 5
         if not self.mouse_dragging:
             if self.left_handle_rect.contains(event.pos()):
                 self.setCursor(self.cursors.get('resize_x'))
@@ -291,94 +315,111 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
             else:
                 self.setCursor(Qt.ArrowCursor)
 
-        # Detect dragging
+        # Detect dragging (only if the user clicked and started dragging beyond the threshold)
         if self.mouse_pressed and not self.mouse_dragging:
-            self.mouse_dragging = True
+                if self.left_handle_rect.contains(event.pos()):
+                    self.mouse_dragging = True
+                    self.left_handle_dragging = True
+                elif self.right_handle_rect.contains(event.pos()):
+                    self.mouse_dragging = True
+                    self.right_handle_dragging = True
+                elif self.scroll_bar_rect.contains(event.pos()):
+                    self.mouse_dragging = True
+                    self.scroll_bar_dragging = True
+                elif abs(self.mouse_position - mouse_pos) > drag_threshold:
+                    # If clicking outside the current selection, initiate drag to create a new selection
+                    self.mouse_dragging = True
+                    self.selection_dragging = True
+                    self.selection_start_pos = event.pos().x()
+                else:
+                    return
 
-            if self.left_handle_rect.contains(event.pos()):
-                self.left_handle_dragging = True
-            elif self.right_handle_rect.contains(event.pos()):
-                self.right_handle_dragging = True
-            elif self.scroll_bar_rect.contains(event.pos()):
-                self.scroll_bar_dragging = True
-            else:
-                self.setCursor(Qt.ArrowCursor)
-
-        # Dragging handle
+        # Handle dragging the selection (scroll bar dragging)
         if self.mouse_dragging:
             if self.left_handle_dragging:
-                # Update scrollbar position
+                # Dragging the left handle to resize the selection
                 delta = (self.mouse_position - mouse_pos) / self.width()
                 new_left_pos = self.scrollbar_position_previous[0] - delta
                 is_left = True
+
                 if int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0:
-                    # SHIFT key pressed (move )
-                        if (self.scrollbar_position_previous[1] + delta) - new_left_pos > self.min_distance:
-                            #both handles if we don't exceed min distance
-                            new_right_pos = self.scrollbar_position_previous[1] + delta
-                        else:
-                            midpoint = (self.scrollbar_position_previous[1] + self.scrollbar_position_previous)/2
-                            new_right_pos = midpoint + (self.min_distance/2)
-                            new_left_pos = midpoint - (self.min_distance/2)
+                    # SHIFT key pressed, move both handles
+                    if (self.scrollbar_position_previous[1] + delta) - new_left_pos > self.min_distance:
+                        new_right_pos = self.scrollbar_position_previous[1] + delta
+                    else:
+                        midpoint = (self.scrollbar_position_previous[1] + self.scrollbar_position_previous[0]) / 2
+                        new_right_pos = midpoint + (self.min_distance / 2)
+                        new_left_pos = midpoint - (self.min_distance / 2)
                 else:
                     new_right_pos = self.scrollbar_position_previous[1]
 
                 # Enforce limits (don't allow handles to go past each other, or out of bounds)
                 new_left_pos, new_right_pos = self.set_handle_limits(new_left_pos, new_right_pos, is_left)
 
-                self.scrollbar_position = [new_left_pos,
-                                           new_right_pos,
-                                           self.scrollbar_position[2],
+                self.scrollbar_position = [new_left_pos, new_right_pos, self.scrollbar_position[2],
                                            self.scrollbar_position[3]]
                 self.delayed_resize_timer.start()
 
             elif self.right_handle_dragging:
+                # Dragging the right handle to resize the selection
                 delta = (self.mouse_position - mouse_pos) / self.width()
-                is_left = False
                 new_right_pos = self.scrollbar_position_previous[1] - delta
+                is_left = False
+
                 if int(QCoreApplication.instance().keyboardModifiers() & Qt.ShiftModifier) > 0:
-                    # SHIFT key pressed (move )
-                        if new_right_pos - (self.scrollbar_position_previous[0] + delta) > self.min_distance:
-                            #both handles if we don't exceed min distance
-                            new_left_pos = self.scrollbar_position_previous[0] + delta
-                        else:
-                            midpoint = (self.scrollbar_position_previous[1] + self.scrollbar_position_previous)/2
-                            new_right_pos = midpoint + (self.min_distance/2)
-                            new_left_pos = midpoint - (self.min_distance/2)
+                    # SHIFT key pressed, move both handles
+                    if new_right_pos - (self.scrollbar_position_previous[0] + delta) > self.min_distance:
+                        new_left_pos = self.scrollbar_position_previous[0] + delta
+                    else:
+                        midpoint = (self.scrollbar_position_previous[1] + self.scrollbar_position_previous[0]) / 2
+                        new_right_pos = midpoint + (self.min_distance / 2)
+                        new_left_pos = midpoint - (self.min_distance / 2)
                 else:
                     new_left_pos = self.scrollbar_position_previous[0]
 
-                # Enforce limits (don't allow handles to go past each other, or out of bounds)
+                # Enforce limits
                 new_left_pos, new_right_pos = self.set_handle_limits(new_left_pos, new_right_pos, is_left)
 
-                self.scrollbar_position = [new_left_pos,
-                                           new_right_pos,
-                                           self.scrollbar_position[2],
+                self.scrollbar_position = [new_left_pos, new_right_pos, self.scrollbar_position[2],
                                            self.scrollbar_position[3]]
                 self.delayed_resize_timer.start()
 
             elif self.scroll_bar_dragging:
-                # Update scrollbar position
+                # Dragging the entire selection (scrolling the timeline)
                 delta = (self.mouse_position - mouse_pos) / self.width()
                 new_left_pos = self.scrollbar_position_previous[0] - delta
                 new_right_pos = self.scrollbar_position_previous[1] - delta
 
-                # Enforce limits (don't allow handles to go past each other, or out of bounds)
+                # Enforce limits
                 new_left_pos, new_right_pos = self.set_handle_limits(new_left_pos, new_right_pos)
 
-                self.scrollbar_position = [new_left_pos,
-                                           new_right_pos,
-                                           self.scrollbar_position[2],
+                self.scrollbar_position = [new_left_pos, new_right_pos, self.scrollbar_position[2],
                                            self.scrollbar_position[3]]
-
-                # Emit signal to scroll Timeline
                 get_app().window.TimelineScroll.emit(new_left_pos)
 
-            # Force re-paint
-            self.update()
+            elif self.selection_dragging:
+                # Handle creating a new selection region
+                new_pos = mouse_pos / self.width()
 
-        # Update mouse position
-        # self.mouse_position = mouse_pos
+                if self.selection_start_pos < mouse_pos:
+                    # Dragging to the right: set both handles to the starting position,
+                    # then move the right handle (left handle stays where the drag started)
+                    new_left_pos = self.selection_start_pos / self.width()
+                    new_right_pos = new_pos
+                else:
+                    # Dragging to the left: set both handles to the starting position,
+                    # then move the left handle (right handle stays where the drag started)
+                    new_right_pos = self.selection_start_pos / self.width()
+                    new_left_pos = new_pos
+
+                # Enforce limits for the new selection
+                new_left_pos, new_right_pos = self.set_handle_limits(new_left_pos, new_right_pos)
+                self.scrollbar_position = [new_left_pos, new_right_pos, self.scrollbar_position[2],
+                                           self.scrollbar_position[3]]
+                self.delayed_resize_timer.start()
+
+            # Force re-paint after any dragging
+            self.update()
 
     def resizeEvent(self, event):
         """Widget resize event"""
@@ -514,7 +555,7 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
         self.marker_rects = []
         self.current_frame = 0
         self.is_auto_center = True
-        self.min_distance = 0.02
+        self.min_distance = 0.002
 
         # Load icon (using display DPI)
         self.cursors = {}


### PR DESCRIPTION
This is a pretty major change to OpenShot, and is attempting to solve a really big "precision" issue when editing clips and transitions in a specific profile FPS (framerate). We want to ensure that **ALL** clip **position**, **start**, and **end** values are snapped to the current profile's FPS grid / precision. Another way of saying this, we want all of the key position values to land exactly on a real frame, and NEVER between frames. So if we are editing a 30 FPS video project, all our our position, start, and end values much be in increments of 1/30 of a second.

When changing profiles and/or exporting to a different FPS profile, we need to ensure that ALL clips and transitions are converted to this new FPS precision also. The challenge of this, some FPS changes cause unavoidable gaps between clips (+ or - 1 to 3 frames) depending on the change. We want to avoid "random black" gaps on our timeline, so when we change FPS in OpenShot, we are now removing TINY gaps that might have been caused by the FPS change (1 to 3 frames).

Since there are 3 ways to remove a gap (position, start trim, or end trim), we have decided to only adjust the "end" trim, since this method maintains and protects the original timing and start positions of all clips. This might even extend the end trim past the duration of a video clip, which will simply repeat the last frame or two. While some edge cases caused by this are not ideal, it's the most reasonable way we can think of to adapt an entire timeline of edits in a different FPS precision, without loosing the original timing or the original start trim of clips.

**Snapping Changes:**
- Moving clips / transitions on the timeline now snaps to accurate frame positions
- Resizing clips / transitions on the timeline now snaps to accurate frame positions
- Manual Property Editing: position, start, end now snaps to accurate frame positions
- Changing Profiles: updates ALL position, start, and end values to be accurate frame positions - and then removes any 1 to 3 frame gaps detected
- Exporting to a different profile FPS: updates ALL position, start, and end values to be accurate frame positions - and then removes any 1 to 3 frame gaps detected