### PR TITLE
Remove unused help button from rename track window

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -2148,8 +2148,16 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         track_name = selected_track.data["label"] or _("Track %s") % display_count
 
-        text, ok = QInputDialog.getText(self, _('Rename Track'), _('Track Name:'), text=track_name)
-        if ok:
+        # Set up rename track dialog
+        rename_dialog = QInputDialog(self)
+        rename_dialog.setWindowTitle(_('Rename Track'))
+        rename_dialog.setLabelText(_('Track Name:'))
+        rename_dialog.setTextValue(track_name)
+        rename_dialog.setWindowFlags(rename_dialog.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        
+        if rename_dialog.exec_() == QDialog.Accepted:
+            text = rename_dialog.textValue()
+            
             # Update track
             selected_track.data["label"] = text
             selected_track.save()


### PR DESCRIPTION
Hello! This is my first pull request to an open source project =)

I added a small fix by removing an unused help button in the rename track window. This window is reached when you right-click on a track and select "Rename Track". Before, this help button was unused and when pressed it turned the mouse into a red circle with a slash. Now, the button is removed. An alternative fix would be to populate this help button with additional information about renaming a track. I thought removing would be the best fix since renaming a track is a simple action that likely does not need further explanation.

Before:
![image](https://github.com/user-attachments/assets/9005c5ee-9865-4b64-b7ed-5259b37b42e4)

After:
![image](https://github.com/user-attachments/assets/d93d1eb0-681c-454b-8c46-3ee88ba1b6ff)
