### PR TITLE
Fix recursive paint bug on Experimental timeline + Missing File Dialog improvements

### DIFF
--- a/src/classes/json_data.py
+++ b/src/classes/json_data.py
@@ -249,6 +249,7 @@ class JsonDataStore:
         # Find absolute path of file (if needed)
         if "@transitions" in path:
             new_path = path.replace("@transitions", os.path.join(info.PATH, "transitions"))
+            new_path = os.path.normpath(new_path)
             new_path = json.dumps(new_path, ensure_ascii=False)
             return '"%s": %s' % (key, new_path)
 

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -1091,53 +1091,113 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         _ = app._tr
 
         log.info("checking project files...")
-        prompt_state = {"cancelled": False}
+        prompt_state = {"cancelled": False, "missing_path_decisions": {}}
 
         def _path_is_missing(path):
             return bool(path) and "%" not in path and not os.path.exists(path)
-
-        def _reader_path(item):
-            if not isinstance(item, dict):
-                return ""
-            reader = item.get("reader")
-            if isinstance(reader, dict):
-                return reader.get("path", "")
-            return ""
 
         def _resolve_missing_path(path):
             """Prompt to locate a missing path, returning resolved path or empty when skipped."""
             if not _path_is_missing(path):
                 return path, False
+
+            # Reuse prior decision for this exact missing path in this load pass.
+            # This avoids duplicate prompts when the same asset path appears in
+            # multiple places (e.g. top-level effect + clip effect).
+            missing_path_decisions = prompt_state.setdefault("missing_path_decisions", {})
+            if path in missing_path_decisions:
+                cached_path = missing_path_decisions[path]
+                if cached_path:
+                    return cached_path, False
+                return "", True
+
             found_path, is_modified, is_skipped = find_missing_file(path, prompt_state)
             if found_path and is_modified and not is_skipped:
                 settings.setDefaultPath(settings.actionType.IMPORT, found_path)
+                missing_path_decisions[path] = found_path
                 return found_path, False
+            if is_skipped:
+                missing_path_decisions[path] = ""
+                skip_mode = prompt_state.get("last_skip")
+                if skip_mode == "all":
+                    skip_detail = " (user selected Skip All)"
+                else:
+                    skip_detail = " (user selected Skip File)"
+                # Use warning level so this is visible even when info logs are filtered.
+                log.warning(
+                    "Missing path skipped during project load%s: %s",
+                    skip_detail,
+                    path,
+                )
             return "", True
 
+        def _collect_effect_path_refs(effect):
+            """Collect mutable refs to path-like fields used by effects."""
+            refs = []
+            seen = set()
+
+            def _add_ref(container, key):
+                if not isinstance(container, dict):
+                    return
+                value = container.get(key, "")
+                if not isinstance(value, str) or not value:
+                    return
+                ref_id = (id(container), key)
+                if ref_id in seen:
+                    return
+                seen.add(ref_id)
+                refs.append((container, key, value))
+
+            def _walk(obj, parent_key=""):
+                if isinstance(obj, dict):
+                    for key, value in obj.items():
+                        if isinstance(value, dict):
+                            if isinstance(value.get("path"), str) and "reader" in key.lower():
+                                _add_ref(value, "path")
+                            _walk(value, key)
+                        elif isinstance(value, list):
+                            _walk(value, key)
+                        elif isinstance(value, str):
+                            if key in {"resource", "protobuf_data_path", "lut_path", "image"}:
+                                _add_ref(obj, key)
+                            elif key == "path" and "reader" in parent_key.lower():
+                                _add_ref(obj, key)
+                elif isinstance(obj, list):
+                    for item in obj:
+                        _walk(item, parent_key)
+
+            _walk(effect)
+            return refs
+
+        def _first_missing_effect_path(effect):
+            for _, _, path in _collect_effect_path_refs(effect):
+                if _path_is_missing(path):
+                    return path
+            return ""
+
         def _repair_effect_paths(effect):
-            """Prompt for missing reader/resource paths on an effect-like dict."""
+            """Prompt for missing paths on an effect-like dict."""
             if not isinstance(effect, dict):
                 return False
 
-            reader = effect.get("reader")
-            reader_path = reader.get("path", "") if isinstance(reader, dict) else ""
-            resource_path = effect.get("resource", "")
-
-            # Process unique missing paths in stable order.
+            path_refs = _collect_effect_path_refs(effect)
             missing_paths = []
