### PR TITLE
Making actionSave_trigger use a synchronous Save function

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -744,7 +744,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 file_path = "%s.osp" % file_path
 
             # Save project
-            threading.Thread(target=self.save_project, args=(file_path,), daemon=True).start()
+            self.save_project(file_path)
 
     def auto_save_project(self):
         """Auto save the project"""


### PR DESCRIPTION
Making actionSave_trigger use a synchronous save method, instead of a Thread, which prevents many race conditions related to "Recent Projects/Open Project" while saving unsaved changes at the same time.

![image](https://github.com/user-attachments/assets/3e0c9d54-fab2-4986-adec-4f4ffa090d99)
