### PR TITLE
Prevent crash on exit (when using --web-backend qwidget)

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -194,6 +194,10 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # begins destroying child widgets, to avoid QThread warnings on shutdown.
         timeline_widget = getattr(self, "timeline", None)
         if timeline_widget and getattr(timeline_widget, "thumbnail_manager", None):
+            log.info(
+                "Shutdown timeline thumbnail thread running=%s",
+                timeline_widget.thumbnail_manager._thread.isRunning(),
+            )
             timeline_widget.thumbnail_manager.shutdown()
 
         # Stop thumbnail server thread (if any)
@@ -209,6 +213,11 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Stop preview thread (and wait for it to end)
         if self.preview_thread:
+            if self.preview_parent and getattr(self.preview_parent, "background", None):
+                log.info(
+                    "Shutdown preview thread running=%s",
+                    self.preview_parent.background.isRunning(),
+                )
             self.preview_thread.player.CloseAudioDevice()
             self.preview_thread.kill()
             if self.videoPreview:

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -100,8 +100,11 @@ class PreviewParent(QObject, UpdateInterface):
         # Stop preview thread (and wait for it to end)
         self.worker.Stop()
         self.worker.kill()
-        self.background.exit()
-        self.background.wait(5000)
+        if self.background.isRunning():
+            log.info("Stopping preview thread (running=%s)", self.background.isRunning())
+        self.background.quit()
+        if not self.background.wait(5000):
+            log.warning("Preview thread did not stop within 5 seconds")
 
     @pyqtSlot(object, object)
     def Init(self, parent, timeline, video_widget, max_length=1):
@@ -112,6 +115,7 @@ class PreviewParent(QObject, UpdateInterface):
 
         # Background Worker Thread (for preview video process)
         self.background = QThread(self)
+        self.background.setObjectName("preview_background")
         self.worker = PlayerWorker()  # no parent!
 
         # Init worker variables
@@ -171,6 +175,8 @@ class PlayerWorker(QObject):
 
     def CheckAudioDevice(self):
         """Check if any audio devices initialization errors, default sample rate, and current open audio device"""
+        s = get_app().get_settings()
+
         # Check audio init error
         audio_error = self.player.GetError()
         if audio_error:
@@ -184,7 +190,6 @@ class PlayerWorker(QObject):
             # Convert float to Integer
             detected_sample_rate_int = round(detected_sample_rate)
 
-            s = get_app().get_settings()
             settings_sample_rate = int(s.get("default-samplerate") or 48000)
             if detected_sample_rate_int != settings_sample_rate:
                 log.warning("Your sample rate (%d) does not match OpenShot (%d). "

--- a/src/windows/views/timeline_backend/qwidget/thumbnails.py
+++ b/src/windows/views/timeline_backend/qwidget/thumbnails.py
@@ -85,6 +85,7 @@ class TimelineThumbnailManager(QObject):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._thread = QThread(self)
+        self._thread.setObjectName("timeline_thumbnail")
         self._worker = _ThumbnailWorker()
         self._worker.moveToThread(self._thread)
         self._request_job.connect(self._worker.request_thumbnail)
@@ -107,6 +108,14 @@ class TimelineThumbnailManager(QObject):
     def shutdown(self):
         """Stop the worker thread."""
         self._clear_jobs.emit()
-        if self._thread.isRunning():
+        was_running = self._thread.isRunning()
+        if was_running:
             self._thread.quit()
-            self._thread.wait(2000)
+            stopped = self._thread.wait(2000)
+            log.info(
+                "Timeline thumbnail thread stop result running_before=%s running_after=%s",
+                was_running,
+                self._thread.isRunning(),
+            )
+            if not stopped:
+                log.warning("Timeline thumbnail thread did not stop within 2 seconds")


### PR DESCRIPTION
Prevent a crash on shutdown when using the qwidget timeline backend (by ensuring the thumbnail thread is properly shut down first)