### PR TITLE
Removing annotation import for python 3.6 compatibility

### DIFF
--- a/src/classes/clip_utils.py
+++ b/src/classes/clip_utils.py
@@ -24,8 +24,6 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-from __future__ import annotations
-
 import logging
 from fractions import Fraction
 from typing import Any, Mapping, Optional


### PR DESCRIPTION
Removing annotation import for python 3.6 compatibility (for bionic build server on launchpad)