### PR TITLE
Fixing Duplicate Imports

### DIFF
--- a/src/classes/path_utils.py
+++ b/src/classes/path_utils.py
@@ -137,3 +137,18 @@ def normalize_path(path_value):
     if not path_value:
         return ""
     return path_value.replace("\\", "/")
+
+
+def comparable_media_path(path_value, project_file=None):
+    """Return a normalized absolute media path suitable for equality checks."""
+    resolved = absolute_media_path(path_value, project_file)
+    if not resolved:
+        return ""
+    return os.path.normcase(os.path.normpath(resolved))
+
+
+def media_paths_equal(path_a, path_b, project_file=None):
+    """Compare two media paths after token expansion and platform normalization."""
+    if not path_a or not path_b:
+        return False
+    return comparable_media_path(path_a, project_file) == comparable_media_path(path_b, project_file)

--- a/src/classes/query.py
+++ b/src/classes/query.py
@@ -32,7 +32,7 @@ import openshot
 
 from classes import info
 from classes.app import get_app
-from classes.path_utils import absolute_media_path
+from classes.path_utils import absolute_media_path, media_paths_equal
 
 
 class QueryObject:
@@ -261,7 +261,15 @@ class File(QueryObject):
 
     def get(**kwargs):
         """ Take any arguments given as filters, and find the first matching object """
-        return QueryObject.get(File, **kwargs)
+        file_path = kwargs.pop("path", None)
+        if file_path is None:
+            return QueryObject.get(File, **kwargs)
+
+        matching_objects = QueryObject.filter(File, **kwargs)
+        for obj in matching_objects:
+            if media_paths_equal(obj.data.get("path"), file_path):
+                return obj
+        return None
 
     def absolute_path(self):
         """ Get absolute file path of file """

--- a/src/tests/query_tests.py
+++ b/src/tests/query_tests.py
@@ -318,6 +318,23 @@ class QueryTests(unittest.TestCase):
         file = File.get(id="invalidID")
         self.assertEqual(file, None)
 
+    def test_get_File_by_path_with_alternate_separators(self):
+        """File.get(path=...) should ignore slash direction differences."""
+        file_obj = File.get(id=self.file_ids[0])
+        self.assertTrue(file_obj)
+
+        original_path = file_obj.data.get("path")
+        self.assertTrue(original_path)
+
+        if "\\" in original_path:
+            alt_path = original_path.replace("\\", "/")
+        else:
+            alt_path = original_path.replace("/", "\\")
+
+        matched = File.get(path=alt_path)
+        self.assertTrue(matched)
+        self.assertEqual(matched.id, file_obj.id)
+
     def test_add_file(self):
 
         # Find number of files in project

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -161,10 +161,10 @@ class FilesModel(QObject, updates.UpdateInterface):
                 # Update a single file (if found)
                 self.update_model(clear=False, update_file_id=action.key[1].get('id', ''))
             else:
-                # Clear existing items
-                self.update_model(clear=True)
+                # Clear existing items. For full project loads, batch updates for faster UI rebuild.
+                self.update_model(clear=True, progressive_ui=False)
 
-    def update_model(self, clear=True, delete_file_id=None, update_file_id=None):
+    def update_model(self, clear=True, delete_file_id=None, update_file_id=None, progressive_ui=True):
         log.debug("updating files model.")
         app = get_app()
 
@@ -292,14 +292,19 @@ class FilesModel(QObject, updates.UpdateInterface):
                 self.model_ids[id] = QPersistentModelIndex(row[5].index())
 
                 row_added_count += 1
-                if row_added_count % 2 == 0:
+                if progressive_ui and row_added_count % 25 == 0:
                     # Update every X items
                     get_app().processEvents(QEventLoop.ExcludeUserInputEvents)
 
-            # Refresh view and filters (to hide or show this new item)
-            get_app().window.resize_contents()
+            # Refresh view/filtering incrementally during interactive updates (i.e. imports)
+            if progressive_ui:
+                get_app().window.resize_contents()
 
         self.ignore_updates = False
+
+        # Single refresh after bulk updates (i.e. opening a project)
+        if not progressive_ui:
+            get_app().window.resize_contents()
 
         # Emit signal when model is updated
         self.ModelRefreshed.emit()

--- a/src/windows/views/timeline.py
+++ b/src/windows/views/timeline.py
@@ -4400,6 +4400,12 @@ class TimelineView(updates.UpdateInterface, ViewClass):
             # Update most recent clip or transition
             self.run_js(JS_SCOPE_SELECTOR + ".updateRecentItemJSON('{}', '{}', '{}');"
                         .format(self.item_type, json.dumps(self.item_ids), get_app().updates.transaction_id))
+            # Keep Delete scoped to timeline items after drop, not project files.
+            files_model = getattr(self.window, "files_model", None)
+            if files_model:
+                files_model.selection_model.clearSelection()
+                files_model.list_selection_model.clearSelection()
+            self.setFocus(Qt.OtherFocusReason)
 
         # Cleanup after drop
         self.new_item = False

--- a/src/windows/views/timeline_backend/qwidget/base.py
+++ b/src/windows/views/timeline_backend/qwidget/base.py
@@ -1604,6 +1604,13 @@ class TimelineWidgetBase(QWidget):
             return
         for idx, item_id in enumerate(self.item_ids):
             self.win.addSelection(str(item_id), item_type, clear_existing=(idx == 0))
+        # A timeline drop should leave timeline items as the sole active selection,
+        # so Delete removes the new clip/transition and not project files.
+        files_model = getattr(self.win, "files_model", None)
+        if files_model:
+            files_model.selection_model.clearSelection()
+            files_model.list_selection_model.clearSelection()
+        self.setFocus(Qt.OtherFocusReason)
         # Geometry was already rebuilt by changed() before the selection was
         # set, so mark it dirty so the next repaint reflects the new state.
         self.geometry.mark_dirty()


### PR DESCRIPTION
This PR fixes some issues with duplicate file paths, which import would not catch due to URL absolute vs relative logic. Also, fixed an issue with timeline focus (Experimental timeline backend) after dropping a new file on the timeline, so DELETE only removes the new clip.  Lastly, batched Project Files model updates during "Open Project", to improve the speed of opening a large project with lots of files.