### PR TITLE
Improve Missing Files Prompts

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -1085,6 +1085,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         _ = app._tr
 
         log.info("checking project files...")
+        prompt_state = {"cancelled": False}
 
         # Loop through each files (in reverse order)
         for file in reversed(self._data["files"]):
@@ -1094,7 +1095,13 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             log.info("checking file %s", path)
             if not os.path.exists(path) and "%" not in path:
                 # File is missing
-                path, is_modified, is_skipped = find_missing_file(path)
+                if prompt_state.get("cancelled"):
+                    # User already cancelled prompts, just remove missing file
+                    log.info('Removed missing file: %s', file_name_with_ext)
+                    self._data["files"].remove(file)
+                    continue
+
+                path, is_modified, is_skipped = find_missing_file(path, prompt_state)
                 if path and is_modified and not is_skipped:
                     # Found file, update path
                     file["path"] = path
@@ -1105,23 +1112,34 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                     log.info('Removed missing file: %s', file_name_with_ext)
                     self._data["files"].remove(file)
 
-        # Loop through each clip (in reverse order)
+        # Build a lookup of valid file IDs after any removals/updates
+        file_paths_by_id = {file.get("id"): file.get("path") for file in self._data["files"]}
+
+        # Loop through each clip (in reverse order). Don't prompt for clips.
         for clip in reversed(self._data["clips"]):
+            file_id = clip.get("file_id") or clip.get("reader", {}).get("id")
+            if file_id and file_id in file_paths_by_id:
+                # Keep clip reader path in sync with its File path
+                reader = clip.get("reader")
+                if not isinstance(reader, dict):
+                    reader = {}
+                    clip["reader"] = reader
+                reader["path"] = file_paths_by_id[file_id]
+
             path = clip.get("reader", {}).get("path", "")
 
-            if path and not os.path.exists(path) and "%" not in path:
-                # File is missing
-                path, is_modified, is_skipped = find_missing_file(path)
-                file_name_with_ext = os.path.basename(path)
+            if file_id and file_id not in file_paths_by_id:
+                # Remove clips with invalid/missing files
+                file_name_with_ext = os.path.basename(path) if path else ""
+                log.info('Removed missing clip: %s', file_name_with_ext)
+                self._data["clips"].remove(clip)
+                continue
 
-                if path and is_modified and not is_skipped:
-                    # Found file, update path
-                    clip["reader"]["path"] = path
-                    log.info("Auto-updated missing file: %s", clip["reader"]["path"])
-                elif is_skipped:
-                    # Remove missing file
-                    log.info('Removed missing clip: %s', file_name_with_ext)
-                    self._data["clips"].remove(clip)
+            if path and not os.path.exists(path) and "%" not in path:
+                # Remove missing clip without prompting
+                file_name_with_ext = os.path.basename(path)
+                log.info('Removed missing clip: %s', file_name_with_ext)
+                self._data["clips"].remove(clip)
 
     def changed(self, action):
         """ This method is invoked by the UpdateManager each time a change happens (i.e UpdateInterface) """

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -1087,8 +1087,12 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         log.info("checking project files...")
         prompt_state = {"cancelled": False}
 
-        # Loop through each files (in reverse order)
-        for file in reversed(self._data["files"]):
+        # Loop through each files in natural-sorted filename order
+        files_sorted = sorted(
+            self._data["files"],
+            key=lambda f: os.path.basename(f.get("path", "")).lower()
+        )
+        for file in files_sorted:
             path = file["path"]
             parent_path, file_name_with_ext = os.path.split(path)
 

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -118,14 +118,17 @@ class TitleEditor(QDialog):
         self.lblPreviewLabel.setFocusPolicy(Qt.NoFocus)
         self.scrollArea.setFocusPolicy(Qt.NoFocus)
 
-        # Set up the buttons
-        self.buttonBox = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
-        self.saveButton = self.buttonBox.button(QDialogButtonBox.Save)
-        self.cancelButton = self.buttonBox.button(QDialogButtonBox.Cancel)
-
-        # Set object names (for theme styles)
+        # Set up the buttons (match Animated Title behavior)
+        app = get_app()
+        _ = app._tr
+        self.buttonBox = QDialogButtonBox()
+        self.saveButton = QPushButton(_('Save'))
         self.saveButton.setObjectName("acceptButton")
+        self.cancelButton = QPushButton(_('Cancel'))
         self.cancelButton.setObjectName("cancelButton")
+        self.buttonBox.addButton(self.saveButton, QDialogButtonBox.AcceptRole)
+        self.buttonBox.addButton(self.cancelButton, QDialogButtonBox.RejectRole)
+        # Set focus policy after adding to buttonBox to prevent override
         self.saveButton.setFocusPolicy(Qt.StrongFocus)
         self.cancelButton.setFocusPolicy(Qt.StrongFocus)
         self.layout().addWidget(self.buttonBox)
