### PR TITLE
Adding CTRL and SHIFT modifiers to Rotation

### DIFF
--- a/doc/clips.rst
+++ b/doc/clips.rst
@@ -318,6 +318,7 @@ Or if the transform tool is disabled, right click on a clip and choose
 - Dragging the blue squares will adjust the **scale** of the image.
 - Dragging the center will move the **location** of the image.
 - Dragging the mouse on the outside of the blue lines will **rotate** the image.
+- Hold :kbd:`Ctrl` or :kbd:`Shift` while rotating to snap to 15-degree increments.
 - Dragging along the blue lines will **shear** the image in that direction.
 - Dragging the circle in the middle will move the **origin point** that controls the center of **rotation**. 
 
@@ -686,6 +687,7 @@ a clip (sideways, upside down, right side up, portrait, landscape), flip a clip,
 
 - **Usage Example:** Simulating a spinning effect by animating the rotation curve.
 - **Tip:** Use this property creatively for effects like rotating text or emulating camera movement.
+- **Tip:** In the preview transform tool, hold :kbd:`Ctrl` or :kbd:`Shift` while rotating to snap to 15-degree increments.
 - **Tip:** Experiment with rotating your video at different angles, not just 90 or 180 degrees. Sometimes a slight tilt or a specific angle can add creative flair to your video, especially for artistic or storytelling purposes.
 - **Tip:** After rotating your video, you might end up with black bars around the edges. Consider cropping and resizing the video to eliminate these bars and maintain a clean, polished look.
 - **Tip:** If you're dealing with vertical videos that are meant to be watched on horizontal screens, rotate them by 90 degrees and then scale them up to fill the frame. This way, your vertical video will occupy more screen real estate.

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -51,6 +51,13 @@ from classes.query import Clip, Effect
 class VideoWidget(QWidget, updates.UpdateInterface):
     """ A QWidget used on the video display widget """
 
+    def _snap_angle(self, angle_degrees, step_degrees=15.0):
+        """Snap an angle to the nearest increment (degrees)."""
+        step = float(step_degrees) if step_degrees else 0.0
+        if step <= 0.0:
+            return angle_degrees
+        return math.floor((angle_degrees + (step / 2.0)) / step) * step
+
     def _compute_handles_opacity(self, fps_float):
         """
         Opacity based on playhead vs. selected clip(s).
@@ -239,6 +246,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.originHandle = None
         self.original_effect_data = None
         self.hover_transform_mode = None
+        self.rotation_drag_value = None
         self.hover_cursor = Qt.ArrowCursor
         self.setCursor(Qt.ArrowCursor)
         self.update()
@@ -726,6 +734,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.mouse_dragging = False
         self.mouse_position = event.pos()
         self.transform_mode = self.hover_transform_mode
+        self.rotation_drag_value = None
         self.setCursor(self.hover_cursor)
 
         # Ignore undo/redo history temporarily (to avoid a huge pile of undo/redo history)
@@ -751,6 +760,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.mouse_pressed = False
         self.mouse_dragging = False
         self.transform_mode = None
+        self.rotation_drag_value = None
         self.region_mode = None
 
         # Save region image data (as QImage)
@@ -1098,7 +1108,9 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
                 elif self.transform_mode == 'rotation':
                     # Get current rotation keyframe value
-                    rotation = raw_properties.get('rotation').get('value')
+                    if self.rotation_drag_value is None:
+                        self.rotation_drag_value = raw_properties.get('rotation').get('value')
+                    rotation = self.rotation_drag_value
                     scale_x = max(float(raw_properties.get('scale_x').get('value')), 0.001)
                     scale_y = max(float(raw_properties.get('scale_y').get('value')), 0.001)
 
@@ -1111,6 +1123,10 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
                     y_adjust = y_motion / ((self.clipBounds.height() * scale_y) / 90)
                     rotation += (y_adjust if is_on_right else -y_adjust)
+
+                    self.rotation_drag_value = rotation
+                    if int(QCoreApplication.instance().keyboardModifiers() & (Qt.ControlModifier | Qt.ShiftModifier)) > 0:
+                        rotation = self._snap_angle(rotation, 15.0)
 
                     # Update keyframe value (or create new one)
                     self.updateClipProperty(
@@ -1304,7 +1320,9 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
                     elif self.transform_mode == 'rotation':
                         # Get current rotation keyframe value
-                        rotation = raw_properties.get('rotation').get('value')
+                        if self.rotation_drag_value is None:
+                            self.rotation_drag_value = raw_properties.get('rotation').get('value')
+                        rotation = self.rotation_drag_value
                         scale_x = max(float(raw_properties.get('scale_x').get('value')), 0.001)
                         scale_y = max(float(raw_properties.get('scale_y').get('value')), 0.001)
 
@@ -1317,6 +1335,10 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
                         y_adjust = y_motion / (self.clipBounds.height() * scale_y / 90)
                         rotation += (y_adjust if is_on_right else -y_adjust)
+
+                        self.rotation_drag_value = rotation
+                        if int(QCoreApplication.instance().keyboardModifiers() & (Qt.ControlModifier | Qt.ShiftModifier)) > 0:
+                            rotation = self._snap_angle(rotation, 15.0)
 
                         # Update keyframe value (or create new one)
                         self.updateEffectProperty(
@@ -1999,6 +2021,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.mouse_position = None
         self.transform_mode = None
         self.hover_transform_mode = None
+        self.rotation_drag_value = None
         self.hover_cursor = Qt.ArrowCursor
         self.original_clip_data = None
         self.original_clip_data_map = {}


### PR DESCRIPTION
Adding CTRL and SHIFT modifiers to snap rotation in the video preview transform handles. We snap by 15 degree increments only when pressing the modifier key.