### PR TITLE
Fix to white space in keyboard shortcuts (user-guide)

### DIFF
--- a/doc/main_window.rst
+++ b/doc/main_window.rst
@@ -180,7 +180,7 @@ Learning a few of these shortcuts can save you a bunch of time!
    Save Project                          :kbd:`Ctrl+S`
    Save Project As...                    :kbd:`Ctrl+Shift+S`
    Select All                            :kbd:`Ctrl+A`
-   Select Item (Ripple)                  :kbd:`Alt+A`            :kbd:`Alt+Click`
+   Select Item (Ripple)                  :kbd:`Alt+A`              :kbd:`Alt+Click`
    Select None                           :kbd:`Ctrl+Shift+A`
    Show All Docks                        :kbd:`Ctrl+Shift+D`
    Simple View                           :kbd:`Alt+Shift+0`


### PR DESCRIPTION
Fix to white space in keyboard shortcuts (user-guide) which caused the table to disappear:
![image](https://github.com/user-attachments/assets/c4478824-c9ac-48f2-b69b-913414252ab9)
