### PR TITLE
Smooth Zooming, Multi-Selection Trimming/Re-timing, New Thumbnail Style

### DIFF
--- a/doc/clips.rst
+++ b/doc/clips.rst
@@ -93,6 +93,9 @@ Here is a list of all methods for cutting and/or trimming clips in OpenShot:
 
 Keep in mind that the above cutting methods also have :ref:`keyboard_shortcut_ref`, to save even more time.
 
+If multiple selected clips and/or transitions share the same left edge or right
+edge, you can drag that shared edge once to trim them together.
+
 Selections
 ----------
 Selecting clips and transitions on the timeline is an essential part of editing in OpenShot. Multiple selection methods
@@ -255,6 +258,9 @@ Timing Tool
 Another way to change a clip's speed is with the :guilabel:`Timing` tool on the timeline toolbar. Enable the clock
 icon and drag a clip's edges. Lengthening the clip slows playback, while shotening it speeds the clip up.
 All keyframes on the clip and its effects are scaled so their relative positions remain intact.
+
+If you select multiple clips and/or transitions that share the same left edge or
+right edge, you can retime that shared edge together in one drag.
 
 Volume
 """"""

--- a/doc/main_window.rst
+++ b/doc/main_window.rst
@@ -118,7 +118,7 @@ keyframes, and common workflows), see :ref:`timeline_ref`.
      - Center the visible timeline area around the current playhead position.
    * - 6
      - Zoom Slider
-     - Control the visible timeline range. Drag handles to zoom in/out, drag center to pan, and double-click to fit timeline.
+     - Control the visible timeline range. Drag handles to zoom in/out, drag center to pan, and double-click to fit timeline. You can also use :kbd:`Ctrl+Scroll Wheel`, or on the QWidget timeline hold :kbd:`Ctrl` and drag with the middle mouse button for smooth zooming.
    * - 7
      - Track toggles (Lock, Keyframe Panel)
      - Per-track controls such as lock and keyframe panel visibility.

--- a/doc/timeline.rst
+++ b/doc/timeline.rst
@@ -91,6 +91,10 @@ retime, razor, markers, centering, and zoom).
 Tip: If timeline editing feels crowded, zoom in with the timeline slider to make
 small clip adjustments easier.
 
+You can also zoom the timeline with :kbd:`Ctrl+Scroll Wheel`. On the QWidget
+timeline, hold :kbd:`Ctrl` and drag with the middle mouse button for smooth
+zooming.
+
 Tracks, Locking, and Inserting
 ------------------------------
 

--- a/src/classes/thumbnail.py
+++ b/src/classes/thumbnail.py
@@ -48,14 +48,32 @@ from socketserver import ThreadingMixIn
 #  http://127.0.0.1:33723/thumbnails/9ATJTBQ71V/1/
 #  http://127.0.0.1:33723/thumbnails/9ATJTBQ71V/1
 REGEX_THUMBNAIL_URL = re.compile(r"/thumbnails/(?P<file_id>.+?)/(?P<file_frame>\d+)/*(?P<only_path>path)?/*(?P<no_cache>no-cache)?")
-THUMBNAIL_CACHE_VERSION = "20260327000000"
+THUMBNAIL_CACHE_VERSION = "20260327170000"
 THUMBNAIL_CACHE_VERSION_TS = datetime.strptime(
     THUMBNAIL_CACHE_VERSION,
     "%Y%m%d%H%M%S",
 ).timestamp()
 
 
-def GetThumbPath(file_id, thumbnail_frame, clear_cache=False):
+def GetThumbDeviceScale():
+    """Return the current Qt device scale used for thumbnail assets."""
+    try:
+        app = get_app()
+        scale = 1.0
+
+        window = getattr(app, "window", None)
+        if window and hasattr(window, "devicePixelRatioF"):
+            scale = float(window.devicePixelRatioF())
+        elif app and hasattr(app, "primaryScreen"):
+            screen = app.primaryScreen()
+            if screen:
+                scale = float(screen.devicePixelRatio())
+    except Exception:
+        scale = 1.0
+    return max(1.0, scale)
+
+
+def GetThumbPath(file_id, thumbnail_frame, clear_cache=False, attempts=1):
     """Get thumbnail path by invoking HTTP thumbnail request"""
 
     # Clear thumb cache (if requested)
@@ -71,12 +89,39 @@ def GetThumbPath(file_id, thumbnail_frame, clear_cache=False):
         file_id,
         thumbnail_frame,
         thumb_cache)
-    r = get(thumb_address)
-    if r.ok:
-        # Update thumbnail path to real one
-        return r.text
-    else:
-        return ''
+    attempts = max(1, int(attempts or 1))
+    for attempt in range(1, attempts + 1):
+        try:
+            r = get(thumb_address)
+        except Exception:
+            log.warning(
+                "Thumbnail path request failed file_id=%s frame=%s attempt=%s/%s",
+                file_id,
+                thumbnail_frame,
+                attempt,
+                attempts,
+                exc_info=1,
+            )
+            r = None
+
+        if r is not None and r.ok and r.text:
+            # Update thumbnail path to real one
+            return r.text
+
+        if r is not None:
+            log.warning(
+                "Thumbnail path request returned empty/miss file_id=%s frame=%s attempt=%s/%s status=%s",
+                file_id,
+                thumbnail_frame,
+                attempt,
+                attempts,
+                getattr(r, "status_code", "n/a"),
+            )
+
+        if attempt < attempts:
+            time.sleep(0.05)
+
+    return ''
 
 
 def GenerateThumbnail(file_path, thumb_path, thumbnail_frame, width, height, mask, overlay):
@@ -93,7 +138,7 @@ def GenerateThumbnail(file_path, thumb_path, thumbnail_frame, width, height, mas
         return
 
     try:
-        scale = float(get_app().devicePixelRatioF())
+        scale = GetThumbDeviceScale()
     except Exception:
         scale = 1.0
 
@@ -101,29 +146,47 @@ def GenerateThumbnail(file_path, thumb_path, thumbnail_frame, width, height, mas
         clip.scale_x.AddPoint(1.0, 1.0 * scale)
         clip.scale_y.AddPoint(1.0, 1.0 * scale)
 
-    # Open reader
-    reader.Open()
-
-    # Get the 'rotate' metadata (if any)
-    rotate = 0.0
-    try:
-        if reader.info.metadata.count("rotate"):
-            rotate_data = reader.info.metadata["rotate"]
-            rotate = float(rotate_data)
-    except ValueError as ex:
-        log.warning("Could not parse rotation value {}: {}".format(rotate_data, ex))
-    except Exception:
-        log.warning("Error reading rotation metadata from {}".format(file_path), exc_info=1)
-
     # Create thumbnail folder (if needed)
     parent_path = os.path.dirname(thumb_path)
     if not os.path.exists(parent_path):
         os.mkdir(parent_path)
 
-    # Save thumbnail image and close readers
-    reader.GetFrame(thumbnail_frame).Thumbnail(thumb_path, round(width * scale), round(height * scale), mask, overlay, "#000", False, "png", 85, rotate)
-    reader.Close()
-    clip.Close()
+    thumb_width = round(width * scale)
+    thumb_height = round(height * scale)
+
+    try:
+        reader.Open()
+
+        # Get the 'rotate' metadata (if any)
+        rotate = 0.0
+        try:
+            if reader.info.metadata.count("rotate"):
+                rotate_data = reader.info.metadata["rotate"]
+                rotate = float(rotate_data)
+        except ValueError as ex:
+            log.warning("Could not parse rotation value {}: {}".format(rotate_data, ex))
+        except Exception:
+            log.warning("Error reading rotation metadata from {}".format(file_path), exc_info=1)
+
+        reader.GetFrame(thumbnail_frame).Thumbnail(
+            thumb_path,
+            thumb_width,
+            thumb_height,
+            mask,
+            overlay,
+            "#000",
+            False,
+            "png",
+            85,
+            rotate,
+            openshot.SCALE_CROP,
+        )
+    finally:
+        try:
+            reader.Close()
+        except Exception:
+            pass
+        clip.Close()
 
 
 def ThumbnailCacheIsStale(thumb_path):

--- a/src/classes/thumbnail.py
+++ b/src/classes/thumbnail.py
@@ -31,6 +31,7 @@ import openshot
 import socket
 import time
 import shutil
+from datetime import datetime
 from requests import get
 from threading import Thread
 from classes import info
@@ -47,6 +48,11 @@ from socketserver import ThreadingMixIn
 #  http://127.0.0.1:33723/thumbnails/9ATJTBQ71V/1/
 #  http://127.0.0.1:33723/thumbnails/9ATJTBQ71V/1
 REGEX_THUMBNAIL_URL = re.compile(r"/thumbnails/(?P<file_id>.+?)/(?P<file_frame>\d+)/*(?P<only_path>path)?/*(?P<no_cache>no-cache)?")
+THUMBNAIL_CACHE_VERSION = "20260327000000"
+THUMBNAIL_CACHE_VERSION_TS = datetime.strptime(
+    THUMBNAIL_CACHE_VERSION,
+    "%Y%m%d%H%M%S",
+).timestamp()
 
 
 def GetThumbPath(file_id, thumbnail_frame, clear_cache=False):
@@ -118,6 +124,14 @@ def GenerateThumbnail(file_path, thumb_path, thumbnail_frame, width, height, mas
     reader.GetFrame(thumbnail_frame).Thumbnail(thumb_path, round(width * scale), round(height * scale), mask, overlay, "#000", False, "png", 85, rotate)
     reader.Close()
     clip.Close()
+
+
+def ThumbnailCacheIsStale(thumb_path):
+    """Return True when an on-disk thumbnail predates the current cache format."""
+    try:
+        return os.path.getmtime(thumb_path) < THUMBNAIL_CACHE_VERSION_TS
+    except OSError:
+        return True
 
 
 class httpThumbnailServer(ThreadingMixIn, HTTPServer):
@@ -245,13 +259,8 @@ class httpThumbnailHandler(BaseHTTPRequestHandler):
             # Try with ID and frame # in filename (for backwards compatibility)
             thumb_path = os.path.join(info.THUMBNAIL_PATH, "%s-%s.png" % (file_id, file_frame))
 
-        if not os.path.exists(thumb_path) or no_cache:
+        if not os.path.exists(thumb_path) or no_cache or ThumbnailCacheIsStale(thumb_path):
             # Generate thumbnail (since we can't find it)
-
-            # Determine if video overlay should be applied to thumbnail
-            overlay_path = ""
-            if file.data["media_type"] == "video":
-                overlay_path = os.path.join(info.IMAGES_PATH, "overlay.png")
 
             # Create thumbnail image
             GenerateThumbnail(
@@ -260,7 +269,7 @@ class httpThumbnailHandler(BaseHTTPRequestHandler):
                 file_frame,
                 98, 64,
                 mask_path,
-                overlay_path)
+                "")
 
         # Send message back to client
         if os.path.exists(thumb_path):

--- a/src/classes/waveform.py
+++ b/src/classes/waveform.py
@@ -31,8 +31,6 @@ from classes.app import get_app
 from classes.logger import log
 from classes.query import File, Clip
 from classes.clip_utils import project_fps_fraction, video_length_to_project_frames
-from PyQt5.QtGui import QCursor
-from PyQt5.QtCore import Qt
 import openshot
 import uuid
 
@@ -115,31 +113,31 @@ def get_waveform_thread(file_id, clip_list, transaction_id):
             log.info(f"file: {file_data['path']} has no audio_data. Skipping")
             return
 
-        # Show waiting cursor
-        get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
+        # Show waiting cursor on the GUI thread
+        get_app().window.WaitCursorSignal.emit(True)
+        try:
+            # Extract audio waveform data (for all channels)
+            # Use max RMS (root mean squared) value for each sample
+            # NOTE: we also have the average RMS value calculated, although we do
+            # not use it yet
+            waveformer = openshot.AudioWaveformer(temp_clip.Reader())
+            file_audio_data = waveformer.ExtractSamples(channel, SAMPLES_PER_SECOND, True)
+            samples_vectors = file_audio_data.vectors()
+            max_samples_vector = samples_vectors[0]  # max sample value dataset
+            rms_samples_vector = samples_vectors[1]  # average RMS sample value dataset
 
-        # Extract audio waveform data (for all channels)
-        # Use max RMS (root mean squared) value for each sample
-        # NOTE: we also have the average RMS value calculated, although we do
-        # not use it yet
-        waveformer = openshot.AudioWaveformer(temp_clip.Reader())
-        file_audio_data = waveformer.ExtractSamples(channel, SAMPLES_PER_SECOND, True)
-        samples_vectors = file_audio_data.vectors()
-        max_samples_vector = samples_vectors[0]  # max sample value dataset
-        rms_samples_vector = samples_vectors[1]  # average RMS sample value dataset
+            # Clear data
+            file_audio_data.clear()
 
-        # Clear data
-        file_audio_data.clear()
+            # Update file with audio data (only if all channels requested)
+            if channel == -1:
+                get_app().window.timeline.fileAudioDataReady.emit(file.id, {"ui": {"audio_data": max_samples_vector}}, tid)
 
-        # Update file with audio data (only if all channels requested)
-        if channel == -1:
-            get_app().window.timeline.fileAudioDataReady.emit(file.id, {"ui": {"audio_data": max_samples_vector}}, tid)
-
-        # Restore cursor
-        get_app().restoreOverrideCursor()
-
-        # Return audio sample dataset
-        return max_samples_vector
+            # Return audio sample dataset
+            return max_samples_vector
+        finally:
+            # Restore cursor on the GUI thread even if extraction fails
+            get_app().window.WaitCursorSignal.emit(False)
 
     # Get file query object
     file = File.get(id=file_id)

--- a/src/tests/test_timeline_helpers.py
+++ b/src/tests/test_timeline_helpers.py
@@ -1798,9 +1798,20 @@ class TimelineHelperTests(unittest.TestCase):
             self.qwidget_clip_module.ClipInteractionMixin._itemResizeMove(helper)
 
         self.assertEqual(sorted(helper._resize_results.keys()), ["A", "B"])
-        self.assertEqual(helper.preview_calls, [("B", 97)])
+        self.assertEqual(helper.preview_calls, [("A", 73)])
         self.assertEqual(helper.transition_preview_calls, [])
         self.assertEqual(helper.update_calls, 1)
+
+    def test_qwidget_resize_preview_focus_item_prefers_primary_resizing_item(self):
+        helper = self.make_qwidget_group_resize_preview_helper()
+        clip = types.SimpleNamespace(id="C1", data={"layer": 2})
+        transition = types.SimpleNamespace(id="T1", data={"layer": 5})
+        helper._resize_items = [transition, clip]
+        helper._resizing_item = clip
+
+        focus = self.qwidget_clip_module.ClipInteractionMixin._resize_preview_focus_item(helper)
+
+        self.assertIs(focus, clip)
 
     def test_qwidget_group_resize_preview_uses_shared_left_edge_for_mixed_items(self):
         helper = self.make_qwidget_shared_resize_math_helper()

--- a/src/tests/test_timeline_helpers.py
+++ b/src/tests/test_timeline_helpers.py
@@ -1119,6 +1119,101 @@ class TimelineHelperTests(unittest.TestCase):
             )
         )
 
+    def test_anchor_transition_endpoint_keyframes_keeps_first_and_last_frames_aligned(self):
+        helper = self.make_helper()
+        transition_data = {
+            "brightness": {
+                "Points": [
+                    {"co": {"X": 2, "Y": 1.0}},
+                    {"co": {"X": 5, "Y": -1.0}},
+                ]
+            },
+            "contrast": {
+                "Points": [
+                    {"co": {"X": 3, "Y": 3.0}},
+                    {"co": {"X": 6, "Y": 3.0}},
+                ]
+            },
+        }
+
+        self.timeline_module.TimelineView._anchor_transition_endpoint_keyframes(
+            helper,
+            transition_data,
+            4,
+        )
+
+        self.assertEqual(transition_data["brightness"]["Points"][0]["co"]["X"], 1)
+        self.assertEqual(transition_data["brightness"]["Points"][-1]["co"]["X"], 5)
+        self.assertEqual(transition_data["contrast"]["Points"][0]["co"]["X"], 1)
+        self.assertEqual(transition_data["contrast"]["Points"][-1]["co"]["X"], 5)
+
+    def test_update_transition_data_reanchors_static_transition_endpoints_without_frame_count_change(self):
+        helper = types.SimpleNamespace(
+            _transition_uses_static_mask=lambda transition_data, fallback_data=None: self.timeline_module.TimelineView._transition_uses_static_mask(
+                helper, transition_data, fallback_data
+            ),
+            _transition_mask_reader=lambda transition_data, fallback_data=None: self.timeline_module.TimelineView._transition_mask_reader(
+                helper, transition_data, fallback_data
+            ),
+            _transition_reader_changed=lambda transition_data, fallback_data=None: self.timeline_module.TimelineView._transition_reader_changed(
+                helper, transition_data, fallback_data
+            ),
+            _scale_keyframes=lambda keyframe, factor: self.timeline_module.TimelineView._scale_keyframes(
+                helper, keyframe, factor
+            ),
+            _anchor_transition_endpoint_keyframes=lambda transition_data, total_frames: self.timeline_module.TimelineView._anchor_transition_endpoint_keyframes(
+                helper, transition_data, total_frames
+            ),
+            _auto_orient_transition_keyframes=lambda transition_data: None,
+            delete_invalid_timeline_item=lambda _item: False,
+            window=types.SimpleNamespace(
+                IgnoreUpdates=types.SimpleNamespace(emit=lambda *_args, **_kwargs: None)
+            ),
+            show_wait_spinner=False,
+        )
+        old_data = {
+            "id": "T1",
+            "layer": 1,
+            "position": 10.0,
+            "start": 0.0,
+            "end": 2.0,
+            "reader": {"has_single_image": True},
+            "brightness": {
+                "Points": [
+                    {"co": {"X": 1, "Y": 1.0}},
+                    {"co": {"X": 62, "Y": -1.0}},
+                ]
+            },
+            "contrast": {"Points": [{"co": {"X": 1, "Y": 3.0}}, {"co": {"X": 62, "Y": 3.0}}]},
+        }
+        saved = []
+        existing_transition = types.SimpleNamespace(
+            id="T1",
+            data=copy.deepcopy(old_data),
+            save=lambda: saved.append(copy.deepcopy(existing_transition.data)),
+        )
+        transition_json = {
+            "id": "T1",
+            "layer": 1,
+            "position": 10.0,
+            "start": 0.0,
+            "end": (61.0 / 30.0),
+            "reader": {"has_single_image": True},
+        }
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(self.timeline_module.Transition, "get", return_value=existing_transition))
+            stack.enter_context(patch.object(self.timeline_module, "get_app", return_value=types.SimpleNamespace(
+                project=types.SimpleNamespace(get=lambda key: {"fps": {"num": 30, "den": 1}}[key]),
+                updates=types.SimpleNamespace(transaction_id=None),
+            )))
+            self.timeline_module.TimelineView.update_transition_data(helper, transition_json, only_basic_props=True)
+
+        self.assertTrue(saved)
+        saved_data = saved[-1]
+        self.assertEqual(saved_data["brightness"]["Points"][0]["co"]["X"], 1)
+        self.assertEqual(saved_data["brightness"]["Points"][-1]["co"]["X"], 62)
+
     def test_find_missing_transition_details_returns_overlap(self):
         clip_data = {"id": "B", "layer": 1, "position": 4.0, "start": 0.0, "end": 6.0}
         existing_clip = types.SimpleNamespace(data={"id": "A", "position": 0.0, "start": 0.0, "end": 5.0})
@@ -1773,9 +1868,9 @@ class TimelineHelperTests(unittest.TestCase):
         self.assertEqual([entry["id"] for entry in helper.clip_updates], ["A", "B"])
         self.assertEqual(helper.clip_updates[0]["override_keys"], ["A", "B"])
         self.assertEqual(helper.clip_updates[1]["override_keys"], ["A", "B"])
-        self.assertFalse(helper._preserve_overrides_once)
-        self.assertEqual(helper._pending_clip_overrides, {})
-        self.assertEqual(helper.changed_calls, 1)
+        self.assertTrue(helper._preserve_overrides_once)
+        self.assertEqual(helper._pending_clip_overrides, {"A": {"position": 1.0}, "B": {"position": 4.0}})
+        self.assertEqual(helper.changed_calls, 0)
 
     def test_qwidget_finish_item_resize_batches_multi_retime_commits(self):
         helper = self.make_qwidget_finish_resize_helper()
@@ -1830,7 +1925,7 @@ class TimelineHelperTests(unittest.TestCase):
             helper.waveform_refresh_calls,
             [(["A", "B"], helper.clip_updates[0]["kwargs"]["transaction_id"])],
         )
-        self.assertEqual(helper.changed_calls, 1)
+        self.assertEqual(helper.changed_calls, 0)
 
     def test_qwidget_finish_item_resize_preserves_shared_right_edge_after_snapping(self):
         helper = self.make_qwidget_finish_resize_helper()

--- a/src/tests/test_timeline_helpers.py
+++ b/src/tests/test_timeline_helpers.py
@@ -271,6 +271,64 @@ class TimelineHelperTests(unittest.TestCase):
 
         return Helper()
 
+    def make_qwidget_drag_move_helper(self):
+        qwidget_clip_module = self.qwidget_clip_module
+
+        class GeometryStub:
+            def __init__(self, helper):
+                self.helper = helper
+                self.updated_rects = {}
+
+            def calc_item_rect(self, item):
+                data = item.data if isinstance(item.data, dict) else {}
+                position = float(data.get("position", 0.0) or 0.0)
+                start = float(data.get("start", 0.0) or 0.0)
+                end = float(data.get("end", start) or start)
+                return QRectF(position * 24.0, 0.0, max(0.0, end - start) * 24.0, 10.0)
+
+            def update_item_rect(self, item, rect):
+                self.updated_rects[item.id] = QRectF(rect)
+
+        class Helper(qwidget_clip_module.ClipInteractionMixin):
+            def __init__(self):
+                self._drag_commit_in_progress = False
+                self.dragging_items = []
+                self._drag_threshold_met = True
+                self._drag_press_pos = QPointF()
+                self._drag_layer_idx_start = 0
+                self.drag_bbox = QRectF()
+                self.drag_clip_offset = 0.0
+                self.pixels_per_second = 24.0
+                self.fps_float = 24.0
+                self.enable_snapping = False
+                self._pending_clip_overrides = {}
+                self._pending_transition_overrides = {}
+                self._drag_initial = {}
+                self._drag_moved = False
+                self.track_list = [types.SimpleNamespace(data={"number": 1})]
+                self._track_num_from_index = {0: 1}
+                self._last_event = types.SimpleNamespace(
+                    pos=lambda: QPointF(0.0, 0.0),
+                    modifiers=lambda: Qt.NoModifier,
+                )
+                self.geometry = GeometryStub(self)
+                self.panel_shifts = []
+                self.update_calls = 0
+
+            def _track_index_at_viewport_y(self, *_args, **_kwargs):
+                return 0
+
+            def _nearest_unlocked_track_index(self, index):
+                return index
+
+            def _panel_shift_item(self, item, delta_sec, frame_delta):
+                self.panel_shifts.append((item.id, float(delta_sec), int(frame_delta)))
+
+            def update(self):
+                self.update_calls += 1
+
+        return Helper()
+
     def make_qwidget_finish_resize_helper(self):
         qwidget_clip_module = self.qwidget_clip_module
 
