### PR TITLE
Fixing Qt compatibility helpers for Ubuntu 18.04

### DIFF
--- a/src/classes/qt_types.py
+++ b/src/classes/qt_types.py
@@ -41,3 +41,19 @@ def str_to_bytes(string):
 def bytes_to_str(bytes):
     """ This is required to load base64 Qt byte array strings into a Qt byte array (to load screen preferences) """
     return bytes.toBase64().data().decode("utf-8")
+
+
+def model_index_sibling_at_column(index, column):
+    """Return a sibling index for a column across old/new Qt bindings."""
+    sibling_at_column = getattr(index, "siblingAtColumn", None)
+    if callable(sibling_at_column):
+        return sibling_at_column(column)
+    return index.sibling(index.row(), column)
+
+
+def font_metrics_horizontal_advance(metrics, text):
+    """Measure text width across old/new Qt bindings."""
+    horizontal_advance = getattr(metrics, "horizontalAdvance", None)
+    if callable(horizontal_advance):
+        return horizontal_advance(text)
+    return metrics.width(text)

--- a/src/tests/test_qt_types.py
+++ b/src/tests/test_qt_types.py
@@ -1,0 +1,71 @@
+"""
+ @file
+ @brief Unit tests for Qt compatibility helpers
+"""
+
+import os
+import sys
+import unittest
+
+
+PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+if PATH not in sys.path:
+    sys.path.append(PATH)
+
+from classes import qt_types
+
+
+class _OldIndex:
+    def __init__(self):
+        self.calls = []
+
+    def row(self):
+        return 7
+
+    def sibling(self, row, column):
+        self.calls.append((row, column))
+        return ("sibling", row, column)
+
+
+class _NewIndex(_OldIndex):
+    def siblingAtColumn(self, column):
+        self.calls.append(("at", column))
+        return ("siblingAtColumn", column)
+
+
+class _OldMetrics:
+    def width(self, text):
+        return len(text) * 10
+
+
+class _NewMetrics(_OldMetrics):
+    def horizontalAdvance(self, text):
+        return len(text) * 12
+
+
+class QtTypesTests(unittest.TestCase):
+    def test_model_index_sibling_at_column_uses_new_api_when_available(self):
+        index = _NewIndex()
+
+        result = qt_types.model_index_sibling_at_column(index, 3)
+
+        self.assertEqual(result, ("siblingAtColumn", 3))
+        self.assertEqual(index.calls, [("at", 3)])
+
+    def test_model_index_sibling_at_column_falls_back_to_old_api(self):
+        index = _OldIndex()
+
+        result = qt_types.model_index_sibling_at_column(index, 2)
+
+        self.assertEqual(result, ("sibling", 7, 2))
+        self.assertEqual(index.calls, [(7, 2)])
+
+    def test_font_metrics_horizontal_advance_uses_new_api_when_available(self):
+        metrics = _NewMetrics()
+
+        self.assertEqual(qt_types.font_metrics_horizontal_advance(metrics, "abc"), 36)
+
+    def test_font_metrics_horizontal_advance_falls_back_to_old_api(self):
+        metrics = _OldMetrics()
+
+        self.assertEqual(qt_types.font_metrics_horizontal_advance(metrics, "abc"), 30)

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -48,6 +48,7 @@ from classes.query import File
 from classes.logger import log
 from classes.app import get_app
 from classes.thumbnail import GetThumbPath
+from classes.qt_types import model_index_sibling_at_column
 
 import openshot
 
@@ -449,7 +450,10 @@ class FilesModel(QObject, updates.UpdateInterface):
             if index.isValid():
                 # Select & scroll to selection
                 self.selection_model.select(index, QItemSelectionModel.Select | QItemSelectionModel.Rows)
-                get_app().window.filesView.scrollTo(index.siblingAtColumn(0), QAbstractItemView.PositionAtCenter)
+                get_app().window.filesView.scrollTo(
+                    model_index_sibling_at_column(index, 0),
+                    QAbstractItemView.PositionAtCenter,
+                )
                 last_selected_index = index
         if last_selected_index.isValid():
             # Keep current index aligned with the newly selected file so actions

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -37,6 +37,7 @@ from classes import info
 from classes.app import get_app
 from classes.logger import log
 from classes.query import File
+from classes.qt_types import font_metrics_horizontal_advance
 from .ai_tools_menu import add_ai_tools_menu
 from .menu import StyledContextMenu
 
@@ -123,7 +124,7 @@ class FilesListProgressDelegate(QStyledItemDelegate):
         if status == "queued":
             label = "Queued"
             fm = QFontMetrics(painter.font())
-            text_w = fm.horizontalAdvance(label)
+            text_w = font_metrics_horizontal_advance(fm, label)
             text_h = fm.height()
             pad_x = 5
             pad_y = 2

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -38,6 +38,7 @@ from classes import info
 from classes.app import get_app
 from classes.logger import log
 from classes.query import File
+from classes.qt_types import font_metrics_horizontal_advance
 from .ai_tools_menu import add_ai_tools_menu
 from .menu import StyledContextMenu
 
@@ -119,7 +120,7 @@ class FilesTreeProgressDelegate(QStyledItemDelegate):
         if status == "queued":
             label = "Queued"
             fm = QFontMetrics(painter.font())
-            text_w = fm.horizontalAdvance(label)
+            text_w = font_metrics_horizontal_advance(fm, label)
             text_h = fm.height()
             pad_x = 5
             pad_y = 2

--- a/src/windows/views/timeline_backend/paint/clip.py
+++ b/src/windows/views/timeline_backend/paint/clip.py
@@ -54,6 +54,7 @@ from classes.logger import log
 from classes.time_parts import secondsToTime
 from classes import info
 from classes.clip_utils import is_single_image_media
+from classes.qt_types import font_metrics_horizontal_advance
 
 from .base import BasePainter
 
@@ -1496,7 +1497,7 @@ class ClipPainter(BasePainter):
             )
             letter = label.strip()[0].upper() if isinstance(label, str) and label.strip() else "?"
 
-            text_width = metrics.horizontalAdvance(letter)
+            text_width = font_metrics_horizontal_advance(metrics, letter)
             badge_width = max(text_width + 6.0, badge_height)
             if badge_width > available:
                 break
@@ -1571,7 +1572,7 @@ class ClipPainter(BasePainter):
         painter.drawText(text_draw_rect, self.w._clip_text_flags, title)
 
         # Restrict hover to actual rendered text, not the entire clip region.
-        text_advance = float(metrics.horizontalAdvance(title))
+        text_advance = float(font_metrics_horizontal_advance(metrics, title))
         hit_width = min(max(1.0, text_advance), max(1.0, text_draw_rect.width()))
         hit_rect = QRectF(text_draw_rect.x(), text_draw_rect.y(), hit_width, max(1.0, text_draw_rect.height()))
         return {"rect": hit_rect, "title": title_raw}


### PR DESCRIPTION
Fixing Qt compatibility helpers for Ubuntu 18.04 (our oldest supported launchpad PPA build), which was missing 2 functions from later versions of Qt, and crash when painting a clip on the timeline.

Fixes https://github.com/OpenShot/openshot-qt/issues/5976