### PR TITLE
Another attempt to fix unit tests on headless build servers (launchpad PPA builders)

### DIFF
--- a/src/tests/__init__.py
+++ b/src/tests/__init__.py
@@ -5,9 +5,11 @@ import os
 from PyQt5.QtCore import QCoreApplication, Qt
 
 
-# Package builders run without an X server, so force Qt to use a headless backend.
-os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-os.environ.setdefault("QTWEBENGINE_DISABLE_SANDBOX", "1")
+# Package builders run without an X server, so use the minimal backend and
+# software OpenGL for compatibility with older Qt stacks.
+os.environ.setdefault("QT_QPA_PLATFORM", "minimal")
+os.environ.setdefault("QT_OPENGL", "software")
+os.environ.setdefault("LIBGL_ALWAYS_SOFTWARE", "1")
 
 # QtWebEngine requires this attribute before any Qt application is created.
 QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts, True)

--- a/src/tests/test_query.py
+++ b/src/tests/test_query.py
@@ -34,12 +34,6 @@ import unittest
 import openshot
 
 from PyQt5.QtGui import QGuiApplication
-try:
-    # QtWebEngineWidgets must be loaded prior to creating a QApplication
-    # But on systems with only WebKit, this will fail (and we ignore the failure)
-    from PyQt5.QtWebEngineWidgets import QWebEngineView  # noqa
-except ImportError:
-    pass
 
 # Import parent folder (so it can find other imports)
 PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))


### PR DESCRIPTION
More work on making unit tests more compatible with build servers, which are headless (no display). Take 4.