@@ -282,15 +340,22 @@ class TimelineHelperTests(unittest.TestCase):
                 self._resize_results = {}
                 self._resize_edge = "right"
                 self._snap_keyframe_seconds = []
+                self._suspend_changed_update = 0
+                self._suspend_keyframe_rebuild = False
                 self._pending_clip_overrides = {}
                 self._pending_transition_overrides = {}
                 self._preserve_overrides_once = False
+                self._preserve_overrides_during_batch = False
+                self._keyframes_dirty = False
+                self._dragging_panel_keyframes = False
+                self._dragging_keyframe = False
                 self.enable_timing = False
                 self.clip_updates = []
                 self.transition_updates = []
                 self.trim_preview_disabled = []
                 self.refresh_calls = []
                 self.waveform_refresh_calls = []
+                self.refresh_keyframe_calls = 0
                 self.snap_reset_calls = 0
                 self.project_duration_updates = 0
                 self.changed_calls = 0
@@ -340,8 +405,12 @@ class TimelineHelperTests(unittest.TestCase):
 
             def changed(self, _value):
                 self.changed_calls += 1
+                preserve_overrides = self._preserve_overrides_once or self._preserve_overrides_during_batch
                 if self._preserve_overrides_once:
                     self._preserve_overrides_once = False
+                if not preserve_overrides:
+                    self._pending_clip_overrides.clear()
+                    self._pending_transition_overrides.clear()
 
             def _release_cursor(self):
                 self.release_calls += 1
@@ -354,6 +423,9 @@ class TimelineHelperTests(unittest.TestCase):
 
             def update(self):
                 self.update_calls += 1
+
+            def _refresh_keyframe_markers(self):
+                self.refresh_keyframe_calls += 1
 
             def _commit_resized_clip(self, clip, start, end, position, context, transaction_id, ignore_refresh):
                 self.retime_calls.append(
@@ -840,6 +912,16 @@ class TimelineHelperTests(unittest.TestCase):
 
             def update(self):
                 self.update_calls += 1
+
+        return Helper()
+
+    def make_qwidget_keyframe_position_helper(self):
+        qwidget_keyframe_module = self.qwidget_keyframe_module
+
+        class Helper(qwidget_keyframe_module.KeyframeMixin):
+            def __init__(self):
+                self._pending_clip_overrides = {}
+                self._pending_transition_overrides = {}
 
         return Helper()
 
@@ -1546,6 +1628,22 @@ class TimelineHelperTests(unittest.TestCase):
         self.assertFalse(helper.mouse_dragging)
         self.assertEqual(helper.release_calls, 1)
 
+    def test_qwidget_transition_keyframe_base_position_uses_pending_override(self):
+        helper = self.make_qwidget_keyframe_position_helper()
+        transition = types.SimpleNamespace(
+            id="T1",
+            data={"id": "T1", "position": 4.0, "start": 0.0, "end": 1.0},
+        )
+        helper._pending_transition_overrides["T1"] = {"position": 6.5}
+
+        with patch.object(self.qwidget_keyframe_module, "Transition", type(transition)):
+            position = self.qwidget_keyframe_module.KeyframeMixin._keyframe_base_position(
+                helper,
+                {"transition": transition},
+            )
+
+        self.assertEqual(position, 6.5)
+
     def test_qwidget_finish_clip_drag_single_transition_keeps_auto_direction(self):
         helper = self.make_qwidget_finish_drag_helper()
 
@@ -1619,6 +1717,39 @@ class TimelineHelperTests(unittest.TestCase):
         self.assertEqual(transition_payload["id"], "T1")
         self.assertNotIn("_auto_transition", clip_payload)
         self.assertNotIn("_auto_direction", transition_payload)
+
+    def test_qwidget_drag_move_preserves_shared_edge_alignment_for_off_frame_selection(self):
+        helper = self.make_qwidget_drag_move_helper()
+
+        clip_a = types.SimpleNamespace(
+            id="A",
+            data={"id": "A", "position": 0.01, "layer": 1, "start": 0.0, "end": 0.59},
+        )
+        clip_b = types.SimpleNamespace(
+            id="B",
+            data={"id": "B", "position": 0.49, "layer": 1, "start": 0.0, "end": 0.11},
+        )
+        helper.dragging_items = [clip_a, clip_b]
+        helper._drag_initial = {
+            "A": {"position": 0.01, "index": 0, "position_frames": 0},
+            "B": {"position": 0.49, "index": 0, "position_frames": 12},
+        }
+        helper.drag_bbox = QRectF(clip_a.data["position"] * 24.0, 0.0, 0.59 * 24.0, 10.0)
+        helper._last_event = types.SimpleNamespace(
+            pos=lambda: QPointF(helper.drag_bbox.x() + 1.0, 0.0),
+            modifiers=lambda: Qt.NoModifier,
+        )
+
+        initial_right_a = clip_a.data["position"] + (clip_a.data["end"] - clip_a.data["start"])
+        initial_right_b = clip_b.data["position"] + (clip_b.data["end"] - clip_b.data["start"])
+        self.assertAlmostEqual(initial_right_a, initial_right_b)
+
+        self.qwidget_clip_module.ClipInteractionMixin._dragMove(helper)
+
+        moved_right_a = clip_a.data["position"] + (clip_a.data["end"] - clip_a.data["start"])
+        moved_right_b = clip_b.data["position"] + (clip_b.data["end"] - clip_b.data["start"])
+        self.assertAlmostEqual(moved_right_a, moved_right_b)
+        self.assertAlmostEqual(moved_right_a - initial_right_a, 1.0 / 24.0)
 
     def test_qwidget_cursor_uses_razor_cursor_for_items_when_enabled(self):
         helper = self.make_qwidget_cursor_helper()
@@ -1879,9 +2010,10 @@ class TimelineHelperTests(unittest.TestCase):
         self.assertEqual([entry["id"] for entry in helper.clip_updates], ["A", "B"])
         self.assertEqual(helper.clip_updates[0]["override_keys"], ["A", "B"])
         self.assertEqual(helper.clip_updates[1]["override_keys"], ["A", "B"])
-        self.assertTrue(helper._preserve_overrides_once)
-        self.assertEqual(helper._pending_clip_overrides, {"A": {"position": 1.0}, "B": {"position": 4.0}})
-        self.assertEqual(helper.changed_calls, 0)
+        self.assertFalse(helper._preserve_overrides_once)
+        self.assertEqual(helper._pending_clip_overrides, {})
+        self.assertEqual(helper.changed_calls, 1)
+        self.assertEqual(helper.refresh_keyframe_calls, 1)
 
     def test_qwidget_finish_item_resize_batches_multi_retime_commits(self):
         helper = self.make_qwidget_finish_resize_helper()
@@ -1936,7 +2068,8 @@ class TimelineHelperTests(unittest.TestCase):
             helper.waveform_refresh_calls,
             [(["A", "B"], helper.clip_updates[0]["kwargs"]["transaction_id"])],
         )
-        self.assertEqual(helper.changed_calls, 0)
+        self.assertEqual(helper.changed_calls, 1)
+        self.assertEqual(helper.refresh_keyframe_calls, 1)
 
     def test_qwidget_finish_item_resize_preserves_shared_right_edge_after_snapping(self):
         helper = self.make_qwidget_finish_resize_helper()

--- a/src/tests/test_timeline_helpers.py
+++ b/src/tests/test_timeline_helpers.py
@@ -93,6 +93,8 @@ class TimelineHelperTests(unittest.TestCase):
         sys.modules.pop("windows.views.timeline", None)
         cls.timeline_module = importlib.import_module("windows.views.timeline")
         cls.qwidget_base_module = importlib.import_module("windows.views.timeline_backend.qwidget.base")
+        cls.geometry_clip_module = importlib.import_module("windows.views.timeline_backend.geometry.clip")
+        cls.geometry_transition_module = importlib.import_module("windows.views.timeline_backend.geometry.transition")
         cls.clip_paint_module = importlib.import_module("windows.views.timeline_backend.paint.clip")
         cls.qwidget_clip_module = importlib.import_module("windows.views.timeline_backend.qwidget.clip")
         cls.qwidget_keyframe_module = importlib.import_module("windows.views.timeline_backend.qwidget.keyframe")
@@ -480,10 +482,10 @@ class TimelineHelperTests(unittest.TestCase):
                     )
                 )
 
-            def _compute_clip_resize(self, item, context=None):
+            def _compute_clip_resize(self, item, context=None, target_edge_seconds=None):
                 return QRectF(), context["initial"]["start"], context["initial"]["end"] + 1.0, context["initial"]["position"]
 
-            def _compute_transition_resize(self, item, context=None):
+            def _compute_transition_resize(self, item, context=None, target_edge_seconds=None):
                 return QRectF(), context["initial"]["start"], context["initial"]["end"] + 1.0, context["initial"]["position"]
 
             def _apply_resize_preview_override(self, item, context, start, end, position):
@@ -500,6 +502,55 @@ class TimelineHelperTests(unittest.TestCase):
 
             def _is_active_resize_item(self, item):
                 return qwidget_clip_module.ClipInteractionMixin._is_active_resize_item(self, item)
+
+        return Helper()
+
+    def make_qwidget_shared_resize_math_helper(self):
+        qwidget_clip_module = self.qwidget_clip_module
+
+        class GeometryStub:
+            def __init__(self, helper):
+                self.helper = helper
+
+            def update_item_rect(self, item, rect):
+                self.helper.updated_rects.append((item.id, rect))
+
+        class Helper(qwidget_clip_module.ClipInteractionMixin):
+            def __init__(self):
+                self._resize_items = []
+                self._resize_initial_map = {}
+                self._resize_results = {}
+                self._resizing_item = None
+                self._resize_edge = "left"
+                self._press_hit = "clip-edge"
+                self._keyframes_dirty = False
+                self.enable_timing = False
+                self.enable_snapping = False
+                self.fps_float = 30.0
+                self.pixels_per_second = 30.0
+                self.track_name_width = 0.0
+                self.updated_rects = []
+                self.update_calls = 0
+                self.preview_calls = []
+                self.transition_preview_calls = []
+                self._last_event = None
+                self.geometry = GeometryStub(self)
+                self.win = types.SimpleNamespace(timeline=None)
+
+            def _seconds_from_x(self, value):
+                return float(value) / float(self.pixels_per_second or 1.0)
+
+            def _snap_trim_delta(self, delta_seconds, edge=None, initial=None):
+                return float(delta_seconds)
+
+            def _resize_preview_focus_item(self):
+                return None
+
+            def _apply_resize_preview_override(self, item, context, start, end, position):
+                return None
+
+            def update(self):
+                self.update_calls += 1
 
         return Helper()
 
@@ -596,9 +647,16 @@ class TimelineHelperTests(unittest.TestCase):
             def _hitTest(self, pos):
                 return "clip"
 
+            def _item_resize_edge_at(self, rect, pos, edge=5):
+                return qwidget_base_module.TimelineWidgetBase._item_resize_edge_at(
+                    self, rect, pos, edge=edge
+                )
+
         return Helper(), EventStub
 
     def make_qwidget_cursor_helper(self):
+        qwidget_base_module = self.qwidget_base_module
+
         class GeometryStub:
             def __init__(self):
                 self.items = []
@@ -672,6 +730,11 @@ class TimelineHelperTests(unittest.TestCase):
 
             def _track_menu_rect(self, rect):
                 return QRectF()
+
+            def _item_resize_edge_at(self, rect, pos, edge=5):
+                return qwidget_base_module.TimelineWidgetBase._item_resize_edge_at(
+                    self, rect, pos, edge=edge
+                )
 
         return Helper()
 
@@ -1481,6 +1544,87 @@ class TimelineHelperTests(unittest.TestCase):
         self.assertIs(helper.cursor_value, helper.cursors["hand"])
         self.assertFalse(helper.unset_cursor_called)
 
+    def test_qwidget_cursor_uses_resize_cursor_on_exact_item_boundary(self):
+        helper = self.make_qwidget_cursor_helper()
+        helper.geometry.items = [(QRectF(10.0, 10.0, 40.0, 20.0), object(), True, "transition")]
+        helper._resize_targets_for_item = lambda _item, _edge: ["selected"]
+
+        self.qwidget_base_module.TimelineWidgetBase._updateCursor(helper, QPointF(50.0, 20.0))
+
+        self.assertIs(helper.cursor_value, helper.cursors["resize_x"])
+        self.assertFalse(helper.unset_cursor_called)
+
+    def test_qwidget_resize_move_ignores_non_handle_press_hits(self):
+        helper = types.SimpleNamespace(
+            _press_hit="clip",
+            _resizing_item=None,
+            _last_event=types.SimpleNamespace(pos=lambda: QPointF(320.0, 20.0)),
+            track_name_width=140.0,
+            changed_calls=[],
+            _itemResizeMove=lambda: (_ for _ in ()).throw(AssertionError("clip resize should not run")),
+            _projectResizeMove=lambda: (_ for _ in ()).throw(AssertionError("project resize should not run")),
+            changed=lambda value: helper.changed_calls.append(value),
+        )
+
+        self.qwidget_clip_module.ClipInteractionMixin._resizeMove(helper)
+
+        self.assertEqual(helper.track_name_width, 140.0)
+        self.assertEqual(helper.changed_calls, [])
+
+    def test_clip_geometry_marks_string_selected_ids_for_numeric_clip_ids(self):
+        module = self.geometry_clip_module
+
+        class Helper(module.ClipGeometryMixin):
+            def __init__(self):
+                self.widget = types.SimpleNamespace(
+                    track_name_width=140.0,
+                    pixels_per_second=10.0,
+                    ruler_height=40.0,
+                    vertical_factor=48.0,
+                    normalize_track_number=lambda value: value,
+                )
+                self.clip_entries = []
+                self._clip_starts = []
+                self._clip_max_rights = []
+
+        clip = types.SimpleNamespace(id=42, data={"position": 1.0, "start": 0.0, "end": 3.0, "layer": 0})
+        helper = Helper()
+        ctx = {"track_offsets": {0: 0.0}, "spacing": 56.0, "top_margin": 0.0}
+        win = types.SimpleNamespace(selected_clips=["42"])
+
+        with patch.object(module.Clip, "filter", return_value=[clip]):
+            helper._populate_clip_rects({0: 0}, ctx, win)
+
+        self.assertEqual(len(helper.clip_entries), 1)
+        self.assertTrue(helper.clip_entries[0].selected)
+
+    def test_transition_geometry_marks_string_selected_ids_for_numeric_transition_ids(self):
+        module = self.geometry_transition_module
+
+        class Helper(module.TransitionGeometryMixin):
+            def __init__(self):
+                self.widget = types.SimpleNamespace(
+                    track_name_width=140.0,
+                    pixels_per_second=10.0,
+                    ruler_height=40.0,
+                    vertical_factor=48.0,
+                    normalize_track_number=lambda value: value,
+                )
+                self.transition_entries = []
+                self._transition_starts = []
+                self._transition_max_rights = []
+
+        transition = types.SimpleNamespace(id=7, data={"position": 2.0, "start": 0.0, "end": 2.0, "layer": 0})
+        helper = Helper()
+        ctx = {"track_offsets": {0: 0.0}, "spacing": 56.0, "top_margin": 0.0}
+        win = types.SimpleNamespace(selected_transitions=["7"])
+
+        with patch.object(module.Transition, "filter", return_value=[transition]):
+            helper._populate_transition_rects({0: 0}, ctx, win)
+
+        self.assertEqual(len(helper.transition_entries), 1)
+        self.assertTrue(helper.transition_entries[0].selected)
+
     def test_qwidget_ctrl_mouse_zoom_starts_on_ctrl_middle_press(self):
         helper, event_cls = self.make_qwidget_ctrl_zoom_helper()
         pos = QPointF(20.0, 120.0)
@@ -1562,6 +1706,41 @@ class TimelineHelperTests(unittest.TestCase):
         self.assertEqual(helper.preview_calls, [("B", 97)])
         self.assertEqual(helper.transition_preview_calls, [])
         self.assertEqual(helper.update_calls, 1)
+
+    def test_qwidget_group_resize_preview_uses_shared_left_edge_for_mixed_items(self):
+        helper = self.make_qwidget_shared_resize_math_helper()
+        class DummyTransition:
+            def __init__(self, item_id, data):
+                self.id = item_id
+                self.data = data
+
+        clip = types.SimpleNamespace(id="C1", data={"position": 55.0, "start": 0.0, "end": 2.0})
+        transition = DummyTransition("T1", {"position": 55.0, "start": 0.5, "end": 2.5})
+        helper._resize_items = [transition, clip]
+        helper._resizing_item = transition
+        helper._resize_initial_map = {
+            "T1": {
+                "initial": {"position": 55.0, "start": 0.5, "end": 2.5, "duration": 2.0},
+                "world_rect": QRectF(55.0 * 30.0, 0.0, 60.0, 40.0),
+                "rect": QRectF(55.0 * 30.0, 0.0, 60.0, 40.0),
+                "static_mask": False,
+            },
+            "C1": {
+                "initial": {"position": 55.0, "start": 0.0, "end": 2.0, "duration": 2.0},
+                "world_rect": QRectF(55.0 * 30.0, 50.0, 60.0, 40.0),
+                "rect": QRectF(55.0 * 30.0, 50.0, 60.0, 40.0),
+                "max_duration": 10.0,
+                "allow_left_overflow": True,
+                "clip_is_single_image": True,
+            },
+        }
+        helper._last_event = types.SimpleNamespace(pos=lambda: QPointF((54.766666666666666 * 30.0), 10.0))
+
+        with patch.object(self.qwidget_clip_module, "Transition", DummyTransition):
+            self.qwidget_clip_module.ClipInteractionMixin._itemResizeMove(helper)
+
+        self.assertAlmostEqual(helper._resize_results["T1"]["position"], 54.766666666666666)
+        self.assertAlmostEqual(helper._resize_results["C1"]["position"], 54.766666666666666)
 
     def test_qwidget_finish_item_resize_preserves_group_overrides_until_final_refresh(self):
         helper = self.make_qwidget_finish_resize_helper()
@@ -1653,6 +1832,48 @@ class TimelineHelperTests(unittest.TestCase):
         )
         self.assertEqual(helper.changed_calls, 1)
 
+    def test_qwidget_finish_item_resize_preserves_shared_right_edge_after_snapping(self):
+        helper = self.make_qwidget_finish_resize_helper()
+        frame = 1.0 / 24.0
+
+        class DummyClip:
+            def __init__(self, item_id, data):
+                self.id = item_id
+                self.data = data
+
+        class DummyTransition:
+            def __init__(self, item_id, data):
+                self.id = item_id
+                self.data = data
+
+        clip = DummyClip("C1", {"id": "C1", "position": 0.0, "start": 0.0, "end": frame, "ui": {}})
+        transition = DummyTransition(
+            "T1",
+            {"id": "T1", "position": 0.0, "start": frame / 2.0, "end": frame * 1.5, "duration": frame},
+        )
+        helper._resizing_item = clip
+        helper._resize_edge = "left"
+        helper._resize_items = [clip, transition]
+        helper._resize_initial_map = {
+            "C1": {"initial": {"start": 0.0, "end": frame, "position": 0.0}},
+            "T1": {"initial": {"start": frame / 2.0, "end": frame * 1.5, "position": 0.0}, "static_mask": False},
+        }
+        helper._resize_results = {
+            "C1": {"start": 0.0, "end": frame, "position": 0.0},
+            "T1": {"start": frame / 2.0, "end": frame * 1.5, "position": 0.0},
+        }
+        helper._snap_time = lambda value: round(value * 24.0) / 24.0
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(self.qwidget_clip_module, "Clip", DummyClip))
+            stack.enter_context(patch.object(self.qwidget_clip_module, "Transition", DummyTransition))
+            self.qwidget_clip_module.ClipInteractionMixin._finishItemResize(helper)
+
+        clip_right = clip.data["position"] + (clip.data["end"] - clip.data["start"])
+        transition_right = transition.data["position"] + (transition.data["end"] - transition.data["start"])
+        self.assertAlmostEqual(clip_right, transition_right)
+        self.assertEqual(clip_right, frame)
+
     def test_qwidget_active_resize_item_helper_matches_group_members(self):
         helper = self.make_qwidget_group_resize_preview_helper()
         clip_a = types.SimpleNamespace(id="A", data={})
@@ -1696,6 +1917,47 @@ class TimelineHelperTests(unittest.TestCase):
         self.assertEqual([item.id for item in left_targets], ["A", "B"])
         self.assertEqual([item.id for item in right_targets], ["B", "C"])
 
+    def test_qwidget_resize_targets_include_mixed_clip_and_transition_on_shared_edge(self):
+        Helper = self.make_qwidget_resize_target_helper()
+        transition_a = types.SimpleNamespace(id="T1", data={"position": 2.0, "start": 0.0, "end": 3.0})
+        clip = types.SimpleNamespace(id="C1", data={"position": 2.0, "start": 1.0, "end": 4.0})
+        transition_b = types.SimpleNamespace(id="T2", data={"position": 2.0, "start": 0.0, "end": 5.0})
+        helper = Helper([
+            (QRectF(), transition_a, True, "transition"),
+            (QRectF(), clip, True, "clip"),
+            (QRectF(), transition_b, True, "transition"),
+        ])
+
+        targets = self.qwidget_clip_module.ClipInteractionMixin._resize_targets_for_item(
+            helper, transition_a, "left"
+        )
+
+        self.assertEqual([item.id for item in targets], ["T1", "C1", "T2"])
+
+    def test_qwidget_resize_targets_tolerate_one_frame_mixed_edge_drift(self):
+        Helper = self.make_qwidget_resize_target_helper()
+        helper = Helper([
+            (
+                QRectF(),
+                types.SimpleNamespace(id="T1", data={"position": 0.0, "start": 0.0, "end": 5.0}),
+                True,
+                "transition",
+            ),
+            (
+                QRectF(),
+                types.SimpleNamespace(id="C1", data={"position": 0.0, "start": 0.0, "end": 5.0 + (1.0 / 30.0)}),
+                True,
+                "clip",
+            ),
+        ])
+        helper.fps_float = 30.0
+
+        targets = self.qwidget_clip_module.ClipInteractionMixin._resize_targets_for_item(
+            helper, helper.geometry.items[0][1], "right"
+        )
+
+        self.assertEqual([item.id for item in targets], ["T1", "C1"])
+
     def test_qwidget_resize_targets_reject_interior_edge_in_multi_selection(self):
         Helper = self.make_qwidget_resize_target_helper()
         left = types.SimpleNamespace(id="L", data={"position": 1.0, "start": 0.0, "end": 3.0})
