### PR TITLE
generate_translations.py: Fix invalid escape sequences

### DIFF
--- a/src/language/generate_translations.py
+++ b/src/language/generate_translations.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-"""
+r"""
  @file
  @brief This file updates the OpenShot.POT (language translation template) by scanning all source files.
  @author Jonathan Thomas <jonathan@openshot.org>
@@ -103,7 +103,7 @@ log.info(" Using xgettext to generate .py POT files")
 log.info("-----------------------------------------------------")
 
 # Generate POT for Source Code strings (i.e. strings marked with a _("translate me"))
-subprocess.call('find %s -iname "*.py" -exec xgettext -j -o %s --keyword=_ {} \;' % (
+subprocess.call(r'find %s -iname "*.py" -exec xgettext -j -o %s --keyword=_ {} \;' % (
 openshot_path, os.path.join(language_folder_path, 'OpenShot_source.pot')), shell=True)
 
 log.info("-----------------------------------------------------")


### PR DESCRIPTION
Invalid escape sequence `\;` is used in two places in the `src/language/generate_translations.py` file. This results in the following warnings appearing when someone tries to bytecompile Python (which is done automatically by some package managers):

```
./usr/lib/python3.12/site-packages/openshot_qt/language/generate_translations.py:2: SyntaxWarning: invalid escape sequence '\;'
  """
./usr/lib/python3.12/site-packages/openshot_qt/language/generate_translations.py:106: SyntaxWarning: invalid escape sequence '\;'
  subprocess.call('find %s -iname "*.py" -exec xgettext -j -o %s --keyword=_ {} \;' % (
```

This PR fixes this problem with `r""` string literals.

This warning appears only in newer versions of Python.