### PR TITLE
Fixing Regression when deleting an item (items were not really being deleted)

### DIFF
--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -107,13 +107,13 @@ class TimelineSync(UpdateInterface):
                 if action.type == "delete":
                     # Clear selection for the deleted object
                     object_id = action.key[1].get("id", None)
-                    self.window.removeSelection(object_id)
+                    self.window.removeSelection(object_id, None)
 
                 # This JSON DIFF is passed to libopenshot to update the timeline
                 self.timeline.ApplyJsonDiff(action.json(is_array=True))
 
         except Exception as e:
-            log.info("Error applying JSON to timeline object in libopenshot: %s. %s" %
+            log.error("Error applying JSON to timeline object in libopenshot: %s. %s" %
                      (e, action.json(is_array=True)))
 
         # Resume video caching original value

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -1171,9 +1171,17 @@ $scope.moveItem = function (x, y) {
   bounding_box.previous_x = results.position.left;
   bounding_box.previous_y = results.position.top;
 
+  // protect against empty .first()
+  if (!bounding_box.elements || !bounding_box.elements.length) return;
+  const $first = bounding_box.elements.first();
+  if (!$first.length) return;
+  const firstId = $first.attr("id");
+  const firstStart = bounding_box.start_clips[firstId];
+  if (!firstStart) return;
+
   // Apply snapping results to the first clip and calculate the delta for the remaining clips
-  var delta_x = results.position.left - bounding_box.start_clips[bounding_box.elements.first().attr("id")].left;
-  var delta_y = results.position.top - bounding_box.start_clips[bounding_box.elements.first().attr("id")].top;
+  const delta_x = results.position.left - firstStart.left;
+  const delta_y = results.position.top - firstStart.top;
 
   // Update the position of each selected element by applying the delta
   if (bounding_box.elements) {


### PR DESCRIPTION
Fixed a small regression which caused deleted clips/transitions/effects to be left in the project, even though the UI showed them gone. Also fixed a small issue outputting errors in Javascript when moving items (on occasion)