### PR TITLE
Use Constant Interpolation when inserting keyframes from Dropdowns

### DIFF
--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -615,6 +615,8 @@ class PropertiesModel(updates.UpdateInterface):
         property_type = property[1]["type"]
         property_key = property[0]
         object_id = property[1]["object_id"]
+        property_choices = property[1].get("choices") or []
+        choice_keyframes_use_constant = bool(property_choices) and interpolation == -1
         objects = {}
         item_data = item.data()
 
@@ -718,6 +720,8 @@ class PropertiesModel(updates.UpdateInterface):
                                 # Update or delete point
                                 if value is not None:
                                     point["co"]["Y"] = int(value) if property_key == "time" else float(value)
+                                    if choice_keyframes_use_constant:
+                                        point["interpolation"] = openshot.CONSTANT
                                     log.debug("updating point: co.X = %d to value: %s",
                                               point["co"]["X"], value)
                                 else:
@@ -769,7 +773,7 @@ class PropertiesModel(updates.UpdateInterface):
                             log.debug("Created new point at X=%d", self.frame_number)
                             clip_data[property_key].setdefault('Points', []).append({
                                 'co': {'X': self.frame_number, 'Y': int(value) if property_key == "time" else value},
-                                'interpolation': 1})
+                                'interpolation': openshot.CONSTANT if choice_keyframes_use_constant else openshot.LINEAR})
 
                 if not clip_updated:
                     # If no keyframe was found, set a basic property


### PR DESCRIPTION
When dropdowns are used to keyframe a value, use constant interpolation, since these values always represent binary choices (like types, enums, modes), and never ranges (linear, bezier). This was done in response to a bug with "Draw Box" on the Tracker effect, which was using linear interpolation between 2 boolean (0 to 1) values.