-            if _path_is_missing(reader_path):
-                missing_paths.append(reader_path)
-            if _path_is_missing(resource_path) and resource_path not in missing_paths:
-                missing_paths.append(resource_path)
+            for _, _, path in path_refs:
+                if _path_is_missing(path) and path not in missing_paths:
+                    missing_paths.append(path)
 
             for missing_path in missing_paths:
                 resolved_path, should_remove = _resolve_missing_path(missing_path)
                 if should_remove:
+                    log.warning(
+                        "Removing effect with unresolved path. effect_id=%s missing_path=%s",
+                        effect.get("id", ""),
+                        missing_path,
+                    )
                     return False
-                if isinstance(effect.get("reader"), dict) and effect["reader"].get("path") == missing_path:
-                    effect["reader"]["path"] = resolved_path
-                if effect.get("resource", "") == missing_path:
-                    effect["resource"] = resolved_path
+                for container, key, current_path in path_refs:
+                    if current_path == missing_path:
+                        container[key] = resolved_path
 
             return True
 
@@ -1152,23 +1212,15 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
             log.info("checking file %s", path)
             if not os.path.exists(path) and "%" not in path:
-                # File is missing
-                if prompt_state.get("cancelled"):
-                    # User already cancelled prompts, just remove missing file
+                # File is missing - prompt/resolve using the shared path-decision cache.
+                resolved_path, should_remove = _resolve_missing_path(path)
+                if should_remove:
                     log.info('Removed missing file: %s', file_name_with_ext)
                     self._data["files"].remove(file)
-                    continue
-
-                path, is_modified, is_skipped = find_missing_file(path, prompt_state)
-                if path and is_modified and not is_skipped:
-                    # Found file, update path
-                    file["path"] = path
-                    settings.setDefaultPath(settings.actionType.IMPORT, path)
-                    log.info("Auto-updated missing file: %s", path)
-                elif is_skipped:
-                    # Remove missing file
-                    log.info('Removed missing file: %s', file_name_with_ext)
-                    self._data["files"].remove(file)
+                elif resolved_path and resolved_path != path:
+                    file["path"] = resolved_path
+                    settings.setDefaultPath(settings.actionType.IMPORT, resolved_path)
+                    log.info("Auto-updated missing file: %s", resolved_path)
 
         # Build a lookup of valid file IDs after any removals/updates
         file_paths_by_id = {file.get("id"): file.get("path") for file in self._data["files"]}
@@ -1202,9 +1254,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         # Loop through top-level effects/transitions and prompt for missing reader/resource paths.
         for effect in reversed(self._data["effects"]):
             if not _repair_effect_paths(effect):
-                reader_path = _reader_path(effect)
-                resource_path = effect.get("resource", "") if isinstance(effect, dict) else ""
-                missing_path = reader_path if _path_is_missing(reader_path) else resource_path
+                missing_path = _first_missing_effect_path(effect)
                 effect_name = os.path.basename(missing_path) if missing_path else effect.get("id", "")
                 log.info("Removed missing effect: %s", effect_name)
                 self._data["effects"].remove(effect)
@@ -1216,9 +1266,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                 continue
             for effect in reversed(effects):
                 if not _repair_effect_paths(effect):
-                    reader_path = _reader_path(effect)
-                    resource_path = effect.get("resource", "") if isinstance(effect, dict) else ""
-                    missing_path = reader_path if _path_is_missing(reader_path) else resource_path
+                    missing_path = _first_missing_effect_path(effect)
                     effect_name = os.path.basename(missing_path) if missing_path else effect.get("id", "")
                     log.info("Removed missing clip effect on %s: %s", clip.get("id", ""), effect_name)
                     effects.remove(effect)

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -1093,6 +1093,54 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         log.info("checking project files...")
         prompt_state = {"cancelled": False}
 
