### PR TITLE
Multi-Drop Improvements

### DIFF
--- a/doc/clips.rst
+++ b/doc/clips.rst
@@ -107,11 +107,10 @@ Here is a list of all methods for selecting clips in OpenShot:
    Selection Method                          Description
    =======================================   ================================================================
    **Box Selection**                         Click and drag a selection box around clips or transitions to select multiple items at once. Hold down :kbd:`Ctrl` to add to your current selection.
-   **Mouse Click**                           Click on a clip or transition to select it. This will deselect all other items unless you hold down :kbd:`Ctrl`.
-   **Ctrl + Click**                          Hold down :kbd:`Ctrl` while clicking to add or remove clips from the current selection, allowing you to select non-adjacent clips.
-   **Shift + Click**                         Hold down :kbd:`Shift` while clicking to ripple select all clips/transitions from your selection to the end of the track.
-   **Ctrl + Shift + Click**                  Hold down both :kbd:`Ctrl` and :kbd:`Shift` to ripple select clips/transitions and add them to the current selection, allowing you to extend the selection.
-   **Click on Timeline**                     Clicking anywhere on the timeline, or on a new clip/transition, will reset the current selection unless :kbd:`Ctrl` is pressed.
+   **Click Selection**                       Click on a clip or transition to select it. This will deselect all other items unless you hold down :kbd:`Ctrl`.
+   **Add to Selection**                      Hold down :kbd:`Ctrl` while clicking to add or remove clips from the current selection, allowing you to select non-adjacent clips.
+   **Ripple Selection**                      Hold down :kbd:`Alt` while clicking to ripple select all clips/transitions from your selection to the end of the track. This always adds to your current selection, even if :kbd:`Ctrl` is not pressed.
+   **Clear Selection**                       Click anywhere on the timeline or on a new clip/transition to reset the current selection, unless :kbd:`Ctrl` is pressed.
    **Select All**                            Press :kbd:`Ctrl+A` to select all clips and transitions on the timeline.
    **Select None**                           Press :kbd:`Ctrl+Shift+A` to deselect all clips and transitions on the timeline.
    =======================================   ================================================================

--- a/doc/clips.rst
+++ b/doc/clips.rst
@@ -109,6 +109,7 @@ Here is a list of all methods for selecting clips in OpenShot:
    **Box Selection**                         Click and drag a selection box around clips or transitions to select multiple items at once. Hold down :kbd:`Ctrl` to add to your current selection.
    **Click Selection**                       Click on a clip or transition to select it. This will deselect all other items unless you hold down :kbd:`Ctrl`.
    **Add to Selection**                      Hold down :kbd:`Ctrl` while clicking to add or remove clips from the current selection, allowing you to select non-adjacent clips.
+   **Range Selection**                       Hold down :kbd:`Shift` while clicking to select a range of clips/transitions from the previous selection to the new selection. This supports ranges that span multiple tracks as well.
    **Ripple Selection**                      Hold down :kbd:`Alt` while clicking to ripple select all clips/transitions from your selection to the end of the track. This always adds to your current selection, even if :kbd:`Ctrl` is not pressed.
    **Clear Selection**                       Click anywhere on the timeline or on a new clip/transition to reset the current selection, unless :kbd:`Ctrl` is pressed.
    **Select All**                            Press :kbd:`Ctrl+A` to select all clips and transitions on the timeline.

--- a/doc/clips.rst
+++ b/doc/clips.rst
@@ -75,7 +75,7 @@ Here is a list of all methods for cutting and/or trimming clips in OpenShot:
    =======================================   ================================================================
    Trim & Slice Method                       Description
    =======================================   ================================================================
-   **Resizing Edge**                         Mouse over the edge of a clip and resize it by dragging left or right.
+   **Resizing Edge**                         Mouse over the edge of a clip and resize it by dragging **left** or **right**. The left edge of a clip can not be resized smaller than 0.0 (*i.e. the first frame of the file*). The right edge of a clip can not be resized larger than the duration of a file (*i.e. the last frame of a file*).
    **Slice All**                             When the play-head overlaps multiple clips, right-click the play-head and choose :guilabel:`Slice All`.
                                              This will cut/slice all intersecting clips on all tracks. You can also use the keyboard shortcuts
                                              :kbd:`Ctrl+Shift+K` to keep both sides, :kbd:`Ctrl+Shift+J` to keep the left side, or :kbd:`Ctrl+Shift+L`

