### PR TITLE
Improvements to caching, trimming, thumbnails, and more

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -941,28 +941,33 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             reader_paths = {}
 
             # Copy all thumbnail files (if not found in target asset folder)
-            for thumb_path in os.listdir(info.THUMBNAIL_PATH):
-                working_thumb_path = os.path.join(info.THUMBNAIL_PATH, thumb_path)
-                target_thumb_filepath = os.path.join(target_thumb_path, thumb_path)
-                if not os.path.exists(target_thumb_filepath):
-                    shutil.copy2(working_thumb_path, target_thumb_filepath)
+            if os.path.abspath(info.THUMBNAIL_PATH) != os.path.abspath(target_thumb_path):
+                for thumb_path in os.listdir(info.THUMBNAIL_PATH):
+                    working_thumb_path = os.path.join(info.THUMBNAIL_PATH, thumb_path)
+                    target_thumb_filepath = os.path.join(target_thumb_path, thumb_path)
+                    if not os.path.exists(target_thumb_filepath):
+                        shutil.copy2(working_thumb_path, target_thumb_filepath)
 
             # Copy all title files (if not found in target asset folder)
-            for title_path in os.listdir(info.TITLE_PATH):
-                working_title_path = os.path.join(info.TITLE_PATH, title_path)
-                target_title_filepath = os.path.join(target_title_path, title_path)
-                if not os.path.exists(target_title_filepath):
-                    shutil.copy2(working_title_path, target_title_filepath)
+            if os.path.abspath(info.TITLE_PATH) != os.path.abspath(target_title_path):
+                for title_path in os.listdir(info.TITLE_PATH):
+                    working_title_path = os.path.join(info.TITLE_PATH, title_path)
+                    target_title_filepath = os.path.join(target_title_path, title_path)
+                    if not os.path.exists(target_title_filepath):
+                        shutil.copy2(working_title_path, target_title_filepath)
 
             # Copy all blender folders (if not found in target asset folder)
-            for blender_path in os.listdir(info.BLENDER_PATH):
-                working_blender_path = os.path.join(info.BLENDER_PATH, blender_path)
-                target_blender_filepath = os.path.join(target_blender_path, blender_path)
-                if os.path.isdir(working_blender_path) and not os.path.exists(target_blender_filepath):
-                    shutil.copytree(working_blender_path, target_blender_filepath)
+            if os.path.abspath(info.BLENDER_PATH) != os.path.abspath(target_blender_path):
+                for blender_path in os.listdir(info.BLENDER_PATH):
+                    working_blender_path = os.path.join(info.BLENDER_PATH, blender_path)
+                    target_blender_filepath = os.path.join(target_blender_path, blender_path)
+                    if os.path.isdir(working_blender_path) and not os.path.exists(target_blender_filepath):
+                        shutil.copytree(working_blender_path, target_blender_filepath)
 
             # Copy all clipboard files (if not found in target asset folder)
-            if os.path.exists(info.CLIPBOARD_PATH):
+            if os.path.exists(info.CLIPBOARD_PATH) and (
+                os.path.abspath(info.CLIPBOARD_PATH) != os.path.abspath(target_clipboard_path)
+            ):
                 for clipboard_path in os.listdir(info.CLIPBOARD_PATH):
                     working_clipboard_path = os.path.join(info.CLIPBOARD_PATH, clipboard_path)
                     target_clipboard_filepath = os.path.join(target_clipboard_path, clipboard_path)
@@ -970,11 +975,12 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                         shutil.copy2(working_clipboard_path, target_clipboard_filepath)
 
             # Copy all protobuf files (if not found in target asset folder)
-            for protobuf_path in os.listdir(info.PROTOBUF_DATA_PATH):
-                working_protobuf_path = os.path.join(info.PROTOBUF_DATA_PATH, protobuf_path)
-                target_protobuf_filepath = os.path.join(target_protobuf_path, protobuf_path)
-                if not os.path.exists(target_protobuf_filepath):
-                    shutil.copy2(working_protobuf_path, target_protobuf_filepath)
+            if os.path.abspath(info.PROTOBUF_DATA_PATH) != os.path.abspath(target_protobuf_path):
+                for protobuf_path in os.listdir(info.PROTOBUF_DATA_PATH):
+                    working_protobuf_path = os.path.join(info.PROTOBUF_DATA_PATH, protobuf_path)
+                    target_protobuf_filepath = os.path.join(target_protobuf_path, protobuf_path)
+                    if not os.path.exists(target_protobuf_filepath):
+                        shutil.copy2(working_protobuf_path, target_protobuf_filepath)
 
             # Copy any necessary assets for File records
             for file in self._data["files"]:
@@ -988,31 +994,31 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                 new_asset_path = None
                 if info.BLENDER_PATH in path:
                     # Copy directory of blender files
-                    log.info("Copying %s", path)
                     old_dir, asset_name = os.path.split(path)
                     if os.path.isdir(old_dir) and old_dir not in copied_assets["blender"]:
                         # Copy dir into new folder
                         old_dir_name = os.path.basename(old_dir)
-                        copied_assets["blender"].add(old_dir)
-                        log.info("Copied dir %s to %s", old_dir_name, target_blender_path)
+                        if os.path.abspath(old_dir) != os.path.abspath(target_blender_path):
+                            copied_assets["blender"].add(old_dir)
+                            log.info("Copied dir %s to %s", old_dir_name, target_blender_path)
                     new_asset_path = os.path.join(target_blender_path, old_dir_name, asset_name)
 
                 if info.TITLE_PATH in path:
                     # Copy title files into assets folder
-                    log.info("Copying %s", path)
                     old_dir, asset_name = os.path.split(path)
                     if asset_name not in copied_assets["title"]:
                         # Copy title into assets title folder
-                        copied_assets["title"].add(asset_name)
-                        log.info("Copied title %s to %s", asset_name, target_title_path)
+                        if os.path.abspath(old_dir) != os.path.abspath(target_title_path):
+                            copied_assets["title"].add(asset_name)
+                            log.info("Copied title %s to %s", asset_name, target_title_path)
                     new_asset_path = os.path.join(target_title_path, asset_name)
 
                 if info.CLIPBOARD_PATH in path:
-                    log.info("Copying %s", path)
                     old_dir, asset_name = os.path.split(path)
                     if asset_name not in copied_assets["clipboard"]:
-                        copied_assets["clipboard"].add(asset_name)
-                        log.info("Copied clipboard %s to %s", asset_name, target_clipboard_path)
+                        if os.path.abspath(old_dir) != os.path.abspath(target_clipboard_path):
+                            copied_assets["clipboard"].add(asset_name)
+                            log.info("Copied clipboard %s to %s", asset_name, target_clipboard_path)
                     new_asset_path = os.path.join(target_clipboard_path, asset_name)
 
                 # Update path in File object to new location

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -314,7 +314,7 @@
     "min": 0.0,
     "max": 1.0,
     "step": 0.1,
-    "value": 0.7,
+    "value": 0.5,
     "title": "Cache Ahead (Percent)",
     "type": "spinner",
     "category": "Cache",
@@ -323,7 +323,7 @@
   {
     "min": 0,
     "max": 1024,
-    "value": 600,
+    "value": 900,
     "title": "Cache Max Frames",
     "type": "spinner-int",
     "category": "Cache",
@@ -332,7 +332,7 @@
   {
     "min": 0,
     "max": 9999999,
-    "value": 512,
+    "value": 768,
     "title": "Cache Limit (MB)",
     "type": "spinner-int",
     "category": "Cache",

--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -803,7 +803,12 @@ App.directive("tlClip", function ($timeout) {
           }
           else {
             // Preview the right side of the clip
-            scope.previewClipFrame(scope.clip.id, snapToFPSGridTime(scope, new_right / scope.pixelsPerSecond));
+            var frame_duration = scope.project.fps.den / scope.project.fps.num;
+            var preview_right = (new_right / scope.pixelsPerSecond) - frame_duration;
+            if (preview_right < 0) {
+              preview_right = 0;
+            }
+            scope.previewClipFrame(scope.clip.id, snapToFPSGridTime(scope, preview_right));
           }
 
           var previewStart = new_left / scope.pixelsPerSecond;

--- a/src/timeline/js/directives/clip.js
+++ b/src/timeline/js/directives/clip.js
@@ -517,6 +517,11 @@ App.directive("tlClip", function ($timeout) {
           scope.setDragging(true);
           resize_disabled = false;
 
+          if (scope.Qt) {
+            timeline.DisableCacheThread();
+            timeline.TrimPreviewMode();
+          }
+
           if (scope.enable_timing) {
             timing_original_start = scope.clip.start;
             timing_original_end = scope.clip.end;
@@ -559,6 +564,10 @@ App.directive("tlClip", function ($timeout) {
         },
         stop: function (e, ui) {
           scope.setDragging(false);
+          if (scope.Qt) {
+            timeline.EnableCacheThread();
+            timeline.TimelinePreviewMode();
+          }
 
           // Stop showing hidden keyframes after drag is done
           stopKeyframePreview();
@@ -651,7 +660,11 @@ App.directive("tlClip", function ($timeout) {
               scope.resizeTimeline();
             });
             if (scope.Qt) {
+              timeline.BeginTrimRefresh();
               timeline.RetimeClip(scope.clip.id, scope.clip.end, scope.clip.position);
+            }
+            if (scope.Qt) {
+              timeline.RefreshTrimmedTimelineItem(JSON.stringify(scope.clip), dragLoc);
             }
             if (timing_original_audio && timing_original_duration > 0) {
               var newDuration = Math.max(scope.clip.end - scope.clip.start, 0);
@@ -687,7 +700,11 @@ App.directive("tlClip", function ($timeout) {
 
             // update clip in Qt (very important =)
             if (scope.Qt) {
+              timeline.BeginTrimRefresh();
               timeline.update_clip_data(JSON.stringify(scope.clip), true, true, false, null);
+            }
+            if (scope.Qt) {
+              timeline.RefreshTrimmedTimelineItem(JSON.stringify(scope.clip), dragLoc);
             }
             updateMaxResizeWidth();
           }

--- a/src/timeline/js/directives/keyframe.js
+++ b/src/timeline/js/directives/keyframe.js
@@ -133,6 +133,7 @@ App.directive("tlKeyframe", function () {
           pendingFrame = currentFrame;
           locateObject();
           if (scope.Qt) {
+            timeline.DisableCacheThread();
             timeline.StartKeyframeDrag(objType, objId, transactionId);
           }
           try { window.getSelection() && window.getSelection().removeAllRanges(); } catch (_) {}
@@ -171,6 +172,9 @@ App.directive("tlKeyframe", function () {
         stop: function (e, ui) {
           scope.setDragging(false);
           exitDragMode();
+          if (scope.Qt) {
+            timeline.EnableCacheThread();
+          }
           locateObject();
           if (!obj || typeof obj.start === "undefined") {
             restoreUserSelect();

--- a/src/timeline/js/directives/transition.js
+++ b/src/timeline/js/directives/transition.js
@@ -183,6 +183,11 @@ App.directive("tlTransition", function () {
           scope.setDragging(true);
           resize_disabled = false;
 
+          if (scope.Qt) {
+            timeline.DisableCacheThread();
+            timeline.TrimPreviewMode();
+          }
+
           // Set bounding box
           setBoundingBox(scope, $(this), "trimming");
 
@@ -208,6 +213,10 @@ App.directive("tlTransition", function () {
         },
         stop: function (e, ui) {
           scope.setDragging(false);
+          if (scope.Qt) {
+            timeline.EnableCacheThread();
+            timeline.TimelinePreviewMode();
+          }
 
           stopTransitionKeyframePreview();
 
@@ -270,7 +279,12 @@ App.directive("tlTransition", function () {
 
           // update transition in Qt (very important =)
           if (scope.Qt) {
+            timeline.BeginTrimRefresh();
             timeline.update_transition_data(JSON.stringify(scope.transition), true, false, null);
+          }
+
+          if (scope.Qt) {
+            timeline.RefreshTrimmedTimelineItem(JSON.stringify(scope.transition), dragLoc);
           }
 
           dragLoc = null;

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -134,6 +134,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     SetKeyframeFilter = pyqtSignal(str)     # Signal to only show keyframes for the selected property
     IgnoreUpdates = pyqtSignal(bool, bool)     # Signal to let widgets know to ignore updates (i.e. batch updates)
     ThemeChangedSignal = pyqtSignal(object)     # Signal when theme is changed
+    ProjectSaved = pyqtSignal(str)
+    ProjectSaveFailed = pyqtSignal(str, str)
 
     # Docks are closable, movable and floatable
     docks_frozen = False
@@ -507,17 +509,24 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 # Save project to file
                 app.project.save(file_path)
 
-                # Set Window title
-                self.SetWindowTitle()
-
-                # Load recent projects again
-                self.load_recent_menu()
-
                 log.info("Saved project %s", file_path)
+                self.ProjectSaved.emit(file_path)
 
             except Exception as ex:
                 log.error("Couldn't save project %s", file_path, exc_info=1)
-                QMessageBox.warning(self, _("Error Saving Project"), str(ex))
+                self.ProjectSaveFailed.emit(file_path, str(ex))
+
+    @pyqtSlot(str)
+    def _on_project_saved(self, file_path):
+        """Update UI after a project save completes."""
+        self.SetWindowTitle()
+        self.load_recent_menu()
+
+    @pyqtSlot(str, str)
+    def _on_project_save_failed(self, file_path, error_message):
+        """Show save errors on the UI thread."""
+        _ = get_app()._tr
+        QMessageBox.warning(self, _("Error Saving Project"), error_message)
 
     def save_recovery(self, file_path):
         """Saves the project and manages recovery files based on configured limits."""
@@ -4207,6 +4216,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Connect theme changed signal
         self.ThemeChangedSignal.connect(self.style_dock_widgets)
+        self.ProjectSaved.connect(self._on_project_saved, Qt.QueuedConnection)
+        self.ProjectSaveFailed.connect(self._on_project_save_failed, Qt.QueuedConnection)
 
         # Connect the signals for each dock widget from self.getDocks()
         for dock_widget in self.getDocks():

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -104,6 +104,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     PauseSignal = pyqtSignal()
     StopSignal = pyqtSignal()
     SeekSignal = pyqtSignal(int)
+    LoadTimelineAndSeekSignal = pyqtSignal(int)
     SpeedSignal = pyqtSignal(float)
     SeekPreviousFrame = pyqtSignal()
     SeekNextFrame = pyqtSignal()
@@ -125,6 +126,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     TimelineResize = pyqtSignal()  # Timeline length changed signal from timeline
     TimelineScroll = pyqtSignal(float)   # Signal to force scroll timeline to specific point
     TimelineCenter = pyqtSignal()        # Signal to force center scroll on playhead
+    TrimPreviewMode = pyqtSignal()
+    TimelinePreviewMode = pyqtSignal()
     SelectionAdded = pyqtSignal(str, str, bool)  # Signal to add a selection
     SelectionRemoved = pyqtSignal(str, str)      # Signal to remove a selection
     SelectionChanged = pyqtSignal()      # Signal after selections have been changed (added/removed)
@@ -1930,7 +1933,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             self.SeekSignal.emit(adjusted_frame)
 
             # Refresh frame (since size of preview might have changed)
-            QTimer.singleShot(500, self.refreshFrameSignal.emit)
+            QTimer.singleShot(500, lambda: self.refreshFrameSignal.emit())
             QTimer.singleShot(500, functools.partial(self.MaxSizeChanged.emit,
                                                      self.videoPreview.size()))
 
@@ -3839,6 +3842,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = True
 
         if not ignore:
+            if getattr(self, "_trim_refresh_pending", False):
+                self.ignore_updates = ignore
+                return
             self.refreshFrameSignal.emit()
             self.propertyTableView.select_frame(self.preview_thread.player.Position())
 
@@ -4228,7 +4234,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         QTimer.singleShot(0, self._apply_saved_timeline_height)
 
         # Refresh frame
-        QTimer.singleShot(100, self.refreshFrameSignal.emit)
+        QTimer.singleShot(100, lambda: self.refreshFrameSignal.emit())
 
         # Main window is initialized
         self.initialized = True

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -163,8 +163,6 @@ class PropertiesModel(updates.UpdateInterface):
                 if self.frame_number > max_frame_number:
                     self.frame_number = max_frame_number
 
-                log.debug("Update frame to %s" % self.frame_number)
-
                 # Update the model data
                 if reload_model:
                     self.update_model(get_app().window.txtPropertyFilter.text())
@@ -977,7 +975,6 @@ class PropertiesModel(updates.UpdateInterface):
         self.items[name] = {"row": row, "property": property}
 
     def update_model(self, filter=""):
-        log.debug("updating clip properties model.")
         app = get_app()
         _ = app._tr
 

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -304,7 +304,8 @@ class PropertiesModel(updates.UpdateInterface):
                         get_audio_data({waveform_file_id: [c.id]})
 
                     # Update the preview
-                    get_app().window.refreshFrameSignal.emit()
+                    if not self._trim_preview_mode:
+                        get_app().window.refreshFrameSignal.emit()
 
                 # Clear selection and restore focus to label column
                 current_row = self.parent.currentIndex().row()
@@ -440,7 +441,8 @@ class PropertiesModel(updates.UpdateInterface):
                         c.save()
 
                         # Update the preview
-                        get_app().window.refreshFrameSignal.emit()
+                        if not self._trim_preview_mode:
+                            get_app().window.refreshFrameSignal.emit()
 
                     # Clear selection and restore focus to label column
                     current_row = self.parent.currentIndex().row()
@@ -1098,6 +1100,7 @@ class PropertiesModel(updates.UpdateInterface):
         self.parent = parent
         self.previous_filter = None
         self.filter_base_properties = []
+        self._trim_preview_mode = False
 
         # Create standard model
         self.model = ClipStandardItemModel()
@@ -1116,3 +1119,11 @@ class PropertiesModel(updates.UpdateInterface):
 
         # Add self as listener to project data updates (used to update the timeline)
         get_app().updates.add_listener(self)
+        get_app().window.TrimPreviewMode.connect(self._enter_trim_preview)
+        get_app().window.TimelinePreviewMode.connect(self._exit_trim_preview)
+
+    def _enter_trim_preview(self):
+        self._trim_preview_mode = True
+
+    def _exit_trim_preview(self):
+        self._trim_preview_mode = False

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -379,7 +379,7 @@ class PlayerWorker(QObject):
                         self.clip_reader.info.has_audio = False
                         new_clip.Reader().info.has_audio = False
                 except Exception:
-                    pass
+                    log.debug("Failed to check has_video on clip reader for %s", path)
                 self.clip_reader.AddClip(new_clip)
             except:
                 log.warning('Failed to load media file into video player: %s' % path)

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -131,6 +131,7 @@ class PreviewParent(QObject, UpdateInterface):
         self.parent.PlaySignal.connect(self.worker.Play)
         self.parent.PauseSignal.connect(self.worker.Pause)
         self.parent.SeekSignal.connect(self.worker.Seek)
+        self.parent.LoadTimelineAndSeekSignal.connect(self.worker.LoadTimelineAndSeek)
         self.parent.SpeedSignal.connect(self.worker.Speed)
         self.parent.StopSignal.connect(self.worker.Stop)
 
@@ -165,6 +166,7 @@ class PlayerWorker(QObject):
         self.number = None
         self.current_frame = None
         self.current_mode = None
+        self.reader_mode = "timeline"
 
         # Create QtPlayer class from libopenshot
         self.player = openshot.QtPlayer()
@@ -307,7 +309,16 @@ class PlayerWorker(QObject):
     def LoadFile(self, path=None):
         """ Load a media file into the video player """
         # Check to see if this path is already loaded
-        if path == self.clip_path or (not path and not self.clip_path):
+        if path == self.clip_path:
+            if self.reader_mode == "clip":
+                return
+            if self.clip_reader:
+                self.original_position = self.player.Position()
+                self.player.Reader(self.clip_reader)
+                self.reader_mode = "clip"
+                self.Seek(1)
+            return
+        if not path and not self.clip_path and self.reader_mode == "timeline":
             return
 
         log.info("LoadFile %s" % path)
@@ -323,6 +334,7 @@ class PlayerWorker(QObject):
             # Return to self.timeline reader
             log.debug("Set timeline reader again in player: %s" % self.timeline)
             self.player.Reader(self.timeline)
+            self.reader_mode = "timeline"
 
             # Clear clip reader reference
             self.clip_reader = None
@@ -341,6 +353,9 @@ class PlayerWorker(QObject):
             sample_rate = int(project.get("sample_rate"))
             channels = int(project.get("channels"))
             channel_layout = int(project.get("channel_layout"))
+            timeline_sync = getattr(get_app().window, "timeline_sync", None)
+            preview_width = getattr(getattr(timeline_sync, "timeline", None), "preview_width", 0)
+            preview_height = getattr(getattr(timeline_sync, "timeline", None), "preview_height", 0)
 
             # Create an instance of a libopenshot Timeline object
             self.clip_reader = openshot.Timeline(width, height,
@@ -353,16 +368,25 @@ class PlayerWorker(QObject):
             self.clip_reader.info.duration = 999999
             self.clip_reader.info.sample_rate = sample_rate
             self.clip_reader.info.channels = channels
+            if preview_width and preview_height:
+                self.clip_reader.SetMaxSize(int(preview_width), int(preview_height))
 
             try:
                 # Add clip for current preview file
                 new_clip = openshot.Clip(path)
+                try:
+                    if new_clip.Reader().info.has_video:
+                        self.clip_reader.info.has_audio = False
+                        new_clip.Reader().info.has_audio = False
+                except Exception:
+                    pass
                 self.clip_reader.AddClip(new_clip)
             except:
                 log.warning('Failed to load media file into video player: %s' % path)
 
             # Assign new clip_reader
             self.clip_path = path
+            self.reader_mode = "clip"
 
             # Keep track of previous clip readers (so we can Close it later)
             self.previous_clips.append(new_clip)
@@ -381,7 +405,10 @@ class PlayerWorker(QObject):
             previous_reader.Close()
 
         # Seek to frame 1, and resume speed
-        self.Seek(seek_position)
+        if not path:
+            QTimer.singleShot(0, lambda: self.Seek(seek_position))
+        else:
+            self.Seek(seek_position)
 
     def Play(self):
         """ Start playing the video player """
@@ -410,6 +437,17 @@ class PlayerWorker(QObject):
         # Seek to frame
         if self.parent.initialized:
             self.player.Seek(number)
+
+    @pyqtSlot(int)
+    def LoadTimelineAndSeek(self, frame):
+        frame = max(1, int(frame))
+        self.original_position = frame
+        if self.timeline:
+            self.player.Reader(self.timeline)
+            self.reader_mode = "timeline"
+            self.clip_reader = None
+            self.clip_path = None
+        self.Seek(frame)
 
     def Speed(self, new_speed):
         """ Set the speed of the video player """

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -1724,8 +1724,9 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
     def _clip_source_dimensions(self, clip, clip_object, frame_number, skip_effect_id=None):
         pixel_adjust = self.pixel_ratio.Reciprocal().ToDouble()
-        width = float(clip.data['reader']['width'])
-        height = float(clip.data['reader']['height']) * pixel_adjust
+        reader = clip.data.get('reader', {})
+        width = float(reader.get('width', self.width()))
+        height = float(reader.get('height', self.height())) * pixel_adjust
 
         for eff in clip_object.Effects():
             if getattr(getattr(eff, 'info', None), 'class_name', '') != 'Crop':

--- a/src/windows/views/timeline.py
+++ b/src/windows/views/timeline.py
@@ -3443,7 +3443,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
                 "edge": edge,
                 "data": item_data,
             }
-            QTimer.singleShot(200, self._apply_pending_trim_refresh)
+            QTimer.singleShot(0, self._apply_pending_trim_refresh)
             return
 
         fps = get_app().project.get("fps")

--- a/src/windows/views/timeline.py
+++ b/src/windows/views/timeline.py
@@ -409,6 +409,13 @@ class TimelineView(updates.UpdateInterface, ViewClass):
                 TimelineWidget.changed(self, None)
             return
 
+        if ViewClass == TimelineWidget and self._pending_trim_refresh:
+            pending = self._pending_trim_refresh
+            item_id = pending.get("id")
+            if item_id and action and action.key and action.key[0] in ["clips", "transitions"]:
+                if self._action_contains_item_id(action, item_id):
+                    self._apply_pending_trim_refresh()
+
         try:
             # Duplicate UpdateAction, and remove unused action attribute (old_values)
             action = action.copy()
@@ -3399,7 +3406,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
         # Refresh frame to ensure our last frame after scrubbing
         # is the final frame shown. Due to some unknown reason, this
         # is required for an accurate end to srubbing
-        QTimer.singleShot(50, self.window.refreshFrameSignal.emit)
+        QTimer.singleShot(50, lambda: self.window.refreshFrameSignal.emit())
 
     @pyqtSlot()
     def DisableCacheThread(self):
@@ -3407,6 +3414,96 @@ class TimelineView(updates.UpdateInterface, ViewClass):
 
         # Disable video caching
         openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = False
+
+    @pyqtSlot()
+    def TrimPreviewMode(self):
+        self.window.TrimPreviewMode.emit()
+
+    @pyqtSlot()
+    def TimelinePreviewMode(self):
+        self.window.TimelinePreviewMode.emit()
+
+    @pyqtSlot()
+    def BeginTrimRefresh(self):
+        setattr(self.window, "_trim_refresh_pending", True)
+
+    @pyqtSlot(str, str)
+    def RefreshTrimmedTimelineItem(self, item_json, edge):
+        try:
+            item_data = json.loads(item_json) if not isinstance(item_json, dict) else item_json
+        except Exception:
+            log.debug("Failed to parse trim JSON data", exc_info=True)
+            return
+
+        setattr(self.window, "_trim_refresh_pending", True)
+        if ViewClass == TimelineWidget:
+            item_id = item_data.get("id")
+            self._pending_trim_refresh = {
+                "id": item_id,
+                "edge": edge,
+                "data": item_data,
+            }
+            QTimer.singleShot(200, self._apply_pending_trim_refresh)
+            return
+
+        fps = get_app().project.get("fps")
+        fps_float = float(fps["num"]) / float(fps["den"]) if fps else 0.0
+        if fps_float <= 0.0:
+            return
+
+        position = float(item_data.get("position", 0.0) or 0.0)
+        start = float(item_data.get("start", 0.0) or 0.0)
+        end = float(item_data.get("end", start) or start)
+        duration = max(0.0, end - start)
+        frame_duration = 1.0 / fps_float
+
+        if edge == "left":
+            target_seconds = position
+        else:
+            target_seconds = position + max(0.0, duration - frame_duration)
+
+        target_frame = max(1, int(round(target_seconds * fps_float)) + 1)
+        self.window.LoadTimelineAndSeekSignal.emit(target_frame)
+        QTimer.singleShot(0, lambda: setattr(self.window, "_trim_refresh_pending", False))
+
+    def _action_contains_item_id(self, action, item_id):
+        if not action or not item_id:
+            return False
+        for part in action.key or []:
+            if isinstance(part, dict) and part.get("id") == item_id:
+                return True
+        values = getattr(action, "values", None)
+        if isinstance(values, dict) and values.get("id") == item_id:
+            return True
+        return False
+
+    def _apply_pending_trim_refresh(self):
+        pending = self._pending_trim_refresh
+        if not pending:
+            return
+        self._pending_trim_refresh = None
+        item_data = pending.get("data") or {}
+        edge = pending.get("edge")
+
+        fps = get_app().project.get("fps")
+        fps_float = float(fps["num"]) / float(fps["den"]) if fps else 0.0
+        if fps_float <= 0.0:
+            return
+
+        position = float(item_data.get("position", 0.0) or 0.0)
+        start = float(item_data.get("start", 0.0) or 0.0)
+        end = float(item_data.get("end", start) or start)
+        duration = max(0.0, end - start)
+        frame_duration = 1.0 / fps_float
+
+        if edge == "left":
+            target_seconds = position
+        else:
+            target_seconds = position + max(0.0, duration - frame_duration)
+
+        target_frame = max(1, int(round(target_seconds * fps_float)) + 1)
+        self.window.LoadTimelineAndSeekSignal.emit(target_frame)
+        QTimer.singleShot(0, lambda: setattr(self.window, "_trim_refresh_pending", False))
 
     @pyqtSlot(str, int)
     def PreviewClipFrame(self, clip_id, frame_number):
@@ -4130,6 +4227,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
         self.setAcceptDrops(True)
         self.last_position_frames = None
         self.context_menu_cursor_position = None
+        self._pending_trim_refresh = None
 
         # Get logger
         self.log_fn = log.log

--- a/src/windows/views/timeline_backend/paint/clip.py
+++ b/src/windows/views/timeline_backend/paint/clip.py
@@ -138,9 +138,6 @@ class ClipPainter(BasePainter):
         if not clip_token:
             return
         clip_id = str(clip_token).split(":", 1)[0]
-        removed_cache = 0
-        removed_pending = 0
-
         if drop_cache:
             cache_keys = [
                 key for key in list(self.thumb_cache.keys())
@@ -148,7 +145,6 @@ class ClipPainter(BasePainter):
             ]
             for key in cache_keys:
                 self.thumb_cache.pop(key, None)
-            removed_cache = len(cache_keys)
 
         if drop_pending:
             pending_keys = [
@@ -159,7 +155,6 @@ class ClipPainter(BasePainter):
                 self._thumb_pending.pop(key, None)
                 self._thumb_regions.pop(key, None)
                 self._thumb_missing_logged.discard(key)
-            removed_pending = len(pending_keys)
 
         if drop_fallback:
             fallback_keys = [

--- a/src/windows/views/timeline_backend/paint/clip.py
+++ b/src/windows/views/timeline_backend/paint/clip.py
@@ -125,6 +125,54 @@ class ClipPainter(BasePainter):
         self._last_thumb_request_time.clear()
         self._slot_fallback_cache.clear()
 
+    def invalidate_clip_thumbnails(
+        self,
+        clip_token,
+        *,
+        drop_cache=True,
+        drop_pending=True,
+        drop_fallback=True,
+        invalidate_render_cache=True,
+    ):
+        """Invalidate thumbnail caches/requests for a single clip."""
+        if not clip_token:
+            return
+        clip_id = str(clip_token).split(":", 1)[0]
+        removed_cache = 0
+        removed_pending = 0
+
+        if drop_cache:
+            cache_keys = [
+                key for key in list(self.thumb_cache.keys())
+                if isinstance(key, tuple) and key and str(key[0]).split(":", 1)[0] == clip_id
+            ]
+            for key in cache_keys:
+                self.thumb_cache.pop(key, None)
+            removed_cache = len(cache_keys)
+
+        if drop_pending:
+            pending_keys = [
+                key for key in list(self._thumb_pending.keys())
+                if isinstance(key, tuple) and key and str(key[0]).split(":", 1)[0] == clip_id
+            ]
+            for key in pending_keys:
+                self._thumb_pending.pop(key, None)
+                self._thumb_regions.pop(key, None)
+                self._thumb_missing_logged.discard(key)
+            removed_pending = len(pending_keys)
+
+        if drop_fallback:
+            fallback_keys = [
+                key for key in list(self._slot_fallback_cache.keys())
+                if isinstance(key, tuple) and key and str(key[0]).split(":", 1)[0] == clip_id
+            ]
+            for key in fallback_keys:
+                self._slot_fallback_cache.pop(key, None)
+
+        self._last_thumb_request_time.pop(clip_id, None)
+        if invalidate_render_cache:
+            self._invalidate_clip_cache_for_clip(clip_id)
+
     def _segment_overdraw(self, view_width):
         """Return the horizontal overdraw (extra pixels) to render beyond the view."""
 
@@ -611,9 +659,12 @@ class ClipPainter(BasePainter):
             return [], None
 
         # Slot dimensions
-        thumb_w = float(self.w.theme.clip.thumb_width or inner.height())
+        theme_thumb_w = float(self.w.theme.clip.thumb_width or inner.height())
+        thumb_w = theme_thumb_w
         thumb_h = float(self.w.theme.clip.thumb_height or inner.height())
-        thumb_w = max(self._min_thumb_slot_width, min(thumb_w, clip_width))
+        # Keep slot width at nominal thumbnail width even for small clips.
+        # This allows the clip bounds to crop thumbnails instead of shrinking them.
+        thumb_w = max(self._min_thumb_slot_width, thumb_w)
         thumb_h = max(self._min_thumb_slot_width, min(thumb_h, inner.height()))
         top = inner.y() + (inner.height() - thumb_h) / 2.0
 
@@ -651,10 +702,20 @@ class ClipPainter(BasePainter):
         media_duration = max(media_duration, clip_duration)
 
         # Slot spacing in time
-        interval_pixels = max(thumb_w, self._min_thumb_slot_width)
+        # Entire style keeps spacing tied to nominal thumb width (not the
+        # shrinking clip width), which prevents end-of-trim slot oscillation.
+        if style == "entire":
+            interval_pixels = max(theme_thumb_w, self._min_thumb_slot_width)
+        else:
+            interval_pixels = max(thumb_w, self._min_thumb_slot_width)
         interval_seconds = interval_pixels / pixels_per_second
         if interval_seconds <= 0.0:
             interval_seconds = 0.01
+        if style == "entire":
+            clip_fps = self._clip_media_fps(clip)
+            if clip_fps > 0.0:
+                interval_frames = max(1, int(round(interval_seconds * clip_fps)))
+                interval_seconds = interval_frames / clip_fps
         half_interval = interval_seconds * 0.5
         slot_duration_seconds = interval_seconds
 
@@ -732,7 +793,12 @@ class ClipPainter(BasePainter):
         elif style == "start-end":
             if includes_start:
                 add_center_world(segment_start_world)
-            if includes_end:
+            # If the visible segment cannot fit two full slots, prioritize the
+            # start slot to avoid the end slot covering it on very short clips.
+            allow_end_slot = True
+            if includes_start and includes_end and segment_duration < (slot_duration_seconds * 2.0):
+                allow_end_slot = False
+            if includes_end and allow_end_slot:
                 # Start slot so its right edge aligns with the clip end
                 clip_end_world = clip_pos + max(0.0, clip_duration - slot_duration_seconds)
                 add_center_world(clip_end_world)
@@ -799,8 +865,7 @@ class ClipPainter(BasePainter):
         pending = False
         generation = getattr(self.w, "thumbnail_generation", 0)
         rounding = self._frame_rounding_increment(clip_fps, interval_seconds)
-        clip_width = float(inner.width())
-        clip_left = inner.x()
+        frame_duration = (1.0 / clip_fps) if clip_fps and clip_fps > 0.0 else 0.0
 
         static_image = self._has_static_image(clip)
         static_frame = 1 if static_image else None
@@ -809,25 +874,43 @@ class ClipPainter(BasePainter):
             slot_start_time = float(time_offset)
             slot_end_time = slot_start_time + slot_duration_seconds
             slot_center_time = slot_start_time + half_slot_duration
-            if slot_center_time < segment_offset:
-                slot_center_time = segment_offset
-            elif slot_center_time > segment_end:
-                slot_center_time = segment_end
+            clamped_center_time = slot_center_time
+            if clamped_center_time < segment_offset:
+                clamped_center_time = segment_offset
+            elif clamped_center_time > segment_end:
+                clamped_center_time = segment_end
 
-            # Correct absolute time in source media
-            clip_time = trim_start + slot_center_time
-            frame = self._frame_for_offset(clip_time, clip_fps)
-            if static_frame:
-                frame = static_frame
             is_edge = (slot_start_time <= segment_offset + edge_epsilon) or (
                 slot_end_time >= segment_end - edge_epsilon
             )
-            if rounding > 1 and not is_edge:
-                frame = max(1, int(round((frame - 1) / rounding) * rounding) + 1)
-            key = (clip_key, frame)
             slot_role = "edge-start" if is_edge and slot_start_time <= segment_offset + edge_epsilon else (
                 "edge-end" if is_edge and slot_end_time >= segment_end - edge_epsilon else "grid"
             )
+
+            # For "start" and "start-end", anchor edge thumbnails to exact trim edges.
+            # Keep strip/entire behavior unchanged (centered sampling).
+            if style in ("start", "start-end") and slot_role == "edge-start":
+                sample_time = segment_offset
+            elif style in ("start", "start-end") and slot_role == "edge-end":
+                if frame_duration > 0.0:
+                    sample_time = max(segment_offset, segment_end - frame_duration)
+                else:
+                    sample_time = segment_end
+            elif style == "entire":
+                # Entire style samples from the first frame in each slot for stable
+                # trim behavior and predictable strip thumbnails.
+                sample_time = slot_start_time
+            else:
+                sample_time = clamped_center_time
+
+            # Correct absolute time in source media
+            clip_time = trim_start + sample_time
+            frame = self._frame_for_offset(clip_time, clip_fps)
+            if static_frame:
+                frame = static_frame
+            if rounding > 1 and (style == "entire" or not is_edge):
+                frame = max(1, int(round((frame - 1) / rounding) * rounding) + 1)
+            key = (clip_key, frame)
             cached = self.thumb_cache.get(key)
             if cached and not cached.isNull():
                 pix = cached
@@ -882,6 +965,9 @@ class ClipPainter(BasePainter):
             if not pix.isNull():
                 self.thumb_cache[key] = pix
                 return pix
+
+        if getattr(self.w, "_suspend_thumbnail_requests", False):
+            return None
 
         if not allow_request:
             return None
@@ -1363,9 +1449,10 @@ class ClipPainter(BasePainter):
     def handle_thumbnail_ready(self, clip_id, frame, thumb_path, generation):
         clip_key = str(clip_id or "")
         key = (clip_key, int(frame or 0))
+        pending_generation = self._thumb_pending.get(key)
 
         # Ignore if not from current generation
-        if self._thumb_pending.get(key) != generation:
+        if pending_generation != generation:
             return
 
         self._thumb_pending.pop(key, None)

--- a/src/windows/views/timeline_backend/qwidget/base.py
+++ b/src/windows/views/timeline_backend/qwidget/base.py
@@ -38,6 +38,7 @@ from PyQt5.QtCore import (
     QSignalTransition,
     QByteArray,
     pyqtSignal,
+    pyqtSlot,
     QObject,
     QMetaMethod,
 )
@@ -273,6 +274,7 @@ class TimelineWidgetBase(QWidget):
         # Thumbnail helpers
         self.thumbnail_style = self._load_thumbnail_style()
         self.thumbnail_generation = 0
+        self._suspend_thumbnail_requests = False
         self.thumbnail_manager = TimelineThumbnailManager(self)
         self._viewport_thumbnail_reset_timer = QTimer(self)
         self._viewport_thumbnail_reset_timer.setSingleShot(True)
@@ -295,7 +297,8 @@ class TimelineWidgetBase(QWidget):
         self.selection_painter = SelectionPainter(self)
         self.scrollbar_painter = ScrollbarPainter(self)
         self.thumbnail_manager.thumbnail_ready.connect(
-            self.clip_painter.handle_thumbnail_ready
+            self._handle_thumbnail_ready,
+            type=Qt.QueuedConnection,
         )
 
         # Keyframe helpers
@@ -405,6 +408,17 @@ class TimelineWidgetBase(QWidget):
             self.thumbnail_manager.clear_pending()
         if hasattr(self, "clip_painter"):
             self.clip_painter.expire_thumbnail_requests(self.thumbnail_generation)
+
+    @pyqtSlot(str, int, str, int)
+    def _handle_thumbnail_ready(self, clip_id, frame, thumb_path, generation):
+        """Forward thumbnail ready events to the clip painter on the GUI thread."""
+        if hasattr(self, "clip_painter"):
+            self.clip_painter.handle_thumbnail_ready(
+                clip_id,
+                frame,
+                thumb_path,
+                generation,
+            )
 
     def _buildStateMachine(self):
         sm = TimelineStateMachine(self)
@@ -720,7 +734,13 @@ class TimelineWidgetBase(QWidget):
         self.fps_float = float(fps_info.get("num", 24)) / float(fps_info.get("den", 1) or 1)
 
         # Invalidate caches and geometry
-        self.clip_painter.clear_cache()
+        win = getattr(self, "win", None)
+        if getattr(win, "_trim_refresh_pending", False):
+            # Keep thumbnail/fallback caches during trim commit to avoid a blank flicker
+            # while new thumbnails are still being generated.
+            self.clip_painter.clip_cache.clear()
+        else:
+            self.clip_painter.clear_cache()
         self.transition_painter.clear_cache()
         self.geometry.mark_dirty()
 

--- a/src/windows/views/timeline_backend/qwidget/base.py
+++ b/src/windows/views/timeline_backend/qwidget/base.py
@@ -28,6 +28,7 @@
 import json
 from functools import partial
 
+import openshot
 from PyQt5.QtCore import (
     Qt,
     QRectF,
@@ -426,6 +427,13 @@ class TimelineWidgetBase(QWidget):
         keydrag.entered.connect(self._startKeyframeDrag)
         keydrag.exited.connect(self._finishKeyframeDrag)
 
+        resize.entered.connect(self._disable_playback_caching)
+        resize.exited.connect(self._enable_playback_caching)
+        playhead.entered.connect(self._disable_playback_caching)
+        playhead.exited.connect(self._enable_playback_caching)
+        keydrag.entered.connect(self._disable_playback_caching)
+        keydrag.exited.connect(self._enable_playback_caching)
+
         sender, pressed_signal = self._event_signal("pressed")
 
         t = _ConditionalTransition(sender, pressed_signal, idle, drag, lambda: self._press_hit == "clip")
@@ -475,6 +483,12 @@ class TimelineWidgetBase(QWidget):
         sm.setInitialState(idle)
         sm.start()
         self._sm = sm
+
+    def _disable_playback_caching(self):
+        openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = False
+
+    def _enable_playback_caching(self):
+        openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = True
 
     def _event_signal(self, name):
         return self.events, self._event_signal_bytes(name)

--- a/src/windows/views/timeline_backend/qwidget/clip.py
+++ b/src/windows/views/timeline_backend/qwidget/clip.py
@@ -27,7 +27,7 @@
 
 import json
 import uuid
-from PyQt5.QtCore import Qt, QRectF, QTimer
+from PyQt5.QtCore import Qt, QRectF
 from PyQt5.QtWidgets import QApplication
 from classes.app import get_app
 from classes.query import Clip, Transition
@@ -932,9 +932,8 @@ class ClipInteractionMixin:
             self.update_transition_data(item.data, only_basic_props=True)
 
         if isinstance(item, (Clip, Transition)):
-            refresh_trim = getattr(self, "RefreshTrimmedTimelineItem", None)
-            if refresh_trim:
-                refresh_trim(json.dumps(item.data), self._resize_edge)
+            if hasattr(self, "RefreshTrimmedTimelineItem"):
+                self.RefreshTrimmedTimelineItem(json.dumps(item.data), self._resize_edge)
 
         if isinstance(item, Clip):
             self._set_trim_thumbnail_suspension(False, item.id)

--- a/src/windows/views/timeline_backend/qwidget/clip.py
+++ b/src/windows/views/timeline_backend/qwidget/clip.py
@@ -35,6 +35,36 @@ from classes.waveform import SAMPLES_PER_SECOND as WAVEFORM_SAMPLES_PER_SECOND
 
 
 class ClipInteractionMixin:
+    def _set_trim_thumbnail_suspension(self, enabled, clip_id=None):
+        """Pause thumbnail generation while trimming and drop stale queued work."""
+        self._suspend_thumbnail_requests = bool(enabled)
+        clip_key = str(clip_id or "")
+        if enabled:
+            if self.thumbnail_manager:
+                self.thumbnail_manager.clear_pending()
+            if clip_key and hasattr(self, "clip_painter"):
+                # Keep existing cached thumbs visible while trimming, but drop in-flight requests.
+                self.clip_painter.invalidate_clip_thumbnails(
+                    clip_key,
+                    drop_cache=False,
+                    drop_pending=True,
+                    drop_fallback=False,
+                    invalidate_render_cache=False,
+                )
+            return
+
+        if self.thumbnail_manager:
+            self.thumbnail_manager.clear_pending()
+        if clip_key and hasattr(self, "clip_painter"):
+            # Preserve existing thumbnails until replacements arrive; only drop stale in-flight requests.
+            self.clip_painter.invalidate_clip_thumbnails(
+                clip_key,
+                drop_cache=False,
+                drop_pending=True,
+                drop_fallback=False,
+                invalidate_render_cache=False,
+            )
+
     def clip_has_pending_override(self, clip):
         if not isinstance(clip, Clip):
             return False
@@ -676,6 +706,7 @@ class ClipInteractionMixin:
             updated_ignore.add(item_id)
             self._snap_ignore_ids = updated_ignore
         if isinstance(item, Clip):
+            self._set_trim_thumbnail_suspension(True, item.id)
             max_duration = self._clip_reader_duration_seconds(item)
             if max_duration is None:
                 max_duration = self._positive_float(self._resize_initial.get("duration"))
@@ -870,6 +901,8 @@ class ClipInteractionMixin:
         if not item:
             return
         if not hasattr(self, "_resize_new_start"):
+            if isinstance(item, Clip):
+                self._set_trim_thumbnail_suspension(False, item.id)
             self._resizing_item = None
             self._snap_keyframe_seconds = []
             self.snap.reset()
@@ -902,6 +935,9 @@ class ClipInteractionMixin:
             refresh_trim = getattr(self, "RefreshTrimmedTimelineItem", None)
             if refresh_trim:
                 refresh_trim(json.dumps(item.data), self._resize_edge)
+
+        if isinstance(item, Clip):
+            self._set_trim_thumbnail_suspension(False, item.id)
 
         self._resizing_item = None
         self._snap_keyframe_seconds = []

--- a/src/windows/views/timeline_backend/qwidget/clip.py
+++ b/src/windows/views/timeline_backend/qwidget/clip.py
@@ -25,8 +25,9 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
+import json
 import uuid
-from PyQt5.QtCore import Qt, QRectF
+from PyQt5.QtCore import Qt, QRectF, QTimer
 from PyQt5.QtWidgets import QApplication
 from classes.app import get_app
 from classes.query import Clip, Transition
@@ -580,6 +581,8 @@ class ClipInteractionMixin:
 
     def _startResize(self):
         if self._press_hit == "clip-edge" and self._resizing_item:
+            if hasattr(self.win, "TrimPreviewMode"):
+                self.win.TrimPreviewMode.emit()
             self._startItemResize()
         elif self._press_hit == "timeline-handle":
             self._startProjectResize()
@@ -600,6 +603,8 @@ class ClipInteractionMixin:
     def _finishResize(self):
         if self._press_hit == "clip-edge" and self._resizing_item:
             self._finishItemResize()
+            if hasattr(self.win, "TimelinePreviewMode"):
+                self.win.TimelinePreviewMode.emit()
         elif self._press_hit == "timeline-handle":
             self._finishProjectResize()
         else:
@@ -864,10 +869,16 @@ class ClipInteractionMixin:
         item = self._resizing_item
         if not item:
             return
+        if not hasattr(self, "_resize_new_start"):
+            self._resizing_item = None
+            self._snap_keyframe_seconds = []
+            self.snap.reset()
+            return
         start = self._resize_new_start
         end = self._resize_new_end
         position = self._resize_new_position
         if isinstance(item, Clip):
+            setattr(self.win, "_trim_refresh_pending", True)
             if self.enable_timing:
                 duration = end - start
                 item.data["start"] = self._timing_original_start
@@ -880,11 +891,17 @@ class ClipInteractionMixin:
                 item.data["position"] = self._snap_time(position)
                 self.update_clip_data(item.data, only_basic_props=True, ignore_reader=True)
         else:
+            setattr(self.win, "_trim_refresh_pending", True)
             item.data["position"] = self._snap_time(position)
             item.data["start"] = 0.0
             item.data["end"] = self._snap_time(end)
             item.data["duration"] = self._snap_time(end)
             self.update_transition_data(item.data, only_basic_props=True)
+
+        if isinstance(item, (Clip, Transition)):
+            refresh_trim = getattr(self, "RefreshTrimmedTimelineItem", None)
+            if refresh_trim:
+                refresh_trim(json.dumps(item.data), self._resize_edge)
 
         self._resizing_item = None
         self._snap_keyframe_seconds = []


### PR DESCRIPTION
Related to https://github.com/OpenShot/libopenshot/pull/1032

Lots of good fixes in this PR:
- New default setting values:
  - New caching defaults
  - Higher cache limits by default
- Trimming improvements:
  - Jump playhead to trimmed frame (after trim)
  - No more flicker in preview refresh (after trim) - or at least reduced flicker
- Thumbnail improvements
  - Smoother thumbnail updates (less flicker)
  - More stable thumbnail slots (on experimental timeline backend)
- Bug fixes:
  - Fix to project save (auto-save) updating window title bar during an export
  - Fix to invalid logs during auto-save about copying assets
  - Reducing some annoying log noise