### PR TITLE
Fixing #5616 - NEEDS LOCAL TESTING - (Read description) - ColorPicker Select Screen Color 

### DIFF
--- a/src/windows/color_picker.py
+++ b/src/windows/color_picker.py
@@ -41,6 +41,7 @@ class ColorPicker(QWidget):
         super().__init__(parent=parent, *args, **kwargs)
         self.setObjectName("ColorPicker")
         # Merge any additional user-supplied options with our own
+        options = QColorDialog.ColorDialogOptions()
         if extra_options > 0:
             options = options | extra_options
         # Set up non-modal color dialog (to avoid blocking the eyedropper)
@@ -52,6 +53,7 @@ class ColorPicker(QWidget):
         if title:
             self.dialog.setWindowTitle(title)
         self.dialog.setWindowFlags(Qt.Tool)
+        self.dialog.setOptions(options)
         # Avoid signal loops
         self.dialog.blockSignals(True)
         self.dialog.colorSelected.connect(callback)

--- a/src/windows/color_picker.py
+++ b/src/windows/color_picker.py
@@ -41,7 +41,6 @@ class ColorPicker(QWidget):
         super().__init__(parent=parent, *args, **kwargs)
         self.setObjectName("ColorPicker")
         # Merge any additional user-supplied options with our own
-        options = QColorDialog.DontUseNativeDialog
         if extra_options > 0:
             options = options | extra_options
         # Set up non-modal color dialog (to avoid blocking the eyedropper)
@@ -53,7 +52,6 @@ class ColorPicker(QWidget):
         if title:
             self.dialog.setWindowTitle(title)
         self.dialog.setWindowFlags(Qt.Tool)
-        self.dialog.setOptions(options)
         # Avoid signal loops
         self.dialog.blockSignals(True)
         self.dialog.colorSelected.connect(callback)


### PR DESCRIPTION
The fix is simple, and removes the `DontUseNativeDialog` option from the color_picker.py file. This results in the program using the native pop-up color picker. I am running Ubuntu 24.04.1 and the colorpicker looks like this:
![image](https://github.com/user-attachments/assets/f0b1110a-656f-4d8c-86e1-cc98c1e7a10a)
Once you press the `+` button, the pop-up changes to one where you can use the eyedropper tool.
![image](https://github.com/user-attachments/assets/00b0b5e2-d9e6-422e-8861-7d6af8d950d7)

I have a feeling that using the native pop-up color picker might not be the most desirable solution, but it does work better than the current option.