--- a/doc/main_window.rst
+++ b/doc/main_window.rst
@@ -177,7 +177,7 @@ Save Current Frame                    :kbd:`Ctrl+Shift+Y`
 Save Project                          :kbd:`Ctrl+S`
 Save Project As...                    :kbd:`Ctrl+Shift+S`
 Select All                            :kbd:`Ctrl+A`
-Select Item (Ripple)                  :kbd:`Shift+A`            :kbd:`Shift+Click`
+Select Item (Ripple)                  :kbd:`Alt+A`              :kbd:`Alt+Click`
 Select None                           :kbd:`Ctrl+Shift+A`
 Show All Docks                        :kbd:`Ctrl+Shift+D`
 Simple View                           :kbd:`Alt+Shift+0`

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -1203,7 +1203,7 @@
     "title": "Select Item (Ripple)",
     "restart": false,
     "setting": "actionRippleSelect",
-    "value": "Shift+A",
+    "value": "Alt+A",
     "type": "text"
   },
   {

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -1103,52 +1103,52 @@ $scope.startManualMove = function (item_type, item_ids) {
     }
   });
 
-  // Prepare to store clip positions
-  var scrolling_tracks = $("#scrolling_tracks");
-  var vert_scroll_offset = scrolling_tracks.scrollTop();
-  var horz_scroll_offset = scrolling_tracks.scrollLeft();
+  // Delay to allow the DOM to update
+  setTimeout(function() {
+    // Prepare to store clip positions
+    var scrolling_tracks = $("#scrolling_tracks");
+    var vert_scroll_offset = scrolling_tracks.scrollTop();
+    var horz_scroll_offset = scrolling_tracks.scrollLeft();
 
-  // Init bounding box
-  bounding_box = {};
+    // Init bounding box
+    bounding_box = {};
 
-  // Set bounding box that contains all selected clips/transitions
-  var selectedClips = $(".ui-selected");
-  selectedClips.each(function () {
-    // Send each selected clip or transition to the bounding box builder
-    setBoundingBox($scope, $(this)); // Pass the element and scope to setBoundingBox
-  });
+    // Set bounding box that contains all selected clips/transitions
+    var selectedClips = $(".ui-selected");
+    selectedClips.each(function () {
+      setBoundingBox($scope, $(this));
+    });
 
-  // After calling setBoundingBox, now initialize the start_clips and move_clips
-  bounding_box.start_clips = {};
-  bounding_box.move_clips = {};
+    // Initialize start_clips and move_clips properties
+    bounding_box.start_clips = {};
+    bounding_box.move_clips = {};
 
-  // Iterate again to set start_clips and move_clips properties
-  selectedClips.each(function () {
-    var element_id = $(this).attr("id");
+    // Iterate again to set start_clips and move_clips properties
+    selectedClips.each(function () {
+      var element_id = $(this).attr("id");
+      bounding_box.start_clips[element_id] = {
+        "top": $(this).position().top + vert_scroll_offset,
+        "left": $(this).position().left + horz_scroll_offset
+      };
+      bounding_box.move_clips[element_id] = {
+        "top": $(this).position().top + vert_scroll_offset,
+        "left": $(this).position().left + horz_scroll_offset
+      };
+    });
 
-    // Store initial positions after setBoundingBox is called
-    bounding_box.start_clips[element_id] = {
-      "top": $(this).position().top + vert_scroll_offset,
-      "left": $(this).position().left + horz_scroll_offset
-    };
-    bounding_box.move_clips[element_id] = {
-      "top": $(this).position().top + vert_scroll_offset,
-      "left": $(this).position().left + horz_scroll_offset
-    };
-  });
+    // Set some additional properties
+    bounding_box.previous_x = bounding_box.left;
+    bounding_box.previous_y = bounding_box.top;
+    bounding_box.offset_x = 0;
+    bounding_box.offset_y = 0;
+    bounding_box.elements = selectedClips;
+    bounding_box.track_position = 0;
 
-  // Init some variables to track the changing position
-  bounding_box.previous_x = bounding_box.left;
-  bounding_box.previous_y = bounding_box.top;
-  bounding_box.offset_x = 0;
-  bounding_box.offset_y = 0;
-  bounding_box.elements = selectedClips;
-  bounding_box.track_position = 0;
-
-  // Set z-order to be above other clips/transitions
-  selectedClips.each(function () {
-    $(this).addClass("manual-move");
-  });
+    // Set z-order to be above other clips/transitions
+    selectedClips.each(function () {
+      $(this).addClass("manual-move");
+    });
+  }, 0);
 };
 
 $scope.moveItem = function (x, y) {

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -578,6 +578,9 @@ App.controller("TimelineCtrl", function ($scope) {
     });
   };
 
