### PR TITLE
Fixing Python Units (for Launchpad builds - take 2)

### DIFF
--- a/src/tests/__init__.py
+++ b/src/tests/__init__.py
@@ -1,0 +1,13 @@
+"""Test package bootstrap for headless Qt environments."""
+
+import os
+
+from PyQt5.QtCore import QCoreApplication, Qt
+
+
+# Package builders run without an X server, so force Qt to use a headless backend.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("QTWEBENGINE_DISABLE_SANDBOX", "1")
+
+# QtWebEngine requires this attribute before any Qt application is created.
+QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts, True)


### PR DESCRIPTION
I added a test bootstrap in src/tests/__init__.py that runs before unittest discover imports the Qt-heavy test modules. It now:

- sets QT_QPA_PLATFORM=offscreen
- sets QTWEBENGINE_DISABLE_SANDBOX=1
- sets Qt.AA_ShareOpenGLContexts before any Qt app is created