### PR TITLE
Use 3 digit milliseconds on Caption Editor

### DIFF
--- a/src/classes/time_parts.py
+++ b/src/classes/time_parts.py
@@ -50,7 +50,7 @@ def secondsToTime(secs, fps_num=30, fps_den=1):
 
     frame = round((milli / 1000.0) * (fps_num / fps_den)) + 1
     return {"week": padNumber(week, 2), "day": padNumber(day, 2), "hour": padNumber(hour, 2),
-            "min": padNumber(min, 2), "sec": padNumber(sec, 2), "milli": padNumber(milli, 2),
+            "min": padNumber(min, 2), "sec": padNumber(sec, 2), "milli": padNumber(milli, 3),
             "frame": padNumber(frame, 2)}
 
 def timecodeToSeconds(time_code="00:00:00:00", fps_num=30, fps_den=1):


### PR DESCRIPTION
Force the insert timestamp button in the Caption editor to use 3 digit milliseconds (which is the standard).

![Screenshot from 2025-05-10 18-12-19](https://github.com/user-attachments/assets/9490f63d-2556-4931-b365-62dae42f442e)