@@ -1736,6 +1998,18 @@ class TimelineHelperTests(unittest.TestCase):
         self.assertEqual(helper._press_hit, "clip-edge")
         self.assertEqual(helper._resize_edge, "left")
         self.assertEqual([item.id for item in helper._resize_items], ["A", "B"])
+
+    def test_qwidget_assign_press_target_accepts_exact_right_boundary_edge_hit(self):
+        target = types.SimpleNamespace(id="A")
+        helper, event_cls = self.make_qwidget_assign_press_helper(resize_items=[target])
+        item = types.SimpleNamespace(id="A", data={"position": 1.0, "start": 0.0, "end": 3.0})
+        helper.geometry.items = [(QRectF(10.0, 10.0, 40.0, 20.0), item, True, "clip")]
+
+        self.qwidget_base_module.TimelineWidgetBase._assign_press_target(helper, event_cls(50.0, 20.0))
+
+        self.assertEqual(helper._press_hit, "clip-edge")
+        self.assertEqual(helper._resize_edge, "right")
+        self.assertEqual([item.id for item in helper._resize_items], ["A"])
 
     def test_slice_triggered_keep_both_splits_transition_and_updates_duration(self):
         helper = self.make_slice_helper()

--- a/src/tests/test_timeline_helpers.py
+++ b/src/tests/test_timeline_helpers.py
@@ -203,7 +203,7 @@ class TimelineHelperTests(unittest.TestCase):
             def _seconds_from_x(self, value):
                 return float(value) / float(self.pixels_per_second or 1.0)
 
-            def _snap_trim_delta(self, delta_seconds, edge=None):
+            def _snap_trim_delta(self, delta_seconds, edge=None, initial=None):
                 return float(delta_seconds)
 
         return Helper()
@@ -268,6 +268,335 @@ class TimelineHelperTests(unittest.TestCase):
                 self.cursor_updates.append(pos)
 
         return Helper()
+
+    def make_qwidget_finish_resize_helper(self):
+        qwidget_clip_module = self.qwidget_clip_module
+
+        class Helper(qwidget_clip_module.ClipInteractionMixin):
+            def __init__(self):
+                self._resizing_item = None
+                self._resize_items = []
+                self._resize_initial_map = {}
+                self._resize_results = {}
+                self._resize_edge = "right"
+                self._snap_keyframe_seconds = []
+                self._pending_clip_overrides = {}
+                self._pending_transition_overrides = {}
+                self._preserve_overrides_once = False
+                self.enable_timing = False
+                self.clip_updates = []
+                self.transition_updates = []
+                self.trim_preview_disabled = []
+                self.refresh_calls = []
+                self.waveform_refresh_calls = []
+                self.snap_reset_calls = 0
+                self.project_duration_updates = 0
+                self.changed_calls = 0
+                self.release_calls = 0
+                self.cursor_updates = []
+                self.geometry_mark_dirty_calls = 0
+                self.update_calls = 0
+                self.retime_calls = []
+                self.win = types.SimpleNamespace(_trim_refresh_pending=False)
+                self.snap = types.SimpleNamespace(reset=self._reset_snap)
+                self._last_event = types.SimpleNamespace(pos=lambda: QPointF(10.0, 10.0))
+                self.geometry = types.SimpleNamespace(mark_dirty=self._mark_geometry_dirty)
+
+            def _reset_snap(self):
+                self.snap_reset_calls += 1
+
+            def _snap_time(self, value):
+                return float(value)
+
+            def update_clip_data(self, clip_data, **kwargs):
+                self.clip_updates.append(
+                    {
+                        "id": clip_data.get("id"),
+                        "override_keys": sorted(self._pending_clip_overrides.keys()),
+                        "kwargs": dict(kwargs),
+                    }
+                )
+
+            def update_transition_data(self, transition_data, **kwargs):
+                self.transition_updates.append((copy.deepcopy(transition_data), dict(kwargs)))
+
+            def _set_trim_thumbnail_suspension(self, enabled, clip_id=None):
+                if not enabled:
+                    self.trim_preview_disabled.append(str(clip_id))
+
+            def RefreshTrimmedTimelineItem(self, payload, edge):
+                self.refresh_calls.append((payload, edge))
+
+            def Show_Waveform_Triggered(self, clip_ids, transaction_id=None):
+                self.waveform_refresh_calls.append((list(clip_ids), transaction_id))
+
+            def _restore_resize_snap_ignore_ids(self, resized_items):
+                return None
+
+            def _update_project_duration(self):
+                self.project_duration_updates += 1
+
+            def changed(self, _value):
+                self.changed_calls += 1
+                if self._preserve_overrides_once:
+                    self._preserve_overrides_once = False
+
+            def _release_cursor(self):
+                self.release_calls += 1
+
+            def _updateCursor(self, pos):
+                self.cursor_updates.append(pos)
+
+            def _mark_geometry_dirty(self):
+                self.geometry_mark_dirty_calls += 1
+
+            def update(self):
+                self.update_calls += 1
+
+            def _commit_resized_clip(self, clip, start, end, position, context, transaction_id, ignore_refresh):
+                self.retime_calls.append(
+                    {
+                        "id": clip.id,
+                        "start": start,
+                        "end": end,
+                        "position": position,
+                        "transaction_id": transaction_id,
+                        "ignore_refresh": ignore_refresh,
+                        "timing": self.enable_timing,
+                    }
+                )
+                return qwidget_clip_module.ClipInteractionMixin._commit_resized_clip(
+                    self,
+                    clip,
+                    start,
+                    end,
+                    position,
+                    context,
+                    transaction_id,
+                    ignore_refresh,
+                )
+
+        return Helper()
+
+    def make_qwidget_ctrl_zoom_helper(self):
+        qwidget_base_module = self.qwidget_base_module
+
+        class TimerStub:
+            def __init__(self):
+                self.started = 0
+
+            def start(self):
+                self.started += 1
+
+        class EventStub:
+            def __init__(self, y, modifiers=Qt.ControlModifier, buttons=Qt.MiddleButton):
+                self._pos = QPointF(20.0, float(y))
+                self._modifiers = modifiers
+                self._buttons = buttons
+                self.accepted = False
+
+            def modifiers(self):
+                return self._modifiers
+
+            def buttons(self):
+                return self._buttons
+
+            def pos(self):
+                return self._pos
+
+            def accept(self):
+                self.accepted = True
+
+        class Helper:
+            def __init__(self):
+                self._ctrl_zoom_anchor_y = None
+                self._ctrl_zoom_step_pixels = 40.0
+                self._ctrl_zooming = False
+                self._pending_zoom_emit = None
+                self._zoom_emit_timer = TimerStub()
+                self.zoom_factor = 15.0
+                self.is_auto_center = False
+                self.zoom_steps = []
+                self.tooltip_values = []
+                self.mouse_dragging = False
+                self.viewport_reset_calls = 0
+                self.update_calls = 0
+
+            def _reset_ctrl_mouse_zoom(self):
+                return qwidget_base_module.TimelineWidgetBase._reset_ctrl_mouse_zoom(self)
+
+            def _start_ctrl_mouse_zoom(self, pos):
+                return qwidget_base_module.TimelineWidgetBase._start_ctrl_mouse_zoom(self, pos)
+
+            def _finish_ctrl_mouse_zoom(self):
+                return qwidget_base_module.TimelineWidgetBase._finish_ctrl_mouse_zoom(self)
+
+            def _apply_zoom_steps(self, steps, emit):
+                self.zoom_steps.append((steps, emit))
+                self.zoom_factor = 12.0
+                return True
+
+            def _set_hover_tooltip(self, value):
+                self.tooltip_values.append(value)
+
+            def _schedule_viewport_thumbnail_reset(self):
+                self.viewport_reset_calls += 1
+
+            def update(self):
+                self.update_calls += 1
+
+        return Helper(), EventStub
+
+    def make_qwidget_group_resize_preview_helper(self):
+        qwidget_clip_module = self.qwidget_clip_module
+
+        class GeometryStub:
+            def __init__(self, helper):
+                self.helper = helper
+
+            def update_item_rect(self, item, rect):
+                self.helper.updated_rects.append((item.id, rect))
+
+        class Helper(qwidget_clip_module.ClipInteractionMixin):
+            def __init__(self):
+                self._resize_items = []
+                self._resize_initial_map = {}
+                self._resize_results = {}
+                self._resizing_item = None
+                self._resize_edge = "right"
+                self._press_hit = "clip-edge"
+                self._keyframes_dirty = False
+                self.enable_timing = False
+                self.fps_float = 24.0
+                self.updated_rects = []
+                self.update_calls = 0
+                self.preview_calls = []
+                self.transition_preview_calls = []
+                self.geometry = GeometryStub(self)
+                self.win = types.SimpleNamespace(
+                    timeline=types.SimpleNamespace(
+                        PreviewClipFrame=lambda clip_id, frame: self.preview_calls.append((clip_id, frame)),
+                        PreviewTransitionFrame=lambda transition_id, frame: self.transition_preview_calls.append((transition_id, frame)),
+                    )
+                )
+
+            def _compute_clip_resize(self, item, context=None):
+                return QRectF(), context["initial"]["start"], context["initial"]["end"] + 1.0, context["initial"]["position"]
+
+            def _compute_transition_resize(self, item, context=None):
+                return QRectF(), context["initial"]["start"], context["initial"]["end"] + 1.0, context["initial"]["position"]
+
+            def _apply_resize_preview_override(self, item, context, start, end, position):
+                return None
+
+            def _snap_time(self, seconds):
+                return float(seconds)
+
+            def update(self):
+                self.update_calls += 1
+
+            def _active_resize_items(self):
+                return qwidget_clip_module.ClipInteractionMixin._active_resize_items(self)
+
+            def _is_active_resize_item(self, item):
+                return qwidget_clip_module.ClipInteractionMixin._is_active_resize_item(self, item)
+
+        return Helper()
+
+    def make_qwidget_resize_target_helper(self):
+        qwidget_clip_module = self.qwidget_clip_module
+
+        class GeometryStub:
+            def __init__(self, items):
+                self.items = list(items)
+
+            def iter_items(self, reverse=False, viewport=True):
+                items = list(self.items)
+                if reverse:
+                    items.reverse()
+                return items
+
+        class Helper(qwidget_clip_module.ClipInteractionMixin):
+            def __init__(self, items):
+                self.geometry = GeometryStub(items)
+                self.fps_float = 24.0
+
+            def _positive_float(self, value):
+                try:
+                    parsed = float(value)
+                except (TypeError, ValueError):
+                    return None
+                return parsed if parsed > 0.0 else None
+
+        return Helper
+
+    def make_qwidget_assign_press_helper(self, resize_items=None):
+        qwidget_base_module = self.qwidget_base_module
+
+        class GeometryStub:
+            def __init__(self):
+                self.items = []
+
+            def iter_items(self, reverse=False):
+                items = list(self.items)
+                if reverse:
+                    items.reverse()
+                return items
+
+        class EventStub:
+            def __init__(self, x, y):
+                self._pos = QPointF(float(x), float(y))
+
+            def pos(self):
+                return self._pos
+
+            def modifiers(self):
+                return Qt.NoModifier
+
+        class Helper:
+            def __init__(self):
+                self.geometry = GeometryStub()
+                self._press_marker = None
+                self._press_keyframe = None
+                self._active_keyframe_marker = None
+                self._press_keyframe_clear = True
+                self._panel_press_info = None
+                self._press_effect_icon = None
+                self._resizing_item = object()
+                self._resize_items = ["stale"]
+                self._resize_edge = "left"
+                self._press_hit = None
+                self.win = types.SimpleNamespace(selected_clips=[], selected_transitions=[])
+                self.resize_items = list(resize_items or [])
+
+            def _marker_at(self, pos):
+                return None
+
+            def _get_keyframe_at(self, pos):
+                return None
+
+            def _panel_add_button_at(self, pos):
+                return None
+
+            def _panel_marker_at(self, pos):
+                return None
+
+            def _panel_lane_at(self, pos):
+                return None
+
+            def _panel_track_at_pos(self, pos):
+                return None
+
+            def _effect_icon_at(self, pos):
+                return None
+
+            def _resize_targets_for_item(self, item, edge):
+                return list(self.resize_items)
+
+            def _hitTest(self, pos):
+                return "clip"
+
+        return Helper(), EventStub
 
     def make_qwidget_cursor_helper(self):
         class GeometryStub:
@@ -539,6 +868,7 @@ class TimelineHelperTests(unittest.TestCase):
             border_width = 1
             border_radius = 0
             border_color = QColor("black")
+            font_color = QColor("black")
             thumb_width = 48
             thumb_height = 36
             thumb_min_visible = 5
@@ -1151,6 +1481,262 @@ class TimelineHelperTests(unittest.TestCase):
         self.assertIs(helper.cursor_value, helper.cursors["hand"])
         self.assertFalse(helper.unset_cursor_called)
 