+        def _path_is_missing(path):
+            return bool(path) and "%" not in path and not os.path.exists(path)
+
+        def _reader_path(item):
+            if not isinstance(item, dict):
+                return ""
+            reader = item.get("reader")
+            if isinstance(reader, dict):
+                return reader.get("path", "")
+            return ""
+
+        def _resolve_missing_path(path):
+            """Prompt to locate a missing path, returning resolved path or empty when skipped."""
+            if not _path_is_missing(path):
+                return path, False
+            found_path, is_modified, is_skipped = find_missing_file(path, prompt_state)
+            if found_path and is_modified and not is_skipped:
+                settings.setDefaultPath(settings.actionType.IMPORT, found_path)
+                return found_path, False
+            return "", True
+
+        def _repair_effect_paths(effect):
+            """Prompt for missing reader/resource paths on an effect-like dict."""
+            if not isinstance(effect, dict):
+                return False
+
+            reader = effect.get("reader")
+            reader_path = reader.get("path", "") if isinstance(reader, dict) else ""
+            resource_path = effect.get("resource", "")
+
+            # Process unique missing paths in stable order.
+            missing_paths = []
+            if _path_is_missing(reader_path):
+                missing_paths.append(reader_path)
+            if _path_is_missing(resource_path) and resource_path not in missing_paths:
+                missing_paths.append(resource_path)
+
+            for missing_path in missing_paths:
+                resolved_path, should_remove = _resolve_missing_path(missing_path)
+                if should_remove:
+                    return False
+                if isinstance(effect.get("reader"), dict) and effect["reader"].get("path") == missing_path:
+                    effect["reader"]["path"] = resolved_path
+                if effect.get("resource", "") == missing_path:
+                    effect["resource"] = resolved_path
+
+            return True
+
         # Loop through each files in natural-sorted filename order
         files_sorted = sorted(
             self._data["files"],
@@ -1150,6 +1198,30 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                 file_name_with_ext = os.path.basename(path)
                 log.info('Removed missing clip: %s', file_name_with_ext)
                 self._data["clips"].remove(clip)
+
+        # Loop through top-level effects/transitions and prompt for missing reader/resource paths.
+        for effect in reversed(self._data["effects"]):
+            if not _repair_effect_paths(effect):
+                reader_path = _reader_path(effect)
+                resource_path = effect.get("resource", "") if isinstance(effect, dict) else ""
+                missing_path = reader_path if _path_is_missing(reader_path) else resource_path
+                effect_name = os.path.basename(missing_path) if missing_path else effect.get("id", "")
+                log.info("Removed missing effect: %s", effect_name)
+                self._data["effects"].remove(effect)
+
+        # Some clip effects can also carry reader/resource paths (e.g. mask/image-driven effects).
+        for clip in self._data["clips"]:
+            effects = clip.get("effects")
+            if not isinstance(effects, list):
+                continue
+            for effect in reversed(effects):
+                if not _repair_effect_paths(effect):
+                    reader_path = _reader_path(effect)
+                    resource_path = effect.get("resource", "") if isinstance(effect, dict) else ""
+                    missing_path = reader_path if _path_is_missing(reader_path) else resource_path
+                    effect_name = os.path.basename(missing_path) if missing_path else effect.get("id", "")
+                    log.info("Removed missing clip effect on %s: %s", clip.get("id", ""), effect_name)
+                    effects.remove(effect)
 
     def changed(self, action):
         """ This method is invoked by the UpdateManager each time a change happens (i.e UpdateInterface) """

--- a/src/launch.py
+++ b/src/launch.py
@@ -46,6 +46,13 @@ import argparse
 import json
 import logging
 
+# Ensure Qt plugin DLL dependencies are found on Windows packaged builds.
+if os.name == "nt":
+    _exe_dir = os.path.dirname(os.path.abspath(sys.executable))
+    _pyqt_dll_dir = os.path.join(_exe_dir, "lib", "PyQt5")
+    if os.path.isdir(_pyqt_dll_dir):
+        os.environ["PATH"] = _pyqt_dll_dir + os.pathsep + os.environ.get("PATH", "")
+
 try:
     # This needs to be imported before PyQt5
     # To prevent some issues on AppImage build: wrapping/forcing older glibc versions

--- a/src/themes/cosmic/theme.py
+++ b/src/themes/cosmic/theme.py
@@ -78,6 +78,11 @@ QDialog {
     color: #91C3FF;
 }
 
+QLabel#lblMissingFileHint,
+QLabel#lblMissingFilePath {
+    color: #9bb2cc;
+}
+
 QWidget#Simple, QWidget#Advanced, QWidget#PreferencePanel {
     background-color: #141923;
     border: none;

--- a/src/themes/humanity/theme.py
+++ b/src/themes/humanity/theme.py
@@ -58,6 +58,11 @@ QComboBox {
 QWidget#videoPreview {
     background-color: #191919;
 }
