### PR TITLE
Adding alpha input back to color picker

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -22,7 +22,7 @@ jobs:
       run: pip install sphinx sphinx_markdown_builder sphinx_rtd_theme
     - name: Build Documentation
       run: cd "$GITHUB_WORKSPACE/doc" && make html
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Documentation
         path: "doc/_build/html/"

--- a/src/windows/color_picker.py
+++ b/src/windows/color_picker.py
@@ -37,7 +37,7 @@ def draw_checkerboard(painter, rect):
     """Draw a checkerboard pattern for transparent backgrounds."""
     # Use logical pixels for the checker size that scales with different DPIs
     scale = get_app().devicePixelRatio()
-    effective_checker_size = 16 / scale
+    effective_checker_size = round(8.0 * scale)
     light_color = QColor(220, 220, 220)
     dark_color = QColor(170, 170, 170)
 

--- a/src/windows/color_picker.py
+++ b/src/windows/color_picker.py
@@ -34,27 +34,31 @@ from classes.app import get_app
 
 
 def draw_checkerboard(painter, rect):
-    """Draw a checkerboard pattern for transparent backgrounds"""
-    checker_size = 8
+    """Draw a checkerboard pattern for transparent backgrounds."""
+    # Use logical pixels for the checker size that scales with different DPIs
+    scale = get_app().devicePixelRatio()
+    effective_checker_size = 16 / scale
     light_color = QColor(220, 220, 220)
     dark_color = QColor(170, 170, 170)
 
     # Save current brush
     old_brush = painter.brush()
 
-    # Draw checkerboard pattern
+    # Draw checkerboard pattern in logical coordinates
+    checker_size = int(effective_checker_size)
     for x in range(0, rect.width(), checker_size):
         for y in range(0, rect.height(), checker_size):
