### PR TITLE
Better support for Animated GIF and Static GIF formats

### DIFF
--- a/src/classes/image_types.py
+++ b/src/classes/image_types.py
@@ -32,7 +32,6 @@ def is_image(file_object):
         ".bmp",
         ".dpx",
         ".exr",
-        ".gif",
         ".jpg",
         ".jpeg",
         ".pam",

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -421,7 +421,7 @@ class FilesModel(QObject, updates.UpdateInterface):
         if dirName in self.ignore_image_sequence_paths:
             return None
 
-        extensions = ["png", "jpg", "jpeg", "gif", "tif", "svg"]
+        extensions = ["png", "jpg", "jpeg", "tif", "svg"]
         match = re.findall(r"(.*[^\d])?(0*)(\d+)\.(%s)" % "|".join(extensions), fileName, re.I)
 
         if not match:


### PR DESCRIPTION
Removing "gif" from list of known images, so it can be handled as a video from FFmpeg (with variable duration/video_length). Related to https://github.com/OpenShot/libopenshot/pull/988 and https://github.com/OpenShot/libopenshot/pull/989