@@ -171,10 +174,12 @@ class TitleEditor(QDialog):
         self.verticalLayout.addWidget(self.titlesView)
 
         # Disable Save button on window load
-        self.buttonBox.button(self.buttonBox.Save).setEnabled(False)
+        if hasattr(self, "saveButton"):
+            self.saveButton.setEnabled(False)
 
         self._apply_tab_order()
-        QTimer.singleShot(0, lambda: self.titlesView.setFocus(Qt.TabFocusReason))
+        if not self.edit_file_path:
+            QTimer.singleShot(0, lambda: self.titlesView.setFocus(Qt.TabFocusReason))
 
         # Connect thumbnail listener
         self.thumbnailReady.connect(self.display_pixmap)
@@ -511,7 +516,8 @@ class TitleEditor(QDialog):
             self.btnFontColor.setEnabled(False)
 
         # Enable Save button when a template is selected
-        self.buttonBox.button(self.buttonBox.Save).setEnabled(True)
+        if hasattr(self, "saveButton"):
+            self.saveButton.setEnabled(True)
 
         self._apply_tab_order()
 

--- a/src/windows/views/emojis_listview.py
+++ b/src/windows/views/emojis_listview.py
@@ -41,6 +41,8 @@ class EmojisListView(QListView):
     """ A QListView QWidget used on the main window """
     drag_item_size = QSize(48, 48)
     drag_item_center = QPoint(24, 24)
+    emoji_icon_size = QSize(75, 75)
+    emoji_grid_size = QSize(80, 95)
 
     def dragEnterEvent(self, event):
         # If dragging urls onto widget, accept
@@ -156,10 +158,10 @@ class EmojisListView(QListView):
         self.setDragEnabled(True)
         self.setDropIndicatorShown(True)
 
-        # Setup header columns
+        # Setup header columns and layout
         self.setModel(self.model)
-        self.setIconSize(info.EMOJI_ICON_SIZE)
-        self.setGridSize(info.EMOJI_GRID_SIZE)
+        self.setIconSize(self.emoji_icon_size)
+        self.setGridSize(self.emoji_grid_size)
         self.setViewMode(QListView.IconMode)
         self.setResizeMode(QListView.Adjust)
         self.setUniformItemSizes(True)

--- a/src/windows/views/find_file.py
+++ b/src/windows/views/find_file.py
@@ -34,11 +34,15 @@ from PyQt5.QtWidgets import QMessageBox, QFileDialog
 known_paths = [info.HOME_PATH]
 
 
-def find_missing_file(file_path):
+def find_missing_file(file_path, prompt_state=None):
     """Find a missing file name or file path, and return valid path."""
     _ = get_app()._tr
     modified = False
     skipped = False
+
+    # If user cancelled prompts, skip searching
+    if prompt_state and prompt_state.get("cancelled"):
+        return ("", modified, True)
 
     # Bail if path is already valid
     if os.path.exists(file_path):
@@ -61,9 +65,23 @@ def find_missing_file(file_path):
             recommended_path = info.HOME_PATH
         else:
             recommended_path = os.path.dirname(recommended_path)
-        QMessageBox.warning(None, _("Missing File (%s)") % file_name,
-                            _("%s cannot be found.") % file_name)
+        message_box = QMessageBox()
+        message_box.setIcon(QMessageBox.Warning)
+        message_box.setWindowTitle(_("Missing File (%s)") % file_name)
+        message_box.setText(_("%s cannot be found.") % file_name)
+        browse_button = message_box.addButton(_("Browse..."), QMessageBox.AcceptRole)
+        cancel_button = message_box.addButton(QMessageBox.Cancel)
+        message_box.setDefaultButton(browse_button)
+        message_box.exec_()
         modified = True
+
+        if message_box.clickedButton() == cancel_button:
+            # User cancelled all missing file prompts
+            skipped = True
+            if prompt_state is not None:
+                prompt_state["cancelled"] = True
+            return ("", modified, skipped)
+
         folder_to_check = QFileDialog.getExistingDirectory(None, _("Find directory that contains: %s" % file_name),
                                                            recommended_path)
         if folder_to_check and folder_to_check not in known_paths:

--- a/src/windows/views/timeline_backend/theme.py
+++ b/src/windows/views/timeline_backend/theme.py
@@ -1648,7 +1648,7 @@ def _apply_css(theme: TimelineTheme, css: str, source: str = "css") -> TimelineT
     if not css:
         return theme
 
-    log_miss = True
+    log_miss = False
 
     _css_apply_background(theme, css, source, log_miss)
     _css_apply_clip(theme, css, source, log_miss)

