### PR TITLE
Enable "Use Blender GPU rendering for Animated Titles" as Default setting

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -185,7 +185,6 @@ win-sign-x64:
   script:
     - $PSVersionTable
     - $env:Path = $env:Path + ";C:\msys64\usr\local\bin;C:\msys64\usr\bin"
-    - $env:BUILD_SERVER_FORCE_BRANCH = "develop"
     - if (-not (Get-ChildItem -Path "build\*-x86_64.exe" -ErrorAction SilentlyContinue)) { throw "No x64 Windows installer found in build\\*-x86_64.exe" }
     - py -3 -u installer/build_server.py "$SLACK_TOKEN" "$GITHUB_USER" "$GITHUB_PASS" "False" "$CI_COMMIT_REF_NAME" "$MAC_PASSWORD" "sign-upload-only"
   when: always
@@ -206,7 +205,6 @@ win-sign-x86:
   script:
     - $PSVersionTable
     - $env:Path = $env:Path + ";C:\msys64\usr\local\bin;C:\msys64\usr\bin"
-    - $env:BUILD_SERVER_FORCE_BRANCH = "develop"
     - if (-not (Get-ChildItem -Path "build\*-x86.exe" -ErrorAction SilentlyContinue)) { throw "No x86 Windows installer found in build\\*-x86.exe" }
     - py -3 -u installer/build_server.py "$SLACK_TOKEN" "$GITHUB_USER" "$GITHUB_PASS" "True" "$CI_COMMIT_REF_NAME" "$MAC_PASSWORD" "sign-upload-only"
   when: always

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -309,11 +309,6 @@ def main():
         git_branch_name = "develop"
         if len(sys.argv) >= 6:
             git_branch_name = sys.argv[5]
-        forced_branch_name = os.getenv("BUILD_SERVER_FORCE_BRANCH", "").strip()
-        if forced_branch_name:
-            output("Forcing build-server branch logic from '%s' to '%s'" % (
-                git_branch_name, forced_branch_name))
-            git_branch_name = forced_branch_name
 
         mac_password = ""
         if len(sys.argv) >= 7:

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -583,7 +583,7 @@
     "setting": "decode_hw_max_height"
   },
   {
-    "value": false,
+    "value": true,
     "title": "Use Blender GPU rendering for Animated Titles (Experimental)",
     "type": "bool",
     "restart": false,


### PR DESCRIPTION
Enable "Use Blender GPU rendering for Animated Titles" setting by default (seems very stable now)