### PR TITLE
Correctly access "rotation" metadata from vertical videos

### DIFF
--- a/src/classes/thumbnail.py
+++ b/src/classes/thumbnail.py
@@ -99,7 +99,7 @@ def GenerateThumbnail(file_path, thumb_path, thumbnail_frame, width, height, mas
     rotate = 0.0
     try:
         if reader.info.metadata.count("rotate"):
-            rotate_data = reader.info.metadata.find("rotate").value()[1]
+            rotate_data = reader.info.metadata["rotate"]
             rotate = float(rotate_data)
     except ValueError as ex:
         log.warning("Could not parse rotation value {}: {}".format(rotate_data, ex))

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -781,6 +781,17 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                 x_motion = event.pos().x() - self.mouse_position.x()
                 y_motion = event.pos().y() - self.mouse_position.y()
 
+                # For all interactions except rotation, adjust the motion vector
+                # to account for the clip's current rotation.
+                if self.transform_mode != 'rotation':
+                    import math
+                    current_rotation = raw_properties.get('rotation').get('value')
+                    if abs(current_rotation) > 0.001:
+                        rad = math.radians(current_rotation)
+                        x_motion_unrotated = math.cos(rad) * x_motion + math.sin(rad) * y_motion
+                        y_motion_unrotated = -math.sin(rad) * x_motion + math.cos(rad) * y_motion
+                        x_motion, y_motion = x_motion_unrotated, y_motion_unrotated
+
                 if self.transform_mode == 'origin':
                     # Get current keyframe value
                     origin_x = raw_properties.get('origin_x').get('value')
@@ -946,7 +957,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                         scale_x += x_motion / half_w
 
                     if int(QCoreApplication.instance().keyboardModifiers() & Qt.ControlModifier) > 0:
-                        # If CTRL key is pressed, fix the scale_y to the correct aspect ration
+                        # If CTRL key is pressed, fix the scale_y to the correct aspect ratio
                         if scale_x:
                             scale_y = scale_x
                         elif scale_y:

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -781,9 +781,9 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                 x_motion = event.pos().x() - self.mouse_position.x()
                 y_motion = event.pos().y() - self.mouse_position.y()
 
-                # For all interactions except rotation, adjust the motion vector
+                # For all interactions except rotation and location, adjust the motion vector
                 # to account for the clip's current rotation.
-                if self.transform_mode != 'rotation':
+                if self.transform_mode not in ['rotation', 'location']:
                     import math
                     current_rotation = raw_properties.get('rotation').get('value')
                     if abs(current_rotation) > 0.001:
@@ -846,9 +846,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
                     # Calculate new location coordinates
                     aspect_ratio = (self.clipBounds.width() / self.clipBounds.height()) * 2.0
-                    shear_x -= (
-                        x_motion) / (
-                        (self.clipBounds.width() * scale_x) / aspect_ratio)
+                    shear_x -= x_motion / ((self.clipBounds.width() * scale_x) / aspect_ratio)
 
                     # Update keyframe value (or create new one)
                     self.updateClipProperty(
@@ -862,9 +860,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
                     # Calculate new location coordinates
                     aspect_ratio = (self.clipBounds.width() / self.clipBounds.height()) * 2.0
-                    shear_x += (
-                        x_motion) / (
-                        (self.clipBounds.width() * scale_x) / aspect_ratio)
+                    shear_x += x_motion / ((self.clipBounds.width() * scale_x) / aspect_ratio)
 
                     # Update keyframe value (or create new one)
                     self.updateClipProperty(
@@ -877,11 +873,8 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                     scale_y = raw_properties.get('scale_y').get('value')
 
                     # Calculate new location coordinates
-                    aspect_ratio = (
-                        self.clipBounds.height() / self.clipBounds.width()) * 2.0
-                    shear_y -= (
-                        y_motion) / (
-                        self.clipBounds.height() * scale_y / aspect_ratio)
+                    aspect_ratio = (self.clipBounds.height() / self.clipBounds.width()) * 2.0
+                    shear_y -= y_motion / (self.clipBounds.height() * scale_y / aspect_ratio)
 
                     # Update keyframe value (or create new one)
                     self.updateClipProperty(
@@ -894,11 +887,8 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                     shear_y = raw_properties.get('shear_y').get('value')
 
                     # Calculate new location coordinates
-                    aspect_ratio = (
-                        self.clipBounds.height() / self.clipBounds.width()) * 2.0
-                    shear_y += (
-                        y_motion) / (
-                        self.clipBounds.height() * scale_y / aspect_ratio)
+                    aspect_ratio = (self.clipBounds.height() / self.clipBounds.width()) * 2.0
+                    shear_y += y_motion / (self.clipBounds.height() * scale_y / aspect_ratio)
 
                     # Update keyframe value (or create new one)
                     self.updateClipProperty(


### PR DESCRIPTION
Fixing the access to "rotate" metadata (which was crashing) and adding better support for transform handles of rotated clips (the math got a bit broken when a clip was rotated). Related to https://github.com/OpenShot/libopenshot/pull/995