### PR TITLE
Fix Undo for Adding Effect to Clip (regression)

### DIFF
--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1990,7 +1990,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Refresh preview
         get_app().window.refreshFrameSignal.emit()
 
-    def actionRemoveClip_trigger(self):
+    def actionRemoveClip_trigger(self, checked=True, refresh=True):
         log.debug('actionRemoveClip_trigger')
 
         locked_tracks = [l.get("number") for l in get_app().project.get('layers') if l.get("lock", False)]
@@ -2010,7 +2010,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 c.delete()
 
         # Refresh preview
-        get_app().window.refreshFrameSignal.emit()
+        if refresh:
+            get_app().window.refreshFrameSignal.emit()
 
     def actionRippleDelete(self):
         log.debug('actionRippleDelete_trigger')
@@ -2136,7 +2137,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Refresh preview
         self.refreshFrameSignal.emit()
 
-    def actionRemoveTransition_trigger(self):
+    def actionRemoveTransition_trigger(self, checked=True, refresh=True):
         log.debug('actionRemoveTransition_trigger')
 
         locked_tracks = [l.get("number")
@@ -2158,7 +2159,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 t.delete()
 
         # Refresh preview
-        self.refreshFrameSignal.emit()
+        if refresh:
+            self.refreshFrameSignal.emit()
 
     def actionRemoveTrack_trigger(self):
         log.debug('actionRemoveTrack_trigger')
@@ -3447,8 +3449,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 self.actionRemove_from_Project_trigger()
             else:
                 # Otherwise, proceed with the normal timeline delete behavior
-                self.actionRemoveClip_trigger()
-                self.actionRemoveTransition_trigger()
+                self.actionRemoveClip_trigger(refresh=False)
+                self.actionRemoveTransition_trigger(refresh=False)
+                self.refreshFrameSignal.emit()
         finally:
             get_app().updates.transaction_id = None
 

--- a/src/windows/views/emojis_listview.py
+++ b/src/windows/views/emojis_listview.py
@@ -35,6 +35,7 @@ from classes.query import File
 from classes.app import get_app
 from classes.logger import log
 import json
+import uuid
 
 
 class EmojisListView(QListView):
@@ -65,6 +66,11 @@ class EmojisListView(QListView):
 
         # Create emoji file before drag starts
         data = json.loads(drag.mimeData().text())
+
+        # Start a transaction so File + Clip are grouped for undo
+        tid = str(uuid.uuid4())
+        get_app().updates.transaction_id = tid
+
         file = self.add_file(data[0])
 
         # Update mimedata for emoji
@@ -75,6 +81,9 @@ class EmojisListView(QListView):
 
         # Start drag
         drag.exec_()
+
+        # End transaction
+        get_app().updates.transaction_id = None
 
     def add_file(self, filepath):
         # Add file into project

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -26,6 +26,8 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
+import uuid
+
 from PyQt5.QtCore import QSize, Qt, QPoint, QRegExp
 from PyQt5.QtGui import QDrag, QCursor, QPixmap, QPainter, QIcon
 from PyQt5.QtWidgets import QListView, QAbstractItemView
@@ -178,8 +180,15 @@ class FilesListView(QListView):
         # Set the hot spot to the center of the composite pixmap
         drag.setHotSpot(composite_pixmap.rect().center())
 
-        # Execute the drag operation
+        # Start a transaction so all clips are grouped for a single undo
+        tid = str(uuid.uuid4())
+        get_app().updates.transaction_id = tid
+
+        # Execute the drag operation (blocking - dropEvent creates clips during this call)
         drag.exec_(supportedActions)
+
+        # End transaction
+        get_app().updates.transaction_id = None
 
     # Without defining this method, the 'copy' action doesn't show with cursor
     def dragMoveEvent(self, event):

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -28,6 +28,7 @@
  """
 
 import os
+import uuid
 
 from PyQt5.QtCore import QSize, Qt, QPoint
 from PyQt5.QtGui import QDrag, QCursor, QPixmap, QPainter, QIcon
@@ -182,8 +183,15 @@ class FilesTreeView(QTreeView):
         # Set the hot spot to the center of the composite pixmap
         drag.setHotSpot(composite_pixmap.rect().center())
 
-        # Execute the drag operation
+        # Start a transaction so all clips are grouped for a single undo
+        tid = str(uuid.uuid4())
+        get_app().updates.transaction_id = tid
+
+        # Execute the drag operation (blocking - dropEvent creates clips during this call)
         drag.exec_(supportedActions)
+
+        # End transaction
+        get_app().updates.transaction_id = None
 
     # Without defining this method, the 'copy' action doesn't show with cursor
     def dragMoveEvent(self, event):

--- a/src/windows/views/timeline.py
+++ b/src/windows/views/timeline.py
@@ -3878,6 +3878,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
                 ):
                     log.info("Applying effect {} to clip ID {}".format(name, clip.id))
                     log.debug(clip)
+                    original_clip_data = json.loads(json.dumps(clip.data))
 
                     # Handle custom effect dialogs
                     if name in effect_options:
@@ -3926,6 +3927,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
 
                     # Update clip data for project
                     self.update_clip_data(clip.data, only_basic_props=False, ignore_reader=True)
+                    get_app().updates.apply_last_action_to_history(original_clip_data)
 
         # Find position from javascript
         self.run_js(JS_SCOPE_SELECTOR + ".getJavaScriptPosition({}, {});"
@@ -3964,6 +3966,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
         if not effect_name:
             return
         log.info("Applying effect %s to clip ID %s", effect_name, clip.id)
+        original_clip_data = json.loads(json.dumps(clip.data))
         if effect_name in effect_options:
             effect_params = effect_options.get(effect_name)
             from windows.process_effect import ProcessEffect
@@ -3992,6 +3995,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
             clip.data["effects"] = effects
         effects.append(effect_json)
         self.update_clip_data(clip.data, only_basic_props=False, ignore_reader=True)
+        get_app().updates.apply_last_action_to_history(original_clip_data)
 
     # Without defining this method, the 'copy' action doesn't show with cursor
     def dragMoveEvent(self, event):


### PR DESCRIPTION
Fixing crash on deleting clips with effects, and fixing regression that causes effects to break the UNDO/REDO system - not allowing the user to undo an effect added to a clip.