+
+QLabel#lblMissingFileHint,
+QLabel#lblMissingFilePath {
+    color: #b8b8b8;
+}
         """
 
     def apply_theme(self):
@@ -115,6 +120,11 @@ QMainWindow::separator:hover {
 
 QWidget#videoPreview {
     background-color: #dedede;
+}
+
+QLabel#lblMissingFileHint,
+QLabel#lblMissingFilePath {
+    color: #5a5a5a;
 }
 
 QComboBox {

--- a/src/windows/add_to_timeline.py
+++ b/src/windows/add_to_timeline.py
@@ -389,6 +389,12 @@ class AddToTimeline(QDialog):
         # Clear transaction
         get_app().updates.transaction_id = None
 
+        # Ensure timeline extension behavior matches all other timeline add/move paths.
+        timeline_view = getattr(get_app().window, "timeline", None)
+        extend_timeline = getattr(timeline_view, "_extend_timeline_to_fit_items", None)
+        if callable(extend_timeline):
+            extend_timeline()
+
         # Auto-select newly added clips
         win = get_app().window
         for idx, clip_id in enumerate(added_clip_ids):

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -720,8 +720,8 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         # Get frame's QImage from libopenshot
         self.current_image = image
 
-        # Force repaint on this widget
-        self.repaint()
+        # Request an async paint to avoid recursive QWidget repaint on Windows.
+        self.update()
 
     def connectSignals(self, renderer):
         """ Connect signals to renderer """
@@ -1968,16 +1968,16 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         else:
             self.resize_button.hide()
 
-        # Repaint widget on zoom
-        self.repaint()
+        # Request repaint asynchronously to avoid recursive paint calls.
+        self.update()
 
     def resize_button_clicked(self):
         """Resize zoom button clicked"""
         self.zoom = 1.0
         self.resize_button.hide()
 
-        # Repaint widget on zoom
-        self.repaint()
+        # Request repaint asynchronously to avoid recursive paint calls.
+        self.update()
 
     def __init__(self, watch_project=True, *args):
         """watch_project: watch for changes in project size / widget size, and

