### PR TITLE
Improved ripple slice & auto-show property dock for keyframes/effects

### DIFF
--- a/src/windows/views/timeline.py
+++ b/src/windows/views/timeline.py
@@ -2893,6 +2893,9 @@ class TimelineView(updates.UpdateInterface, ViewClass):
         # Seek to frame
         self.window.SeekSignal.emit(frame_number)
 
+        # Display properties (if not visible)
+        self.window.actionProperties.trigger()
+
     @pyqtSlot(int)
     def PlayheadMoved(self, position_frames):
 
@@ -2944,6 +2947,9 @@ class TimelineView(updates.UpdateInterface, ViewClass):
     def addSelection(self, item_id, item_type, clear_existing=False):
         """ Add the selected item to the current selection """
         self.window.SelectionAdded.emit(item_id, item_type, clear_existing)
+        if item_id and item_type == "effect":
+            # Display properties for effect (if not visible)
+            self.window.actionProperties.trigger()
 
     def addRippleSelection(self, item_id, item_type):
         if item_type == "clip":


### PR DESCRIPTION
Improved ripple slice to seek playhead to new position when `Slice->Keep Right Side (Ripple)` is selected. This make is much more clear where the slice has moved to. This PR also adds an improvement to show the Properties dock when an effect or keyframe is selected on the timeline.