+  // Initialize last selected item
+  $scope.lastSelectedItem = null;
+
   // Select item (either clip or transition)
   $scope.selectItem = function (item_id, item_type, clear_selections, event, force_ripple) {
     // Trim item_id
@@ -586,16 +589,16 @@ App.controller("TimelineCtrl", function ($scope) {
     // Check for modifier keys
     var is_ctrl = event && event.ctrlKey;
     var is_shift = event && event.shiftKey;
+    var is_alt = event && event.altKey;
 
     // If no ID is provided (id == ""), unselect all items
     if (id === "") {
       if (clear_selections) {
-        // Unselect all clips
+        // Unselect all clips and transitions
         $scope.project.clips.forEach(function (clip) {
           clip.selected = false;
           if ($scope.Qt) { timeline.removeSelection(clip.id, "clip"); }
         });
-        // Unselect all transitions
         $scope.project.effects.forEach(function (transition) {
           transition.selected = false;
           if ($scope.Qt) { timeline.removeSelection(transition.id, "transition"); }
@@ -611,26 +614,9 @@ App.controller("TimelineCtrl", function ($scope) {
       return; // Don't select if razor mode is enabled
     }
 
-    // Clear all selections if necessary (no CTRL modifier)
-    if (clear_selections && !is_ctrl) {
-      // Unselect all clips
-      $scope.project.clips.forEach(function (clip) {
-        clip.selected = false;
-        if ($scope.Qt) { timeline.removeSelection(clip.id, "clip"); }
-      });
-      // Unselect all transitions
-      $scope.project.effects.forEach(function (transition) {
-        transition.selected = false;
-        if ($scope.Qt) { timeline.removeSelection(transition.id, "transition"); }
-      });
-    }
-
-    // Get the correct array based on item_type
-    var items = item_type === "clip" ? $scope.project.clips : $scope.project.effects;
-
-    // Handle ripple selection (SHIFT key) for both clips and transitions
-    if (is_shift || force_ripple) {
-      var selected_item = items.find(item => item.id === id);
+    // Handle ripple selection (ALT key) for both clips and transitions
+    if (is_alt || force_ripple) {
+      var selected_item = (item_type === "clip" ? $scope.project.clips : $scope.project.effects).find(item => item.id === id);
       if (selected_item) {
         var selected_layer = selected_item.layer;
         var selected_position = selected_item.position;
@@ -649,22 +635,104 @@ App.controller("TimelineCtrl", function ($scope) {
           }
         });
       }
+
+      // If CTRL is not pressed, clear previous selections (unless clear_selections is false)
+      if (clear_selections && !is_ctrl) {
+        $scope.project.clips.forEach(function (clip) {
+          if (!clip.selected) {
+            if ($scope.Qt) { timeline.removeSelection(clip.id, "clip"); }
+          }
+        });
+        $scope.project.effects.forEach(function (transition) {
+          if (!transition.selected) {
+            if ($scope.Qt) { timeline.removeSelection(transition.id, "transition"); }
+          }
+        });
+      }
+
+      // Do not update lastSelectedItem when ALT is pressed
       return; // No need to do normal selection logic after ripple select
     }
 
-    // Update selection for clips or transitions
-    for (var i = 0; i < items.length; i++) {
-      var item = items[i];
-      if (item.id === id) {
+    // Handle SHIFT + Click selection (for both clips and transitions)
+    if (is_shift && $scope.lastSelectedItem) {
+      // If CTRL is not pressed, clear previous selections (unless clear_selections is false)
+      if (clear_selections && !is_ctrl) {
+        $scope.project.clips.forEach(function (clip) {
+          clip.selected = false;
+          if ($scope.Qt) { timeline.removeSelection(clip.id, "clip"); }
+        });
+        $scope.project.effects.forEach(function (transition) {
+          transition.selected = false;
+          if ($scope.Qt) { timeline.removeSelection(transition.id, "transition"); }
+        });
+      }
+
+      // Get the selected item
+      var selectedItem = (item_type === "clip" ? $scope.project.clips : $scope.project.effects).find(item => item.id === id);
+
+      if (selectedItem && $scope.lastSelectedItem) {
+        // Get the start (left edge) and end (right edge) of both selected items
+        var selectedItemStart = selectedItem.position;
+        var selectedItemEnd = selectedItem.position + (selectedItem.end - selectedItem.start);
+        var lastSelectedItemStart = $scope.lastSelectedItem.position;
+        var lastSelectedItemEnd = $scope.lastSelectedItem.position + ($scope.lastSelectedItem.end - $scope.lastSelectedItem.start);
+
+        // Calculate the proper selection range based on the leftmost and rightmost edges
+        var minPosition = Math.min(selectedItemStart, lastSelectedItemStart);
+        var maxPosition = Math.max(selectedItemEnd, lastSelectedItemEnd);
+        var minLayer = Math.min($scope.lastSelectedItem.layer, selectedItem.layer);
+        var maxLayer = Math.max($scope.lastSelectedItem.layer, selectedItem.layer);
+
+        // Select all clips and transitions that fall completely within the range
+        $scope.project.clips.forEach(function (clip) {
+          var clipEnd = clip.position + (clip.end - clip.start);
+          if (clip.position >= minPosition && clipEnd <= maxPosition &&
+              clip.layer >= minLayer && clip.layer <= maxLayer) {
+            clip.selected = true;
+            if ($scope.Qt) { timeline.addSelection(clip.id, "clip", false); }
+          }
+        });
+
+        $scope.project.effects.forEach(function (transition) {
+          var transitionEnd = transition.position + (transition.end - transition.start);
+          if (transition.position >= minPosition && transitionEnd <= maxPosition &&
+              transition.layer >= minLayer && transition.layer <= maxLayer) {
+            transition.selected = true;
+            if ($scope.Qt) { timeline.addSelection(transition.id, "transition", false); }
+          }
+        });
+      }
+    } else {
+      // Clear selections if necessary (and not CTRL)
+      if (clear_selections && !is_ctrl) {
+        $scope.project.clips.forEach(function (clip) {
+          clip.selected = false;
+          if ($scope.Qt) { timeline.removeSelection(clip.id, "clip"); }
+        });
+        $scope.project.effects.forEach(function (transition) {
+          transition.selected = false;
+          if ($scope.Qt) { timeline.removeSelection(transition.id, "transition"); }
+        });
+      }
+
+      // Update selection for the clicked item (either clip or transition)
+      var item = (item_type === "clip" ? $scope.project.clips : $scope.project.effects).find(item => item.id === id);
+      if (item) {
         // Invert selection if CTRL is pressed and item is already selected
         if (is_ctrl && clear_selections && item.selected) {
           item.selected = false;
           if ($scope.Qt) { timeline.removeSelection(item.id, item_type); }
         } else {
           item.selected = true;
-          if ($scope.Qt) { timeline.addSelection(item.id, item_type, !is_ctrl && clear_selections); }
+          if ($scope.Qt) { timeline.addSelection(item.id, item_type, false); }
         }
       }
+    }
+
+    // Update last selected item (do not update if ALT is pressed)
+    if (!is_alt) {
+      $scope.lastSelectedItem = (item_type === "clip" ? $scope.project.clips : $scope.project.effects).find(item => item.id === id);
     }
   };
 

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -1146,11 +1146,9 @@ $scope.startManualMove = function (item_type, item_ids) {
   bounding_box.track_position = 0;
 
   // Set z-order to be above other clips/transitions
-  if (item_type !== "os_drop") {
-    selectedClips.each(function () {
-      $(this).addClass("manual-move");
-    });
-  }
+  selectedClips.each(function () {
+    $(this).addClass("manual-move");
+  });
 };
 
 $scope.moveItem = function (x, y) {

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -3186,7 +3186,13 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def selectAll(self):
         """Select all clips and transitions"""
-        self.timeline.SelectAll()
+        # Check if filesView has focus
+        if self.filesView.hasFocus():
+            # Select all files
+            self.filesView.selectAll()
+        else:
+            # Select all clips / transitions
+            self.timeline.SelectAll()
 
     def selectNone(self):
         """Clear all selections for clips and transitions"""

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1119,13 +1119,18 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         player = self.preview_thread.player
         current_speed = player.Speed()
 
+        min_frame = 1
+        if self.preview_thread and self.preview_thread.timeline:
+            min_frame = self.preview_thread.timeline.GetMinFrame()
+
         # Switch speed back to forward (and then pause)
         # This will allow video caching to start working in the forward direction
         self.SpeedSignal.emit(1)
         self.SpeedSignal.emit(0)
 
         # Seek to the 1st frame
-        self.SeekSignal.emit(1)
+        self.SeekSignal.emit(min_frame)
+        QTimer.singleShot(50, self.actionCenterOnPlayhead_trigger)
 
         # If playing, continue playing
         if current_speed >= 0:
@@ -1140,6 +1145,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Determine last frame (based on clips) & seek there
         max_frame = get_app().window.timeline_sync.timeline.GetMaxFrame()
         self.SeekSignal.emit(max_frame)
+        QTimer.singleShot(50, self.actionCenterOnPlayhead_trigger)
 
     def onPlayCallback(self):
         """Handle when playback is started"""

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -31,6 +31,7 @@ import json
 import re
 import glob
 import functools
+import uuid
 
 from PyQt5.QtCore import (
     QMimeData, Qt, pyqtSignal, QEventLoop, QObject,
@@ -487,6 +488,10 @@ class FilesModel(QObject, updates.UpdateInterface):
         import_quietly = False
         media_paths = []
 
+        # Transaction
+        tid = str(uuid.uuid4())
+        get_app().updates.transaction_id = tid
+
         for uri in qurl_list:
             filepath = uri.toLocalFile()
             if not os.path.exists(filepath):
@@ -512,6 +517,7 @@ class FilesModel(QObject, updates.UpdateInterface):
         media_paths.sort()
         log.debug("Importing file list: {}".format(media_paths))
         self.add_files(media_paths, quiet=import_quietly)
+        get_app().updates.transaction_id = None
 
     def update_file_thumbnail(self, file_id):
         """Update/re-generate the thumbnail of a specific file"""

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -483,9 +483,8 @@ class FilesModel(QObject, updates.UpdateInterface):
         }
         return parameters
 
-    def process_urls(self, qurl_list):
+    def process_urls(self, qurl_list, import_quietly=False, prevent_image_seq=False):
         """Recursively process QUrls from a QDropEvent"""
-        import_quietly = False
         media_paths = []
 
         # Transaction
@@ -516,7 +515,7 @@ class FilesModel(QObject, updates.UpdateInterface):
         # Import all new media files
         media_paths.sort()
         log.debug("Importing file list: {}".format(media_paths))
-        self.add_files(media_paths, quiet=import_quietly)
+        self.add_files(media_paths, quiet=import_quietly, prevent_image_seq=prevent_image_seq)
         get_app().updates.transaction_id = None
 
     def update_file_thumbnail(self, file_id):

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -93,14 +93,18 @@ class FilesTreeView(QTreeView):
         menu.popup(event.globalPos())
 
     def mouseDoubleClickEvent(self, event):
-        super(FilesTreeView, self).mouseDoubleClickEvent(event)
-        # Preview File, File Properties, or Split File (depending on Shift/Ctrl)
-        if int(get_app().keyboardModifiers() & Qt.ShiftModifier) > 0:
-            get_app().window.actionSplitFile.trigger()
-        elif int(get_app().keyboardModifiers() & Qt.ControlModifier) > 0:
-            get_app().window.actionFile_Properties.trigger()
+        # Get the index of the item at the click position
+        index = self.indexAt(event.pos())
+        if index.column() == 0:
+            # If column 0 (thumbnail) is double-clicked, trigger the custom actions
+            if int(get_app().keyboardModifiers() & Qt.ShiftModifier) > 0:
+                get_app().window.actionSplitFile.trigger()
+            elif int(get_app().keyboardModifiers() & Qt.ControlModifier) > 0:
+                get_app().window.actionFile_Properties.trigger()
+            else:
+                get_app().window.actionPreview_File.trigger()
         else:
-            get_app().window.actionPreview_File.trigger()
+            super(FilesTreeView, self).mouseDoubleClickEvent(event)
 
     def dragEnterEvent(self, event):
         # If dragging urls onto widget, accept

--- a/src/windows/views/timeline.py
+++ b/src/windows/views/timeline.py
@@ -3022,7 +3022,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
             urls = event.mimeData().urls()
 
             # Import list of files
-            get_app().window.files_model.process_urls(urls)
+            get_app().window.files_model.process_urls(urls, import_quietly=True, prevent_image_seq=True)
 
             # Get File objects and add JSON data
             for uri in urls:

--- a/src/windows/views/timeline.py
+++ b/src/windows/views/timeline.py
@@ -3082,8 +3082,6 @@ class TimelineView(updates.UpdateInterface, ViewClass):
                 if new_item:
                     pos += QPointF(new_item["end"] - new_item["start"], 0)
 
-            get_app().updates.transaction_id = None
-
         # Get JS position and pass initial position to the callback
         self.run_js(JS_SCOPE_SELECTOR + ".getJavaScriptPosition({}, {});"
                     .format(initial_pos.x(), initial_pos.y()), partial(handle_js_position, initial_pos))

--- a/src/windows/views/timeline.py
+++ b/src/windows/views/timeline.py
@@ -3001,13 +3001,12 @@ class TimelineView(updates.UpdateInterface, ViewClass):
 
     # An item is being dragged onto the timeline (mouse is entering the timeline now)
     def dragEnterEvent(self, event):
+        # Wait cursor
+        get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
+
         # Clear previous selections
         self.ClearAllSelections()
         get_app().processEvents()
-
-        # Group drag/drop transactions
-        tid = self.get_uuid()
-        get_app().updates.transaction_id = tid
 
         # Initialize a list to hold file data (either from mime data or newly created files)
         data_list = []
@@ -3051,8 +3050,15 @@ class TimelineView(updates.UpdateInterface, ViewClass):
         self.new_item = True
         self.item_ids = []
 
+        # Restore cursor
+        get_app().restoreOverrideCursor()
+
         # Nested callback to handle JavaScript position response
         def handle_js_position(pos, js_position_data):
+            # Group drag/drop transactions
+            tid = self.get_uuid()
+            get_app().updates.transaction_id = tid
+
             js_position = snap_to_grid(js_position_data.get('position', 0.0))
             js_nearest_track = js_position_data.get('track', 0)
 
@@ -3075,6 +3081,8 @@ class TimelineView(updates.UpdateInterface, ViewClass):
                 # Adjust position for the next clip/transition
                 if new_item:
                     pos += QPointF(new_item["end"] - new_item["start"], 0)
+
+            get_app().updates.transaction_id = None
 
         # Get JS position and pass initial position to the callback
         self.run_js(JS_SCOPE_SELECTOR + ".getJavaScriptPosition({}, {});"


### PR DESCRIPTION
This PR includes several key improvements and fixes related to the timeline and file selection in OpenShot:

- **Multi-Drop Fixes**: Addressed issues with multiple drops on the timeline by querying JS position and track only once and calculating clip durations correctly. Added snapping to FPS grid.
- **Selection Improvements**: 
  - Ctrl+A to select all files if the file view is focused, otherwise selects all timeline items (clips/transitions).
  - Shift+Click now allows range selection between items on the timeline. Ripple selection moved to Alt+Click.
  - Updated documentation for resizing edges of clips and range selection.
- **JumpToStart Update**: Modified behavior to use `GetMinFrame()` to jump to the first clip and scroll the timeline.
- **os_drop Refactor**: Major refactor of `os_drop` to improve drag-and-drop behavior with Project Files. Introduced disabling updates when dropping large numbers of clips.
- **Transaction Handling**: Added transactions around adding multiple files to avoid race conditions and improve performance.
