### PR TITLE
Fixing unit tests discovery issues (failing on launchpad builders)

### DIFF
--- a/src/language/test_translations.py
+++ b/src/language/test_translations.py
@@ -68,8 +68,12 @@ class Color:
         return cls._green + str(*args) + cls._reset
 
 
-# Get app instance
-app = QCoreApplication(sys.argv)
+def get_app() -> QCoreApplication:
+    """Create the translation app lazily so test discovery doesn't lock in QCoreApplication."""
+    app = QCoreApplication.instance()
+    if app is not None:
+        return app
+    return QCoreApplication(sys.argv)
 
 
 def build_stringlists() -> Dict[str, List]:
@@ -92,6 +96,7 @@ def build_stringlists() -> Dict[str, List]:
 
 def check_trans(strings: List) -> List[Tuple[str, str]]:
     """Check all strings in a list against a given .qm file"""
+    app = get_app()
     # Test translation of all strings
     translations = {
         source: app.translate("", source)
@@ -139,6 +144,7 @@ def check_trans(strings: List) -> List[Tuple[str, str]]:
 
 def process_qm(file: str, stringlists: Dict[str, List[str]]) -> int:
     """Scan a translation file against all provided strings"""
+    app = get_app()
     # Attempt to load translation file
     basename = os.path.splitext(file)[0]
     translator = QTranslator(app)

--- a/src/qt_test_app.py
+++ b/src/qt_test_app.py
@@ -1,0 +1,53 @@
+"""Helpers for unit tests that need an OpenShot-like Qt application."""
+
+import types
+
+from PyQt5.QtWidgets import QApplication
+
+
+def get_or_create_app(factory):
+    """Return the current Qt app or create one with factory()."""
+    app = QApplication.instance()
+    if app is not None:
+        return app, False
+    return factory(), True
+
+
+def ensure_app_state(
+    app,
+    settings_factory,
+    project_factory=None,
+    updates_factory=None,
+    extra_attrs=None,
+):
+    """Attach OpenShot-style attributes/methods to any Qt application instance."""
+    if not hasattr(app, "settings") or app.settings is None:
+        app.settings = settings_factory()
+
+    if not callable(getattr(app, "get_settings", None)):
+        app.get_settings = types.MethodType(lambda self: self.settings, app)
+
+    if not callable(getattr(app, "_tr", None)):
+        app._tr = types.MethodType(lambda self, text: text, app)
+
+    if project_factory is not None:
+        project = getattr(app, "project", None)
+        if (
+            project is None
+            or not hasattr(project, "get")
+            or not hasattr(project, "generate_id")
+        ):
+            app.project = project_factory()
+
+    if updates_factory is not None:
+        app.updates = updates_factory()
+        if hasattr(app.updates, "add_listener") and getattr(app, "project", None) is not None:
+            app.updates.add_listener(app.project)
+        if hasattr(app.updates, "reset"):
+            app.updates.reset()
+
+    for attr, value in (extra_attrs or {}).items():
+        if not hasattr(app, attr):
+            setattr(app, attr, value)
+
+    return app

--- a/src/tests/test_json_data.py
+++ b/src/tests/test_json_data.py
@@ -42,6 +42,7 @@ from PyQt5.QtWidgets import QApplication
 
 from classes import info
 from classes.json_data import JsonDataStore
+from qt_test_app import ensure_app_state as ensure_qt_app_state, get_or_create_app
 
 
 class DummySettings:
@@ -83,31 +84,24 @@ def ensure_app_state(app):
     from classes.project_data import ProjectDataStore
     from classes.updates import UpdateManager
 
-    if not hasattr(app, "settings") or app.settings is None:
-        app.settings = DummySettings()
-    if (
-        not hasattr(app, "project")
-        or app.project is None
-        or not hasattr(app.project, "get")
-        or not hasattr(app.project, "generate_id")
-    ):
-        app.project = ProjectDataStore()
-    app.updates = UpdateManager()
-    app.updates.add_listener(app.project)
-    app.updates.reset()
-    if not hasattr(app, "window"):
-        app.window = None
-    return app
+    return ensure_qt_app_state(
+        app,
+        DummySettings,
+        project_factory=ProjectDataStore,
+        updates_factory=UpdateManager,
+        extra_attrs={"window": None},
+    )
 
 
 class JsonDataTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.app = ensure_app_state(QApplication.instance() or DummyApp())
+        app, cls._owns_app = get_or_create_app(DummyApp)
+        cls.app = ensure_app_state(app)
 
     @classmethod
     def tearDownClass(cls):
-        if cls.app:
+        if getattr(cls, "_owns_app", False) and cls.app:
             cls.app.quit()
 
     def test_read_from_file_repairs_windows_drive_corruption(self):

--- a/src/tests/test_main_window.py
+++ b/src/tests/test_main_window.py
@@ -47,6 +47,7 @@ from PyQt5.QtWidgets import QApplication
 
 from classes.project_data import ProjectDataStore
 from classes.updates import UpdateManager
+from qt_test_app import ensure_app_state as ensure_qt_app_state, get_or_create_app
 
 QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts, True)
 
@@ -92,23 +93,13 @@ class DummyApp(QApplication):
 
 
 def ensure_app_state(app):
-    if not hasattr(app, "settings") or app.settings is None:
-        app.settings = DummySettings()
-    if (
-        not hasattr(app, "project")
-        or app.project is None
-        or not hasattr(app.project, "get")
-        or not hasattr(app.project, "generate_id")
-    ):
-        app.project = ProjectDataStore()
-    app.updates = UpdateManager()
-    app.updates.add_listener(app.project)
-    app.updates.reset()
-    if not hasattr(app, "window"):
-        app.window = None
-    if not hasattr(app, "logger_libopenshot"):
-        app.logger_libopenshot = None
-    return app
+    return ensure_qt_app_state(
+        app,
+        DummySettings,
+        project_factory=ProjectDataStore,
+        updates_factory=UpdateManager,
+        extra_attrs={"window": None, "logger_libopenshot": None},
+    )
 
 
 class SignalRecorder:
@@ -122,7 +113,8 @@ class SignalRecorder:
 class MainWindowTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.app = ensure_app_state(QApplication.instance() or DummyApp())
+        app, cls._owns_app = get_or_create_app(DummyApp)
+        cls.app = ensure_app_state(app)
         metrics = types.ModuleType("classes.metrics")
         metrics.track_metric_session = lambda *args, **kwargs: None
         metrics.track_metric_screen = lambda *args, **kwargs: None
@@ -131,7 +123,7 @@ class MainWindowTests(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if cls.app:
+        if getattr(cls, "_owns_app", False) and cls.app:
             cls.app.quit()
 
     def setUp(self):

--- a/src/tests/test_project_data.py
+++ b/src/tests/test_project_data.py
@@ -42,6 +42,7 @@ from PyQt5.QtWidgets import QApplication
 
 from classes.project_data import ProjectDataStore
 from classes.updates import UpdateManager
+from qt_test_app import ensure_app_state as ensure_qt_app_state, get_or_create_app
 
 
 class DummySettings:
@@ -86,21 +87,13 @@ class DummyApp(QApplication):
 
 
 def ensure_app_state(app):
-    if not hasattr(app, "settings") or app.settings is None:
-        app.settings = DummySettings()
-    if (
-        not hasattr(app, "project")
-        or app.project is None
-        or not hasattr(app.project, "get")
-        or not hasattr(app.project, "generate_id")
-    ):
-        app.project = ProjectDataStore()
-    app.updates = UpdateManager()
-    app.updates.add_listener(app.project)
-    app.updates.reset()
-    if not hasattr(app, "window"):
-        app.window = None
-    return app
+    return ensure_qt_app_state(
+        app,
+        DummySettings,
+        project_factory=ProjectDataStore,
+        updates_factory=UpdateManager,
+        extra_attrs={"window": None},
+    )
 
 
 class DummyAction:
@@ -123,11 +116,12 @@ def make_store():
 class ProjectDataTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.app = ensure_app_state(QApplication.instance() or DummyApp())
+        app, cls._owns_app = get_or_create_app(DummyApp)
+        cls.app = ensure_app_state(app)
 
     @classmethod
     def tearDownClass(cls):
-        if cls.app:
+        if getattr(cls, "_owns_app", False) and cls.app:
             cls.app.quit()
 
     def setUp(self):

--- a/src/tests/test_query.py
+++ b/src/tests/test_query.py
@@ -49,8 +49,27 @@ if PATH not in sys.path:
 from classes.app import OpenShotApp
 from classes.query import Clip, File, Transition
 from classes import info
+from classes.project_data import ProjectDataStore
+from classes.updates import UpdateManager
+from qt_test_app import ensure_app_state as ensure_qt_app_state
 
 info.LOG_LEVEL_CONSOLE = "ERROR"
+
+
+class DummySettings:
+    def __init__(self):
+        self.values = {
+            "default-profile": "HD 720p 30 fps",
+            "default-samplerate": 48000,
+            "default-channels": 2,
+            "legacy-based-timeline": False,
+        }
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value):
+        self.values[key] = value
 
 
 def ensure_open_shot_app():
@@ -58,9 +77,16 @@ def ensure_open_shot_app():
 
     instance = QGuiApplication.instance()
     if instance:
-        return instance, False
+        return ensure_qt_app_state(
+            instance,
+            DummySettings,
+            project_factory=ProjectDataStore,
+            updates_factory=UpdateManager,
+            extra_attrs={"window": None},
+        ), False
 
-    return OpenShotApp(sys.argv, mode="unittest"), True
+    app = OpenShotApp(sys.argv, mode="unittest")
+    return ensure_qt_app_state(app, DummySettings), True
 
 
 class QueryTests(unittest.TestCase):

--- a/src/tests/test_timeline_helpers.py
+++ b/src/tests/test_timeline_helpers.py
@@ -45,6 +45,7 @@ from PyQt5.QtCore import QCoreApplication, QPointF, QRectF, Qt
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import QApplication
 from classes.updates import UpdateAction
+from qt_test_app import ensure_app_state as ensure_qt_app_state, get_or_create_app
 
 QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts, True)
 
@@ -77,10 +78,15 @@ class DummyApp(QApplication):
         return text
 
 
+def ensure_app_state(app):
+    return ensure_qt_app_state(app, DummySettings)
+
+
 class TimelineHelperTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.app = QApplication.instance() or DummyApp()
+        app, cls._owns_app = get_or_create_app(DummyApp)
+        cls.app = ensure_app_state(app)
         cls.timeline_module = importlib.import_module("windows.views.timeline")
         cls.clip_paint_module = importlib.import_module("windows.views.timeline_backend.paint.clip")
         cls.qwidget_clip_module = importlib.import_module("windows.views.timeline_backend.qwidget.clip")
@@ -107,6 +113,11 @@ class TimelineHelperTests(unittest.TestCase):
                 return timeline_module.TimelineView._collect_clip_ids_from_value(self, value, clip_ids)
 
         return Helper()
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "_owns_app", False) and cls.app:
+            cls.app.quit()
 
     def make_time_helper(self):
         timeline_module = self.timeline_module


### PR DESCRIPTION
- Added a shared test helper at src/qt_test_app.py so tests can retrofit an existing Qt app instance with the OpenShot-like methods/state they need.
- Changed src/language/test_translations.py to create its QCoreApplication lazily instead of at import time, which removes the discovery-order poison pill.