### PR TITLE
Fixing lens flare error (Emission Strength in Blender 4.3+)

### DIFF
--- a/src/blender/lens_flare.xml
+++ b/src/blender/lens_flare.xml
@@ -60,7 +60,7 @@
 	<param name="strength" type="spinner" title="Emission Strength" description="">
 		<min>0.0</min>
 		<max>30.0</max>
-		<default>6.0</default>
+		<default>0.75</default>
 	</param>
 
 	<param name="glare1_type" type="dropdown" title="Glare 1: Type of Glare" description="">

--- a/src/blender/scripts/lens_flare.py.in
+++ b/src/blender/scripts/lens_flare.py.in
@@ -105,7 +105,8 @@ material_object = bpy.data.materials["Material.001"]
 bpy.data.materials["Material.001"].node_tree.nodes[1].inputs["Base Color"].default_value = params["diffuse_color"]
 bpy.data.materials["Material.001"].node_tree.nodes["Principled BSDF"].inputs[26].default_value = params["diffuse_color"]  # Emission color
 bpy.data.materials["Material.001"].node_tree.nodes[1].inputs["Alpha"].default_value = params["alpha"]
-bpy.data.materials["Material.001"].node_tree.nodes["Principled BSDF"].inputs[27].default_value = params["strength"]
+strength_value = params["strength"]
+bpy.data.materials["Material.001"].node_tree.nodes["Principled BSDF"].inputs[27].default_value = (strength_value, strength_value, strength_value, 1.0)
 
 # Change Composite Node settings
 glare_node = bpy.data.scenes[0].node_tree.nodes["Glare"]


### PR DESCRIPTION
Fixing lens flare error, caused by emission strength syntax change, and updated the default value since it seems Blender has changed how this works.

![Screenshot from 2025-03-11 14-05-23](https://github.com/user-attachments/assets/7a725fa3-f3e2-4518-8843-77ad8e4d5dc1)
