### PR TITLE
Improve Auto-Selections on Experimental Timeline (qwidget)

### DIFF
--- a/src/timeline/index.html
+++ b/src/timeline/index.html
@@ -87,7 +87,7 @@
 				</div>
 				
 				<!-- CLIPS -->
-				<div ng-hide tl-clip ng-repeat="clip in project.clips track by (clip.id || $index)" id="clip_{{clip.id}}" ng-click="selectClip(clip.id, true, $event)" ng-right-click="showClipMenu(clip.id, $event)" class="clip droppable" ng-class="getClipStyle(clip)" style="width:{{(clip.end - clip.start) * pixelsPerSecond}}px; left:{{clip.position * pixelsPerSecond}}px; top:{{getTrackTop(clip.layer)}}px;z-index:{{getZindex(clip, 1000, $index)}};">
+				<div ng-hide tl-clip ng-repeat="clip in project.clips track by (clip.id || $index)" id="clip_{{clip.id}}" ng-click="selectClip(clip.id, true, $event)" ng-dblclick="showProperties()" ng-right-click="showClipMenu(clip.id, $event)" class="clip droppable" ng-class="getClipStyle(clip)" style="width:{{(clip.end - clip.start) * pixelsPerSecond}}px; left:{{clip.position * pixelsPerSecond}}px; top:{{getTrackTop(clip.layer)}}px;z-index:{{getZindex(clip, 1000, $index)}};">
 					<div class="clip_top">
 						<div tl-clip-menu class="menu clip_menu" ng-if="!enable_razor" ng-mousedown="showClipMenu(clip.id, $event)" tooltip-enable="!enable_razor" uib-tooltip="{{clip.title}}" tooltip-placement="bottom" tooltip-popup-delay="400"></div>
 
@@ -128,7 +128,7 @@
 				</div>
 
 				<!-- TRANSITIONS -->
-				<div ng-hide tl-transition ng-repeat="transition in project.effects track by (transition.id || $index)" id="transition_{{transition.id}}" ng-click="selectTransition(transition.id, true, $event)" ng-right-click="showTransitionMenu(transition.id, $event)" class="transition droppable" ng-class="getClipStyle(transition)" style="width:{{ (transition.end - transition.start) * pixelsPerSecond}}px; left:{{transition.position * pixelsPerSecond}}px; top:{{getTrackTop(transition.layer)}}px;z-index:{{getZindex(transition, 5000, $index)}};">
+				<div ng-hide tl-transition ng-repeat="transition in project.effects track by (transition.id || $index)" id="transition_{{transition.id}}" ng-click="selectTransition(transition.id, true, $event)" ng-dblclick="showProperties()" ng-right-click="showTransitionMenu(transition.id, $event)" class="transition droppable" ng-class="getClipStyle(transition)" style="width:{{ (transition.end - transition.start) * pixelsPerSecond}}px; left:{{transition.position * pixelsPerSecond}}px; top:{{getTrackTop(transition.layer)}}px;z-index:{{getZindex(transition, 5000, $index)}};">
 					<div class="transition_top">
 						<div tl-clip-menu class="transition_menu" ng-if="!enable_razor" ng-mousedown="showTransitionMenu(transition.id, $event)"></div>
 

--- a/src/timeline/js/controllers.js
+++ b/src/timeline/js/controllers.js
@@ -1203,6 +1203,12 @@ $scope.selectItem = function (item_id, item_type, clear_selections, event, force
   };
 
 // Show clip context menu