-            if (x // checker_size + y // checker_size) % 2 == 0:
-                painter.fillRect(rect.x() + x, rect.y() + y,
-                                min(checker_size, rect.width() - x),
-                                min(checker_size, rect.height() - y),
-                                light_color)
+            if ((x // checker_size) + (y // checker_size)) % 2 == 0:
+                color = light_color
             else:
-                painter.fillRect(rect.x() + x, rect.y() + y,
-                                min(checker_size, rect.width() - x),
-                                min(checker_size, rect.height() - y),
-                                dark_color)
+                color = dark_color
+            painter.fillRect(
+                rect.x() + x,
+                rect.y() + y,
+                min(checker_size, rect.width() - x),
+                min(checker_size, rect.height() - y),
+                color
+            )
 
     # Restore brush
     painter.setBrush(old_brush)

--- a/src/windows/color_picker.py
+++ b/src/windows/color_picker.py
@@ -25,11 +25,46 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-from PyQt5.QtWidgets import QColorDialog, QPushButton, QDialog
-from PyQt5.QtGui import QColor, QPainter, QPen, QCursor
-from PyQt5.QtCore import Qt, QRect
+from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5.QtWidgets import QColorDialog, QPushButton, QDialog, QWidget, QFrame
+from PyQt5.QtGui import QColor, QPainter, QPen, QCursor, QBrush
+from PyQt5.QtCore import Qt, QRect, QPoint
 from classes.logger import log
 from classes.app import get_app
+
+
+def draw_checkerboard(painter, rect):
+    """Draw a checkerboard pattern for transparent backgrounds"""
+    checker_size = 8
+    light_color = QColor(220, 220, 220)
+    dark_color = QColor(170, 170, 170)
+
+    # Save current brush
+    old_brush = painter.brush()
+
+    # Draw checkerboard pattern
+    for x in range(0, rect.width(), checker_size):
+        for y in range(0, rect.height(), checker_size):
+            if (x // checker_size + y // checker_size) % 2 == 0:
+                painter.fillRect(rect.x() + x, rect.y() + y,
+                                min(checker_size, rect.width() - x),
+                                min(checker_size, rect.height() - y),
+                                light_color)
+            else:
+                painter.fillRect(rect.x() + x, rect.y() + y,
+                                min(checker_size, rect.width() - x),
+                                min(checker_size, rect.height() - y),
+                                dark_color)
+
+    # Restore brush
+    painter.setBrush(old_brush)
+
+class BlockPaintFilter(QtCore.QObject):
+    def eventFilter(self, obj, event):
+        if event.type() == QtCore.QEvent.Paint:
+            # Block the paint event so the widget doesn’t draw its own contents.
+            return True
+        return super().eventFilter(obj, event)
 
 
 class ColorPicker(QColorDialog):
@@ -39,6 +74,11 @@ class ColorPicker(QColorDialog):
         self.parent_window = parent
         self.callback = callback
         self.picked_pixmap = None
+        self.hover_color = initial_color  # Track the color being hovered
+
+        # Keep track of the dialog dimensions to handle resizing
+        self.dialog_width = self.width()
+        self.dialog_height = self.height()
 
         if title:
             self.setWindowTitle(title)
@@ -50,12 +90,60 @@ class ColorPicker(QColorDialog):
         # Set the current color after options are set
         self.setCurrentColor(initial_color)
         self.colorSelected.connect(self.on_color_selected)
+        self.currentColorChanged.connect(self.on_current_color_changed)
 
         # Override the "Pick Screen Color" button signal
         self._override_pick_screen_color()
 
         # Automatically open the dialog
         self.open()
+
+        # Calculate preview rectangle positions based on dialog size
+        self.update_preview_rectangles()
+
+    def update_preview_rectangles(self):
+        """Update the positions of preview rectangles based on current dialog size"""
+        all_frames = self.findChildren(QFrame)
+        # Filter to exact QFrame instances (not subclasses)
+        exact_frames = [w for w in all_frames if type(w) is QFrame]
+        preview_frame = exact_frames[-1]
+        if preview_frame:
+            # Map the top-left (0,0) of preview_frame to the dialog's coordinate system
+            topLeft = preview_frame.mapTo(self, QPoint(0, 0))
+            self.current_color_rect = QRect(topLeft, preview_frame.size())
+
+            # Install our paint blocking filter on the preview frame
+            filter = BlockPaintFilter(preview_frame)
+            preview_frame.installEventFilter(filter)
+            self._preview_paint_filter = filter
+
+    def resizeEvent(self, event):
+        """Handle window resize events to update preview rectangle positions"""
+        super().resizeEvent(event)
+        #self.update_preview_rectangles()
+        self.update()  # Force repaint
+
+    def on_current_color_changed(self, color):
+        """Track when the current color changes (hover or selection)"""
+        self.hover_color = color
+        self.update()  # Trigger a repaint
+
+    def paintEvent(self, event):
+        """Override paintEvent to add checkerboard pattern to color preview areas"""
+        # Call the parent class's paintEvent first
+        super().paintEvent(event)
+
+        # Create painter for our custom drawing
+        painter = QPainter(self)
+
+        # Draw checkerboard pattern under the current color
+        draw_checkerboard(painter, self.current_color_rect)
+
+        # Draw the current color with its alpha over the checkerboard
+        painter.setCompositionMode(QPainter.CompositionMode_SourceOver)
+        painter.fillRect(self.current_color_rect, self.currentColor())
+
+        painter.end()
 
     def _override_pick_screen_color(self):
         # Get first pushbutton (color picker)
@@ -109,8 +197,11 @@ class PickingDialog(QDialog):
             preview_y = cursor_pos.y() + 15
             preview_size = 50
 
-            # Draw checkerboard pattern for transparency
+            # Create preview rectangle
             preview_rect = QRect(preview_x, preview_y, preview_size, preview_size)
+
+            # Draw checkerboard pattern for transparency
+            draw_checkerboard(painter, preview_rect)
 
             # Draw the color with proper alpha over the checkerboard
             painter.setCompositionMode(QPainter.CompositionMode_SourceOver)

--- a/src/windows/color_picker.py
+++ b/src/windows/color_picker.py
@@ -27,14 +27,15 @@
 
 from PyQt5.QtWidgets import QColorDialog, QPushButton, QDialog
 from PyQt5.QtGui import QColor, QPainter, QPen, QCursor
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QRect
 from classes.logger import log
 from classes.app import get_app
 
 
 class ColorPicker(QColorDialog):
     def __init__(self, initial_color, parent=None, title=None, callback=None, *args, **kwargs):
-        super().__init__(initial_color, parent, *args, **kwargs)
+        # Initialize with parent only first
+        super().__init__(parent=parent, *args, **kwargs)
         self.parent_window = parent
         self.callback = callback
         self.picked_pixmap = None
@@ -42,7 +43,12 @@ class ColorPicker(QColorDialog):
         if title:
             self.setWindowTitle(title)
 
+        # Enable alpha channel and disable native dialog
         self.setOption(QColorDialog.DontUseNativeDialog)
+        self.setOption(QColorDialog.ShowAlphaChannel)
+
+        # Set the current color after options are set
+        self.setCurrentColor(initial_color)
         self.colorSelected.connect(self.on_color_selected)
 
         # Override the "Pick Screen Color" button signal
@@ -54,12 +60,10 @@ class ColorPicker(QColorDialog):
     def _override_pick_screen_color(self):
         # Get first pushbutton (color picker)
         color_picker_button = self.findChildren(QPushButton)[0]
-        log.debug(f"Color picker button text: {color_picker_button.text()}")
 
         # Connect to button signals
         color_picker_button.clicked.disconnect()
         color_picker_button.clicked.connect(self.start_color_picking)
-        log.debug("Overridden the 'Pick Screen Color' button action")
 
     def start_color_picking(self):
         if self.parent_window:
@@ -74,7 +78,6 @@ class ColorPicker(QColorDialog):
         self.raise_()
 
     def on_color_selected(self, color):
-        log.debug(f"Color selected: {color.name()}")
         if self.callback:
             self.callback(color)
 
@@ -98,13 +101,27 @@ class PickingDialog(QDialog):
     def paintEvent(self, event):
         painter = QPainter(self)
         painter.drawPixmap(self.rect(), self.pixmap)
+
         # Draw color preview rectangle near the cursor
         if self.color_preview:
+            cursor_pos = self.mapFromGlobal(QCursor.pos())
+            preview_x = cursor_pos.x() + 15
+            preview_y = cursor_pos.y() + 15
+            preview_size = 50
+
+            # Draw checkerboard pattern for transparency
+            preview_rect = QRect(preview_x, preview_y, preview_size, preview_size)
+
+            # Draw the color with proper alpha over the checkerboard
+            painter.setCompositionMode(QPainter.CompositionMode_SourceOver)
+            painter.fillRect(preview_rect, self.color_preview)
+
+            # Draw border around preview
             pen = QPen(Qt.black, 2)
             painter.setPen(pen)
-            painter.setBrush(self.color_preview)
-            cursor_pos = self.mapFromGlobal(QCursor.pos())
-            painter.drawRect(cursor_pos.x() + 15, cursor_pos.y() + 15, 50, 50)  # Rectangle offset from cursor
+            painter.setBrush(Qt.NoBrush)
+            painter.drawRect(preview_x, preview_y, preview_size, preview_size)
+
         painter.end()
 
     def mouseMoveEvent(self, event):
@@ -114,8 +131,15 @@ class PickingDialog(QDialog):
             scaled_x = int(event.x() * self.device_pixel_ratio)
             scaled_y = int(event.y() * self.device_pixel_ratio)
             if 0 <= scaled_x < image.width() and 0 <= scaled_y < image.height():
-                color = QColor(image.pixel(scaled_x, scaled_y))
+                pixel = image.pixel(scaled_x, scaled_y)
+                color = QColor(pixel)
+                # Ensure alpha channel is preserved in preview
+                # Get alpha value from pixel (first 8 bits are alpha in ARGB format)
+                alpha = (pixel >> 24) & 0xff
+                color.setAlpha(alpha)
                 self.color_preview = color
+
+                # Force update display
                 self.update()
 
     def mousePressEvent(self, event):
@@ -125,7 +149,13 @@ class PickingDialog(QDialog):
             scaled_x = int(event.x() * self.device_pixel_ratio)
             scaled_y = int(event.y() * self.device_pixel_ratio)
             if 0 <= scaled_x < image.width() and 0 <= scaled_y < image.height():
-                color = QColor(image.pixel(scaled_x, scaled_y))
+                pixel = image.pixel(scaled_x, scaled_y)
+                color = QColor(pixel)
+                # Ensure alpha channel is preserved
+                # Get alpha value from pixel (first 8 bits are alpha in ARGB format)
+                alpha = (pixel >> 24) & 0xff
+                color.setAlpha(alpha)
+
+                # Set the selected color in the dialog
                 self.color_picker.setCurrentColor(color)
-                log.debug(f"Picked color: {color.name()}")
         self.accept()  # Close the dialog

--- a/src/windows/color_picker.py
+++ b/src/windows/color_picker.py
@@ -25,9 +25,9 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtWidgets import QColorDialog, QPushButton, QDialog, QWidget, QFrame
-from PyQt5.QtGui import QColor, QPainter, QPen, QCursor, QBrush
+from PyQt5 import QtCore
+from PyQt5.QtWidgets import QColorDialog, QPushButton, QDialog, QFrame
+from PyQt5.QtGui import QColor, QPainter, QPen, QCursor
 from PyQt5.QtCore import Qt, QRect, QPoint
 from classes.logger import log
 from classes.app import get_app

--- a/src/windows/color_picker.py
+++ b/src/windows/color_picker.py
@@ -36,8 +36,7 @@ from classes.app import get_app
 def draw_checkerboard(painter, rect):
     """Draw a checkerboard pattern for transparent backgrounds."""
     # Use logical pixels for the checker size that scales with different DPIs
-    scale = get_app().devicePixelRatio()
-    effective_checker_size = round(8.0 * scale)
+    effective_checker_size = 8
     light_color = QColor(220, 220, 220)
     dark_color = QColor(170, 170, 170)
 

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -350,14 +350,20 @@ class PropertiesModel(updates.UpdateInterface):
                     log_id = "{}/{}".format(clip_id, object_id) if object_id else clip_id
                     log.debug("%s: update color property %s. %s", log_id, property_key, clip_data.get(property_key))
 
-                    # Loop through each keyframe (red, blue, and green)
+                    # Loop through each keyframe (red, blue, green, and alpha)
                     for color, new_value in [
                             ("red", new_color.red()),
                             ("blue", new_color.blue()),
                             ("green", new_color.green()),
+                            ("alpha", new_color.alpha()),
                             ]:
 
                         # Keyframe
+                        # Make sure this color property exists in the clip data
+                        if color not in clip_data[property_key]:
+                            log.debug(f"Creating new color component: {color}")
+                            clip_data[property_key][color] = {"Points": []}
+
                         # Loop through points, find a matching points on this frame
                         found_point = False
                         for point in clip_data[property_key][color].get("Points", []):
@@ -806,7 +812,8 @@ class PropertiesModel(updates.UpdateInterface):
                 red = int(property[1]["red"]["value"])
                 green = int(property[1]["green"]["value"])
                 blue = int(property[1]["blue"]["value"])
-                col.setBackground(QColor(red, green, blue))
+                alpha = int(property[1]["alpha"]["value"])
+                col.setBackground(QColor(red, green, blue, alpha))
 
             if readonly or type in ["color", "font", "caption"] or choices or label == "Track":
                 col.setFlags(Qt.ItemIsEnabled)
@@ -907,7 +914,8 @@ class PropertiesModel(updates.UpdateInterface):
                 red = int(property[1]["red"]["value"])
                 green = int(property[1]["green"]["value"])
                 blue = int(property[1]["blue"]["value"])
-                col.setBackground(QColor(red, green, blue))
+                alpha = int(property[1]["alpha"]["value"])
+                col.setBackground(QColor(red, green, blue, alpha))
 
             # Update helper dictionary
             row.append(col)

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -39,7 +39,7 @@ import threading
 # Is one even necessary, or is it safe to use xml.dom.minidom for that?
 from xml.dom import minidom
 
-from PyQt5.QtCore import Qt, pyqtSlot, QTimer, pyqtSignal
+from PyQt5.QtCore import Qt, pyqtSlot, QTimer, pyqtSignal, QRect, QPoint, QSize, QEvent
 from PyQt5.QtGui import QFontDatabase, QColor, QIcon, QFont, QFontInfo, QPixmap, QPainter
 from PyQt5.QtWidgets import (
     QWidget,
@@ -83,12 +83,16 @@ class TitleEditor(QDialog):
         self.project = self.app.project
         self.edit_file_path = edit_file_path
         self.duplicate = duplicate
+        self.filename = None
 
         # Load UI from designer
         ui_util.load_ui(self, self.ui_path)
 
         # Init UI
         ui_util.init_ui(self)
+
+        # In your widget's initialization:
+        self.lblPreviewLabel.installEventFilter(self)
 
         # Set up the buttons
         self.buttonBox = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
@@ -161,6 +165,12 @@ class TitleEditor(QDialog):
             # Display image (slight delay to allow screen to be shown first)
             QTimer.singleShot(50, self.display_svg)
 
+    def eventFilter(self, obj, event):
+        if obj is self.lblPreviewLabel and event.type() == QEvent.Resize:
+            # Update preview image when label is resized
+            self.update_timer.start(50)
+        return super(TitleEditor, self).eventFilter(obj, event)
+
     def get_font(self, requested_font_name):
         """
         Checks for a valid font name and returns a QFont object.
@@ -221,38 +231,47 @@ class TitleEditor(QDialog):
         clip = openshot.Clip(self.filename)
         reader = clip.Reader()
 
-        # Scale preview for high DPI (if needed)
+        # Get the device pixel ratio (for high DPI)
         scale = get_app().devicePixelRatio()
-        if scale > 1.0:
-            clip.scale_x.AddPoint(1.0, 1.0 * scale)
-            clip.scale_y.AddPoint(1.0, 1.0 * scale)
 
-        # Open the reader and generate thumbnail
+        # Get the available size (logical) and the original title size
+        avail_size = self.lblPreviewLabel.rect().size()
+        orig_size = QSize(reader.info.width, reader.info.height)
+
+        # Compute the target rectangle that preserves the title's aspect ratio
+        target_size = orig_size.scaled(avail_size, Qt.KeepAspectRatio)
+        target_rect = QRect(QPoint(0, 0), target_size)
+        target_rect.moveCenter(self.lblPreviewLabel.rect().center())
+
+        # Determine thumbnail dimensions in physical pixels
+        thumb_width = round(target_rect.width() * scale)
+        thumb_height = round(target_rect.height() * scale)
+
+        # Generate the thumbnail.
         reader.Open()
         reader.GetFrame(1).Thumbnail(
             tmp_filename,
-            round(self.lblPreviewLabel.width() * scale),
-            round(self.lblPreviewLabel.height() * scale),
+            thumb_width,
+            thumb_height,
             "", "", "#00000000", False, "png", 85, 0.0)
         reader.Close()
         clip.Close()
 
-        # Load the generated thumbnail pixmap
-        preview_pixmap = QIcon(tmp_filename).pixmap(self.lblPreviewLabel.size())
-
-        # Remove temporary file
+        # Load the thumbnail pixmap and set its device pixel ratio
+        preview_pixmap = QIcon(tmp_filename).pixmap(thumb_width, thumb_height)
+        preview_pixmap.setDevicePixelRatio(scale)
         os.unlink(tmp_filename)
 
-        # Create a new pixmap to composite the checkerboard and the preview image
-        final_pixmap = QPixmap(preview_pixmap.size())
-        final_pixmap.fill(Qt.transparent)
+        # Create the final pixmap filled with the label's background color
+        final_pixmap = QPixmap(avail_size * scale)
+        final_pixmap.setDevicePixelRatio(scale)
+        bg_color = self.lblPreviewLabel.palette().color(self.lblPreviewLabel.backgroundRole())
+        final_pixmap.fill(bg_color)
 
-        # Create a painter for compositing
+        # Composite the checkerboard and the preview image into the target area
         painter = QPainter(final_pixmap)
-        # Draw the checkerboard pattern in the entire pixmap area
-        draw_checkerboard(painter, final_pixmap.rect())
-        # Draw the preview image on top
-        painter.drawPixmap(0, 0, preview_pixmap)
+        draw_checkerboard(painter, target_rect)
+        painter.drawPixmap(target_rect, preview_pixmap)
         painter.end()
 
         # Emit the final pixmap
@@ -478,6 +497,9 @@ class TitleEditor(QDialog):
 
     def save_and_reload_thread(self):
         """Run inside thread, to update and display new SVG - so we don't block the main UI thread"""
+        if not self.filename:
+            return
+
         self.is_thread_busy = True
         self.writeToFile(self.xmldoc)
         self.display_svg()

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -40,7 +40,7 @@ import threading
 from xml.dom import minidom
 
 from PyQt5.QtCore import Qt, pyqtSlot, QTimer, pyqtSignal
-from PyQt5.QtGui import QFontDatabase, QColor, QIcon, QFont, QFontInfo
+from PyQt5.QtGui import QFontDatabase, QColor, QIcon, QFont, QFontInfo, QPixmap, QPainter
 from PyQt5.QtWidgets import (
     QWidget,
     QMessageBox, QDialog, QColorDialog, QFontDialog,
@@ -53,7 +53,7 @@ from classes import info, ui_util
 from classes.logger import log
 from classes.app import get_app
 from classes.metrics import track_metric_screen
-from windows.color_picker import ColorPicker
+from windows.color_picker import ColorPicker, draw_checkerboard
 from classes.style_tools import style_to_dict, dict_to_style, set_if_existing
 from windows.views.titles_listview import TitlesListView
 
@@ -213,7 +213,7 @@ class TitleEditor(QDialog):
         self.update_timer.start()
 
     def display_svg(self):
-        # Create a temp file for this thumbnail image
+        # Create a temp file for the thumbnail image
         new_file, tmp_filename = tempfile.mkstemp(suffix=".png")
         os.close(new_file)
 
@@ -221,32 +221,42 @@ class TitleEditor(QDialog):
         clip = openshot.Clip(self.filename)
         reader = clip.Reader()
 
-        # Scale preview for high DPI display (if any)
+        # Scale preview for high DPI (if needed)
         scale = get_app().devicePixelRatio()
         if scale > 1.0:
             clip.scale_x.AddPoint(1.0, 1.0 * scale)
             clip.scale_y.AddPoint(1.0, 1.0 * scale)
 
-        # Open reader
+        # Open the reader and generate thumbnail
         reader.Open()
-
-        # Overwrite temp file with thumbnail image and close readers
         reader.GetFrame(1).Thumbnail(
             tmp_filename,
             round(self.lblPreviewLabel.width() * scale),
             round(self.lblPreviewLabel.height() * scale),
-            "", "", "#000", False, "png", 85, 0.0)
+            "", "", "#00000000", False, "png", 85, 0.0)
         reader.Close()
         clip.Close()
 
-        # Attempt to load saved thumbnail
-        display_pixmap = QIcon(tmp_filename).pixmap(self.lblPreviewLabel.size())
-
-        # Display temp image
-        self.thumbnailReady.emit(display_pixmap)
+        # Load the generated thumbnail pixmap
+        preview_pixmap = QIcon(tmp_filename).pixmap(self.lblPreviewLabel.size())
 
         # Remove temporary file
         os.unlink(tmp_filename)
+
+        # Create a new pixmap to composite the checkerboard and the preview image
+        final_pixmap = QPixmap(preview_pixmap.size())
+        final_pixmap.fill(Qt.transparent)
+
+        # Create a painter for compositing
+        painter = QPainter(final_pixmap)
+        # Draw the checkerboard pattern in the entire pixmap area
+        draw_checkerboard(painter, final_pixmap.rect())
+        # Draw the preview image on top
+        painter.drawPixmap(0, 0, preview_pixmap)
+        painter.end()
+
+        # Emit the final pixmap
+        self.thumbnailReady.emit(final_pixmap)
 
     def create_temp_title(self, template_path):
         """Set temp file path & make copy of template"""

--- a/src/windows/ui/title-editor.ui
+++ b/src/windows/ui/title-editor.ui
@@ -115,7 +115,7 @@
          <property name="minimumSize">
           <size>
            <width>0</width>
-           <height>200</height>
+           <height>214</height>
           </size>
          </property>
          <property name="styleSheet">

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -231,7 +231,7 @@ class BlenderListView(QListView):
         color_value = self.params[param["name"]]
         currentColor = QColor("#FFFFFF")
         if len(color_value) >= 3:
-            currentColor.setRgbF(color_value[0], color_value[1], color_value[2])
+            currentColor.setRgbF(color_value[0], color_value[1], color_value[2], color_value[3])
         # Store our arguments for the callback to pick up again
         self._color_scratchpad = (widget, param)
         ColorPicker(currentColor, callback=self.color_selected, parent=self.win)

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -358,6 +358,7 @@ class PropertiesTableView(QTableView):
     def color_callback(self, newColor: QColor):
         # Set the new color keyframe
         if newColor.isValid():
+            log.debug(f"Color callback received: {newColor.name()}, Alpha: {newColor.alpha()}")
             self.clip_properties_model.color_update(
                 self.selected_item, newColor)
 
@@ -383,10 +384,17 @@ class PropertiesTableView(QTableView):
                 red = cur_property[1]["red"]["value"]
                 green = cur_property[1]["green"]["value"]
                 blue = cur_property[1]["blue"]["value"]
+                # Get alpha value (if present) or default to fully opaque
+                alpha = cur_property[1].get("alpha", {}).get("value", 255)
 
-                # Show color dialog
-                currentColor = QColor(int(red), int(green), int(blue))
-                log.debug("Launching ColorPicker for %s", currentColor.name())
+                # Show color dialog with alpha support
+                try:
+                    # Create color with alpha
+                    currentColor = QColor(int(red), int(green), int(blue), int(alpha))
+                except (ValueError, TypeError):
+                    # Default to opaque red if conversion fails
+                    currentColor = QColor(255, 0, 0, 255)
+                
                 ColorPicker(
                     currentColor, parent=self, title=_("Select a Color"),
                     callback=self.color_callback)
@@ -855,10 +863,17 @@ class PropertiesTableView(QTableView):
         red = int(cur_property[1]["red"]["value"])
         green = int(cur_property[1]["green"]["value"])
         blue = int(cur_property[1]["blue"]["value"])
+        # Get alpha value (if present) or default to fully opaque
+        alpha = int(cur_property[1].get("alpha", {}).get("value", 255))
 
-        # Show color dialog
-        currentColor = QColor(red, green, blue)
-        log.debug("Launching ColorPicker for %s", currentColor.name())
+        # Show color dialog with alpha support
+        try:
+            # Create color with alpha
+            currentColor = QColor(red, green, blue, alpha)
+        except (ValueError, TypeError):
+            # Default to opaque red if conversion fails
+            currentColor = QColor(255, 0, 0, 255)
+            
         ColorPicker(
             currentColor, parent=self, title=_("Select a Color"),
             callback=self.color_callback)


### PR DESCRIPTION
Adding alpha input back to color picker, so transparency can be set in the title editor and property editors. This also fixes an issue which preventing the previous color from initializing correctly in the color picker.

![image](https://github.com/user-attachments/assets/102fc40f-5c94-48b4-aa41-d433fb1ee394)
![Screenshot from 2025-03-11 11-24-20](https://github.com/user-attachments/assets/5cfb7e62-f4c0-4a31-b53a-9aacbfbdd291)
