### PR TITLE
Select + Scroll to Imported Files

### DIFF
--- a/doc/files.rst
+++ b/doc/files.rst
@@ -37,7 +37,9 @@ You can also toggle the view between :guilabel:`details` and :guilabel:`thumbnai
 
 Import Files
 ------------
-These are all possible methods to import media files into OpenShot:
+There are many different ways to import media files into an OpenShot project. When a file is imported successfully,
+it will be automatically selected and scrolled into view (in the **Project Files** panel). Also, if the **Project Files** panel
+is not currently visible, OpenShot will automatically display the panel.
 
 .. table::
    :widths: 25 80

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -278,7 +278,7 @@ class FilesModel(QObject, updates.UpdateInterface):
         # Make sure we're working with a list of files
         if not isinstance(files, (list, tuple)):
             files = [files]
-        new_file_objects = []
+        scroll_to_files = []
 
         start_count = len(files)
         for count, filepath in enumerate(files):
@@ -289,6 +289,8 @@ class FilesModel(QObject, updates.UpdateInterface):
 
             # If this file is already found, exit
             if new_file:
+                # Still add the file (to be selected and scrolled to)
+                scroll_to_files.append(new_file)
                 del new_file
                 continue
 
@@ -369,7 +371,7 @@ class FilesModel(QObject, updates.UpdateInterface):
 
                 # Save file
                 new_file.save()
-                new_file_objects.append(new_file)
+                scroll_to_files.append(new_file)
 
                 if start_count > 15:
                     message = _("Importing %(count)d / %(total)d") % {
@@ -397,7 +399,7 @@ class FilesModel(QObject, updates.UpdateInterface):
 
         # Select all new files (clear previous selection)
         self.selection_model.clearSelection()
-        for file_object in new_file_objects:
+        for file_object in scroll_to_files:
             # Get the index of the newly added file in the proxy model
             index = self.proxy_model.get_file_index(file_object.id)
             if index.isValid():


### PR DESCRIPTION
When new files are imported into OpenShot, it can be difficult to find the file (in Project Files list) on large projects with many, many files. Thus, OpenShot should automatically select all newly imported files, and scroll to them (centering them in the file view, if possible). Also, if a file is skipped during import because it already exists in the project, we should still select and scroll to it… making it easy for the user to find the file.

![image](https://github.com/user-attachments/assets/76d4ea8f-bec2-4e23-a024-5aad6748e442)