--- a/src/windows/views/timeline_backend/theme.py
+++ b/src/windows/views/timeline_backend/theme.py
@@ -9,6 +9,9 @@ from PyQt5.QtGui import QColor, QPixmap
 from classes.logger import log
 from classes.info import PATH
 
+LOG_THEME_MISS = False
+LOG_THEME_INFO = False
+
 
 def _apply_overrides(obj, overrides: dict, *, allow_unknown: bool = False) -> None:
     """Apply keyword overrides to a theme object, optionally ignoring unknown keys."""
@@ -187,8 +190,8 @@ def _css_prop(
     prop: str,
     source: str,
     *,
-    log_selector: bool = True,
-    log_property: bool = True,
+    log_selector: bool = LOG_THEME_MISS,
+    log_property: bool = LOG_THEME_MISS,
 ) -> Optional[str]:
     """Return property *prop* from the CSS *selector* block.
 
@@ -257,8 +260,8 @@ def _parse_color(
     prop: Union[str, Sequence[str]],
     source: str,
     *,
-    log_miss: bool = True,
-    log_selector: bool = True,
+    log_miss: bool = LOG_THEME_MISS,
+    log_selector: bool = LOG_THEME_MISS,
 ) -> Optional[QColor]:
     props = (prop,) if isinstance(prop, str) else tuple(prop)
     val = None
@@ -313,7 +316,7 @@ def _parse_color(
 
 
 def _parse_gradient(
-    css: str, selector: str, prop: str, source: str, *, log_miss: bool = True
+    css: str, selector: str, prop: str, source: str, *, log_miss: bool = LOG_THEME_MISS
 ):
     """Return up to two colors from a CSS gradient.
 
@@ -371,8 +374,8 @@ def _parse_float(
     prop: Union[str, Sequence[str]],
     source: str,
     *,
-    log_miss: bool = True,
-    log_selector: bool = True,
+    log_miss: bool = LOG_THEME_MISS,
+    log_selector: bool = LOG_THEME_MISS,
 ) -> Optional[float]:
     props = (prop,) if isinstance(prop, str) else tuple(prop)
     val = None
@@ -419,7 +422,7 @@ def _parse_pixmap(
     prop: str,
     source: str,
     *,
-    log_miss: bool = True,
+    log_miss: bool = LOG_THEME_MISS,
 ) -> Optional[QPixmap]:
     val = _css_prop(css, selector, prop, source)
     if not val:
@@ -447,7 +450,7 @@ def _parse_pixmap(
         if os.path.exists(path):
             img = _load_pixmap_with_meta(path)
             if img:
-                if selector in {".playhead-top", ".marker_icon"} and prop == "background-image":
+                if LOG_THEME_INFO and selector in {".playhead-top", ".marker_icon"} and prop == "background-image":
                     log.info(
                         "Theme [%s] %s %s loaded '%s'",
                         source,
@@ -503,7 +506,7 @@ def _parse_box_shadow(
 
 
 def _theme_pixmap(
-    qt_theme, selector: str, prop: str, *, log_miss: bool = True
+    qt_theme, selector: str, prop: str, *, log_miss: bool = LOG_THEME_MISS
 ) -> Optional[QPixmap]:
     if not qt_theme or not hasattr(qt_theme, "style_sheet"):
         return None
@@ -550,7 +553,7 @@ def _theme_pixmap(
         if os.path.exists(path):
             img = _load_pixmap_with_meta(path)
             if img:
-                if selector in {".playhead-top", ".marker_icon"} and prop == "background-image":
+                if LOG_THEME_INFO and selector in {".playhead-top", ".marker_icon"} and prop == "background-image":
                     log.info(
                         "Theme [theme] %s %s loaded '%s'",
                         selector,
@@ -568,7 +571,7 @@ def _theme_get_color(
     selector: str,
     prop: Union[str, Sequence[str]],
     *,
-    log_miss: bool = True,
+    log_miss: bool = LOG_THEME_MISS,
 ):
     if not qt_theme:
         return None
@@ -595,7 +598,7 @@ def _theme_get_int(
     selector: str,
     prop: Union[str, Sequence[str]],
     *,
-    log_miss: bool = True,
+    log_miss: bool = LOG_THEME_MISS,
 ):
     if not qt_theme:
         return None
@@ -669,7 +672,7 @@ def _theme_apply_color(
     selector: str,
     prop: Union[str, Sequence[str]],
     *,
-    log_miss: bool = True,
+    log_miss: bool = LOG_THEME_MISS,
 ) -> None:
     col = _theme_get_color(qt_theme, selector, prop, log_miss=log_miss)
     _assign_color(target, attr, col)
@@ -683,7 +686,7 @@ def _theme_apply_int(
     prop: Union[str, Sequence[str]],
     *,
     transform: Optional[Callable[[Union[int, float]], Union[int, float]]] = None,
-    log_miss: bool = True,
+    log_miss: bool = LOG_THEME_MISS,
 ) -> None:
     val = _theme_get_int(qt_theme, selector, prop, log_miss=log_miss)
     _assign_value(target, attr, val, transform=transform)
@@ -716,8 +719,8 @@ def _apply_css_color_value(
     prop: Union[str, Sequence[str]],
     source: str,
     *,
-    log_miss: bool = True,
-    log_selector: bool = True,
+    log_miss: bool = LOG_THEME_MISS,
+    log_selector: bool = LOG_THEME_MISS,
 ) -> None:
     col = _parse_color(
         css,
@@ -738,8 +741,8 @@ def _apply_css_float_value(
     prop: Union[str, Sequence[str]],
     source: str,
     *,
-    log_miss: bool = True,
-    log_selector: bool = True,
+    log_miss: bool = LOG_THEME_MISS,
+    log_selector: bool = LOG_THEME_MISS,
     transform: Optional[Callable[[float], Union[int, float]]] = None,
 ) -> None:
     val = _parse_float(
@@ -991,8 +994,12 @@ def _theme_apply_ruler(theme: TimelineTheme, qt_theme, css_sheet: str) -> None:
         "background2",
         lambda: _ruler_gradient(css_sheet, "theme"),
         lambda: _ruler_theme_background(qt_theme),
-        miss_log=lambda: log.info(
-            "Theme MISS [theme] selector '#scrolling_ruler' property 'background'"
+        miss_log=(
+            (lambda: log.info(
+                "Theme MISS [theme] selector '#scrolling_ruler' property 'background'"
+            ))
+            if LOG_THEME_MISS
+            else None
         ),
     )
     _apply_gradient_with_fallback(
@@ -1432,9 +1439,13 @@ def _css_apply_ruler(theme: TimelineTheme, css: str, source: str, log_miss: bool
         "background2",
         lambda: _ruler_gradient(css, source),
         lambda: _ruler_css_background(css, source),
-        miss_log=lambda: log.info(
-            "Theme MISS [%s] selector '#scrolling_ruler' property 'background'",
-            source,
+        miss_log=(
+            (lambda: log.info(
+                "Theme MISS [%s] selector '#scrolling_ruler' property 'background'",
+                source,
+            ))
+            if LOG_THEME_MISS and log_miss
+            else None
         ),
     )
     _apply_gradient_with_fallback(
@@ -1690,10 +1701,11 @@ def apply_theme(widget, css: str = "") -> bool:
         default_path = os.path.normpath(os.path.join(base, "../images/playhead.svg"))
         if os.path.exists(default_path):
             t.playhead_icon = QPixmap(default_path)
-            log.info(
-                "Theme [default] .playhead-top background-image loaded '%s'",
-                default_path,
-            )
+            if LOG_THEME_INFO:
+                log.info(
+                    "Theme [default] .playhead-top background-image loaded '%s'",
+                    default_path,
+                )
 
     def _load_fallback_icon(*parts):
         path = os.path.normpath(os.path.join(PATH, *parts))
@@ -1702,7 +1714,8 @@ def apply_theme(widget, css: str = "") -> bool:
         pix = _load_pixmap_with_meta(path)
         if not pix:
             return None
-        log.info("Theme [default] fallback icon loaded '%s'", path)
+        if LOG_THEME_INFO:
+            log.info("Theme [default] fallback icon loaded '%s'", path)
         return pix
 
     def _ensure_icon(attr, parts):

--- a/src/windows/views/titles_listview.py
+++ b/src/windows/views/titles_listview.py
@@ -36,6 +36,9 @@ class TitlesListView(QListView):
     """ A QListView QWidget used on the title editor window """
 
     def currentChanged(self, current: QModelIndex, previous: QModelIndex):
+        # When editing/duplicating an existing title, don't override the SVG
+        if getattr(self.win, "edit_file_path", None):
+            return
         # Get current selection (if any)
         current = self.selectionModel().currentIndex()
         if not current.isValid():
@@ -53,6 +56,10 @@ class TitlesListView(QListView):
 
         # Sort by column 0
         self.title_model.proxy_model.sort(0)
+
+        # When editing/duplicating an existing title, keep template selection inactive.
+        if getattr(self.win, "edit_file_path", None):
+            return
 
         # Ensure a default selection (top item) to load controls.
         if not self.selectionModel().hasSelection() and self.model().rowCount() > 0:


### PR DESCRIPTION
We need a quick way to bail out of the "Missing Files" prompt loop (i.e. cancel button), and to only prompt 1 time per file (not per clip). 
<img width="253" height="174" alt="Screenshot from 2026-02-03 20-26-48" src="https://github.com/user-attachments/assets/63e17e9f-e47f-4981-b231-0df4bea23bb8" />