+    def test_qwidget_ctrl_mouse_zoom_starts_on_ctrl_middle_press(self):
+        helper, event_cls = self.make_qwidget_ctrl_zoom_helper()
+        pos = QPointF(20.0, 120.0)
+
+        started = self.qwidget_base_module.TimelineWidgetBase._start_ctrl_mouse_zoom(helper, pos)
+
+        self.assertTrue(started)
+        self.assertTrue(helper._ctrl_zooming)
+        self.assertTrue(helper.mouse_dragging)
+        self.assertEqual(helper._ctrl_zoom_anchor_y, 120.0)
+        self.assertEqual(helper.zoom_steps, [])
+
+    def test_qwidget_ctrl_mouse_zoom_moves_up_to_zoom_in(self):
+        helper, event_cls = self.make_qwidget_ctrl_zoom_helper()
+        helper._ctrl_zooming = True
+        helper._ctrl_zoom_anchor_y = 120.0
+        event = event_cls(100.0)
+
+        handled = self.qwidget_base_module.TimelineWidgetBase._handle_ctrl_mouse_zoom(helper, event)
+
+        self.assertTrue(handled)
+        self.assertTrue(event.accepted)
+        self.assertEqual(helper._ctrl_zoom_anchor_y, 100.0)
+        self.assertEqual(len(helper.zoom_steps), 1)
+        self.assertAlmostEqual(helper.zoom_steps[0][0], 0.5)
+        self.assertFalse(helper.zoom_steps[0][1])
+        self.assertTrue(helper.is_auto_center)
+        self.assertEqual(helper._pending_zoom_emit, 12.0)
+        self.assertEqual(helper._zoom_emit_timer.started, 1)
+
+    def test_qwidget_ctrl_mouse_zoom_requires_middle_button_and_ctrl(self):
+        helper, event_cls = self.make_qwidget_ctrl_zoom_helper()
+        helper._ctrl_zooming = True
+        helper._ctrl_zoom_anchor_y = 120.0
+        event = event_cls(90.0, buttons=Qt.LeftButton)
+
+        handled = self.qwidget_base_module.TimelineWidgetBase._handle_ctrl_mouse_zoom(helper, event)
+
+        self.assertFalse(handled)
+        self.assertFalse(event.accepted)
+        self.assertIsNone(helper._ctrl_zoom_anchor_y)
+        self.assertFalse(helper._ctrl_zooming)
+        self.assertEqual(helper.zoom_steps, [])
+
+    def test_qwidget_ctrl_mouse_zoom_finish_releases_cursor(self):
+        helper, _event_cls = self.make_qwidget_ctrl_zoom_helper()
+        helper._ctrl_zooming = True
+        helper._ctrl_zoom_anchor_y = 120.0
+        helper.mouse_dragging = True
+
+        self.qwidget_base_module.TimelineWidgetBase._finish_ctrl_mouse_zoom(helper)
+
+        self.assertFalse(helper._ctrl_zooming)
+        self.assertIsNone(helper._ctrl_zoom_anchor_y)
+        self.assertFalse(helper.mouse_dragging)
+        self.assertEqual(helper.viewport_reset_calls, 1)
+        self.assertEqual(helper.update_calls, 1)
+
+    def test_qwidget_group_resize_preview_updates_all_resize_items(self):
+        helper = self.make_qwidget_group_resize_preview_helper()
+        class DummyClip:
+            def __init__(self, item_id, data):
+                self.id = item_id
+                self.data = data
+
+        clip_a = DummyClip("A", {"position": 1.0, "start": 0.0, "end": 2.0, "layer": 2})
+        clip_b = DummyClip("B", {"position": 4.0, "start": 0.0, "end": 3.0, "layer": 5})
+        helper._resize_items = [clip_a, clip_b]
+        helper._resizing_item = clip_a
+        helper._resize_initial_map = {
+            "A": {"initial": {"position": 1.0, "start": 0.0, "end": 2.0}},
+            "B": {"initial": {"position": 4.0, "start": 0.0, "end": 3.0}},
+        }
+
+        with patch.object(self.qwidget_clip_module, "Clip", DummyClip):
+            self.qwidget_clip_module.ClipInteractionMixin._itemResizeMove(helper)
+
+        self.assertEqual(sorted(helper._resize_results.keys()), ["A", "B"])
+        self.assertEqual(helper.preview_calls, [("B", 97)])
+        self.assertEqual(helper.transition_preview_calls, [])
+        self.assertEqual(helper.update_calls, 1)
+
+    def test_qwidget_finish_item_resize_preserves_group_overrides_until_final_refresh(self):
+        helper = self.make_qwidget_finish_resize_helper()
+
+        class DummyClip:
+            def __init__(self, item_id, data):
+                self.id = item_id
+                self.data = data
+
+        clip_a = DummyClip("A", {"id": "A", "position": 1.0, "start": 0.0, "end": 2.0})
+        clip_b = DummyClip("B", {"id": "B", "position": 4.0, "start": 0.0, "end": 3.0})
+        helper._resizing_item = clip_a
+        helper._resize_items = [clip_a, clip_b]
+        helper._resize_initial_map = {
+            "A": {"initial": {"start": 0.0}},
+            "B": {"initial": {"start": 0.0}},
+        }
+        helper._resize_results = {
+            "A": {"start": 0.0, "end": 2.5, "position": 1.0},
+            "B": {"start": 0.0, "end": 3.5, "position": 4.0},
+        }
+        helper._resize_new_start = 0.0
+        helper._resize_new_end = 2.5
+        helper._resize_new_position = 1.0
+        helper._pending_clip_overrides = {"A": {"position": 1.0}, "B": {"position": 4.0}}
+
+        with patch.object(self.qwidget_clip_module, "Clip", DummyClip):
+            self.qwidget_clip_module.ClipInteractionMixin._finishItemResize(helper)
+
+        self.assertEqual([entry["id"] for entry in helper.clip_updates], ["A", "B"])
+        self.assertEqual(helper.clip_updates[0]["override_keys"], ["A", "B"])
+        self.assertEqual(helper.clip_updates[1]["override_keys"], ["A", "B"])
+        self.assertFalse(helper._preserve_overrides_once)
+        self.assertEqual(helper._pending_clip_overrides, {})
+        self.assertEqual(helper.changed_calls, 1)
+
+    def test_qwidget_finish_item_resize_batches_multi_retime_commits(self):
+        helper = self.make_qwidget_finish_resize_helper()
+        helper.enable_timing = True
+
+        class DummyClip:
+            def __init__(self, item_id, data):
+                self.id = item_id
+                self.data = data
+
+        clip_a = DummyClip("A", {"id": "A", "position": 1.0, "start": 0.0, "end": 2.0, "ui": {"audio_data": [0.1]}})
+        clip_b = DummyClip("B", {"id": "B", "position": 4.0, "start": 0.0, "end": 3.0, "ui": {"audio_data": [0.2]}})
+        helper._resizing_item = clip_a
+        helper._resize_items = [clip_a, clip_b]
+        helper._resize_initial_map = {
+            "A": {"initial": {"start": 0.0}},
+            "B": {"initial": {"start": 0.0}},
+        }
+        helper._resize_results = {
+            "A": {"start": -1.0, "end": 2.5, "position": 0.0},
+            "B": {"start": -1.0, "end": 3.5, "position": 3.0},
+        }
+        helper._resize_new_start = -1.0
+        helper._resize_new_end = 2.5
+        helper._resize_new_position = 0.0
+        helper._pending_clip_overrides = {"A": {"position": 0.0}, "B": {"position": 3.0}}
+
+        retime_invocations = []
+
+        def fake_retime_clip(clip, new_end, new_position, direction=1):
+            retime_invocations.append((clip.id, new_end, new_position, direction))
+            clip.data["end"] = new_end
+            clip.data["position"] = new_position
+            clip.data["duration"] = new_end - float(clip.data.get("start", 0.0) or 0.0)
+            return True
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(self.qwidget_clip_module, "Clip", DummyClip))
+            stack.enter_context(patch.object(self.qwidget_clip_module, "retime_clip", side_effect=fake_retime_clip))
+            self.qwidget_clip_module.ClipInteractionMixin._finishItemResize(helper)
+
+        self.assertEqual(retime_invocations, [("A", 3.5, 0.0, 1), ("B", 4.5, 3.0, 1)])
+        self.assertEqual([call["id"] for call in helper.retime_calls], ["A", "B"])
+        self.assertEqual(len(helper.clip_updates), 2)
+        self.assertEqual(helper.clip_updates[0]["kwargs"]["ignore_refresh"], True)
+        self.assertEqual(helper.clip_updates[1]["kwargs"]["ignore_refresh"], False)
+        self.assertEqual(
+            helper.clip_updates[0]["kwargs"]["transaction_id"],
+            helper.clip_updates[1]["kwargs"]["transaction_id"],
+        )
+        self.assertEqual(
+            helper.waveform_refresh_calls,
+            [(["A", "B"], helper.clip_updates[0]["kwargs"]["transaction_id"])],
+        )
+        self.assertEqual(helper.changed_calls, 1)
+
+    def test_qwidget_active_resize_item_helper_matches_group_members(self):
+        helper = self.make_qwidget_group_resize_preview_helper()
+        clip_a = types.SimpleNamespace(id="A", data={})
+        clip_b = types.SimpleNamespace(id="B", data={})
+        helper._resize_items = [clip_a]
+        helper._resizing_item = clip_a
+
+        self.assertTrue(self.qwidget_clip_module.ClipInteractionMixin._is_active_resize_item(helper, clip_a))
+        self.assertFalse(self.qwidget_clip_module.ClipInteractionMixin._is_active_resize_item(helper, clip_b))
+
+    def test_clip_painter_trim_preview_helper_accepts_group_resize_items(self):
+        painter = self.make_clip_painter()
+        clip = types.SimpleNamespace(id="C1", data={})
+        painter.w._pending_clip_overrides = {
+            "C1": {"start": 0.0, "end": 2.0, "position": 1.0, "scale": False}
+        }
+        painter.w._press_hit = "clip-edge"
+        painter.w.clip_has_pending_override = lambda candidate: getattr(candidate, "id", None) == "C1"
+        painter.w._is_active_resize_item = lambda candidate: getattr(candidate, "id", None) == "C1"
+
+        self.assertTrue(painter._is_trim_preview_active(clip))
+
+    def test_qwidget_resize_targets_only_include_shared_outer_edge_items(self):
+        Helper = self.make_qwidget_resize_target_helper()
+        item_a = types.SimpleNamespace(id="A", data={"position": 2.0, "start": 0.0, "end": 3.0})
+        item_b = types.SimpleNamespace(id="B", data={"position": 2.0, "start": 0.0, "end": 5.0})
+        item_c = types.SimpleNamespace(id="C", data={"position": 5.0, "start": 0.0, "end": 2.0})
+        helper = Helper([
+            (QRectF(), item_a, True, "clip"),
+            (QRectF(), item_b, True, "clip"),
+            (QRectF(), item_c, True, "clip"),
+        ])
+
+        left_targets = self.qwidget_clip_module.ClipInteractionMixin._resize_targets_for_item(
+            helper, item_a, "left"
+        )
+        right_targets = self.qwidget_clip_module.ClipInteractionMixin._resize_targets_for_item(
+            helper, item_b, "right"
+        )
+
+        self.assertEqual([item.id for item in left_targets], ["A", "B"])
+        self.assertEqual([item.id for item in right_targets], ["B", "C"])
+
+    def test_qwidget_resize_targets_reject_interior_edge_in_multi_selection(self):
+        Helper = self.make_qwidget_resize_target_helper()
+        left = types.SimpleNamespace(id="L", data={"position": 1.0, "start": 0.0, "end": 3.0})
+        middle = types.SimpleNamespace(id="M", data={"position": 3.0, "start": 0.0, "end": 2.0})
+        right = types.SimpleNamespace(id="R", data={"position": 6.0, "start": 0.0, "end": 2.0})
+        helper = Helper([
+            (QRectF(), left, True, "clip"),
+            (QRectF(), middle, True, "clip"),
+            (QRectF(), right, True, "clip"),
+        ])
+
+        targets = self.qwidget_clip_module.ClipInteractionMixin._resize_targets_for_item(
+            helper, middle, "left"
+        )
+
+        self.assertEqual(targets, [])
+
+    def test_qwidget_assign_press_target_falls_back_to_drag_for_invalid_multi_edge(self):
+        helper, event_cls = self.make_qwidget_assign_press_helper(resize_items=[])
+        item = types.SimpleNamespace(id="A", data={"position": 1.0, "start": 0.0, "end": 3.0})
+        helper.geometry.items = [(QRectF(10.0, 10.0, 40.0, 20.0), item, True, "clip")]
+
+        self.qwidget_base_module.TimelineWidgetBase._assign_press_target(helper, event_cls(10.0, 20.0))
+
+        self.assertEqual(helper._press_hit, "clip")
+        self.assertIsNone(helper._resize_edge)
+        self.assertEqual(helper._resize_items, [])
+
+    def test_qwidget_assign_press_target_keeps_group_resize_for_valid_outer_edge(self):
+        target_a = types.SimpleNamespace(id="A")
+        target_b = types.SimpleNamespace(id="B")
+        helper, event_cls = self.make_qwidget_assign_press_helper(resize_items=[target_a, target_b])
+        item = types.SimpleNamespace(id="A", data={"position": 1.0, "start": 0.0, "end": 3.0})
+        helper.geometry.items = [(QRectF(10.0, 10.0, 40.0, 20.0), item, True, "clip")]
+
+        self.qwidget_base_module.TimelineWidgetBase._assign_press_target(helper, event_cls(10.0, 20.0))
+
+        self.assertEqual(helper._press_hit, "clip-edge")
+        self.assertEqual(helper._resize_edge, "left")
+        self.assertEqual([item.id for item in helper._resize_items], ["A", "B"])
+
     def test_slice_triggered_keep_both_splits_transition_and_updates_duration(self):
         helper = self.make_slice_helper()
         left_transition = types.SimpleNamespace(
@@ -1274,9 +1860,33 @@ class TimelineHelperTests(unittest.TestCase):
         medium_increment = painter._frame_rounding_increment(24.0, 2.0)
         zoomed_increment = painter._frame_rounding_increment(24.0, 0.02)
 
-        self.assertEqual(wide_increment, 8)
-        self.assertEqual(medium_increment, 6)
+        self.assertEqual(wide_increment, 15)
+        self.assertEqual(medium_increment, 12)
         self.assertEqual(zoomed_increment, 1)
+
+    def test_frame_rounding_increment_doubles_local_rounding_before_cap(self):
+        painter = self.make_clip_painter(project_fps=24.0)
+        increment = painter._frame_rounding_increment(24.0, 0.2)
+
+        self.assertEqual(increment, 10)
+
+    def test_frame_rounding_increment_keeps_tighter_rounding_for_time_mapped_clips(self):
+        painter = self.make_clip_painter(project_fps=30.0)
+        clip = types.SimpleNamespace(
+            data={
+                "reader": {"fps": {"num": 24, "den": 1}, "duration": 52.2, "video_length": 1252},
+                "time": {
+                    "Points": [
+                        {"co": {"X": 1, "Y": 1566}, "interpolation": openshot.LINEAR},
+                        {"co": {"X": 1567, "Y": 1}, "interpolation": openshot.LINEAR},
+                    ]
+                },
+            }
+        )
+
+        increment = painter._frame_rounding_increment(24.0, 2.0, clip=clip, project_fps=30.0)
+
+        self.assertEqual(increment, 6)
 
     def test_timing_resize_preview_stretches_cached_clip_render(self):
         painter, clip, full_rect, segment_rect = self.make_timing_preview_painter()
@@ -1947,6 +2557,23 @@ class TimelineHelperTests(unittest.TestCase):
         self.assertEqual(end, 12.0)
         self.assertEqual(position, 0.0)
         self.assertEqual(rect.width(), 240.0)
+
+    def test_qwidget_snap_trim_delta_accepts_explicit_initial_context(self):
+        helper = self.make_qwidget_clip_helper()
+        snap_calls = []
+        helper.snap = types.SimpleNamespace(
+            snap_edge=lambda edge_sec, delta: snap_calls.append((edge_sec, delta)) or (delta + 0.25)
+        )
+
+        result = self.qwidget_clip_module.ClipInteractionMixin._snap_trim_delta(
+            helper,
+            1.5,
+            edge="right",
+            initial={"position": 2.0, "start": 1.0, "end": 4.0},
+        )
+
+        self.assertEqual(snap_calls, [(5.0, 1.5)])
+        self.assertEqual(result, 1.75)
 
     def test_thumbnail_worker_sorts_requests_and_reuses_clip_instance(self):
         worker = self.thumbnails_module._ThumbnailWorker()

--- a/src/tests/test_timeline_helpers.py
+++ b/src/tests/test_timeline_helpers.py
@@ -2037,7 +2037,7 @@ class TimelineHelperTests(unittest.TestCase):
 
         frames = self.collect_thumbnail_frames(clip)
 
-        self.assertEqual(frames, [1, 25, 72])
+        self.assertEqual(frames, [25, 61])
 
     def test_draw_thumbnails_entire_style_freeze_curve_maps_to_reader_frames(self):
         clip = types.SimpleNamespace(
@@ -2061,7 +2061,7 @@ class TimelineHelperTests(unittest.TestCase):
 
         frames = self.collect_thumbnail_frames(clip)
 
-        self.assertEqual(frames, [1, 25, 48])
+        self.assertEqual(frames, [25, 37])
 
     def test_draw_thumbnails_entire_style_reverse_curve_uses_reversed_reader_frames(self):
         clip = types.SimpleNamespace(
@@ -2083,7 +2083,7 @@ class TimelineHelperTests(unittest.TestCase):
 
         frames = self.collect_thumbnail_frames(clip)
 
-        self.assertEqual(frames, [72, 48, 2])
+        self.assertEqual(frames, [48, 13])
 
     def test_draw_thumbnails_entire_style_reverse_curve_with_trimmed_start_uses_trimmed_reader_frames(self):
         clip = types.SimpleNamespace(
@@ -2105,7 +2105,7 @@ class TimelineHelperTests(unittest.TestCase):
 
         frames = self.collect_thumbnail_frames(clip)
 
-        self.assertEqual(frames, [96, 49, 26])
+        self.assertEqual(frames, [84, 49])
 
     def test_draw_thumbnails_entire_style_reverse_curve_uses_reader_frame_range_in_mixed_fps_project(self):
         clip = types.SimpleNamespace(
@@ -2133,7 +2133,7 @@ class TimelineHelperTests(unittest.TestCase):
             project_fps=30.0,
         )
 
-        self.assertEqual(frames[:2], [1252, 1169])
+        self.assertEqual(frames[:2], [1169, 989])
         self.assertEqual(frames, sorted(frames, reverse=True))
         self.assertTrue(all(1 <= frame <= 1252 for frame in frames))
 
@@ -2163,7 +2163,7 @@ class TimelineHelperTests(unittest.TestCase):
             project_fps=30.0,
         )
 
-        self.assertEqual(frames, [1252, 1025, 875, 719, 570, 420, 264, 114, 2])
+        self.assertEqual(frames, [1175, 1025, 875, 719, 570, 420, 264, 114, 18])
 
     def test_draw_thumbnails_entire_style_long_retimed_clip_generates_tail_slots(self):
         clip = types.SimpleNamespace(
@@ -2265,6 +2265,28 @@ class TimelineHelperTests(unittest.TestCase):
         self.assertEqual(interval, 2.0)
         self.assertIn(8.0, starts)
 
+    def test_expire_thumbnail_requests_clears_edge_slot_fallback_cache(self):
+        painter = self.make_clip_painter(thumbnail_style="entire", pixels_per_second=24.0, project_fps=24.0)
+        painter._thumb_pending = {
+            ("C1", 1): 3,
+            ("C1", 30): 4,
+        }
+        painter._thumb_regions = {
+            ("C1", 1): self.clip_paint_module.QRectF(0.0, 0.0, 48.0, 36.0),
+            ("C1", 30): self.clip_paint_module.QRectF(48.0, 0.0, 48.0, 36.0),
+        }
+        painter._thumb_missing_logged = {("C1", 1), ("C1", 30)}
+        painter._slot_fallback_cache = {
+            ("C1", "edge-start"): object(),
+            ("C1", "edge-end"): object(),
+        }
+
+        painter.expire_thumbnail_requests(4)
+
+        self.assertNotIn(("C1", 1), painter._thumb_pending)
+        self.assertIn(("C1", 30), painter._thumb_pending)
+        self.assertEqual(painter._slot_fallback_cache, {})
+
     def test_draw_thumbnails_start_style_reverse_curve_uses_last_reader_frame(self):
         clip = types.SimpleNamespace(
             id="C1",
@@ -2356,6 +2378,43 @@ class TimelineHelperTests(unittest.TestCase):
         pix_call = next(item for item in drawn if item[0] == "pix")
         offset = pix_call[1]
         self.assertEqual(offset.x(), 0.0)
+
+    def test_draw_thumbnails_entire_style_partial_leading_slot_uses_visible_center_sampling(self):
+        painter = self.make_clip_painter(thumbnail_style="entire", pixels_per_second=24.0, project_fps=24.0)
+        clip = types.SimpleNamespace(
+            id="C1",
+            data={
+                "file_id": "F1",
+                "start": 0.0,
+                "end": 4.0,
+                "duration": 4.0,
+                "position": 0.0,
+                "reader": {"fps": {"num": 24, "den": 1}, "duration": 4.0},
+            },
+        )
+        frames = []
+
+        def fake_get_thumbnail_pixmap(_self, clip_key, file_id, frame, rect, generation, allow_request=True):
+            frames.append(frame)
+            return None
+
+        painter._get_thumbnail_pixmap = types.MethodType(fake_get_thumbnail_pixmap, painter)
+        painter._frame_rounding_increment = lambda *args, **kwargs: 1
+        inner = self.clip_paint_module.QRectF(0, 0, 72.0, 40)
+        segment = {
+            "segment_width": 72.0,
+            "clip_width": 96.0,
+            "offset_seconds": 0.25,
+            "duration_seconds": 3.0,
+            "clip_duration": 4.0,
+            "includes_start": False,
+            "includes_end": False,
+        }
+
+        painter._draw_thumbnails(None, clip, inner, segment)
+
+        self.assertGreaterEqual(len(frames), 1)
+        self.assertEqual(frames[0], 28)
 
     def test_trim_preview_freezes_edge_thumbnail_styles(self):
         for style in ("start", "start-end"):

--- a/src/windows/animated_title.py
+++ b/src/windows/animated_title.py
@@ -134,14 +134,12 @@ class AnimatedTitle(QDialog):
         """ Actually close window and accept dialog """
         self.blenderView.Cancel()
         self.blenderView.end_processing()
-        QApplication.restoreOverrideCursor()
         super().accept()
 
     def reject(self):
         # Stop threads
         self.blenderView.Cancel()
         self.blenderView.end_processing()
-        QApplication.restoreOverrideCursor()
         super().reject()
 
     def clear_effect_controls(self):

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -137,6 +137,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     SelectionChanged = pyqtSignal()      # Signal after selections have been changed (added/removed)
     SetKeyframeFilter = pyqtSignal(str)     # Signal to only show keyframes for the selected property
     IgnoreUpdates = pyqtSignal(bool, bool)     # Signal to let widgets know to ignore updates (i.e. batch updates)
+    WaitCursorSignal = pyqtSignal(bool)
     ThemeChangedSignal = pyqtSignal(object)     # Signal when theme is changed
     ProjectSaved = pyqtSignal(str)
     ProjectSaveFailed = pyqtSignal(str, str)
@@ -1012,12 +1013,13 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.SpeedSignal.emit(0)
         self.PauseSignal.emit()
 
-        # Set cursor to waiting
-        get_app().setOverrideCursor(QCursor(Qt.WaitCursor))
-
-        # Show dialog
-        from windows.preferences import Preferences
-        win = Preferences()
+        get_app().window.WaitCursorSignal.emit(True)
+        try:
+            # Show dialog
+            from windows.preferences import Preferences
+            win = Preferences()
+        finally:
+            get_app().window.WaitCursorSignal.emit(False)
         # Run the dialog event loop - blocking interaction on this window during this time
         result = win.exec_()
         if result == QDialog.Accepted:
@@ -1028,9 +1030,6 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Save settings
         s = get_app().get_settings()
         s.save()
-
-        # Restore normal cursor
-        get_app().restoreOverrideCursor()
 
     def actionFilesShowAll_trigger(self, checked=True):
         self.refreshFilesSignal.emit()
@@ -4020,27 +4019,14 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def ignore_updates_callback(self, ignore, show_wait=True):
         """Ignore updates callback - used to stop updating this widget during batch updates"""
-        app = get_app()
-
         if ignore and not self.ignore_updates:
             if show_wait:
-                # Wait for mass updates to finish
-                app.setOverrideCursor(QCursor(Qt.WaitCursor))
-                self._wait_cursor_requests += 1
+                self._acquire_wait_cursor()
             openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = False
-            app.processEvents()
+            get_app().processEvents()
         elif not ignore and self.ignore_updates:
-            if self._wait_cursor_requests:
-                # Ensure we unwind any wait cursors that we previously applied
-                while self._wait_cursor_requests and app.overrideCursor():
-                    app.restoreOverrideCursor()
-                    self._wait_cursor_requests -= 1
-                if self._wait_cursor_requests:
-                    # Cursor stack unexpectedly empty; reset our counter to keep it accurate
-                    self._wait_cursor_requests = 0
-            elif show_wait and app.overrideCursor():
-                # Fallback for callers expecting an unconditional restore
-                app.restoreOverrideCursor()
+            if show_wait:
+                self._release_wait_cursor()
             openshot.Settings.Instance().ENABLE_PLAYBACK_CACHING = True
 
         if not ignore:
@@ -4052,6 +4038,30 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Keep track of ignore / not ignore
         self.ignore_updates = ignore
+
+    def _acquire_wait_cursor(self):
+        """Push a wait cursor request on the GUI thread."""
+        app = get_app()
+        app.setOverrideCursor(QCursor(Qt.WaitCursor))
+        self._wait_cursor_requests += 1
+
+    def _release_wait_cursor(self):
+        """Release a wait cursor request on the GUI thread."""
+        app = get_app()
+        if self._wait_cursor_requests:
+            if app.overrideCursor():
+                app.restoreOverrideCursor()
+            self._wait_cursor_requests -= 1
+            return
+        if app.overrideCursor():
+            app.restoreOverrideCursor()
+
+    def handle_wait_cursor_signal(self, enabled):
+        """Handle cross-thread wait cursor requests safely on the GUI thread."""
+        if enabled:
+            self._acquire_wait_cursor()
+        else:
+            self._release_wait_cursor()
 
     def style_dock_widgets(self):
         """Check if any dock widget is part of a tabbed group and hide the title text if tabbed."""
@@ -4412,6 +4422,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.ignore_updates = False
         self._wait_cursor_requests = 0
         self.IgnoreUpdates.connect(self.ignore_updates_callback)
+        self.WaitCursorSignal.connect(self.handle_wait_cursor_signal)
 
         # Connect playhead moved signals
         self.SeekSignal.connect(self.handleSeek)

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -146,6 +146,7 @@ class FileFilterProxyModel(QSortFilterProxyModel):
 class FilesModel(QObject, updates.UpdateInterface):
     ModelRefreshed = pyqtSignal()
     PLACEHOLDER_PREFIX = "__genjob__:"
+    PROJECT_FILE_THUMB_ATTEMPTS = 3
 
     def _thumbnail_source_for_file(self, file, clear_cache=False):
         """Return the thumbnail/artwork source path and display name for a file."""
@@ -159,7 +160,12 @@ class FilesModel(QObject, updates.UpdateInterface):
                 fps = file.data["fps"]
                 fps_float = float(fps["num"]) / float(fps["den"])
                 thumbnail_frame = round(float(file.data['start']) * fps_float) + 1
-            thumb_source = GetThumbPath(file.id, thumbnail_frame, clear_cache=clear_cache)
+            thumb_source = GetThumbPath(
+                file.id,
+                thumbnail_frame,
+                clear_cache=clear_cache,
+                attempts=self.PROJECT_FILE_THUMB_ATTEMPTS,
+            )
         else:
             thumb_source = os.path.join(info.PATH, "images", "AudioThumbnail.svg")
 

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -147,6 +147,28 @@ class FilesModel(QObject, updates.UpdateInterface):
     ModelRefreshed = pyqtSignal()
     PLACEHOLDER_PREFIX = "__genjob__:"
 
+    def _thumbnail_source_for_file(self, file, clear_cache=False):
+        """Return the thumbnail/artwork source path and display name for a file."""
+        path, filename = os.path.split(file.data["path"])
+        name = file.data.get("name", filename)
+        media_type = file.data.get("media_type")
+
+        if media_type in ["video", "image"]:
+            thumbnail_frame = 1
+            if 'start' in file.data:
+                fps = file.data["fps"]
+                fps_float = float(fps["num"]) / float(fps["den"])
+                thumbnail_frame = round(float(file.data['start']) * fps_float) + 1
+            thumb_source = GetThumbPath(file.id, thumbnail_frame, clear_cache=clear_cache)
+        else:
+            thumb_source = os.path.join(info.PATH, "images", "AudioThumbnail.svg")
+
+        return thumb_source, name, media_type
+
+    def _project_file_icon_for_file(self, file):
+        thumb_source, name, media_type = self._thumbnail_source_for_file(file)
+        return QIcon(thumb_source), name, media_type
+
     # This method is invoked by the UpdateManager each time a change happens (i.e UpdateInterface)
     def changed(self, action):
 
@@ -232,24 +254,7 @@ class FilesModel(QObject, updates.UpdateInterface):
 
             path, filename = os.path.split(file.data["path"])
             tags = file.data.get("tags", "")
-            name = file.data.get("name", filename)
-
-            media_type = file.data.get("media_type")
-
-            # Generate thumbnail for file (if needed)
-            if media_type in ["video", "image"]:
-                # Check for start and end attributes (optional)
-                thumbnail_frame = 1
-                if 'start' in file.data:
-                    fps = file.data["fps"]
-                    fps_float = float(fps["num"]) / float(fps["den"])
-                    thumbnail_frame = round(float(file.data['start']) * fps_float) + 1
-
-                # Get thumb path
-                thumb_icon = QIcon(GetThumbPath(file.id, thumbnail_frame))
-            else:
-                # Audio file
-                thumb_icon = QIcon(os.path.join(info.PATH, "images", "AudioThumbnail.svg"))
+            thumb_icon, name, media_type = self._project_file_icon_for_file(file)
 
             row = []
             flags = Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsDragEnabled | Qt. ItemNeverHasChildren
@@ -584,9 +589,6 @@ class FilesModel(QObject, updates.UpdateInterface):
         path, filename = os.path.split(file.data["path"])
         name = file.data.get("name", filename)
 
-        fps = file.data["fps"]
-        fps_float = float(fps["num"]) / float(fps["den"])
-
         # Refresh thumbnail for updated file
         self.ignore_updates = True
         m = self.model
@@ -597,18 +599,8 @@ class FilesModel(QObject, updates.UpdateInterface):
             if not id_index.isValid():
                 return
 
-            # Generate thumbnail for file (if needed)
-            if file.data.get("media_type") in ["video", "image"]:
-                # Check for start and end attributes (optional)
-                thumbnail_frame = 1
-                if 'start' in file.data:
-                    thumbnail_frame = round(float(file.data['start']) * fps_float) + 1
-
-                # Get thumb path
-                thumb_icon = QIcon(GetThumbPath(file.id, thumbnail_frame, clear_cache=True))
-            else:
-                # Audio file
-                thumb_icon = QIcon(os.path.join(info.PATH, "images", "AudioThumbnail.svg"))
+            thumb_source, _, _ = self._thumbnail_source_for_file(file, clear_cache=True)
+            thumb_icon = QIcon(thumb_source)
 
             # Update thumb for file
             thumb_index = id_index.sibling(id_index.row(), 0)

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -121,9 +121,6 @@ class Preferences(QDialog):
         # Highlight invalid keyboard shortcuts
         self.check_shortcut_validity()
 
-        # Restore normal cursor
-        get_app().restoreOverrideCursor()
-
     def category_tab_changed(self, index):
         """Update the Restore Defaults button label based on the selected tab."""
         # Get the current widget for the selected tab

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -286,7 +286,7 @@ class BlenderListView(QListView):
 
         # Show 'Wait' cursor
         if cursor:
-            QApplication.setOverrideCursor(Qt.WaitCursor)
+            get_app().window.WaitCursorSignal.emit(True)
 
     @pyqtSlot()
     def end_processing(self):
@@ -297,7 +297,7 @@ class BlenderListView(QListView):
         self.win.statusContainer.hide()
 
         # Restore normal cursor and keyboard focus
-        QApplication.restoreOverrideCursor()
+        get_app().window.WaitCursorSignal.emit(False)
         if self.focus_owner:
             self.focus_owner.setFocus()
 

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -39,6 +39,7 @@ from classes.logger import log
 from classes.query import File
 from classes.qt_types import font_metrics_horizontal_advance
 from .ai_tools_menu import add_ai_tools_menu
+from .files_thumbnail_overlay import paint_media_overlay
 from .menu import StyledContextMenu
 
 
@@ -71,6 +72,16 @@ class FilesListProgressDelegate(QStyledItemDelegate):
         if not source_index or not source_index.isValid():
             return
 
+        opt = QStyleOptionViewItem(option)
+        self.initStyleOption(opt, index)
+        style = opt.widget.style() if opt.widget else self.view.style()
+        deco_rect = style.subElementRect(QStyle.SE_ItemViewItemDecoration, opt, opt.widget)
+        if not deco_rect.isValid():
+            return
+
+        media_type = source_index.sibling(source_index.row(), 3).data(Qt.DisplayRole)
+        paint_media_overlay(painter, deco_rect, media_type)
+
         file_id = source_index.sibling(source_index.row(), 5).data(Qt.DisplayRole)
         queue = getattr(self.view.win, "generation_queue", None)
         if not file_id or not queue:
@@ -95,13 +106,6 @@ class FilesListProgressDelegate(QStyledItemDelegate):
             # Keep active jobs visible even before numeric progress starts.
             progress = max(progress, 2)
         if progress <= 0:
-            return
-
-        opt = QStyleOptionViewItem(option)
-        self.initStyleOption(opt, index)
-        style = opt.widget.style() if opt.widget else self.view.style()
-        deco_rect = style.subElementRect(QStyle.SE_ItemViewItemDecoration, opt, opt.widget)
-        if not deco_rect.isValid():
             return
 
         bar_height = 3

--- a/src/windows/views/files_thumbnail_overlay.py
+++ b/src/windows/views/files_thumbnail_overlay.py
@@ -5,29 +5,24 @@
 
 import os
 
-from PyQt5.QtCore import QRectF, Qt
-from PyQt5.QtGui import QColor, QPainter
+from PyQt5.QtCore import QRectF
+from PyQt5.QtGui import QPainter
 from PyQt5.QtSvg import QSvgRenderer
 
 from classes import info
 
 
-_OVERLAY_ICON_NAMES = {
-    "image": "ai-action-create-image.svg",
-    "audio": "ai-action-create-audio.svg",
-    "video": "ai-action-create-video.svg",
-}
+_VIDEO_OVERLAY_ICON = "tool-media-play.svg"
 
 
 def _overlay_icon_path(media_type):
-    icon_name = _OVERLAY_ICON_NAMES.get(str(media_type or "").strip().lower())
-    if not icon_name:
+    if str(media_type or "").strip().lower() != "video":
         return ""
-    return os.path.join(info.PATH, "themes", "cosmic", "images", icon_name)
+    return os.path.join(info.PATH, "themes", "cosmic", "images", _VIDEO_OVERLAY_ICON)
 
 
 def paint_media_overlay(painter, deco_rect, media_type):
-    """Paint a translucent media-type badge over a thumbnail decoration rect."""
+    """Paint a centered translucent play glyph for video thumbnails."""
     if not deco_rect or not deco_rect.isValid():
         return
 
@@ -37,21 +32,15 @@ def paint_media_overlay(painter, deco_rect, media_type):
 
     painter.save()
     painter.setRenderHint(QPainter.Antialiasing, True)
+    painter.setOpacity(0.7)
 
-    badge_size = max(14.0, min(deco_rect.width(), deco_rect.height()) * 0.32)
-    margin = max(3.0, min(deco_rect.width(), deco_rect.height()) * 0.06)
-    badge_rect = QRectF(
-        deco_rect.right() - badge_size - margin + 1.0,
-        deco_rect.bottom() - badge_size - margin + 1.0,
-        badge_size,
-        badge_size,
+    glyph_size = max(16.0, min(deco_rect.width(), deco_rect.height()) * 0.36)
+    glyph_rect = QRectF(
+        deco_rect.center().x() - (glyph_size / 2.0),
+        deco_rect.center().y() - (glyph_size / 2.0),
+        glyph_size,
+        glyph_size,
     )
-
-    painter.setPen(Qt.NoPen)
-    painter.setBrush(QColor(18, 24, 31, 112))
-    painter.drawRoundedRect(badge_rect, badge_size * 0.24, badge_size * 0.24)
-
-    glyph_rect = badge_rect.adjusted(badge_size * 0.16, badge_size * 0.16, -badge_size * 0.16, -badge_size * 0.16)
     renderer = QSvgRenderer(icon_path)
     renderer.render(painter, glyph_rect)
 

--- a/src/windows/views/files_thumbnail_overlay.py
+++ b/src/windows/views/files_thumbnail_overlay.py
@@ -1,0 +1,58 @@
+"""
+ @file
+ @brief Dynamic media-type overlay painter for project file thumbnails.
+"""
+
+import os
+
+from PyQt5.QtCore import QRectF, Qt
+from PyQt5.QtGui import QColor, QPainter
+from PyQt5.QtSvg import QSvgRenderer
+
+from classes import info
+
+
+_OVERLAY_ICON_NAMES = {
+    "image": "ai-action-create-image.svg",
+    "audio": "ai-action-create-audio.svg",
+    "video": "ai-action-create-video.svg",
+}
+
+
+def _overlay_icon_path(media_type):
+    icon_name = _OVERLAY_ICON_NAMES.get(str(media_type or "").strip().lower())
+    if not icon_name:
+        return ""
+    return os.path.join(info.PATH, "themes", "cosmic", "images", icon_name)
+
+
+def paint_media_overlay(painter, deco_rect, media_type):
+    """Paint a translucent media-type badge over a thumbnail decoration rect."""
+    if not deco_rect or not deco_rect.isValid():
+        return
+
+    icon_path = _overlay_icon_path(media_type)
+    if not icon_path or not os.path.exists(icon_path):
+        return
+
+    painter.save()
+    painter.setRenderHint(QPainter.Antialiasing, True)
+
+    badge_size = max(14.0, min(deco_rect.width(), deco_rect.height()) * 0.32)
+    margin = max(3.0, min(deco_rect.width(), deco_rect.height()) * 0.06)
+    badge_rect = QRectF(
+        deco_rect.right() - badge_size - margin + 1.0,
+        deco_rect.bottom() - badge_size - margin + 1.0,
+        badge_size,
+        badge_size,
+    )
+
+    painter.setPen(Qt.NoPen)
+    painter.setBrush(QColor(18, 24, 31, 112))
+    painter.drawRoundedRect(badge_rect, badge_size * 0.24, badge_size * 0.24)
+
+    glyph_rect = badge_rect.adjusted(badge_size * 0.16, badge_size * 0.16, -badge_size * 0.16, -badge_size * 0.16)
+    renderer = QSvgRenderer(icon_path)
+    renderer.render(painter, glyph_rect)
+
+    painter.restore()

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -40,6 +40,7 @@ from classes.logger import log
 from classes.query import File
 from classes.qt_types import font_metrics_horizontal_advance
 from .ai_tools_menu import add_ai_tools_menu
+from .files_thumbnail_overlay import paint_media_overlay
 from .menu import StyledContextMenu
 
 
@@ -67,6 +68,16 @@ class FilesTreeProgressDelegate(QStyledItemDelegate):
         if index.column() != 0:
             return
 
+        opt = QStyleOptionViewItem(option)
+        self.initStyleOption(opt, index)
+        style = opt.widget.style() if opt.widget else self.view.style()
+        deco_rect = style.subElementRect(QStyle.SE_ItemViewItemDecoration, opt, opt.widget)
+        if not deco_rect.isValid():
+            return
+
+        media_type = index.sibling(index.row(), 3).data(Qt.DisplayRole)
+        paint_media_overlay(painter, deco_rect, media_type)
+
         file_id = index.sibling(index.row(), 5).data(Qt.DisplayRole)
         queue = getattr(self.view.win, "generation_queue", None)
         if not file_id or not queue:
@@ -91,13 +102,6 @@ class FilesTreeProgressDelegate(QStyledItemDelegate):
             # Keep active jobs visible even before numeric progress starts.
             progress = max(progress, 2)
         if progress <= 0:
-            return
-
-        opt = QStyleOptionViewItem(option)
-        self.initStyleOption(opt, index)
-        style = opt.widget.style() if opt.widget else self.view.style()
-        deco_rect = style.subElementRect(QStyle.SE_ItemViewItemDecoration, opt, opt.widget)
-        if not deco_rect.isValid():
             return
 
         bar_height = 3

--- a/src/windows/views/timeline.py
+++ b/src/windows/views/timeline.py
@@ -731,6 +731,23 @@ class TimelineView(updates.UpdateInterface, ViewClass):
             if "co" in point and "X" in point["co"] and point["co"]["X"] != 1:
                 point["co"]["X"] = round((point["co"]["X"] - 1) * factor) + 1
 
+    def _anchor_transition_endpoint_keyframes(self, transition_data, total_frames):
+        """Keep static transition endpoint keyframes anchored to the clip edges."""
+        if total_frames <= 0 or not isinstance(transition_data, dict):
+            return
+        last_frame = int(total_frames) + 1
+        for prop in ("brightness", "contrast"):
+            keyframe = transition_data.get(prop)
+            points = keyframe.get("Points") if isinstance(keyframe, dict) else None
+            if not isinstance(points, list) or len(points) < 2:
+                continue
+            first = points[0].get("co") if isinstance(points[0], dict) else None
+            last = points[-1].get("co") if isinstance(points[-1], dict) else None
+            if isinstance(first, dict):
+                first["X"] = 1
+            if isinstance(last, dict):
+                last["X"] = last_frame
+
     def _transition_mask_reader(self, transition_data, fallback_data=None):
         """Return reader metadata for a transition payload."""
         if isinstance(transition_data, dict):
@@ -1027,6 +1044,8 @@ class TimelineView(updates.UpdateInterface, ViewClass):
                 for prop in ("brightness", "contrast"):
                     if prop in existing_item.data:
                         self._scale_keyframes(existing_item.data[prop], scale)
+            if uses_static_mask and new_frames:
+                self._anchor_transition_endpoint_keyframes(existing_item.data, new_frames)
         elif old_data and self._transition_reader_changed(existing_item.data, old_data):
             self._set_transition_mask_defaults(existing_item.data, old_data)
 

--- a/src/windows/views/timeline_backend/geometry/clip.py
+++ b/src/windows/views/timeline_backend/geometry/clip.py
@@ -39,7 +39,10 @@ class ClipGeometryMixin:
         w = self.widget
         overrides_map = getattr(w, "_pending_clip_overrides", {})
         entries = []
-        selected_ids = set(getattr(win, "selected_clips", []) or [])
+        selected_ids = {
+            str(item_id)
+            for item_id in (getattr(win, "selected_clips", []) or [])
+        }
         for clip in Clip.filter():
             clip_data = clip.data if isinstance(clip.data, dict) else {}
             override = overrides_map.get(clip.id, {})
@@ -96,7 +99,7 @@ class ClipGeometryMixin:
         max_right = float("-inf")
         max_rights = []
         for left, rect, clip in entries:
-            is_selected = clip.id in selected_ids
+            is_selected = str(getattr(clip, "id", "")) in selected_ids
             clip_entries.append(_GeometryEntry(rect=rect, obj=clip, selected=is_selected))
             clip_starts.append(left)
             max_right = max(max_right, rect.right())

--- a/src/windows/views/timeline_backend/geometry/transition.py
+++ b/src/windows/views/timeline_backend/geometry/transition.py
@@ -39,7 +39,10 @@ class TransitionGeometryMixin:
         w = self.widget
         overrides_map = getattr(w, "_pending_transition_overrides", {})
         entries = []
-        selected_ids = set(getattr(win, "selected_transitions", []) or [])
+        selected_ids = {
+            str(item_id)
+            for item_id in (getattr(win, "selected_transitions", []) or [])
+        }
         for tr in Transition.filter():
             tr_data = tr.data if isinstance(tr.data, dict) else {}
             override = overrides_map.get(tr.id, {})
@@ -89,7 +92,7 @@ class TransitionGeometryMixin:
         max_right = float("-inf")
         max_rights = []
         for left, rect, tran in entries:
-            is_selected = tran.id in selected_ids
+            is_selected = str(getattr(tran, "id", "")) in selected_ids
             transition_entries.append(
                 _GeometryEntry(rect=rect, obj=tran, selected=is_selected)
             )

--- a/src/windows/views/timeline_backend/paint/clip.py
+++ b/src/windows/views/timeline_backend/paint/clip.py
@@ -1153,11 +1153,12 @@ class ClipPainter(BasePainter):
             slot_start_clip_time = center_world - clip_pos
             slot_end_clip_time = slot_start_clip_time + slot_duration_seconds
 
-            # Require overlap with visible segment (lenient for boundary cases)
-            if (
-                slot_end_clip_time < segment_start - epsilon
-                or slot_start_clip_time > segment_end + epsilon
-            ):
+            # Require positive overlap with the visible segment. Boundary-only
+            # slots can oscillate in/out during smooth zoom and fight with the
+            # first real visible slot.
+            overlap_start = max(slot_start_clip_time, segment_start)
+            overlap_end = min(slot_end_clip_time, segment_end)
+            if (overlap_end - overlap_start) <= epsilon:
                 return
 
             # Slot coverage in media time
@@ -1171,9 +1172,11 @@ class ClipPainter(BasePainter):
                 ):
                     return
 
-            # X coordinate within the visible segment (lenient for boundary cases)
+            # Require positive visible width in the current segment.
             local_x = (slot_start_clip_time - segment_start) * pixels_per_second
-            if local_x > view_right + epsilon or (local_x + thumb_w) < view_left - epsilon:
+            visible_left = max(local_x, view_left)
+            visible_right = min(local_x + thumb_w, view_right)
+            if (visible_right - visible_left) <= epsilon:
                 return
 
             # Deduplicate by clip-local time to avoid overlapping slots
@@ -1250,13 +1253,16 @@ class ClipPainter(BasePainter):
         segment_offset = float(timing.get("offset", 0.0) or 0.0)
         segment_duration = float(timing.get("duration", 0.0) or 0.0)
         segment_end = segment_offset + segment_duration
+        edge_epsilon = 1e-6
         frame_duration = (1.0 / project_fps) if project_fps and project_fps > 0.0 else 0.0
+        edge_time_epsilon = max(edge_epsilon, frame_duration * 0.5) if frame_duration > 0.0 else edge_epsilon
+        segment_at_clip_start = segment_offset <= edge_time_epsilon
+        segment_at_clip_end = abs(clip_duration - segment_end) <= edge_time_epsilon
         clip_start_frame = _frame_for_seconds(trim_start + segment_offset, clip_fps)
         if frame_duration > 0.0:
             clip_end_frame = _frame_for_seconds(max(trim_start + segment_offset, trim_start + segment_end - frame_duration), clip_fps)
         else:
             clip_end_frame = _frame_for_seconds(trim_start + segment_end, clip_fps)
-        edge_epsilon = 1e-6
         checker = getattr(self.w, "_is_active_resize_item", None)
         if callable(checker):
             is_resizing_clip = bool(checker(clip))
@@ -1294,17 +1300,27 @@ class ClipPainter(BasePainter):
                 clamped_center_time = segment_offset
             elif clamped_center_time > segment_end:
                 clamped_center_time = segment_end
+            visible_slot_start = max(slot_start_time, segment_offset)
+            visible_slot_end = min(slot_end_time, segment_end)
+            visible_center_time = clamped_center_time
+            if visible_slot_end >= visible_slot_start:
+                visible_center_time = visible_slot_start + ((visible_slot_end - visible_slot_start) * 0.5)
 
             touches_start = slot_start_time <= segment_offset + edge_epsilon
             touches_end = slot_end_time >= segment_end - edge_epsilon
             is_first_slot = slot_index == 0
             is_last_slot = slot_index == (len(slots) - 1)
-            is_edge = (touches_start and is_first_slot) or (touches_end and is_last_slot)
             slot_role = "grid"
-            if touches_start and is_first_slot:
-                slot_role = "edge-start"
-            elif touches_end and is_last_slot:
-                slot_role = "edge-end"
+            is_edge = False
+            if style != "entire":
+                is_edge = (
+                    (segment_at_clip_start and touches_start and is_first_slot)
+                    or (segment_at_clip_end and touches_end and is_last_slot)
+                )
+                if segment_at_clip_start and touches_start and is_first_slot:
+                    slot_role = "edge-start"
+                elif segment_at_clip_end and touches_end and is_last_slot:
+                    slot_role = "edge-end"
 
             # For "start" and "start-end", anchor edge thumbnails to exact trim edges.
             # Keep strip/entire behavior unchanged (centered sampling).
@@ -1316,17 +1332,7 @@ class ClipPainter(BasePainter):
                 else:
                     sample_time = segment_end
             elif style == "entire":
-                # Sample the visual center of each strip thumbnail, but clamp the
-                # first/last visible slots to the actual clip edges.
-                if slot_role == "edge-start":
-                    sample_time = segment_offset
-                elif slot_role == "edge-end":
-                    if frame_duration > 0.0:
-                        sample_time = max(segment_offset, segment_end - frame_duration)
-                    else:
-                        sample_time = segment_end
-                else:
-                    sample_time = clamped_center_time
+                sample_time = visible_center_time
             else:
                 sample_time = clamped_center_time
 
@@ -1932,6 +1938,9 @@ class ClipPainter(BasePainter):
             self._thumb_pending.pop(key, None)
             self._thumb_regions.pop(key, None)
             self._thumb_missing_logged.discard(key)
+        # Edge-slot fallbacks are keyed only by clip/role, so a viewport change
+        # can make them point at the wrong first/last visible frame.
+        self._slot_fallback_cache.clear()
 
     def handle_thumbnail_ready(self, clip_id, frame, thumb_path, generation):
         clip_key = str(clip_id or "")

--- a/src/windows/views/timeline_backend/paint/clip.py
+++ b/src/windows/views/timeline_backend/paint/clip.py
@@ -113,6 +113,11 @@ def _scaled_time_keyframe_points(clip, clip_fps, project_fps):
     return scaled_time.get("Points", []) if isinstance(scaled_time, dict) else []
 
 
+def _has_time_curve(clip, clip_fps, project_fps=None):
+    """Return True when a clip has a multi-point time mapping curve."""
+    return len(_scaled_time_keyframe_points(clip, clip_fps, project_fps)) >= 2
+
+
 def resolve_source_frame(clip, clip_time_seconds, clip_fps, project_fps=None, fallback_frame=None):
     """Resolve a source-media frame for a clip-local timestamp.
 
@@ -304,6 +309,9 @@ class ClipPainter(BasePainter):
         overrides = getattr(self.w, "_pending_clip_overrides", {}).get(clip.id, {})
         if not isinstance(overrides, dict) or not overrides.get("scale"):
             return False
+        checker = getattr(self.w, "_is_active_resize_item", None)
+        if callable(checker):
+            return bool(checker(clip))
         return (
             getattr(self.w, "_resizing_item", None) is clip
             and getattr(self.w, "_press_hit", "") == "clip-edge"
@@ -319,6 +327,9 @@ class ClipPainter(BasePainter):
         overrides = getattr(self.w, "_pending_clip_overrides", {}).get(clip.id, {})
         if not isinstance(overrides, dict) or overrides.get("scale"):
             return False
+        checker = getattr(self.w, "_is_active_resize_item", None)
+        if callable(checker):
+            return bool(checker(clip))
         return (
             getattr(self.w, "_resizing_item", None) is clip
             and getattr(self.w, "_press_hit", "") == "clip-edge"
@@ -538,11 +549,12 @@ class ClipPainter(BasePainter):
     def _frame_for_offset(self, offset, fps):
         return _frame_for_seconds(offset, fps)
 
-    def _frame_rounding_increment(self, fps, interval_seconds):
+    def _frame_rounding_increment(self, fps, interval_seconds, clip=None, project_fps=None):
         """Return frame rounding increment based on frames-per-slot at current zoom.
 
         Keep rounding local enough to reuse nearby thumbnails while avoiding
-        visible multi-second jumps as the zoom level changes.
+        visible multi-second jumps as the zoom level changes. Use a coarser
+        half-second ceiling to reduce churn while zooming.
         """
         fps = float(fps or 0.0)
         if fps <= 0.0 or not interval_seconds or interval_seconds <= 0.0:
@@ -550,9 +562,17 @@ class ClipPainter(BasePainter):
         frames_per_slot = fps * float(interval_seconds)
         if frames_per_slot <= 1.25:
             return 1
-        # Cap rounding at roughly a quarter-second so cache reuse stays local.
-        max_increment = max(1, int(round(fps / 4.0)))
-        return max(1, min(int(round(frames_per_slot)), max_increment))
+        if clip is not None and _has_time_curve(clip, fps, project_fps):
+            # Time-mapped clips are sensitive to project-frame rounding because
+            # small changes in timeline time can map to large source-frame jumps.
+            # Keep the earlier, tighter rounding so slot thumbnails stay anchored.
+            max_increment = max(1, int(round(fps / 4.0)))
+            return max(1, min(int(round(frames_per_slot)), max_increment))
+        # Cap rounding at roughly a half-second so cache reuse stays local
+        # without rolling through nearby frames on tiny zoom changes.
+        max_increment = max(1, int(round(fps / 2.0)))
+        increment = max(1, min(int(round(frames_per_slot)), max_increment))
+        return max(1, min(increment * 2, max_increment))
 
     def _segment_timing(self, segment, clip_duration):
         segment = segment or {}
@@ -1237,15 +1257,23 @@ class ClipPainter(BasePainter):
         else:
             clip_end_frame = _frame_for_seconds(trim_start + segment_end, clip_fps)
         edge_epsilon = 1e-6
-        is_resizing_clip = (
-            getattr(self.w, "_resizing_item", None) is clip
-            and getattr(self.w, "_press_hit", "") == "clip-edge"
-        )
+        checker = getattr(self.w, "_is_active_resize_item", None)
+        if callable(checker):
+            is_resizing_clip = bool(checker(clip))
+        else:
+            is_resizing_clip = (
+                getattr(self.w, "_resizing_item", None) is clip
+                and getattr(self.w, "_press_hit", "") == "clip-edge"
+            )
         throttle_requests = is_resizing_clip and style in ("start", "start-end")
-
         pending = False
         generation = getattr(self.w, "thumbnail_generation", 0)
-        rounding = self._frame_rounding_increment(clip_fps, interval_seconds)
+        rounding = self._frame_rounding_increment(
+            clip_fps,
+            interval_seconds,
+            clip=clip,
+            project_fps=project_fps,
+        )
         static_image = self._has_static_image(clip)
         static_frame = 1 if static_image else None
 
@@ -1302,13 +1330,13 @@ class ClipPainter(BasePainter):
             else:
                 sample_time = clamped_center_time
 
+            frame = None
+            pix = None
             clip_time = trim_start + sample_time
             frame = self._frame_for_offset(clip_time, clip_fps)
-            pre_round_frame = frame
             if rounding > 1 and (style == "entire" or not is_edge):
                 frame = max(1, int(round((frame - 1) / rounding) * rounding) + 1)
             frame = min(max(frame, clip_start_frame), clip_end_frame)
-            rounded_frame = frame
             mapped_frame = resolve_source_frame(
                 clip,
                 clip_time,

--- a/src/windows/views/timeline_backend/qwidget/base.py
+++ b/src/windows/views/timeline_backend/qwidget/base.py
@@ -807,6 +807,10 @@ class TimelineWidgetBase(QWidget):
         self.transition_painter.clear_cache()
         self.geometry.mark_dirty()
 
+        # Some trim/retime commits intentionally leave preview overrides alive
+        # for exactly one backend-driven refresh. This avoids rebuilding
+        # keyframes/geometry against committed data while stale preview state is
+        # still being torn down.
         preserve_overrides = getattr(self, "_preserve_overrides_once", False)
         if preserve_overrides:
             self._preserve_overrides_once = False

--- a/src/windows/views/timeline_backend/qwidget/base.py
+++ b/src/windows/views/timeline_backend/qwidget/base.py
@@ -328,9 +328,11 @@ class TimelineWidgetBase(QWidget):
         self._active_keyframe_marker = None
         self._press_keyframe_clear = True
         self._press_effect_icon = None
+        self._suspend_keyframe_rebuild = False
         self._pending_clip_overrides = {}
         self._pending_transition_overrides = {}
         self._preserve_overrides_once = False
+        self._preserve_overrides_during_batch = False
         self._drag_payload = None
         self._drag_preview_items = []
         self._drag_commit_in_progress = False
@@ -811,9 +813,13 @@ class TimelineWidgetBase(QWidget):
         # for exactly one backend-driven refresh. This avoids rebuilding
         # keyframes/geometry against committed data while stale preview state is
         # still being torn down.
-        preserve_overrides = getattr(self, "_preserve_overrides_once", False)
+        preserve_overrides = (
+            getattr(self, "_preserve_overrides_once", False)
+            or getattr(self, "_preserve_overrides_during_batch", False)
+        )
         if preserve_overrides:
-            self._preserve_overrides_once = False
+            if getattr(self, "_preserve_overrides_once", False):
+                self._preserve_overrides_once = False
         else:
             self._pending_clip_overrides.clear()
             self._pending_transition_overrides.clear()

--- a/src/windows/views/timeline_backend/qwidget/base.py
+++ b/src/windows/views/timeline_backend/qwidget/base.py
@@ -2671,20 +2671,16 @@ class TimelineWidgetBase(QWidget):
         # Clip/transition edges and drags (transitions prioritized)
         edge = 5
         for rect, _item, _selected, _type in self.geometry.iter_items(reverse=True):
-            if rect.contains(pos):
-                resize_edge = None
-                if abs(pos.x() - rect.left()) <= edge:
-                    resize_edge = "left"
-                elif abs(pos.x() - rect.right()) <= edge:
-                    resize_edge = "right"
-                if resize_edge:
-                    resize_items = self._resize_targets_for_item(_item, resize_edge)
-                    if resize_items:
-                        self.setCursor(self.cursors["resize_x"])
-                    else:
-                        self.setCursor(self.cursors["hand"])
+            resize_edge = self._item_resize_edge_at(rect, pos, edge=edge)
+            if resize_edge:
+                resize_items = self._resize_targets_for_item(_item, resize_edge)
+                if resize_items:
+                    self.setCursor(self.cursors["resize_x"])
                 else:
                     self.setCursor(self.cursors["hand"])
+                return
+            if rect.contains(pos):
+                self.setCursor(self.cursors["hand"])
                 return
 
         # Track menu icons
@@ -2906,9 +2902,8 @@ class TimelineWidgetBase(QWidget):
         self._press_effect_icon = None
         edge = 5
         for rect, item, _selected, _type in self.geometry.iter_items(reverse=True):
-            if not rect.contains(pos):
-                continue
-            if abs(pos.x() - rect.left()) <= edge:
+            resize_edge = self._item_resize_edge_at(rect, pos, edge=edge)
+            if resize_edge == "left":
                 resize_items = self._resize_targets_for_item(item, "left")
                 if resize_items:
                     self._press_hit = "clip-edge"
@@ -2917,7 +2912,7 @@ class TimelineWidgetBase(QWidget):
                     self._resize_edge = "left"
                     return
                 break
-            if abs(pos.x() - rect.right()) <= edge:
+            if resize_edge == "right":
                 resize_items = self._resize_targets_for_item(item, "right")
                 if resize_items:
                     self._press_hit = "clip-edge"
@@ -2930,6 +2925,20 @@ class TimelineWidgetBase(QWidget):
         self._resize_items = []
         self._resize_edge = None
         self._press_hit = self._hitTest(pos)
+
+    def _item_resize_edge_at(self, rect, pos, edge=5):
+        """Return the clip/transition edge under *pos* without requiring interior hits."""
+        if not isinstance(rect, QRectF) or rect.isNull():
+            return None
+        if pos.y() < rect.top() or pos.y() > rect.bottom():
+            return None
+
+        left_distance = abs(pos.x() - rect.left())
+        right_distance = abs(pos.x() - rect.right())
+        nearest = min(left_distance, right_distance)
+        if nearest > edge:
+            return None
+        return "left" if left_distance <= right_distance else "right"
 
     def _panel_track_at_pos(self, pos):
         """Return track number when *pos* lies within any keyframe panel area."""

--- a/src/windows/views/timeline_backend/qwidget/base.py
+++ b/src/windows/views/timeline_backend/qwidget/base.py
@@ -213,6 +213,9 @@ class TimelineWidgetBase(QWidget):
         self._zoom_emit_timer.setInterval(50)
         self._zoom_emit_timer.timeout.connect(self._emit_pending_zoom)
         self._pending_zoom_emit = None
+        self._ctrl_zoom_anchor_y = None
+        self._ctrl_zoom_step_pixels = 40.0
+        self._ctrl_zooming = False
 
         # Internal flag to defer repaint scheduling from changed()
         self._suspend_changed_update = 0
@@ -264,6 +267,8 @@ class TimelineWidgetBase(QWidget):
         self._resize_edge = None
         self._resize_initial_rect = QRectF()
         self._resize_initial = {}
+        self._resize_items = []
+        self._resize_initial_map = {}
         self._timing_original_start = 0.0
         self._fixed_cursor = None
 
@@ -1879,6 +1884,58 @@ class TimelineWidgetBase(QWidget):
         else:
             event.ignore()
 
+    def _reset_ctrl_mouse_zoom(self):
+        """Reset the transient anchor used for ctrl+mouse-move zooming."""
+        self._ctrl_zoom_anchor_y = None
+        self._ctrl_zooming = False
+
+    def _start_ctrl_mouse_zoom(self, pos):
+        """Begin a ctrl+middle-button smooth zoom gesture."""
+        self._ctrl_zooming = True
+        self.mouse_dragging = True
+        self._ctrl_zoom_anchor_y = float(pos.y())
+        self._set_hover_tooltip("")
+        return True
+
+    def _handle_ctrl_mouse_zoom(self, event):
+        """Zoom the timeline smoothly while ctrl+middle-dragging vertically."""
+        modifiers = event.modifiers() if hasattr(event, "modifiers") else Qt.NoModifier
+        buttons = event.buttons() if hasattr(event, "buttons") else Qt.NoButton
+        if not self._ctrl_zooming or not (modifiers & Qt.ControlModifier) or not (buttons & Qt.MiddleButton):
+            self._reset_ctrl_mouse_zoom()
+            self.mouse_dragging = False
+            return False
+
+        pos_y = float(event.pos().y())
+        if self._ctrl_zoom_anchor_y is None:
+            self._ctrl_zoom_anchor_y = pos_y
+            self._set_hover_tooltip("")
+            event.accept()
+            return True
+
+        delta_pixels = self._ctrl_zoom_anchor_y - pos_y
+        self._ctrl_zoom_anchor_y = pos_y
+        if abs(delta_pixels) > 1e-6:
+            steps = delta_pixels / float(self._ctrl_zoom_step_pixels or 1.0)
+            self.is_auto_center = True
+            if self._apply_zoom_steps(steps, emit=False):
+                self._pending_zoom_emit = self.zoom_factor
+                self._zoom_emit_timer.start()
+
+        self._set_hover_tooltip("")
+        event.accept()
+        return True
+
+    def _finish_ctrl_mouse_zoom(self):
+        """Finish a ctrl+middle-button smooth zoom gesture."""
+        if not self._ctrl_zooming:
+            return
+        self._ctrl_zooming = False
+        self._ctrl_zoom_anchor_y = None
+        self.mouse_dragging = False
+        self._schedule_viewport_thumbnail_reset()
+        self.update()
+
     def _flush_pending_vertical_scroll(self):
         """Apply any pending vertical scroll updates triggered by the wheel."""
         delta = self._pending_vscroll_delta
@@ -2615,8 +2672,17 @@ class TimelineWidgetBase(QWidget):
         edge = 5
         for rect, _item, _selected, _type in self.geometry.iter_items(reverse=True):
             if rect.contains(pos):
-                if abs(pos.x() - rect.left()) <= edge or abs(pos.x() - rect.right()) <= edge:
-                    self.setCursor(self.cursors["resize_x"])
+                resize_edge = None
+                if abs(pos.x() - rect.left()) <= edge:
+                    resize_edge = "left"
+                elif abs(pos.x() - rect.right()) <= edge:
+                    resize_edge = "right"
+                if resize_edge:
+                    resize_items = self._resize_targets_for_item(_item, resize_edge)
+                    if resize_items:
+                        self.setCursor(self.cursors["resize_x"])
+                    else:
+                        self.setCursor(self.cursors["hand"])
                 else:
                     self.setCursor(self.cursors["hand"])
                 return
@@ -2647,6 +2713,7 @@ class TimelineWidgetBase(QWidget):
         super().mouseDoubleClickEvent(event)
 
     def mousePressEvent(self, event):
+        self._reset_ctrl_mouse_zoom()
         self._press_marker = None
         if event.button() == Qt.RightButton:
             self._last_event = event
@@ -2666,6 +2733,11 @@ class TimelineWidgetBase(QWidget):
             return
 
         if event.button() == Qt.MiddleButton:
+            modifiers = event.modifiers() if hasattr(event, "modifiers") else Qt.NoModifier
+            if modifiers & Qt.ControlModifier:
+                if self._start_ctrl_mouse_zoom(event.pos()):
+                    event.accept()
+                    return
             if self._startMiddlePan(event.pos()):
                 event.accept()
                 return
@@ -2709,6 +2781,9 @@ class TimelineWidgetBase(QWidget):
         self.events.pressed.emit(event)
 
     def leaveEvent(self, event):
+        if self._ctrl_zooming:
+            self._finish_ctrl_mouse_zoom()
+        self._reset_ctrl_mouse_zoom()
         self._set_hover_tooltip("")
         if self._toolbar_hover_key is not None or self._toolbar_pressed_inside:
             self._toolbar_hover_key = None
@@ -2834,16 +2909,25 @@ class TimelineWidgetBase(QWidget):
             if not rect.contains(pos):
                 continue
             if abs(pos.x() - rect.left()) <= edge:
-                self._press_hit = "clip-edge"
-                self._resizing_item = item
-                self._resize_edge = "left"
-                return
+                resize_items = self._resize_targets_for_item(item, "left")
+                if resize_items:
+                    self._press_hit = "clip-edge"
+                    self._resizing_item = item
+                    self._resize_items = list(resize_items)
+                    self._resize_edge = "left"
+                    return
+                break
             if abs(pos.x() - rect.right()) <= edge:
-                self._press_hit = "clip-edge"
-                self._resizing_item = item
-                self._resize_edge = "right"
-                return
+                resize_items = self._resize_targets_for_item(item, "right")
+                if resize_items:
+                    self._press_hit = "clip-edge"
+                    self._resizing_item = item
+                    self._resize_items = list(resize_items)
+                    self._resize_edge = "right"
+                    return
+                break
         self._resizing_item = None
+        self._resize_items = []
         self._resize_edge = None
         self._press_hit = self._hitTest(pos)
 
@@ -2874,6 +2958,9 @@ class TimelineWidgetBase(QWidget):
 
     def mouseMoveEvent(self, event):
         self._last_event = event
+
+        if self._handle_ctrl_mouse_zoom(event):
+            return
 
         if self.scroll_bar_dragging:
             self._set_hover_tooltip("")
@@ -2935,6 +3022,7 @@ class TimelineWidgetBase(QWidget):
 
     def mouseReleaseEvent(self, event):
         self._last_event = event
+        self._reset_ctrl_mouse_zoom()
 
         if event.button() == Qt.LeftButton and self._toolbar_pressed_key:
             button = self._get_toolbar_button(*self._toolbar_pressed_key)
@@ -2955,6 +3043,10 @@ class TimelineWidgetBase(QWidget):
 
         if event.button() == Qt.MiddleButton and self._middle_panning:
             self._finishMiddlePan()
+            return
+        if event.button() == Qt.MiddleButton and self._ctrl_zooming:
+            self._finish_ctrl_mouse_zoom()
+            event.accept()
             return
         if self.scroll_bar_dragging or self.v_scroll_bar_dragging:
             self.scroll_bar_dragging = False

--- a/src/windows/views/timeline_backend/qwidget/clip.py
+++ b/src/windows/views/timeline_backend/qwidget/clip.py
@@ -302,24 +302,17 @@ class ClipInteractionMixin:
         return False
 
     def _resize_preview_focus_item(self):
-        """Choose a single item from the resize group for player preview updates."""
+        """Choose the primary grabbed item for player preview updates."""
         items = list(self._active_resize_items())
         if not items:
             return None
-
-        def sort_key(item):
-            data = getattr(item, "data", None)
-            if not isinstance(data, dict):
-                data = {}
-            try:
-                layer = int(data.get("layer", 0) or 0)
-            except (TypeError, ValueError):
-                layer = 0
-            item_id = str(getattr(item, "id", "") or "")
-            is_clip = isinstance(item, Clip)
-            return (1 if is_clip else 0, layer, item_id)
-
-        return max(items, key=sort_key)
+        primary = getattr(self, "_resizing_item", None)
+        if primary is not None:
+            primary_id = getattr(primary, "id", None)
+            for item in items:
+                if item is primary or getattr(item, "id", None) == primary_id:
+                    return item
+        return items[0]
 
     def _transition_uses_static_mask(self, transition_data):
         reader = {}

--- a/src/windows/views/timeline_backend/qwidget/clip.py
+++ b/src/windows/views/timeline_backend/qwidget/clip.py
@@ -206,6 +206,22 @@ class ClipInteractionMixin:
             item_id for item_id in ignore_ids if item_id not in resized_ids
         }
 
+    def _finalize_resize_preview_state(self, resize_items, backend_refresh_requested):
+        """
+        End a resize gesture's preview state.
+
+        When a backend refresh is already in flight, keep the preview overrides
+        alive for the next `changed()` call. That refresh will clear them after
+        geometry/keyframes have been rebuilt from the committed data.
+        """
+        if backend_refresh_requested:
+            self._preserve_overrides_once = True
+            return
+
+        for candidate in resize_items:
+            self._clear_resize_preview_overrides(candidate)
+        self.changed(None)
+
     def _normalize_resize_commit_bounds(self, start, end, position):
         """
         Quantize resize results while preserving the snapped outer right edge.
@@ -1512,10 +1528,10 @@ class ClipInteractionMixin:
         self._resize_items = []
         self._resize_initial_map = {}
         self._resize_results = {}
-        self._preserve_overrides_once = True
         transaction_id = str(uuid.uuid4())
         total = len(resize_items)
         waveform_clips = []
+        requested_backend_refresh = False
         for idx, candidate in enumerate(resize_items):
             result = resize_results.get(candidate.id)
             if not isinstance(result, dict):
@@ -1525,6 +1541,8 @@ class ClipInteractionMixin:
             position = result["position"]
             setattr(self.win, "_trim_refresh_pending", True)
             ignore_refresh = idx < total - 1
+            if not ignore_refresh:
+                requested_backend_refresh = True
             if isinstance(candidate, Clip):
                 context = resize_initial_map.get(candidate.id, {})
                 audio_data = candidate.data.get("ui", {}).get("audio_data")
@@ -1549,6 +1567,10 @@ class ClipInteractionMixin:
                 transition_data["end"] = end
                 transition_data["duration"] = self._snap_time(transition_data["end"] - transition_data["start"])
                 transition_data["_auto_direction"] = static_mask
+                # update_transition_data() can synchronously notify listeners.
+                # Drop the live resize override first so keyframe rebuilds use
+                # the committed transition timing instead of preview scaling.
+                self._pending_transition_overrides.pop(candidate.id, None)
                 self.update_transition_data(
                     transition_data,
                     only_basic_props=True,
@@ -1562,8 +1584,6 @@ class ClipInteractionMixin:
 
             if isinstance(candidate, Clip):
                 self._set_trim_thumbnail_suspension(False, candidate.id)
-            else:
-                self._pending_transition_overrides.pop(candidate.id, None)
 
         self._snap_keyframe_seconds = []
         self.snap.reset()
@@ -1571,9 +1591,7 @@ class ClipInteractionMixin:
         self._update_project_duration()
         if waveform_clips and hasattr(self, "Show_Waveform_Triggered"):
             self.Show_Waveform_Triggered(waveform_clips, transaction_id=transaction_id)
-        self.changed(None)
-        for candidate in resize_items:
-            self._clear_resize_preview_overrides(candidate)
+        self._finalize_resize_preview_state(resize_items, requested_backend_refresh)
         self._release_cursor()
         if self._last_event:
             self._updateCursor(self._last_event.pos())

--- a/src/windows/views/timeline_backend/qwidget/clip.py
+++ b/src/windows/views/timeline_backend/qwidget/clip.py
@@ -69,7 +69,9 @@ class ClipInteractionMixin:
     def _resize_edge_tolerance(self):
         fps = self._positive_float(getattr(self, "fps_float", None))
         if fps:
-            return max(1e-6, 0.5 / fps)
+            # Allow one-frame drift so mixed clip/transition selections keep
+            # behaving as a shared edge after commit quantization.
+            return max(1e-6, (1.0 / fps) + 1e-9)
         return 1e-6
 
     def _resize_targets_for_item(self, item, edge):
@@ -204,6 +206,27 @@ class ClipInteractionMixin:
             item_id for item_id in ignore_ids if item_id not in resized_ids
         }
 
+    def _normalize_resize_commit_bounds(self, start, end, position):
+        """
+        Quantize resize results while preserving the snapped outer right edge.
+
+        Snapping ``position``, ``start``, and ``end`` independently can move
+        the item's timeline right edge by a frame, which breaks later
+        multi-selection shared-edge detection. Snap the absolute right edge
+        once, then derive ``end`` from the snapped left-side values.
+        """
+        snapped_position = self._snap_time(position)
+        snapped_start = self._snap_time(start)
+        snapped_right = self._snap_time(position + max(0.0, end - start))
+
+        fps = float(getattr(self, "fps_float", 0.0) or 0.0)
+        min_len = (1.0 / fps) if fps > 0.0 else 0.0
+        snapped_span = max(min_len, snapped_right - snapped_position)
+        snapped_end = self._snap_time(snapped_start + snapped_span)
+        if min_len > 0.0 and snapped_end - snapped_start < min_len:
+            snapped_end = snapped_start + min_len
+        return snapped_start, snapped_end, snapped_position
+
     def _commit_resized_clip(self, clip, start, end, position, context, transaction_id, ignore_refresh):
         """Persist a resized clip, batching retime commits the same way as trims."""
         if self.enable_timing:
@@ -228,9 +251,10 @@ class ClipInteractionMixin:
             )
             return True
 
-        clip.data["start"] = self._snap_time(start)
-        clip.data["end"] = self._snap_time(end)
-        clip.data["position"] = self._snap_time(position)
+        start, end, position = self._normalize_resize_commit_bounds(start, end, position)
+        clip.data["start"] = start
+        clip.data["end"] = end
+        clip.data["position"] = position
         self.update_clip_data(
             clip.data,
             only_basic_props=True,
@@ -1079,7 +1103,7 @@ class ClipInteractionMixin:
             self._startItemResize()
         elif self._press_hit == "timeline-handle":
             self._startProjectResize()
-        else:
+        elif self._press_hit == "handle":
             self._resize_start = self.track_name_width
 
     def _resizeMove(self):
@@ -1087,7 +1111,7 @@ class ClipInteractionMixin:
             self._itemResizeMove()
         elif self._press_hit == "timeline-handle":
             self._projectResizeMove()
-        else:
+        elif self._press_hit == "handle":
             new_width = max(40, self._last_event.pos().x())
             if new_width != self.track_name_width:
                 self.track_name_width = new_width
@@ -1216,14 +1240,36 @@ class ClipInteractionMixin:
         self._resize_results = {}
         preview_item = self._resize_preview_focus_item()
         preview_result = None
+        primary_item = self._resizing_item if self._resizing_item in resize_items else resize_items[0]
+        primary_context = self._resize_initial_map.get(getattr(primary_item, "id", None))
+        shared_edge_seconds = None
+        primary_result = None
+        if primary_context:
+            if isinstance(primary_item, Transition):
+                primary_result = self._compute_transition_resize(primary_item, primary_context)
+            else:
+                primary_result = self._compute_clip_resize(primary_item, primary_context)
+            _rect, start, end, position = primary_result
+            shared_edge_seconds = self._resize_result_edge_seconds(start, end, position)
+
         for item in resize_items:
             context = self._resize_initial_map.get(item.id)
             if not context:
                 continue
-            if isinstance(item, Transition):
-                rect, start, end, position = self._compute_transition_resize(item, context)
+            if item is primary_item and primary_result is not None:
+                rect, start, end, position = primary_result
+            elif isinstance(item, Transition):
+                rect, start, end, position = self._compute_transition_resize(
+                    item,
+                    context,
+                    target_edge_seconds=shared_edge_seconds,
+                )
             else:
-                rect, start, end, position = self._compute_clip_resize(item, context)
+                rect, start, end, position = self._compute_clip_resize(
+                    item,
+                    context,
+                    target_edge_seconds=shared_edge_seconds,
+                )
 
             self._resize_results[item.id] = {
                 "start": start,
@@ -1273,7 +1319,12 @@ class ClipInteractionMixin:
                     timeline.PreviewTransitionFrame(str(item_id), max(1, frame))
         self.update()
 
-    def _compute_transition_resize(self, item, context=None):
+    def _resize_result_edge_seconds(self, start, end, position):
+        if getattr(self, "_resize_edge", None) == "left":
+            return position
+        return position + max(0.0, end - start)
+
+    def _compute_transition_resize(self, item, context=None, target_edge_seconds=None):
         event = self._last_event
         pps = self.pixels_per_second
         min_len = 1.0 / self.fps_float
@@ -1294,8 +1345,11 @@ class ClipInteractionMixin:
         static_mask = bool(context.get("static_mask"))
 
         if self._resize_edge == "left":
-            delta_sec = (event.pos().x() - rect.left()) / pps
-            if self.enable_snapping:
+            if target_edge_seconds is not None:
+                delta_sec = target_edge_seconds - pos
+            else:
+                delta_sec = (event.pos().x() - rect.left()) / pps
+            if target_edge_seconds is None and self.enable_snapping:
                 delta_sec = self.snap.snap_edge(pos, delta_sec)
             max_delta = width - min_len
             if delta_sec > max_delta:
@@ -1311,8 +1365,11 @@ class ClipInteractionMixin:
                     new_start = start + (new_position - pos)
             rect_left = self.track_name_width + new_position * pps
         else:
-            delta_sec = (event.pos().x() - rect.right()) / pps
-            if self.enable_snapping:
+            if target_edge_seconds is not None:
+                delta_sec = target_edge_seconds - (pos + width)
+            else:
+                delta_sec = (event.pos().x() - rect.right()) / pps
+            if target_edge_seconds is None and self.enable_snapping:
                 delta_sec = self.snap.snap_edge(pos + width, delta_sec)
             min_delta = -(width - min_len)
             if delta_sec < min_delta:
@@ -1326,7 +1383,7 @@ class ClipInteractionMixin:
         geom_rect = QRectF(rect_left, world_rect.y(), rect_width, world_rect.height())
         return geom_rect, new_start, new_end, new_position
 
-    def _compute_clip_resize(self, item, context=None):
+    def _compute_clip_resize(self, item, context=None, target_edge_seconds=None):
         event = self._last_event
         pps = float(self.pixels_per_second or 0.0)
         if context is None:
@@ -1352,16 +1409,18 @@ class ClipInteractionMixin:
         single_image_resize = bool(context.get("clip_is_single_image", False))
         overflow_enabled = allow_left_overflow and single_image_resize and not self.enable_timing
 
-        if event is None or pps <= 0.0:
+        if target_edge_seconds is None and (event is None or pps <= 0.0):
             geom_rect = QRectF(world_rect)
             return geom_rect, start, end, pos
 
-        cursor_sec = self._seconds_from_x(event.pos().x())
+        cursor_sec = target_edge_seconds
+        if cursor_sec is None:
+            cursor_sec = self._seconds_from_x(event.pos().x())
         clip_span = max(end - start, min_len)
 
         if self._resize_edge == "left":
             delta_sec = cursor_sec - pos
-            if self.enable_snapping:
+            if target_edge_seconds is None and self.enable_snapping:
                 delta_sec = self._snap_trim_delta(delta_sec, edge="left", initial=initial)
             if overflow_enabled and max_duration is not None:
                 extra_capacity = max(0.0, max_duration - end)
@@ -1395,7 +1454,7 @@ class ClipInteractionMixin:
         else:
             timeline_right = pos + clip_span
             delta_sec = cursor_sec - timeline_right
-            if self.enable_snapping:
+            if target_edge_seconds is None and self.enable_snapping:
                 delta_sec = self._snap_trim_delta(delta_sec, edge="right", initial=initial)
             new_end = end + delta_sec
             new_start = start
@@ -1484,9 +1543,10 @@ class ClipInteractionMixin:
                 context = resize_initial_map.get(candidate.id, {})
                 static_mask = bool(context.get("static_mask"))
                 transition_data = json.loads(json.dumps(candidate.data))
-                transition_data["position"] = self._snap_time(position)
-                transition_data["start"] = self._snap_time(start)
-                transition_data["end"] = self._snap_time(end)
+                start, end, position = self._normalize_resize_commit_bounds(start, end, position)
+                transition_data["position"] = position
+                transition_data["start"] = start
+                transition_data["end"] = end
                 transition_data["duration"] = self._snap_time(transition_data["end"] - transition_data["start"])
                 transition_data["_auto_direction"] = static_mask
                 self.update_transition_data(

--- a/src/windows/views/timeline_backend/qwidget/clip.py
+++ b/src/windows/views/timeline_backend/qwidget/clip.py
@@ -210,14 +210,9 @@ class ClipInteractionMixin:
         """
         End a resize gesture's preview state.
 
-        When a backend refresh is already in flight, keep the preview overrides
-        alive for the next `changed()` call. That refresh will clear them after
-        geometry/keyframes have been rebuilt from the committed data.
+        Resize commits are now batched, so once the saves complete we can drop
+        all preview overrides immediately and rebuild from committed data.
         """
-        if backend_refresh_requested:
-            self._preserve_overrides_once = True
-            return
-
         for candidate in resize_items:
             self._clear_resize_preview_overrides(candidate)
         self.changed(None)
@@ -906,15 +901,10 @@ class ClipInteractionMixin:
 
             # New values
             if frame_offset is not None:
-                start_frame = info.get("position_frames")
-                if start_frame is None:
-                    start_frame = int(round(start_pos_sec * fps))
-                new_frame = max(0, start_frame + frame_offset)
-                new_pos_sec = new_frame / fps
+                new_pos_sec = start_pos_sec + (frame_offset / fps)
             else:
                 new_pos_sec = start_pos_sec + delta_sec
             new_pos_sec = max(0.0, new_pos_sec)
-            new_pos_sec = self._snap_time(new_pos_sec)
             new_idx = start_idx + delta_idx
             new_idx = max(0, min(new_idx, len(self.track_list) - 1))
             unlocked_idx = self._nearest_unlocked_track_index(new_idx)
@@ -950,11 +940,7 @@ class ClipInteractionMixin:
             # already snapped to the final frame-aligned position.
             applied_delta_sec = new_pos_sec - start_pos_sec
             if fps > 0.0:
-                start_frame_for_item = info.get("position_frames")
-                if start_frame_for_item is None:
-                    start_frame_for_item = int(round(start_pos_sec * fps))
-                new_frame_for_item = int(round(new_pos_sec * fps))
-                applied_frame_delta = new_frame_for_item - start_frame_for_item
+                applied_frame_delta = int(round(applied_delta_sec * fps))
             else:
                 applied_frame_delta = 0
             # Always apply panel shift, even for 0 delta. When snapping returns to
@@ -1521,62 +1507,72 @@ class ClipInteractionMixin:
         self._resize_items = []
         self._resize_initial_map = {}
         self._resize_results = {}
+        self._keyframes_dirty = True
+        suspend_keyframe_rebuild = (
+            len(resize_items) > 1
+            and any(isinstance(candidate, Transition) for candidate in resize_items)
+        )
+        if suspend_keyframe_rebuild:
+            self._suspend_keyframe_rebuild = True
         transaction_id = str(uuid.uuid4())
         total = len(resize_items)
         waveform_clips = []
         requested_backend_refresh = False
-        for idx, candidate in enumerate(resize_items):
-            result = resize_results.get(candidate.id)
-            if not isinstance(result, dict):
-                continue
-            start = result["start"]
-            end = result["end"]
-            position = result["position"]
-            setattr(self.win, "_trim_refresh_pending", True)
-            ignore_refresh = idx < total - 1
-            if not ignore_refresh:
-                requested_backend_refresh = True
-            if isinstance(candidate, Clip):
-                context = resize_initial_map.get(candidate.id, {})
-                audio_data = candidate.data.get("ui", {}).get("audio_data")
-                has_waveform = audio_data not in (None, [])
-                if self._commit_resized_clip(
-                    candidate,
-                    start,
-                    end,
-                    position,
-                    context,
-                    transaction_id,
-                    ignore_refresh,
-                ) and has_waveform:
-                    waveform_clips.append(candidate.id)
-            else:
-                context = resize_initial_map.get(candidate.id, {})
-                static_mask = bool(context.get("static_mask"))
-                transition_data = json.loads(json.dumps(candidate.data))
-                start, end, position = self._normalize_resize_commit_bounds(start, end, position)
-                transition_data["position"] = position
-                transition_data["start"] = start
-                transition_data["end"] = end
-                transition_data["duration"] = self._snap_time(transition_data["end"] - transition_data["start"])
-                transition_data["_auto_direction"] = static_mask
-                # update_transition_data() can synchronously notify listeners.
-                # Drop the live resize override first so keyframe rebuilds use
-                # the committed transition timing instead of preview scaling.
-                self._pending_transition_overrides.pop(candidate.id, None)
-                self.update_transition_data(
-                    transition_data,
-                    only_basic_props=True,
-                    ignore_refresh=ignore_refresh,
-                    transaction_id=transaction_id,
-                )
-                candidate.data = transition_data
+        self._suspend_changed_update += 1
+        self._preserve_overrides_during_batch = True
+        try:
+            for idx, candidate in enumerate(resize_items):
+                result = resize_results.get(candidate.id)
+                if not isinstance(result, dict):
+                    continue
+                start = result["start"]
+                end = result["end"]
+                position = result["position"]
+                setattr(self.win, "_trim_refresh_pending", True)
+                ignore_refresh = idx < total - 1
+                if not ignore_refresh:
+                    requested_backend_refresh = True
+                if isinstance(candidate, Clip):
+                    context = resize_initial_map.get(candidate.id, {})
+                    audio_data = candidate.data.get("ui", {}).get("audio_data")
+                    has_waveform = audio_data not in (None, [])
+                    if self._commit_resized_clip(
+                        candidate,
+                        start,
+                        end,
+                        position,
+                        context,
+                        transaction_id,
+                        ignore_refresh,
+                    ) and has_waveform:
+                        waveform_clips.append(candidate.id)
+                else:
+                    context = resize_initial_map.get(candidate.id, {})
+                    static_mask = bool(context.get("static_mask"))
+                    transition_data = json.loads(json.dumps(candidate.data))
+                    start, end, position = self._normalize_resize_commit_bounds(start, end, position)
+                    transition_data["position"] = position
+                    transition_data["start"] = start
+                    transition_data["end"] = end
+                    transition_data["duration"] = self._snap_time(transition_data["end"] - transition_data["start"])
+                    transition_data["_auto_direction"] = static_mask
+                    self.update_transition_data(
+                        transition_data,
+                        only_basic_props=True,
+                        ignore_refresh=ignore_refresh,
+                        transaction_id=transaction_id,
+                    )
+                    candidate.data = transition_data
 
-            if isinstance(candidate, (Clip, Transition)) and hasattr(self, "RefreshTrimmedTimelineItem"):
-                self.RefreshTrimmedTimelineItem(json.dumps(candidate.data), resize_edge)
+                if isinstance(candidate, (Clip, Transition)) and hasattr(self, "RefreshTrimmedTimelineItem"):
+                    self.RefreshTrimmedTimelineItem(json.dumps(candidate.data), resize_edge)
 
-            if isinstance(candidate, Clip):
-                self._set_trim_thumbnail_suspension(False, candidate.id)
+                if isinstance(candidate, Clip):
+                    self._set_trim_thumbnail_suspension(False, candidate.id)
+        finally:
+            self._preserve_overrides_during_batch = False
+            self._suspend_changed_update = max(0, self._suspend_changed_update - 1)
+            self._suspend_keyframe_rebuild = False
 
         self._snap_keyframe_seconds = []
         self.snap.reset()
@@ -1585,6 +1581,11 @@ class ClipInteractionMixin:
         if waveform_clips and hasattr(self, "Show_Waveform_Triggered"):
             self.Show_Waveform_Triggered(waveform_clips, transaction_id=transaction_id)
         self._finalize_resize_preview_state(resize_items, requested_backend_refresh)
+        if hasattr(self, "_refresh_keyframe_markers") and not self._dragging_panel_keyframes and not self._dragging_keyframe:
+            self._refresh_keyframe_markers()
+        else:
+            self._keyframes_dirty = True
+        self.update()
         self._release_cursor()
         if self._last_event:
             self._updateCursor(self._last_event.pos())

--- a/src/windows/views/timeline_backend/qwidget/clip.py
+++ b/src/windows/views/timeline_backend/qwidget/clip.py
@@ -34,9 +34,253 @@ from classes.app import get_app
 from classes.clip_utils import is_single_image_media
 from classes.query import Clip, Transition
 from classes.waveform import SAMPLES_PER_SECOND as WAVEFORM_SAMPLES_PER_SECOND
+from windows.views.retime import retime_clip
 
 
 class ClipInteractionMixin:
+    def _selected_resize_candidates(self):
+        """Return selected clips/transitions from the current geometry."""
+        items = []
+        geometry = getattr(self, "geometry", None)
+        if geometry is None or not hasattr(geometry, "iter_items"):
+            return items
+        for _rect, item, selected, _type in geometry.iter_items(viewport=False):
+            if selected:
+                items.append(item)
+        return items
+
+    def _resize_edge_value(self, item, edge):
+        """Return the timeline position of the requested item's edge."""
+        data = getattr(item, "data", None)
+        if not isinstance(data, dict):
+            return None
+        try:
+            position = float(data.get("position", 0.0) or 0.0)
+            start = float(data.get("start", 0.0) or 0.0)
+            end = float(data.get("end", start) or start)
+        except (TypeError, ValueError):
+            return None
+        if edge == "left":
+            return position
+        if edge == "right":
+            return position + max(0.0, end - start)
+        return None
+
+    def _resize_edge_tolerance(self):
+        fps = self._positive_float(getattr(self, "fps_float", None))
+        if fps:
+            return max(1e-6, 0.5 / fps)
+        return 1e-6
+
+    def _resize_targets_for_item(self, item, edge):
+        """
+        Resolve which selected items should respond to an edge resize.
+
+        For multi-selection, only shared outer edges are resizable. Interior
+        edges fall back to normal drag behavior.
+        """
+        if edge not in ("left", "right") or item is None:
+            return []
+
+        item_id = str(getattr(item, "id", "") or "")
+        selected_items = self._selected_resize_candidates()
+        selected_ids = {
+            str(getattr(candidate, "id", "") or "")
+            for candidate in selected_items
+        }
+
+        if item_id not in selected_ids or len(selected_items) <= 1:
+            return [item]
+
+        candidate_edge = self._resize_edge_value(item, edge)
+        if candidate_edge is None:
+            return []
+
+        edge_values = []
+        for candidate in selected_items:
+            value = self._resize_edge_value(candidate, edge)
+            if value is not None:
+                edge_values.append(value)
+        if not edge_values:
+            return []
+
+        outer_edge = min(edge_values) if edge == "left" else max(edge_values)
+        tolerance = self._resize_edge_tolerance()
+        if abs(candidate_edge - outer_edge) > tolerance:
+            return []
+
+        return [
+            candidate
+            for candidate in selected_items
+            if abs((self._resize_edge_value(candidate, edge) or 0.0) - outer_edge) <= tolerance
+        ]
+
+    def _build_resize_context(self, item):
+        """Capture the per-item baseline state used during trim/retime preview."""
+        world_rect = self.geometry.calc_item_rect(item)
+        rect = self.geometry.calc_item_rect(item, viewport=True)
+        initial = {
+            "start": float(item.data.get("start", 0.0)),
+            "end": float(item.data.get("end", 0.0)),
+            "position": float(item.data.get("position", 0.0)),
+            "duration": float(item.data.get("duration", item.data.get("end", 0.0) - item.data.get("start", 0.0))),
+        }
+        context = {
+            "item": item,
+            "world_rect": QRectF(world_rect),
+            "rect": QRectF(rect),
+            "initial": initial,
+            "max_duration": None,
+            "clip_is_single_image": False,
+            "allow_left_overflow": False,
+            "static_mask": False,
+        }
+        if isinstance(item, Clip):
+            max_duration = self._clip_reader_duration_seconds(item)
+            if max_duration is None:
+                max_duration = self._positive_float(initial.get("duration"))
+            current_end = initial["end"]
+            if max_duration is not None and current_end > max_duration:
+                max_duration = current_end
+            clip_is_single_image = self._clip_is_single_image(item)
+            context["max_duration"] = max_duration
+            context["clip_is_single_image"] = clip_is_single_image
+            context["allow_left_overflow"] = bool(self.enable_timing or clip_is_single_image)
+        else:
+            context["static_mask"] = self._transition_uses_static_mask(item.data)
+        return context
+
+    def _clear_resize_preview_overrides(self, item):
+        if isinstance(item, Transition):
+            self._pending_transition_overrides.pop(item.id, None)
+        else:
+            self._pending_clip_overrides.pop(item.id, None)
+
+    def _apply_resize_preview_override(self, item, context, start, end, position):
+        if isinstance(item, Clip):
+            override = self._pending_clip_overrides.setdefault(
+                item.id,
+                {
+                    "start": start,
+                    "end": end,
+                    "position": position,
+                    "initial_start": context["initial"].get("start", start),
+                    "initial_end": context["initial"].get("end", end),
+                    "initial_position": context["initial"].get("position", position),
+                },
+            )
+            override["start"] = start
+            override["end"] = end
+            override["position"] = position
+            override["scale"] = bool(self.enable_timing)
+        else:
+            override = self._pending_transition_overrides.setdefault(
+                item.id,
+                {
+                    "position": position,
+                    "start": start,
+                    "end": end,
+                    "initial_start": context["initial"].get("start", start),
+                    "initial_end": context["initial"].get("end", end),
+                },
+            )
+            override["position"] = position
+            override["start"] = start
+            override["end"] = end
+            override["scale"] = bool(context.get("static_mask"))
+
+    def _restore_resize_snap_ignore_ids(self, resized_items):
+        if hasattr(self, "_resize_snap_ignore_backup"):
+            ignore_ids = set(self._resize_snap_ignore_backup)
+            del self._resize_snap_ignore_backup
+        else:
+            ignore_ids = set(getattr(self, "_snap_ignore_ids", set()))
+
+        resized_ids = {
+            getattr(item, "id", None)
+            for item in (resized_items or [])
+        }
+        self._snap_ignore_ids = {
+            item_id for item_id in ignore_ids if item_id not in resized_ids
+        }
+
+    def _commit_resized_clip(self, clip, start, end, position, context, transaction_id, ignore_refresh):
+        """Persist a resized clip, batching retime commits the same way as trims."""
+        if self.enable_timing:
+            initial_start = context.get("initial", {}).get("start")
+            if initial_start is None:
+                initial_start = start
+            original_start = float(initial_start)
+            duration = end - start
+            target_end = self._snap_time(original_start + duration)
+            target_position = self._snap_time(position)
+            if not retime_clip(clip, target_end, target_position, direction=1):
+                return False
+            ui_data = clip.data.get("ui")
+            if isinstance(ui_data, dict) and "audio_data" in ui_data:
+                ui_data.pop("audio_data", None)
+            self.update_clip_data(
+                clip.data,
+                only_basic_props=False,
+                ignore_reader=True,
+                ignore_refresh=ignore_refresh,
+                transaction_id=transaction_id,
+            )
+            return True
+
+        clip.data["start"] = self._snap_time(start)
+        clip.data["end"] = self._snap_time(end)
+        clip.data["position"] = self._snap_time(position)
+        self.update_clip_data(
+            clip.data,
+            only_basic_props=True,
+            ignore_reader=True,
+            ignore_refresh=ignore_refresh,
+            transaction_id=transaction_id,
+        )
+        return True
+
+    def _active_resize_items(self):
+        """Return the items currently participating in an edge resize gesture."""
+        if getattr(self, "_press_hit", "") != "clip-edge":
+            return []
+        items = list(getattr(self, "_resize_items", None) or [])
+        if items:
+            return items
+        item = getattr(self, "_resizing_item", None)
+        return [item] if item is not None else []
+
+    def _is_active_resize_item(self, item):
+        """Return True when *item* is part of the current edge-resize preview."""
+        if item is None:
+            return False
+        for candidate in self._active_resize_items():
+            if candidate is item:
+                return True
+            if getattr(candidate, "id", None) == getattr(item, "id", None):
+                return True
+        return False
+
+    def _resize_preview_focus_item(self):
+        """Choose a single item from the resize group for player preview updates."""
+        items = list(self._active_resize_items())
+        if not items:
+            return None
+
+        def sort_key(item):
+            data = getattr(item, "data", None)
+            if not isinstance(data, dict):
+                data = {}
+            try:
+                layer = int(data.get("layer", 0) or 0)
+            except (TypeError, ValueError):
+                layer = 0
+            item_id = str(getattr(item, "id", "") or "")
+            is_clip = isinstance(item, Clip)
+            return (1 if is_clip else 0, layer, item_id)
+
+        return max(items, key=sort_key)
+
     def _transition_uses_static_mask(self, transition_data):
         reader = {}
         if isinstance(transition_data, dict):
@@ -806,14 +1050,15 @@ class ClipInteractionMixin:
         finally:
             self._snap_ignore_ids = original_ignore
 
-    def _snap_trim_delta(self, delta_seconds, edge=None):
+    def _snap_trim_delta(self, delta_seconds, edge=None, initial=None):
         """
         Apply directional edge snapping to trim deltas.
 
         Uses the trim edge's original timeline position (left/right) and lets
         SnapHelper.snap_edge() handle direction-aware target selection.
         """
-        initial = getattr(self, "_resize_initial", None)
+        if initial is None:
+            initial = getattr(self, "_resize_initial", None)
         if not isinstance(initial, dict):
             return delta_seconds
 
@@ -904,6 +1149,8 @@ class ClipInteractionMixin:
             return
         if self._is_track_locked((item.data if isinstance(item.data, dict) else {}).get("layer")):
             self._resizing_item = None
+            self._resize_items = []
+            self._resize_initial_map = {}
             self._resize_edge = None
             self._release_cursor()
             return
@@ -911,59 +1158,48 @@ class ClipInteractionMixin:
             self.win.TrimPreviewMode.emit()
         self.snap.reset()
         self._fix_cursor(self.cursors["resize_x"])
-        world_rect = self.geometry.calc_item_rect(item)
-        self._resize_initial_world_rect = QRectF(world_rect)
-        rect = self.geometry.calc_item_rect(item, viewport=True)
-        self._resize_initial_rect = rect
-        self._resize_initial = {
-            "start": float(item.data.get("start", 0.0)),
-            "end": float(item.data.get("end", 0.0)),
-            "position": float(item.data.get("position", 0.0)),
-            "duration": float(item.data.get("duration", item.data.get("end", 0.0) - item.data.get("start", 0.0))),
-        }
+        resize_items = list(getattr(self, "_resize_items", None) or [item])
+        self._resize_items = resize_items
+        self._resize_initial_map = {}
+        primary_context = None
         self._resize_clip_max_duration = None
         self._resize_clip_is_single_image = False
         self._resize_allow_left_overflow = False
         self._resize_snap_ignore_backup = set(getattr(self, "_snap_ignore_ids", set()))
-        item_id = getattr(item, "id", None)
-        if item_id is not None:
-            updated_ignore = set(self._resize_snap_ignore_backup)
-            updated_ignore.add(item_id)
-            self._snap_ignore_ids = updated_ignore
+        updated_ignore = set(self._resize_snap_ignore_backup)
+        for candidate in resize_items:
+            candidate_id = getattr(candidate, "id", None)
+            if candidate_id is not None:
+                updated_ignore.add(candidate_id)
+            context = self._build_resize_context(candidate)
+            self._resize_initial_map[candidate.id] = context
+            self._apply_resize_preview_override(
+                candidate,
+                context,
+                context["initial"]["start"],
+                context["initial"]["end"],
+                context["initial"]["position"],
+            )
+            if isinstance(candidate, Clip):
+                self._set_trim_thumbnail_suspension(True, candidate.id)
+            if candidate is item:
+                primary_context = context
+        self._snap_ignore_ids = updated_ignore
+        if primary_context is None:
+            primary_context = self._build_resize_context(item)
+            self._resize_initial_map[item.id] = primary_context
+
+        self._resize_initial_world_rect = QRectF(primary_context["world_rect"])
+        self._resize_initial_rect = QRectF(primary_context["rect"])
+        self._resize_initial = dict(primary_context["initial"])
+        self._resize_clip_max_duration = primary_context.get("max_duration")
+        self._resize_clip_is_single_image = bool(primary_context.get("clip_is_single_image"))
+        self._resize_allow_left_overflow = bool(primary_context.get("allow_left_overflow"))
         if isinstance(item, Clip):
-            self._set_trim_thumbnail_suspension(True, item.id)
-            max_duration = self._clip_reader_duration_seconds(item)
-            if max_duration is None:
-                max_duration = self._positive_float(self._resize_initial.get("duration"))
-            current_end = self._resize_initial["end"]
-            if max_duration is not None and current_end > max_duration:
-                max_duration = current_end
-            self._resize_clip_max_duration = max_duration
-            self._resize_clip_is_single_image = self._clip_is_single_image(item)
-            self._resize_allow_left_overflow = bool(self.enable_timing or self._resize_clip_is_single_image)
             self._timing_original_start = self._resize_initial["start"]
-            self._pending_clip_overrides[item.id] = {
-                "start": self._resize_initial["start"],
-                "end": self._resize_initial["end"],
-                "position": self._resize_initial["position"],
-                "initial_start": self._resize_initial["start"],
-                "initial_end": self._resize_initial["end"],
-                "initial_position": self._resize_initial["position"],
-                "scale": bool(self.enable_timing),
-            }
             sel_type = "clip"
         else:
             sel_type = "transition"
-            static_mask = self._transition_uses_static_mask(item.data)
-            self._pending_transition_overrides[item.id] = {
-                "position": self._resize_initial["position"],
-                "start": self._resize_initial["start"],
-                "end": self._resize_initial["end"],
-                "initial_start": self._resize_initial["start"],
-                "initial_end": self._resize_initial["end"],
-                # Transition keyframes should preview as scaled while trimming.
-                "scale": static_mask,
-            }
             self._snap_keyframe_seconds = []
         # Ensure item is selected
         self.win.addSelection(item.id, sel_type, False)
@@ -974,86 +1210,88 @@ class ClipInteractionMixin:
             self._update_snap_keyframe_targets(item)
 
     def _itemResizeMove(self):
-        item = self._resizing_item
-        if not item:
+        resize_items = list(getattr(self, "_resize_items", None) or [])
+        if not resize_items:
             return
-        if isinstance(item, Transition):
-            rect, start, end, position = self._compute_transition_resize(item)
-        else:
-            rect, start, end, position = self._compute_clip_resize(item)
+        self._resize_results = {}
+        preview_item = self._resize_preview_focus_item()
+        preview_result = None
+        for item in resize_items:
+            context = self._resize_initial_map.get(item.id)
+            if not context:
+                continue
+            if isinstance(item, Transition):
+                rect, start, end, position = self._compute_transition_resize(item, context)
+            else:
+                rect, start, end, position = self._compute_clip_resize(item, context)
 
-        self._resize_new_start = start
-        self._resize_new_end = end
-        self._resize_new_position = position
-        self.geometry.update_item_rect(item, rect)
-        if isinstance(item, Clip):
-            override = self._pending_clip_overrides.setdefault(
-                item.id,
-                {
+            self._resize_results[item.id] = {
+                "start": start,
+                "end": end,
+                "position": position,
+            }
+            self.geometry.update_item_rect(item, rect)
+            self._apply_resize_preview_override(item, context, start, end, position)
+            self._keyframes_dirty = True
+
+            if item is self._resizing_item:
+                self._resize_new_start = start
+                self._resize_new_end = end
+                self._resize_new_position = position
+            if item is preview_item:
+                preview_result = {
+                    "item": item,
                     "start": start,
                     "end": end,
                     "position": position,
-                    "initial_start": self._resize_initial.get("start", start),
-                    "initial_end": self._resize_initial.get("end", end),
-                    "initial_position": self._resize_initial.get("position", position),
-                },
-            )
-            override["start"] = start
-            override["end"] = end
-            override["position"] = position
-            override["scale"] = bool(self.enable_timing)
-            self._keyframes_dirty = True
-            if not self.enable_timing:
-                timeline = getattr(self.win, "timeline", None)
-                clip_id = getattr(item, "id", None)
-                if timeline and self.fps_float and clip_id:
+                }
+            if isinstance(item, Clip) and self.enable_timing:
+                self._snap_keyframe_seconds = []
+
+        timeline = getattr(self.win, "timeline", None)
+        if preview_result and timeline and self.fps_float:
+            item = preview_result["item"]
+            start = preview_result["start"]
+            end = preview_result["end"]
+            if isinstance(item, Clip):
+                item_id = getattr(item, "id", None)
+                if item_id:
                     if self._resize_edge == "left":
                         frame_seconds = self._snap_time(start)
                     else:
                         frame_seconds = self._snap_time(end)
                     frame = int(round(frame_seconds * self.fps_float)) + 1
-                    timeline.PreviewClipFrame(str(clip_id), max(1, frame))
-            else:
-                self._snap_keyframe_seconds = []
-        else:
-            static_mask = self._transition_uses_static_mask(item.data)
-            override = self._pending_transition_overrides.setdefault(
-                item.id,
-                {
-                    "position": position,
-                    "start": start,
-                    "end": end,
-                    "initial_start": self._resize_initial.get("start", start),
-                    "initial_end": self._resize_initial.get("end", end),
-                },
-            )
-            override["position"] = position
-            override["start"] = start
-            override["end"] = end
-            override["scale"] = static_mask
-            self._keyframes_dirty = True
-            timeline = getattr(self.win, "timeline", None)
-            transition_id = getattr(item, "id", None)
-            if timeline and self.fps_float and transition_id:
-                if self._resize_edge == "left":
-                    frame_seconds = self._snap_time(start)
-                else:
-                    frame_seconds = self._snap_time(end)
-                frame = int(round(frame_seconds * self.fps_float)) + 1
-                timeline.PreviewTransitionFrame(str(transition_id), max(1, frame))
+                    timeline.PreviewClipFrame(str(item_id), max(1, frame))
+            elif isinstance(item, Transition):
+                item_id = getattr(item, "id", None)
+                if item_id:
+                    if self._resize_edge == "left":
+                        frame_seconds = self._snap_time(start)
+                    else:
+                        frame_seconds = self._snap_time(end)
+                    frame = int(round(frame_seconds * self.fps_float)) + 1
+                    timeline.PreviewTransitionFrame(str(item_id), max(1, frame))
         self.update()
 
-    def _compute_transition_resize(self, item):
+    def _compute_transition_resize(self, item, context=None):
         event = self._last_event
         pps = self.pixels_per_second
         min_len = 1.0 / self.fps_float
-        rect = self._resize_initial_rect
-        world_rect = getattr(self, "_resize_initial_world_rect", rect)
-        start = self._resize_initial["start"]
-        end = self._resize_initial["end"]
+        if context is None:
+            context = {
+                "rect": self._resize_initial_rect,
+                "world_rect": getattr(self, "_resize_initial_world_rect", self._resize_initial_rect),
+                "initial": self._resize_initial,
+                "static_mask": self._transition_uses_static_mask(item.data),
+            }
+        rect = context["rect"]
+        world_rect = context.get("world_rect", rect)
+        initial = context["initial"]
+        start = initial["start"]
+        end = initial["end"]
         width = max(end - start, min_len)
-        pos = self._resize_initial["position"]
-        static_mask = self._transition_uses_static_mask(item.data)
+        pos = initial["position"]
+        static_mask = bool(context.get("static_mask"))
 
         if self._resize_edge == "left":
             delta_sec = (event.pos().x() - rect.left()) / pps
@@ -1088,20 +1326,30 @@ class ClipInteractionMixin:
         geom_rect = QRectF(rect_left, world_rect.y(), rect_width, world_rect.height())
         return geom_rect, new_start, new_end, new_position
 
-    def _compute_clip_resize(self, item):
+    def _compute_clip_resize(self, item, context=None):
         event = self._last_event
         pps = float(self.pixels_per_second or 0.0)
-        rect = self._resize_initial_rect
-        world_rect = getattr(self, "_resize_initial_world_rect", rect)
-        start = self._resize_initial["start"]
-        end = self._resize_initial["end"]
-        pos = self._resize_initial["position"]
-        duration = self._resize_initial["duration"]
+        if context is None:
+            context = {
+                "rect": self._resize_initial_rect,
+                "world_rect": getattr(self, "_resize_initial_world_rect", self._resize_initial_rect),
+                "initial": self._resize_initial,
+                "max_duration": getattr(self, "_resize_clip_max_duration", None),
+                "allow_left_overflow": bool(getattr(self, "_resize_allow_left_overflow", False)),
+                "clip_is_single_image": bool(getattr(self, "_resize_clip_is_single_image", False)),
+            }
+        rect = context["rect"]
+        world_rect = context.get("world_rect", rect)
+        initial = context["initial"]
+        start = initial["start"]
+        end = initial["end"]
+        pos = initial["position"]
+        duration = initial["duration"]
         fps = self.fps_float or 1.0
         min_len = 1.0 / fps
-        max_duration = getattr(self, "_resize_clip_max_duration", None)
-        allow_left_overflow = bool(getattr(self, "_resize_allow_left_overflow", False))
-        single_image_resize = bool(getattr(self, "_resize_clip_is_single_image", False))
+        max_duration = context.get("max_duration")
+        allow_left_overflow = bool(context.get("allow_left_overflow", False))
+        single_image_resize = bool(context.get("clip_is_single_image", False))
         overflow_enabled = allow_left_overflow and single_image_resize and not self.enable_timing
 
         if event is None or pps <= 0.0:
@@ -1114,7 +1362,7 @@ class ClipInteractionMixin:
         if self._resize_edge == "left":
             delta_sec = cursor_sec - pos
             if self.enable_snapping:
-                delta_sec = self._snap_trim_delta(delta_sec, edge="left")
+                delta_sec = self._snap_trim_delta(delta_sec, edge="left", initial=initial)
             if overflow_enabled and max_duration is not None:
                 extra_capacity = max(0.0, max_duration - end)
                 min_delta = -start - extra_capacity
@@ -1148,7 +1396,7 @@ class ClipInteractionMixin:
             timeline_right = pos + clip_span
             delta_sec = cursor_sec - timeline_right
             if self.enable_snapping:
-                delta_sec = self._snap_trim_delta(delta_sec, edge="right")
+                delta_sec = self._snap_trim_delta(delta_sec, edge="right", initial=initial)
             new_end = end + delta_sec
             new_start = start
             new_position = pos
@@ -1170,25 +1418,24 @@ class ClipInteractionMixin:
 
     def _finishItemResize(self):
         item = self._resizing_item
+        resize_items = list(getattr(self, "_resize_items", None) or ([item] if item else []))
         if not item:
             return
         if not hasattr(self, "_resize_new_start"):
-            if isinstance(item, Clip):
-                self._set_trim_thumbnail_suspension(False, item.id)
-            elif isinstance(item, Transition):
-                # Resize can start/end without a move event; clear any preview
-                # override seeded in _startItemResize().
-                self._pending_transition_overrides.pop(item.id, None)
+            for candidate in resize_items:
+                if isinstance(candidate, Clip):
+                    self._set_trim_thumbnail_suspension(False, candidate.id)
+                else:
+                    # Resize can start/end without a move event; clear any preview
+                    # override seeded in _startItemResize().
+                    self._pending_transition_overrides.pop(candidate.id, None)
+                self._clear_resize_preview_overrides(candidate)
             self._resizing_item = None
+            self._resize_items = []
+            self._resize_initial_map = {}
             self._snap_keyframe_seconds = []
             self.snap.reset()
-            if hasattr(self, "_resize_snap_ignore_backup"):
-                ignore_ids = set(self._resize_snap_ignore_backup)
-                del self._resize_snap_ignore_backup
-                item_id = getattr(item, "id", None)
-                if item_id is not None and item_id in ignore_ids:
-                    ignore_ids.discard(item_id)
-                self._snap_ignore_ids = ignore_ids
+            self._restore_resize_snap_ignore_ids(resize_items)
             # Ensure selection visuals are fully refreshed even when resize
             # starts/ends without movement (click on edge).
             self.changed(None)
@@ -1199,62 +1446,74 @@ class ClipInteractionMixin:
             if self._last_event:
                 self._updateCursor(self._last_event.pos())
             return
-        start = self._resize_new_start
-        end = self._resize_new_end
-        position = self._resize_new_position
-        if isinstance(item, Clip):
-            setattr(self.win, "_trim_refresh_pending", True)
-            if self.enable_timing:
-                duration = end - start
-                item.data["start"] = self._timing_original_start
-                item.data["end"] = self._snap_time(self._timing_original_start + duration)
-                item.data["position"] = self._snap_time(position)
-                self.RetimeClip(item.id, item.data["end"], item.data["position"])
-            else:
-                item.data["start"] = self._snap_time(start)
-                item.data["end"] = self._snap_time(end)
-                item.data["position"] = self._snap_time(position)
-                self.update_clip_data(item.data, only_basic_props=True, ignore_reader=True)
-        else:
-            setattr(self.win, "_trim_refresh_pending", True)
-            static_mask = self._transition_uses_static_mask(item.data)
-            # Use a copied payload so update_transition_data() can compare
-            # existing transition timing against the new timing and scale
-            # keyframes correctly during trim/resize.
-            transition_data = json.loads(json.dumps(item.data))
-            transition_data["position"] = self._snap_time(position)
-            transition_data["start"] = self._snap_time(start)
-            transition_data["end"] = self._snap_time(end)
-            transition_data["duration"] = self._snap_time(transition_data["end"] - transition_data["start"])
-            transition_data["_auto_direction"] = static_mask
-            self.update_transition_data(transition_data, only_basic_props=True)
-            item.data = transition_data
-
-        if isinstance(item, (Clip, Transition)):
-            if hasattr(self, "RefreshTrimmedTimelineItem"):
-                self.RefreshTrimmedTimelineItem(json.dumps(item.data), self._resize_edge)
-
-        if isinstance(item, Clip):
-            self._set_trim_thumbnail_suspension(False, item.id)
-        elif isinstance(item, Transition):
-            self._pending_transition_overrides.pop(item.id, None)
-
+        resize_results = getattr(self, "_resize_results", {}) or {}
+        resize_initial_map = dict(getattr(self, "_resize_initial_map", {}) or {})
+        resize_edge = self._resize_edge
         self._resizing_item = None
+        self._resize_items = []
+        self._resize_initial_map = {}
+        self._resize_results = {}
+        self._preserve_overrides_once = True
+        transaction_id = str(uuid.uuid4())
+        total = len(resize_items)
+        waveform_clips = []
+        for idx, candidate in enumerate(resize_items):
+            result = resize_results.get(candidate.id)
+            if not isinstance(result, dict):
+                continue
+            start = result["start"]
+            end = result["end"]
+            position = result["position"]
+            setattr(self.win, "_trim_refresh_pending", True)
+            ignore_refresh = idx < total - 1
+            if isinstance(candidate, Clip):
+                context = resize_initial_map.get(candidate.id, {})
+                audio_data = candidate.data.get("ui", {}).get("audio_data")
+                has_waveform = audio_data not in (None, [])
+                if self._commit_resized_clip(
+                    candidate,
+                    start,
+                    end,
+                    position,
+                    context,
+                    transaction_id,
+                    ignore_refresh,
+                ) and has_waveform:
+                    waveform_clips.append(candidate.id)
+            else:
+                context = resize_initial_map.get(candidate.id, {})
+                static_mask = bool(context.get("static_mask"))
+                transition_data = json.loads(json.dumps(candidate.data))
+                transition_data["position"] = self._snap_time(position)
+                transition_data["start"] = self._snap_time(start)
+                transition_data["end"] = self._snap_time(end)
+                transition_data["duration"] = self._snap_time(transition_data["end"] - transition_data["start"])
+                transition_data["_auto_direction"] = static_mask
+                self.update_transition_data(
+                    transition_data,
+                    only_basic_props=True,
+                    ignore_refresh=ignore_refresh,
+                    transaction_id=transaction_id,
+                )
+                candidate.data = transition_data
+
+            if isinstance(candidate, (Clip, Transition)) and hasattr(self, "RefreshTrimmedTimelineItem"):
+                self.RefreshTrimmedTimelineItem(json.dumps(candidate.data), resize_edge)
+
+            if isinstance(candidate, Clip):
+                self._set_trim_thumbnail_suspension(False, candidate.id)
+            else:
+                self._pending_transition_overrides.pop(candidate.id, None)
+
         self._snap_keyframe_seconds = []
         self.snap.reset()
-        if hasattr(self, "_resize_snap_ignore_backup"):
-            ignore_ids = set(self._resize_snap_ignore_backup)
-            del self._resize_snap_ignore_backup
-        else:
-            ignore_ids = set(getattr(self, "_snap_ignore_ids", set()))
-
-        # Ensure the resized item is no longer ignored for future snaps
-        item_id = getattr(item, "id", None)
-        if item_id is not None and item_id in ignore_ids:
-            ignore_ids.discard(item_id)
-        self._snap_ignore_ids = ignore_ids
+        self._restore_resize_snap_ignore_ids(resize_items)
         self._update_project_duration()
+        if waveform_clips and hasattr(self, "Show_Waveform_Triggered"):
+            self.Show_Waveform_Triggered(waveform_clips, transaction_id=transaction_id)
         self.changed(None)
+        for candidate in resize_items:
+            self._clear_resize_preview_overrides(candidate)
         self._release_cursor()
         if self._last_event:
             self._updateCursor(self._last_event.pos())

--- a/src/windows/views/timeline_backend/qwidget/keyframe.py
+++ b/src/windows/views/timeline_backend/qwidget/keyframe.py
@@ -38,6 +38,29 @@ from ..colors import effect_color_qcolor
 
 
 class KeyframeMixin:
+    def _keyframe_item_position(self, item):
+        """Return the item's timeline position, honoring live preview overrides."""
+        if not item:
+            return 0.0
+
+        data = item.data if isinstance(getattr(item, "data", None), dict) else {}
+        position = data.get("position", 0.0)
+        item_id = getattr(item, "id", None)
+
+        overrides = None
+        if isinstance(item, Clip):
+            overrides = getattr(self, "_pending_clip_overrides", {}).get(item_id)
+        elif isinstance(item, Transition):
+            overrides = getattr(self, "_pending_transition_overrides", {}).get(item_id)
+
+        if isinstance(overrides, dict) and overrides.get("position") is not None:
+            position = overrides.get("position")
+
+        try:
+            return float(position or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+
     def _lookup_interpolation(self, value):
         try:
             idx = int(value)
@@ -516,6 +539,9 @@ class KeyframeMixin:
         self._update_keyframe_marker_viewports(state)
 
     def _ensure_keyframe_markers(self):
+        if getattr(self, "_suspend_keyframe_rebuild", False):
+            self._update_keyframe_marker_viewports()
+            return
         if self._keyframes_dirty:
             self._refresh_keyframe_markers()
         else:
@@ -945,17 +971,9 @@ class KeyframeMixin:
 
         base_position = 0.0
         if clip:
-            data = clip.data if isinstance(clip.data, dict) else {}
-            try:
-                base_position = float(data.get("position", 0.0) or 0.0)
-            except (TypeError, ValueError):
-                base_position = 0.0
+            base_position = self._keyframe_item_position(clip)
         elif transition:
-            data = transition.data if isinstance(transition.data, dict) else {}
-            try:
-                base_position = float(data.get("position", 0.0) or 0.0)
-            except (TypeError, ValueError):
-                base_position = 0.0
+            base_position = self._keyframe_item_position(transition)
         return base_position
 
     def _marker_absolute_seconds(self, marker):
@@ -1021,10 +1039,7 @@ class KeyframeMixin:
         clip_obj = marker.get("clip") if isinstance(marker, dict) else None
         if isinstance(clip_obj, Clip):
             clip_data = clip_obj.data if isinstance(clip_obj.data, dict) else {}
-            try:
-                clip_position = float(clip_data.get("position", 0.0) or 0.0)
-            except (TypeError, ValueError):
-                clip_position = 0.0
+            clip_position = self._keyframe_item_position(clip_obj)
             try:
                 clip_start = float(clip_data.get("start", 0.0) or 0.0)
             except (TypeError, ValueError):
@@ -1043,10 +1058,7 @@ class KeyframeMixin:
         transition_obj = marker.get("transition") if isinstance(marker, dict) else None
         if isinstance(transition_obj, Transition):
             tran_data = transition_obj.data if isinstance(transition_obj.data, dict) else {}
-            try:
-                tran_position = float(tran_data.get("position", 0.0) or 0.0)
-            except (TypeError, ValueError):
-                tran_position = 0.0
+            tran_position = self._keyframe_item_position(transition_obj)
             try:
                 tran_start = float(tran_data.get("start", 0.0) or 0.0)
             except (TypeError, ValueError):


### PR DESCRIPTION
Lots of changes in this PR - all related to editing ease-of-use:

- Multi-selection trimming / re-timing (when edges are aligned)
- Smooth Zooming (CTRL+Press Scroll Wheel+Move Mouse)
- New Thumbnail Style (no film-strip overlay, larger thumbnails without black bars)
- Other fixes to qwidget timeline clip/transition trimming (paint issues, glitches)