### PR TITLE
title_editor: fix multi-lines titles update error if missing line 1 (Fixes #5864)

### DIFF
--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -409,8 +409,9 @@ class TitleEditor(QDialog):
         title_text = []
         for i, node in enumerate(self.tspan_nodes):
             if len(node.childNodes) < 1:
-                continue
-            text = node.childNodes[0].data
+                text = ""
+            else:
+                text = node.childNodes[0].data
             title_text.append(text)
 
             # Create Label

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -213,10 +213,11 @@ class TitleEditor(QDialog):
 
         # Update text values in the SVG
         for i, node in enumerate(self.tspan_nodes):
-            if len(node.childNodes) > 0 and i <= (len(text_list) - 1):
+            if i <= (len(text_list) - 1):
                 new_text_node = self.xmldoc.createTextNode(text_list[i])
-                old_text_node = node.childNodes[0]
-                node.removeChild(old_text_node)
+                if len(node.childNodes) > 0:
+                    old_text_node = node.childNodes[0]
+                    node.removeChild(old_text_node)
                 # add new text node
                 node.appendChild(new_text_node)
 

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -409,7 +409,7 @@ class TitleEditor(QDialog):
         title_text = []
         for i, node in enumerate(self.tspan_nodes):
             if len(node.childNodes) < 1:
-                text = ""
+                text = "NOT UPDATABLE: previously empty field"
             else:
                 text = node.childNodes[0].data
             title_text.append(text)

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -410,7 +410,7 @@ class TitleEditor(QDialog):
         title_text = []
         for i, node in enumerate(self.tspan_nodes):
             if len(node.childNodes) < 1:
-                text = "NOT UPDATABLE: previously empty field"
+                text = ""
             else:
                 text = node.childNodes[0].data
             title_text.append(text)


### PR DESCRIPTION
Fixes https://github.com/OpenShot/openshot-qt/issues/5864

Example: "Standard 3" title:
    
* if line 1 and line 3 are missing, then line 2 is immutable (can not update).
    
* if line 1 is missing, then update to line 2 is lost and update to line 3 becomes line 2.
    
Note that if line 3 is missing, then update to line 1 and line 2 are working fine.
    
The fix is to always display all the lines, even if they are empty, which fixes all the update problems above.

Since all the lines are displayed, even those previously empty, the fix also allows to set new values for those previously empty lines.

This removes the previous restriction that once a line is empty, it disappears from the title editor, meaning the end-user can not change its mind and set a value for those line again.  Now the end-user can change its mind anytime.  Any lines can change from being empty or not, any time.

Manually tested against "Standard 3" and "Standard 4" titles, but I believe this fix will impact all multi-lines titles.  Is there an automated way to test all of them?