+  $scope.showProperties = function () {
+    if ($scope.Qt) {
+      timeline.ShowProperties();
+    }
+  };
+
   $scope.showClipMenu = function (clip_id, event) {
     if ($scope.Qt && !$scope.enable_razor) {
       setTimeout(function() {

--- a/src/windows/add_to_timeline.py
+++ b/src/windows/add_to_timeline.py
@@ -187,6 +187,9 @@ class AddToTimeline(QDialog):
         fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
 
+        # Track added clip IDs for auto-selection
+        added_clip_ids = []
+
         # Loop through each file (in the current order)
         for file in self.treeFiles.timeline_model.files:
             # Create a clip
@@ -378,12 +381,22 @@ class AddToTimeline(QDialog):
             # Save Clip
             clip.data = new_clip
             clip.save()
+            added_clip_ids.append(clip.data.get("id"))
 
             # Increment position by length of clip
             position += (end_time - start_time)
 
         # Clear transaction
         get_app().updates.transaction_id = None
+
+        # Auto-select newly added clips
+        win = get_app().window
+        for idx, clip_id in enumerate(added_clip_ids):
+            if clip_id:
+                win.addSelection(str(clip_id), "clip", clear_existing=(idx == 0))
+        if added_clip_ids and hasattr(win.timeline, "geometry"):
+            win.timeline.geometry.mark_dirty()
+            win.timeline.update()
 
         # Accept dialog
         super(AddToTimeline, self).accept()

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -518,13 +518,18 @@ class FilesModel(QObject, updates.UpdateInterface):
         }
         return parameters
 
-    def process_urls(self, qurl_list, import_quietly=False, prevent_image_seq=False):
+    def process_urls(self, qurl_list, import_quietly=False, prevent_image_seq=False,
+                     transaction_id=None):
         """Recursively process QUrls from a QDropEvent"""
         media_paths = []
 
-        # Transaction
-        tid = str(uuid.uuid4())
-        get_app().updates.transaction_id = tid
+        # Transaction — use caller's transaction_id when provided so the
+        # caller can group file imports with subsequent operations (e.g.
+        # clip creation on timeline drop) into a single undo step.
+        owns_transaction = transaction_id is None
+        if owns_transaction:
+            transaction_id = str(uuid.uuid4())
+        get_app().updates.transaction_id = transaction_id
 
         for uri in qurl_list:
             filepath = uri.toLocalFile()
@@ -546,12 +551,15 @@ class FilesModel(QObject, updates.UpdateInterface):
             elif os.path.isfile(filepath):
                 media_paths.append(filepath)
         if not media_paths:
+            if owns_transaction:
+                get_app().updates.transaction_id = None
             return
         # Import all new media files
         media_paths.sort()
         log.debug("Importing file list: {}".format(media_paths))
         self.add_files(media_paths, quiet=import_quietly, prevent_image_seq=prevent_image_seq)
-        get_app().updates.transaction_id = None
+        if owns_transaction:
+            get_app().updates.transaction_id = None
 
     def update_file_thumbnail(self, file_id):
         """Update/re-generate the thumbnail of a specific file"""

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -56,11 +56,7 @@ class FilesListView(QListView):
         if not index.isValid():
             self.clearSelection()
         else:
-            self.setCurrentIndex(index)
-            self.selectionModel().select(
-                index,
-                QItemSelectionModel.ClearAndSelect,
-            )
+            self.selectionModel().setCurrentIndex(index, QItemSelectionModel.NoUpdate)
 
         # Build menu
         menu = StyledContextMenu(parent=self)

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -30,7 +30,7 @@
 import os
 import uuid
 
-from PyQt5.QtCore import QSize, Qt, QPoint
+from PyQt5.QtCore import QSize, Qt, QPoint, QItemSelectionModel
 from PyQt5.QtGui import QDrag, QCursor, QPixmap, QPainter, QIcon
 from PyQt5.QtWidgets import QTreeView, QAbstractItemView, QSizePolicy, QHeaderView
 
@@ -57,6 +57,8 @@ class FilesTreeView(QTreeView):
         index = self.indexAt(event.pos())
         if not index.isValid():
             self.clearSelection()
+        else:
+            self.selectionModel().setCurrentIndex(index, QItemSelectionModel.NoUpdate)
 
         # Build menu
         menu = StyledContextMenu(parent=self)

--- a/src/windows/views/timeline.py
+++ b/src/windows/views/timeline.py
@@ -1093,6 +1093,11 @@ class TimelineView(updates.UpdateInterface, ViewClass):
         self.context_menu_cursor_position = QCursor.pos()
         return menu.popup(self.context_menu_cursor_position)
 
+    @pyqtSlot()
+    def ShowProperties(self):
+        """Show the Properties dock (triggered by double-click on a clip/transition)."""
+        self.window.actionProperties.trigger()
+
     @pyqtSlot(str)
     def ShowClipMenu(self, clip_id=None):
         log.debug('ShowClipMenu: %s' % clip_id)

--- a/src/windows/views/timeline_backend/qwidget/base.py
+++ b/src/windows/views/timeline_backend/qwidget/base.py
@@ -26,6 +26,7 @@
 """
 
 import json
+import os
 import uuid
 from functools import partial
 from types import SimpleNamespace
@@ -1042,10 +1043,18 @@ class TimelineWidgetBase(QWidget):
         mime = event.mimeData()
 
         if mime.hasUrls():
+            urls = mime.urls()
+            payload = self._preimport_os_drop_urls(urls)
+            if payload:
+                self._drag_payload = payload
+                self.item_type = payload.get("type")
+                self.new_item = True
+                event.accept()
+                return
             event.accept()
             self.new_item = True
             self.item_type = "os_drop"
-            self._drag_payload = {"type": "os_drop", "urls": mime.urls()}
+            self._drag_payload = {"type": "os_drop", "urls": urls}
             return
 
         mime_html = mime.html()
@@ -1101,18 +1110,28 @@ class TimelineWidgetBase(QWidget):
         mime = event.mimeData()
         mime_html = mime.html()
         if mime.hasUrls():
-            urls = mime.urls()
-            # Wrap file import + clip creation + auto-transitions in a single
-            # transaction so a single Undo reverts everything.
-            os_drop_tid = str(uuid.uuid4())
-            self.win.files_model.process_urls(
-                urls, import_quietly=True, prevent_image_seq=True,
-                transaction_id=os_drop_tid,
-            )
-            # process_urls preserves our transaction when given a transaction_id
-            for uri in urls:
-                for f in File.filter(path=uri.toLocalFile()):
-                    file_ids.append(f.id)
+            payload = self._drag_payload or {}
+            if (
+                payload.get("type") == "clip"
+                and payload.get("source") == "os_drop"
+                and payload.get("ids")
+            ):
+                file_ids.extend(payload.get("ids") or [])
+                os_drop_tid = payload.get("transaction_id")
+                mime_html = "clip"
+            else:
+                urls = mime.urls()
+                # Wrap file import + clip creation + auto-transitions in a single
+                # transaction so a single Undo reverts everything.
+                os_drop_tid = str(uuid.uuid4())
+                self.win.files_model.process_urls(
+                    urls, import_quietly=True, prevent_image_seq=True,
+                    transaction_id=os_drop_tid,
+                )
+                # process_urls preserves our transaction when given a transaction_id
+                for uri in urls:
+                    for f in File.filter(path=uri.toLocalFile()):
+                        file_ids.append(f.id)
         elif mime_html == "clip":
             try:
                 ids = json.loads(mime.text())
@@ -1209,7 +1228,14 @@ class TimelineWidgetBase(QWidget):
             return self._drag_payload
         mime = event.mimeData()
         if mime.hasUrls():
-            self._drag_payload = {"type": "os_drop", "urls": mime.urls()}
+            urls = mime.urls()
+            payload = self._preimport_os_drop_urls(urls)
+            if payload:
+                self._drag_payload = payload
+                self.item_type = payload.get("type")
+                self.new_item = True
+                return self._drag_payload
+            self._drag_payload = {"type": "os_drop", "urls": urls}
             return self._drag_payload
         mime_html = mime.html()
         if mime_html in {"clip", "transition"}:
@@ -1598,40 +1624,48 @@ class TimelineWidgetBase(QWidget):
         if not total:
             self._reset_drag_preview()
             return
+        payload = self._drag_payload or {}
+        drag_transaction_id = payload.get("transaction_id")
+        if drag_transaction_id:
+            get_app().updates.transaction_id = drag_transaction_id
         committed_any = False
-        for idx, entry in enumerate(self._drag_preview_items):
-            source_id = entry.get("source_id")
-            if source_id is None:
-                continue
-            track_num = self.normalize_track_number(entry.get("layer"))
-            if track_num is None:
-                continue
-            position = max(0.0, float(entry.get("position", 0.0) or 0.0))
-            ignore_refresh = idx < total - 1
-            if entry.get("type") == "transition":
-                transition = self.addTransition(
-                    source_id,
-                    QPointF(position, 0),
-                    track_num,
-                    ignore_refresh=ignore_refresh,
-                    call_manual_move=False,
-                )
-                if transition is None:
-                    log.warning("Deferred transition drop failed for path: %s", source_id)
+        try:
+            for idx, entry in enumerate(self._drag_preview_items):
+                source_id = entry.get("source_id")
+                if source_id is None:
                     continue
-                committed_any = True
-            else:
-                auto_transition = total == 1
-                clip = self.addClip(
-                    source_id,
-                    QPointF(position, 0),
-                    track_num,
-                    ignore_refresh=ignore_refresh,
-                    call_manual_move=False,
-                    auto_transition=auto_transition,
-                )
-                if clip is not None:
+                track_num = self.normalize_track_number(entry.get("layer"))
+                if track_num is None:
+                    continue
+                position = max(0.0, float(entry.get("position", 0.0) or 0.0))
+                ignore_refresh = idx < total - 1
+                if entry.get("type") == "transition":
+                    transition = self.addTransition(
+                        source_id,
+                        QPointF(position, 0),
+                        track_num,
+                        ignore_refresh=ignore_refresh,
+                        call_manual_move=False,
+                    )
+                    if transition is None:
+                        log.warning("Deferred transition drop failed for path: %s", source_id)
+                        continue
                     committed_any = True
+                else:
+                    auto_transition = total == 1
+                    clip = self.addClip(
+                        source_id,
+                        QPointF(position, 0),
+                        track_num,
+                        ignore_refresh=ignore_refresh,
+                        call_manual_move=False,
+                        auto_transition=auto_transition,
+                    )
+                    if clip is not None:
+                        committed_any = True
+        finally:
+            if drag_transaction_id:
+                get_app().updates.transaction_id = None
 
         # Auto-select newly added clips/transitions
         preview_type = "clip"
@@ -1650,6 +1684,45 @@ class TimelineWidgetBase(QWidget):
         if committed_any:
             self.changed(None)
         self.update()
+
+    def _preimport_os_drop_urls(self, urls):
+        """Pre-import OS-dropped files so timeline drag preview can render clip shapes."""
+        local_file_urls = []
+        for uri in urls or []:
+            if not uri.isLocalFile():
+                return None
+            local_path = uri.toLocalFile()
+            if not local_path or not os.path.isfile(local_path):
+                return None
+            local_file_urls.append(uri)
+        if not local_file_urls:
+            return None
+
+        os_drop_tid = str(uuid.uuid4())
+        self.win.files_model.process_urls(
+            local_file_urls,
+            import_quietly=True,
+            prevent_image_seq=True,
+            transaction_id=os_drop_tid,
+        )
+        # The caller-provided transaction remains active; close it now and
+        # reopen only when committing clip creation on drop.
+        get_app().updates.transaction_id = None
+
+        file_ids = []
+        for uri in local_file_urls:
+            for f in File.filter(path=uri.toLocalFile()):
+                file_ids.append(f.id)
+        if not file_ids:
+            return None
+
+        return {
+            "type": "clip",
+            "ids": file_ids,
+            "source": "os_drop",
+            "urls": local_file_urls,
+            "transaction_id": os_drop_tid,
+        }
 
 
 

--- a/src/windows/views/timeline_backend/qwidget/base.py
+++ b/src/windows/views/timeline_backend/qwidget/base.py
@@ -2400,6 +2400,17 @@ class TimelineWidgetBase(QWidget):
 
         self.unsetCursor()
 
+    def mouseDoubleClickEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self.geometry.ensure()
+            pos = event.pos()
+            for rect, item, _selected, _type in self.geometry.iter_items(reverse=True):
+                if rect.contains(pos):
+                    self.win.actionProperties.trigger()
+                    event.accept()
+                    return
+        super().mouseDoubleClickEvent(event)
+
     def mousePressEvent(self, event):
         self._press_marker = None
         if event.button() == Qt.RightButton:

--- a/src/windows/views/timeline_backend/qwidget/base.py
+++ b/src/windows/views/timeline_backend/qwidget/base.py
@@ -26,6 +26,7 @@
 """
 
 import json
+import uuid
 from functools import partial
 from types import SimpleNamespace
 
@@ -1096,11 +1097,19 @@ class TimelineWidgetBase(QWidget):
 
         file_ids = []
         effect_names = []
+        os_drop_tid = None
         mime = event.mimeData()
         mime_html = mime.html()
         if mime.hasUrls():
             urls = mime.urls()
-            self.win.files_model.process_urls(urls, import_quietly=True, prevent_image_seq=True)
+            # Wrap file import + clip creation + auto-transitions in a single
+            # transaction so a single Undo reverts everything.
+            os_drop_tid = str(uuid.uuid4())
+            self.win.files_model.process_urls(
+                urls, import_quietly=True, prevent_image_seq=True,
+                transaction_id=os_drop_tid,
+            )
+            # process_urls preserves our transaction when given a transaction_id
             for uri in urls:
                 for f in File.filter(path=uri.toLocalFile()):
                     file_ids.append(f.id)
@@ -1130,6 +1139,8 @@ class TimelineWidgetBase(QWidget):
             effect_names.extend(names)
 
         if not file_ids and not effect_names:
+            if os_drop_tid:
+                get_app().updates.transaction_id = None
             self._reset_drag_preview()
             return
 
@@ -1139,6 +1150,8 @@ class TimelineWidgetBase(QWidget):
         pos_seconds, track_num, _ = coords
         track_num = self._nearest_unlocked_track_number(track_num)
         if track_num is None:
+            if os_drop_tid:
+                get_app().updates.transaction_id = None
             self._reset_drag_preview()
             return
         pos = QPointF(pos_seconds, 0)
@@ -1177,6 +1190,14 @@ class TimelineWidgetBase(QWidget):
                 )
                 if clip:
                     pos.setX(pos.x() + (clip.get("end", 0.0) - clip.get("start", 0.0)))
+
+        # Close the OS-drop transaction (file import + clip + auto-transition)
+        if os_drop_tid:
+            get_app().updates.transaction_id = None
+
+        # Auto-select newly added clips/transitions
+        self._select_added_items("transition" if mime_html == "transition" else "clip")
+
         self._reset_drag_preview()
 
     def dragLeaveEvent(self, event):
@@ -1551,6 +1572,16 @@ class TimelineWidgetBase(QWidget):
             bbox = bbox.united(rect)
         return bbox
 
+    def _select_added_items(self, item_type):
+        """Auto-select items just added via drag-and-drop."""
+        if not getattr(self, "item_ids", None):
+            return
+        for idx, item_id in enumerate(self.item_ids):
+            self.win.addSelection(str(item_id), item_type, clear_existing=(idx == 0))
+        # Geometry was already rebuilt by changed() before the selection was
+        # set, so mark it dirty so the next repaint reflects the new state.
+        self.geometry.mark_dirty()
+
     def _reset_drag_preview(self):
         self._set_drag_preview_thumbnail_suspension(False)
         self._drag_preview_items = []
@@ -1601,6 +1632,13 @@ class TimelineWidgetBase(QWidget):
                 )
                 if clip is not None:
                     committed_any = True
+
+        # Auto-select newly added clips/transitions
+        preview_type = "clip"
+        if self._drag_preview_items and self._drag_preview_items[0].get("type") == "transition":
+            preview_type = "transition"
+        self._select_added_items(preview_type)
+
         self._update_project_duration()
         self._drag_preview_items = []
         self._drag_payload = None


### PR DESCRIPTION
When right clicking on multiple project file selections, this PR fixes our context menus - so it no longer accidentally unselects the multiple files.