### PR TITLE
Fix misaligned tracks/track labels, and incorrect playhead height

### DIFF
--- a/src/themes/cosmic/theme.py
+++ b/src/themes/cosmic/theme.py
@@ -702,7 +702,6 @@ QMessageBox QPushButton[text="&{_('Cancel')}"] {{
             .playhead-line {
               z-index: 9999;
               position: absolute;
-              height: 316px;
               top: 0;
               width: 2px;
               background-color: #FABE0A;

--- a/src/timeline/app.js
+++ b/src/timeline/app.js
@@ -66,12 +66,6 @@ $(document).ready(function () {
         var h = trackContainer.getBoundingClientRect().height;
         playheadLine.style.height = h + "px";
       }
-
-      // force Angular to re-digest so clips get re-positioned instantly anytime the resize happens (i.e. tracks added/removed/resized)
-      var scope = body_object.scope();
-      if (!scope.$$phase) {
-        scope.$apply();
-      }
     }
 
     // Re-sync on window resize

--- a/src/timeline/app.js
+++ b/src/timeline/app.js
@@ -39,34 +39,57 @@ $(document).ready(function () {
   // Initialize Qt Mixin (WebEngine or WebKit)
   init_mixin();
 
-  // Always ensure caching thread has been resumed on any mouse-up event.
-  // The cache thread can be disabled while scrubbing, and the normal mouse-up event
-  // can be missed if the cursor is dragged outside the timeline.
-  $(document).on("mouseup", function (e) {
-      if (body_object.scope().Qt) {
-          // Enable caching thread after scrubbing
-          timeline.EnableCacheThread();
+  // Ensure caching thread is resumed on any mouse-up event during scrubbing
+  $(document).on("mouseup", function () {
+    if (body_object.scope().Qt) {
+      timeline.EnableCacheThread();
+    }
+  });
+
+  /// Capture window resize event, and resize scrollable track divs and playhead-line height
+  (function () {
+    var trackControls   = document.getElementById("track_controls");
+    var scrollTracks    = document.getElementById("scrolling_tracks");
+    var trackContainer  = document.getElementById("track-container");
+    var playheadLine    = document.querySelector(".playhead-line");
+
+    function syncAll() {
+      // Resize both control and tracks container to fill window height
+      if (trackControls && scrollTracks) {
+        var offsetTop = trackControls.getBoundingClientRect().top;
+        var newH = window.innerHeight - offsetTop;
+        trackControls.style.height   = newH + "px";
+        scrollTracks.style.height    = newH + "px";
       }
-  });
+      // Adjust playhead-line height to match track stack
+      if (trackContainer && playheadLine) {
+        var h = trackContainer.getBoundingClientRect().height;
+        playheadLine.style.height = h + "px";
+      }
 
-  /// Capture window resize event, and resize scrollable divs (i.e. track container)
-  $(window).resize(function () {
+      // force Angular to re-digest so clips get re-positioned instantly anytime the resize happens (i.e. tracks added/removed/resized)
+      var scope = body_object.scope();
+      if (!scope.$$phase) {
+        scope.$apply();
+      }
+    }
 
-    // Determine Y offset for track container div
-    var track_controls = $("#track_controls");
-    var track_offset = track_controls.offset().top;
+    // Re-sync on window resize
+    window.addEventListener("resize", syncAll);
 
-    // Set the height of the scrollable divs. This resizes the tracks to fit the remaining
-    // height of the web page. As the user changes the size of the web page, this will continue
-    // to fire, and resize the child divs to fit.
-    var new_track_height = $(this).height() - track_offset;
+    // Observe structural changes in the track container
+    if (window.ResizeObserver && trackContainer) {
+      new ResizeObserver(syncAll).observe(trackContainer);
+    } else if (trackContainer) {
+      new MutationObserver(syncAll).observe(trackContainer, { childList: true });
+    }
 
-    track_controls.height(new_track_height);
-    $("#scrolling_tracks").height(new_track_height);
-    body_object.scope().playhead_height = $("#track-container").height();
-    $(".playhead-line").height(body_object.scope().playhead_height);
-  });
+    // Observe Angular's style override on playhead-line
+    if (window.MutationObserver && playheadLine) {
+      new MutationObserver(syncAll).observe(playheadLine, { attributes: true, attributeFilter: ["style"] });
+    }
 
-  // Manually trigger the window resize code (to verify it runs at least once)
-  $(window).trigger("resize");
+    // Initial sync
+    syncAll();
+  })();
 });

--- a/src/timeline/app.js
+++ b/src/timeline/app.js
@@ -28,13 +28,13 @@
 
 // Initialize Angular application
 /*global App, angular, timeline, init_mixin*/
-var App = angular.module("openshot-timeline", ["ui.bootstrap", "ngAnimate"]);
+const App = angular.module("openshot-timeline", ["ui.bootstrap", "ngAnimate"]);
 
 
 // Wait for document ready event
 $(document).ready(function () {
 
-  var body_object = $("body");
+  const body_object = $("body");
 
   // Initialize Qt Mixin (WebEngine or WebKit)
   init_mixin();
@@ -48,23 +48,29 @@ $(document).ready(function () {
 
   /// Capture window resize event, and resize scrollable track divs and playhead-line height
   (function () {
-    var trackControls   = document.getElementById("track_controls");
-    var scrollTracks    = document.getElementById("scrolling_tracks");
-    var trackContainer  = document.getElementById("track-container");
-    var playheadLine    = document.querySelector(".playhead-line");
+    const trackControls   = document.getElementById("track_controls");
+    const scrollTracks    = document.getElementById("scrolling_tracks");
+    const trackContainer  = document.getElementById("track-container");
+    const playheadLine    = document.querySelector(".playhead-line");
 
     function syncAll() {
       // Resize both control and tracks container to fill window height
       if (trackControls && scrollTracks) {
-        var offsetTop = trackControls.getBoundingClientRect().top;
-        var newH = window.innerHeight - offsetTop;
+        const offsetTop = trackControls.getBoundingClientRect().top;
+        const newH = window.innerHeight - offsetTop;
         trackControls.style.height   = newH + "px";
         scrollTracks.style.height    = newH + "px";
       }
       // Adjust playhead-line height to match track stack
       if (trackContainer && playheadLine) {
-        var h = trackContainer.getBoundingClientRect().height;
+        const h = trackContainer.getBoundingClientRect().height;
         playheadLine.style.height = h + "px";
+      }
+      // Adjust snapping-line height to match track stack
+      const snappingLine = document.querySelector(".snapping-line");
+      if (trackContainer && snappingLine) {
+        const h = trackContainer.getBoundingClientRect().height;
+        snappingLine.style.height = h + "px";
       }
     }
 
@@ -81,6 +87,12 @@ $(document).ready(function () {
     // Observe Angular's style override on playhead-line
     if (window.MutationObserver && playheadLine) {
       new MutationObserver(syncAll).observe(playheadLine, { attributes: true, attributeFilter: ["style"] });
+    }
+
+    // Observe Angular's style override on snapping-line
+    const snappingLine = document.querySelector(".snapping-line");
+    if (window.MutationObserver && snappingLine) {
+      new MutationObserver(syncAll).observe(snappingLine, { attributes: true, attributeFilter: ["style"] });
     }
 
     // Initial sync

--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -144,10 +144,10 @@
 			</div>
 
 			<!-- FLOATING PLAYHEAD LINE -->
-			<div class="playhead playhead-line" style="height: {{ playhead_height }}px; left:{{project.playhead_position * pixelsPerSecond}}px;"></div>
+			<div class="playhead playhead-line" style="left:{{project.playhead_position * pixelsPerSecond}}px;"></div>
 
 			<!-- SNAPPING HINT LINE -->
-			<div ng-show="snapline" class="snapping-line" style="height: {{ playhead_height }}px; left:{{ snapline_position}}px;"></div>
+			<div ng-show="snapline" class="snapping-line" style="left:{{ snapline_position}}px;"></div>
 
 		</div>
 		

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -1642,8 +1642,12 @@ $scope.updateLayerIndex = function () {
         // Re-sort clips and transitions array
         $scope.sortItems();
 
-        // Re-index Layer Y values
-        $scope.updateLayerIndex();
+        // Re-index Layer Y values after DOM has been updated
+        setTimeout(function() {
+          $scope.$apply(function () {
+            $scope.updateLayerIndex();
+          });
+        }, 0);
       }
     }
 

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -57,7 +57,6 @@ App.controller("TimelineCtrl", function ($scope) {
   // Additional variables used to control the rendering of HTML
   $scope.pixelsPerSecond = parseFloat($scope.project.tick_pixels) / parseFloat($scope.project.scale);
   $scope.playhead_animating = false;
-  $scope.playhead_height = 300;
   $scope.playheadTime = secondsToTime($scope.project.playhead_position, $scope.project.fps.num, $scope.project.fps.den);
   $scope.snapline_position = 0.0;
   $scope.snapline = false;
@@ -1208,10 +1207,6 @@ $scope.updateLayerIndex = function () {
       layer.height = layer_elem.outerHeight();
     }
   }
-
-  // Update playhead height
-  $scope.playhead_height = $("#track-container").height();
-  $(".playhead-line").height($scope.playhead_height);
 };
 
   // Sort clips and transitions by position

--- a/src/timeline/media/css/main.css
+++ b/src/timeline/media/css/main.css
@@ -568,7 +568,6 @@ img {
 .snapping-line {
   z-index: 9998;
   position: absolute;
-  height: 316px;
   top: 0;
   width: 1px;
   background-color: #32b7ea;

--- a/src/timeline/media/css/main.css
+++ b/src/timeline/media/css/main.css
@@ -246,7 +246,6 @@ img {
 .playhead-line {
   z-index: 9999;
   position: absolute;
-  height: 316px;
   top: 0;
   width: 2px;
   background-color: #ff0024;


### PR DESCRIPTION
Refactor how scrolling track divs are resized to fit the webview widget, and how the playhead-line & snapping-line height is kept in-sync with the track heights. Also, this fixes a bug where clips don't instantly render when a track is removed, and also fixes a bug where track Y coordinates were out of sync with the UI (when adding/removing tracks), causing clips to jump to nearby tracks incorrectly.

![Screenshot from 2025-05-09 16-19-21](https://github.com/user-attachments/assets/194da7d7-00b9-4c95-8007-701a4b6b9d3f)
