### PR TITLE
Adding "None" option for Mask/Transition Source Property

### DIFF
--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -655,11 +655,16 @@ class PropertiesModel(updates.UpdateInterface):
                     # Transition
                     clip_updated = True
                     try:
-                        clip_object = openshot.Clip(value)
-                        clip_object.Open()
-                        clip_data[property_key] = json.loads(clip_object.Reader().Json())
-                        clip_object.Close()
-                        clip_object = None
+                        if value:
+                            # Set a new source
+                            clip_object = openshot.Clip(value)
+                            clip_object.Open()
+                            clip_data[property_key] = json.loads(clip_object.Reader().Json())
+                            clip_object.Close()
+                            clip_object = None
+                        else:
+                            # Clear the source (set to a dict with a type field)
+                            clip_data[property_key] = {"type": ""}
                     except Exception:
                         log.warn('Invalid Reader value passed to property: %s', value, exc_info=1)
 

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -394,7 +394,7 @@ class PropertiesTableView(QTableView):
                 except (ValueError, TypeError):
                     # Default to opaque red if conversion fails
                     currentColor = QColor(255, 0, 0, 255)
-                
+
                 ColorPicker(
                     currentColor, parent=self, title=_("Select a Color"),
                     callback=self.color_callback)
@@ -674,6 +674,10 @@ class PropertiesTableView(QTableView):
                                          "icon": icon
                                          })
 
+                # Add None option to clear the source
+                self.choices.append({"name": _("None"), "value": "", "selected": False, "icon": None})
+
+
                 # Add root file choice
                 if file_choices:
                     self.choices.append({"name": _("Files"), "value": file_choices, "selected": False, icon: None})
@@ -873,7 +877,7 @@ class PropertiesTableView(QTableView):
         except (ValueError, TypeError):
             # Default to opaque red if conversion fails
             currentColor = QColor(255, 0, 0, 255)
-            
+
         ColorPicker(
             currentColor, parent=self, title=_("Select a Color"),
             callback=self.color_callback)


### PR DESCRIPTION
Adding "None" option for Mask/Transition source attribute, and really any "Reader" based property of any object. This clears the current reader.