--- a/src/windows/views/find_file.py
+++ b/src/windows/views/find_file.py
@@ -26,12 +26,115 @@
  """
 
 import os
+import html
 from classes import info
 from classes.app import get_app
-from PyQt5.QtWidgets import QMessageBox, QFileDialog
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QFileDialog, QDialog, QVBoxLayout, QHBoxLayout,
+    QPushButton, QLabel
+)
 
 # Keep track of all previously checked paths, and keep checking them
 known_paths = [info.HOME_PATH]
+
+
+def _relative_display_path(file_path, starting_dir):
+    if starting_dir:
+        try:
+            return os.path.relpath(file_path, starting_dir)
+        except Exception:
+            pass
+    return file_path
+
+
+def _relative_display_path_html(file_path, starting_dir):
+    rel_path = _relative_display_path(file_path, starting_dir)
+    rel_dir, rel_name = os.path.split(rel_path)
+    if rel_dir:
+        return f"{html.escape(rel_dir)}/{'<b>' + html.escape(rel_name) + '</b>'}"
+    return f"<b>{html.escape(rel_name)}</b>"
+
+
+def _relative_display_dir(file_path, starting_dir):
+    rel_path = _relative_display_path(file_path, starting_dir)
+    rel_dir = os.path.dirname(rel_path)
+    if rel_dir:
+        return f"{rel_dir}/"
+    return "./"
+
+
+def _show_missing_file_dialog(file_name, file_path, starting_dir):
+    _ = get_app()._tr
+    dialog = QDialog(None)
+    dialog.setWindowTitle(_("Locate Missing Files"))
+    dialog.setModal(True)
+    dialog.setMinimumSize(420, 130)
+
+    layout = QVBoxLayout(dialog)
+    layout.setContentsMargins(12, 10, 12, 10)
+    layout.setSpacing(0)
+
+    intro_label = QLabel(_("This file is missing. You can locate it or remove it from the project."))
+    intro_label.setObjectName("lblMissingFileHint")
+    intro_label.setWordWrap(True)
+    layout.addWidget(intro_label)
+    layout.addSpacing(12)
+
+    name_label = QLabel(f"<b>{html.escape(file_name)}</b>")
+    name_label.setTextFormat(Qt.RichText)
+    name_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+    name_label.setContentsMargins(8, 0, 0, 0)
+    layout.addWidget(name_label)
+
+    dir_label = QLabel(_relative_display_dir(file_path, starting_dir))
+    dir_label.setObjectName("lblMissingFilePath")
+    dir_label.setWordWrap(True)
+    dir_label.setTextFormat(Qt.PlainText)
+    dir_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+    dir_label.setContentsMargins(8, 0, 0, 0)
+    layout.addWidget(dir_label)
+    layout.addStretch(1)
+
+    button_row = QHBoxLayout()
+    button_row.setContentsMargins(0, 0, 0, 0)
+    button_row.setSpacing(6)
+    skip_all_button = QPushButton(_("Remove All Missing"))
+    skip_file_button = QPushButton(_("Remove"))
+    browse_button = QPushButton(_("Browse..."))
+    browse_button.setObjectName("acceptButton")
+    button_row.addWidget(skip_all_button)
+    button_row.addStretch(1)
+    button_row.addWidget(skip_file_button)
+    button_row.addWidget(browse_button)
+    layout.addLayout(button_row)
+
+    result = {"action": "file", "path": file_path}
+
+    def pick_browse():
+        selected_path = QFileDialog.getOpenFileName(
+            None,
+            _("Locate media file: %s") % file_name,
+            starting_dir,
+        )[0]
+        if selected_path:
+            result["action"] = "locate"
+            result["path"] = selected_path
+            dialog.accept()
+
+    def pick_skip_all():
+        result["action"] = "all"
+        dialog.reject()
+
+    browse_button.clicked.connect(pick_browse)
+    skip_file_button.clicked.connect(dialog.reject)
+    skip_all_button.clicked.connect(pick_skip_all)
+    browse_button.setDefault(True)
+    browse_button.setAutoDefault(True)
+    browse_button.setFocus()
+
+    dialog.exec_()
+    return result["action"], result["path"]
 
 
 def find_missing_file(file_path, prompt_state=None):
@@ -69,18 +172,10 @@ def find_missing_file(file_path, prompt_state=None):
             recommended_path = info.HOME_PATH
         else:
             recommended_path = os.path.dirname(recommended_path)
-        message_box = QMessageBox()
-        message_box.setIcon(QMessageBox.Warning)
-        message_box.setWindowTitle(_("Missing File (%s)") % file_name)
-        message_box.setText(_("%s cannot be found.") % file_name)
-        browse_button = message_box.addButton(_("Browse..."), QMessageBox.AcceptRole)
-        skip_file_button = message_box.addButton(_("Skip File"), QMessageBox.DestructiveRole)
-        skip_all_button = message_box.addButton(_("Skip All"), QMessageBox.RejectRole)
-        message_box.setDefaultButton(browse_button)
-        message_box.exec_()
+        action, selected_path = _show_missing_file_dialog(file_name, file_path, recommended_path)
         modified = True
 
-        if message_box.clickedButton() == skip_all_button:
+        if action == "all":
             # User skipped all missing file prompts
             skipped = True
             if prompt_state is not None:
@@ -88,24 +183,17 @@ def find_missing_file(file_path, prompt_state=None):
                 prompt_state["last_skip"] = "all"
             return ("", modified, skipped)
 
-        if message_box.clickedButton() == skip_file_button:
+        if action == "file":
             # User skipped this missing file only
             skipped = True
             if prompt_state is not None:
                 prompt_state["last_skip"] = "file"
             return ("", modified, skipped)
 
-        folder_to_check = QFileDialog.getExistingDirectory(None, _("Find directory that contains: %s" % file_name),
-                                                           recommended_path)
+        file_path = selected_path
+        folder_to_check = os.path.dirname(file_path)
         if folder_to_check and folder_to_check not in known_paths:
             known_paths.append(folder_to_check)
-        if folder_to_check == "":
-            # User hit cancel on folder dialog - treat as skip this file.
-            skipped = True
-            if prompt_state is not None:
-                prompt_state["last_skip"] = "file"
-            return ("", modified, skipped)
-        file_path = os.path.join(folder_to_check, file_name)
 
     # Return found file_path
     return (file_path, modified, skipped)

--- a/src/windows/views/find_file.py
+++ b/src/windows/views/find_file.py
@@ -39,9 +39,13 @@ def find_missing_file(file_path, prompt_state=None):
     _ = get_app()._tr
     modified = False
     skipped = False
+    if prompt_state is not None:
+        prompt_state["last_skip"] = None
 
     # If user cancelled prompts, skip searching
     if prompt_state and prompt_state.get("cancelled"):
+        if prompt_state is not None:
+            prompt_state["last_skip"] = "all"
         return ("", modified, True)
 
     # Bail if path is already valid
@@ -70,16 +74,25 @@ def find_missing_file(file_path, prompt_state=None):
         message_box.setWindowTitle(_("Missing File (%s)") % file_name)
         message_box.setText(_("%s cannot be found.") % file_name)
         browse_button = message_box.addButton(_("Browse..."), QMessageBox.AcceptRole)
-        cancel_button = message_box.addButton(QMessageBox.Cancel)
+        skip_file_button = message_box.addButton(_("Skip File"), QMessageBox.DestructiveRole)
+        skip_all_button = message_box.addButton(_("Skip All"), QMessageBox.RejectRole)
         message_box.setDefaultButton(browse_button)
         message_box.exec_()
         modified = True
 
-        if message_box.clickedButton() == cancel_button:
-            # User cancelled all missing file prompts
+        if message_box.clickedButton() == skip_all_button:
+            # User skipped all missing file prompts
             skipped = True
             if prompt_state is not None:
                 prompt_state["cancelled"] = True
+                prompt_state["last_skip"] = "all"
+            return ("", modified, skipped)
+
+        if message_box.clickedButton() == skip_file_button:
+            # User skipped this missing file only
+            skipped = True
+            if prompt_state is not None:
+                prompt_state["last_skip"] = "file"
             return ("", modified, skipped)
 
         folder_to_check = QFileDialog.getExistingDirectory(None, _("Find directory that contains: %s" % file_name),
@@ -87,8 +100,10 @@ def find_missing_file(file_path, prompt_state=None):
         if folder_to_check and folder_to_check not in known_paths:
             known_paths.append(folder_to_check)
         if folder_to_check == "":
-            # User hit cancel
+            # User hit cancel on folder dialog - treat as skip this file.
             skipped = True
+            if prompt_state is not None:
+                prompt_state["last_skip"] = "file"
             return ("", modified, skipped)
         file_path = os.path.join(folder_to_check, file_name)
 

--- a/src/windows/views/timeline_backend/qwidget/base.py
+++ b/src/windows/views/timeline_backend/qwidget/base.py
@@ -217,6 +217,7 @@ class TimelineWidgetBase(QWidget):
 
         # Guard against re-entrant paintEvent calls
         self._in_paint_event = False
+        self._repaint_after_paint = False
 
         # Strong references to dynamically created state transitions
         self._transitions = []
@@ -795,7 +796,7 @@ class TimelineWidgetBase(QWidget):
         if self._in_paint_event:
             log.warning("TimelineWidgetBase paintEvent skipped due to re-entrancy")
             event.accept()
-            self.update()
+            self._repaint_after_paint = True
             return
 
         self._in_paint_event = True
@@ -847,6 +848,9 @@ class TimelineWidgetBase(QWidget):
             if painter.isActive():
                 painter.end()
             self._in_paint_event = False
+            if self._repaint_after_paint:
+                self._repaint_after_paint = False
+                QTimer.singleShot(0, self.update)
 
     def _paint_drag_preview(self, painter):
         """Paint transient drag previews without inserting real timeline items."""

--- a/src/windows/views/timeline_backend/qwidget/clip.py
+++ b/src/windows/views/timeline_backend/qwidget/clip.py
@@ -394,23 +394,6 @@ class ClipInteractionMixin:
             if delta_sec < min_delta_sec:
                 delta_sec = min_delta_sec
 
-        project_duration = 0.0
-        project = get_app().project if get_app() else None
-        if project:
-            try:
-                project_duration = float(project.get("duration") or 0.0)
-            except Exception:
-                project_duration = 0.0
-
-        end_positions = [
-            info["position"] + info.get("duration", 0.0)
-            for info in self._drag_initial.values()
-        ]
-        if project_duration > 0.0 and end_positions:
-            max_delta_sec = project_duration - max(end_positions)
-            if delta_sec > max_delta_sec:
-                delta_sec = max_delta_sec
-
         fps = float(self.fps_float or 0.0)
         frame_offset = None
         if fps > 0.0:
@@ -426,37 +409,13 @@ class ClipInteractionMixin:
                 if frame_offset < min_frame_offset:
                     frame_offset = min_frame_offset
 
-            if project_duration > 0.0:
-                timeline_frames = int(round(project_duration * fps))
-            else:
-                timeline_frames = None
-
-            end_frames = []
-            for info in self._drag_initial.values():
-                start_frame = info.get("position_frames")
-                if start_frame is None:
-                    start_frame = int(round(info["position"] * fps))
-                duration_frames = info.get("duration_frames")
-                if duration_frames is None:
-                    duration_frames = int(round(info.get("duration", 0.0) * fps))
-                end_frames.append(start_frame + duration_frames)
-
-            if timeline_frames is not None and end_frames:
-                max_frame_offset = timeline_frames - max(end_frames)
-                if frame_offset > max_frame_offset:
-                    frame_offset = max_frame_offset
-
             delta_sec = frame_offset / fps
 
-        # Reapply second-based bounds to account for frame rounding
+        # Reapply left bound to account for frame rounding
         if start_positions:
             min_delta_sec = -min(start_positions)
             if delta_sec < min_delta_sec:
                 delta_sec = min_delta_sec
-        if project_duration > 0.0 and end_positions:
-            max_delta_sec = project_duration - max(end_positions)
-            if delta_sec > max_delta_sec:
-                delta_sec = max_delta_sec
 
         # -------- Apply identical deltas ------------
         for itm in self.dragging_items:

--- a/src/windows/views/zoom_slider.py
+++ b/src/windows/views/zoom_slider.py
@@ -494,8 +494,8 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
     def wheelEvent(self, event):
         event.accept()
 
-        # Repaint widget on zoom
-        self.repaint()
+        # Use async repaint to avoid recursive paint on some Qt/Windows paths.
+        self.update()
 
     def setZoomFactor(self, zoom_factor, center=False, emit=True):
         """Set the current zoom factor (do not clamp width here — backend owns authoritative geometry)."""
@@ -505,8 +505,8 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
         if center:
             get_app().window.TimelineCenter.emit()
 
-        # Force re-paint
-        self.repaint()
+        # Force re-paint asynchronously
+        self.update()
 
     def zoomIn(self):
         """Zoom into timeline"""
@@ -547,25 +547,25 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
         # Disable auto center
         self.is_auto_center = False
 
-        # Force re-paint
-        self.repaint()
+        # Force re-paint asynchronously
+        self.update()
 
     def handle_selection(self):
         # Force recalculation of clips and repaint
         self.changed(None)
-        self.repaint()
+        self.update()
 
     def timeline_resized(self):
         # Force recalculation of clips and repaint
-        self.repaint()
+        self.update()
         self.delayed_resize_timer.start()
 
     def update_playhead_pos(self, currentFrame):
         """Callback when position is changed"""
         self.current_frame = currentFrame
 
-        # Force re-paint
-        self.repaint()
+        # Force re-paint asynchronously
+        self.update()
 
     def handle_play(self):
         """Callback when play button is clicked"""
@@ -582,7 +582,7 @@ class ZoomSlider(QWidget, updates.UpdateInterface):
             # Force recalculation and repaint
             self.ignore_updates = ignore
             self.changed(None)
-            self.repaint()
+            self.update()
         self.ignore_updates = ignore
 
     def __init__(self, *args):


### PR DESCRIPTION
Fix recursive paint on Experimental timeline by adding repaint_after_paint.

Crash this fixes:
```
DEBUG preview_thread: Max timeline length/frames detected: 8227
DEBUG preview_thread: refreshFrame
DEBUG preview_thread: refreshFrame
[swscaler @ 00000229579c6bc0] Warning: data is not aligned! This can lead to a speed loss
QPaintDevice: Cannot destroy paint device that is being painted
QWidget::repaint: Recursive repaint detected
Caught signal 11 (SIGSEGV)
---- Unhandled Exception: Stack Trace ----
[3] _C_specific_handler, address 0x131FBD10
[4] _chkstk, address 0x13F260F0
[5] RtlLocateExtendedFeature, address 0x13DD1D90
[6] KiUserExceptionDispatcher, address 0x13F25AA0
[7] ZN8QPainter3endEv, address 0x45A418C0
[8] PyInit_QtGui, address 0xF010ADE0
[9] PyLong_FromUnsignedLong, address 0xD4B3F890
[10] PyObject_MakeTpCall, address 0xD4B2B9E0
[11] PyEval_EvalFrameDefault, address 0xD4B20A00
[12] PyEval_EvalCodeWithName, address 0xD4B1CBD0
[13] PyFunction_Vectorcall, address 0xD4B30770
[14] PyMethod_New, address 0xD4B3C0C0
[15] PyVectorcall_Call, address 0xD4B3C590
[16] ???
[17] ???
[18] ???
[19] PyInit_QtWidgets, address 0xF03CECA0
[20] ZN7QWidget5eventEP6QEvent, address 0xF5AC7200
[21] PyInit_QtWidgets, address 0xF03CECA0
[22] ZN19QApplicationPrivate13notify_helperEP7QObjectP6QEvent, address 0xF5A87F50
[23] PyInit_QtWidgets, address 0xF03CECA0
[24] ZN16QCoreApplication20sendSpontaneousEventEP7QObjectP6QEvent, address 0xF6235200
[25] ZN14QWidgetPrivate14sendPaintEventERK7QRegion, address 0xF5ABFED0
[26] ZN14QWidgetPrivate10drawWidgetEP12QPaintDeviceRK7QRegionRK6QPoint6QFlagsINS_14DrawWidgetFlagEEP8QPainterP21QWidgetRepaintManager, address 0xF5ABFF40
[27] ZNK14QWidgetPrivate24shouldDiscardSyncRequestEv, address 0xF5A93C90
[28] ZN7QWidget5eventEP6QEvent, address 0xF5AC7200
[29] PyInit_QtWidgets, address 0xF03CECA0
[30] ZN19QApplicationPrivate13notify_helperEP7QObjectP6QEvent, address 0xF5A87F50
[31] PyInit_QtWidgets, address 0xF03CECA0
[32] ZN16QCoreApplication9sendEventEP7QObjectP6QEvent, address 0xF6235010
[33] ZNK14QWidgetPrivate24shouldDiscardSyncRequestEv, address 0xF5A93C90
[34] ZN12QPixmapStyle11qt_metacallEN11QMetaObject4CallEiPPv, address 0xF5DFAB20
[35] ZThn16_NK7QWidget13sharedPainterEv, address 0xF5AAC2A0
[36] ZN7QWidget7repaintEv, address 0xF5AB23B0
[37] PyInit_QtWidgets, address 0xF03CECA0
[38] PyLong_FromUnsignedLong, address 0xD4B3F890
[39] PyObject_MakeTpCall, address 0xD4B2B9E0
[40] PyEval_EvalFrameDefault, address 0xD4B20A00
[41] PyCell_New, address 0xD4B30990
[42] PyMethod_New, address 0xD4B3C0C0
[43] PyVectorcall_Call, address 0xD4B3C590
[44] PyInit_QtCore, address 0xF09EA730
[45] PyInit_QtCore, address 0xF09EA730
[46] PyInit_QtCore, address 0xF09EA730
[47] PyInit_QtCore, address 0xF09EA730
[48] PyInit_QtCore, address 0xF09EA730
[49] ZN7QObject5eventEP6QEvent, address 0xF6262330
[50] ZN19QApplicationPrivate13notify_helperEP7QObjectP6QEvent, address 0xF5A87F50
[51] PyInit_QtWidgets, address 0xF03CECA0
[52] ZN16QCoreApplication15notifyInternal2EP7QObjectP6QEvent, address 0xF6234910
[53] ZN23QCoreApplicationPrivate16sendPostedEventsEP7QObjectiP11QThreadData, address 0xF623AF90
[54] qt_plugin_instance, address 0xEFF3EEF0
[55] ZN21QEventDispatcherWin3213processEventsE6QFlagsIN10QEventLoop17ProcessEventsFlagEE, address 0xF6290990
[56] qt_plugin_instance, address 0xEFF3EEF0
[57] ZN10QEventLoop4execE6QFlagsINS_17ProcessEventsFlagEE, address 0xF6233350
[58] ZN16QCoreApplication4execEv, address 0xF623C0B0
[59] PyInit_QtWidgets, address 0xF03CECA0
[60] PyLong_FromUnsignedLong, address 0xD4B3F890
[61] PyObject_MakeTpCall, address 0xD4B2B9E0
[62] PyEval_EvalFrameDefault, address 0xD4B20A00
---- End of Stack Trace ----

C:\Program Files\OpenShot Video Editor>
```