### PR TITLE
New "Extract->Depth", "Extract->Lines", and "Change Video Style" Workflows (Advanced AI)

### DIFF
--- a/doc/ai.rst
+++ b/doc/ai.rst
@@ -63,6 +63,9 @@ Use this quick setup path before trying any AI workflow in OpenShot:
 4. Start ComfyUI, then open :guilabel:`Edit->Preferences->Advanced` and set :guilabel:`ComfyUI URL`.
 5. Click :guilabel:`Check` to confirm OpenShot can reach the server.
 
+For a full step-by-step server setup guide, see the OpenShot wiki:
+`ComfyUI: Advanced AI Setup Guide <https://github.com/OpenShot/openshot-qt/wiki/ComfyUI:-Advanced-AI-Setup-Guide>`_.
+
 For full ComfyUI installation details, see the official repository:
 `ComfyUI on GitHub <https://github.com/comfyanonymous/ComfyUI>`_.
 

--- a/doc/ai.rst
+++ b/doc/ai.rst
@@ -69,6 +69,7 @@ For full ComfyUI installation details, see the official repository:
 Required Custom Nodes
 ^^^^^^^^^^^^^^^^^^^^^
 
+- `comfyui_controlnet_aux <https://github.com/Fannovel16/comfyui_controlnet_aux>`_
 - `ComfyUI-Frame-Interpolation <https://github.com/Fannovel16/ComfyUI-Frame-Interpolation>`_
 - `ComfyUI-VideoHelperSuite <https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite>`_
 - `ComfyUI-Video-Segmentation <https://github.com/miaoshouai/ComfyUI-Video-Segmentation>`_
@@ -78,6 +79,7 @@ Required Custom Nodes
 Required Models / Files
 ^^^^^^^^^^^^^^^^^^^^^^^
 
+- ``ComfyUI/models/diffusion_models/wan2.1_vace_1.3B_fp16.safetensors``
 - ``ComfyUI/custom_nodes/ComfyUI-Frame-Interpolation/ckpts/rife/rife47.pth``
 - ``ComfyUI/models/checkpoints/sd_xl_base_1.0.safetensors``
 - ``ComfyUI/models/checkpoints/sd_xl_refiner_1.0.safetensors``
@@ -97,7 +99,6 @@ Required Models / Files
 - ``ComfyUI/models/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors``
 - ``ComfyUI/models/TTS/Ace-Step1.5/acestep-v15-turbo/silence_latent.pt``
 - ``ComfyUI/models/upscale_models/RealESRGAN_x4plus.safetensors``
-- ``ComfyUI/models/vae/split_files/vae/wan_2.1_vae.safetensors``
 - ``ComfyUI/models/vae/wan_2.1_vae.safetensors``
 - ``ComfyUI/models/vae/wan2.2_vae.safetensors``
 - ``ComfyUI/models/VLM/transnetv2-pytorch-weights/transnetv2-pytorch-weights.pth``
@@ -172,6 +173,7 @@ What you can do in the dialog:
 - Enter the prompt text.
 - Preview the selected source file (for enhance workflows).
 - Set the output name for generated media.
+- Pick a reference image in the :guilabel:`Reference` tab for workflows that require one.
 - Provide tracking points/rectangles for tracking workflows.
 - Start the job with :guilabel:`Generate` or close with :guilabel:`Cancel`.
 
@@ -307,19 +309,47 @@ Change Image Style... (``img2img-basic``)
 - How: Choose :guilabel:`Enhance with AI` on an image, enter a style prompt, then generate.
 - Details: Uses ``comfyui/img2img-basic.json`` with ``sd_xl_base_1.0.safetensors``.
 
-Image to Video... (``img2video-svd``)
+Depth (``image-extract-depth``)
+"""""""""""""""""""""""""""""""""""
+
+- Why: Export a grayscale depth-map image from a source image.
+- How: Choose :guilabel:`Enhance with AI` -> :guilabel:`Extract` -> :guilabel:`Depth` on an image, then generate.
+- Details: Uses ``comfyui/image-extract-depth.json`` with ``DepthAnythingV2Preprocessor``.
+
+Lines (``image-extract-lines``)
+""""""""""""""""""""""""""""""""""
+
+- Why: Export a line-map image from a source image.
+- How: Choose :guilabel:`Enhance with AI` -> :guilabel:`Extract` -> :guilabel:`Lines` on an image, then generate.
+- Details: Uses ``comfyui/image-extract-lines.json`` with ``LineArtPreprocessor``.
+
+Image to Video... (``img2video-wan``)
 """""""""""""""""""""""""""""""""""""
 
 - Why: Turn a still image into a generated video shot.
 - How: Choose :guilabel:`Enhance with AI` on an image, provide prompt guidance, then generate.
-- Details: Uses ``comfyui/img2video-svd.json`` with WAN image-to-video models.
+- Details: Uses ``comfyui/img2video-wan.json`` with WAN 2.2 image-to-video models.
 
 Change Video Style... (``video2video-basic``)
 """"""""""""""""""""""""""""""""""""""""""""""
 
 - Why: Apply a new visual style to a source video.
-- How: Choose :guilabel:`Enhance with AI` on a video, enter a style prompt, then generate.
-- Details: Uses ``comfyui/video2video-basic.json`` with ``sd_xl_base_1.0.safetensors``.
+- How: Choose :guilabel:`Enhance with AI` on a video, enter a style prompt, pick a reference image in the :guilabel:`Reference` tab, then generate.
+- Details: Uses ``comfyui/video2video-basic.json`` with WAN VACE video-to-video nodes, a required reference image, blended ``DepthAnythingV2Preprocessor`` depth plus Canny edge control, and the ``wan2.1_vace_1.3B_fp16.safetensors``, ``wan_2.1_vae.safetensors``, and ``umt5_xxl_fp8_e4m3fn_scaled.safetensors`` models.
+
+Depth (``video-extract-depth``)
+"""""""""""""""""""""""""""""""""""
+
+- Why: Export a grayscale depth-map version of a source video.
+- How: Choose :guilabel:`Enhance with AI` -> :guilabel:`Extract` -> :guilabel:`Depth` on a video, then generate.
+- Details: Uses ``comfyui/video-extract-depth.json`` with ``DepthAnythingV2Preprocessor`` and preserves the source frame rate.
+
+Lines (``video-extract-lines``)
+""""""""""""""""""""""""""""""""""
+
+- Why: Export a line-map version of a source video.
+- How: Choose :guilabel:`Enhance with AI` -> :guilabel:`Extract` -> :guilabel:`Lines` on a video, then generate.
+- Details: Uses ``comfyui/video-extract-lines.json`` with ``LineArtPreprocessor`` and preserves the source frame rate.
 
 Increase Resolution (image) (``upscale-realesrgan-x4``)
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/src/classes/comfy_templates.py
+++ b/src/classes/comfy_templates.py
@@ -62,10 +62,14 @@ KNOWN_NODE_TYPES = {
     "saveimage",
     "savevideo",
     "saveaudio",
+    "getimagesize",
+    "vhs_getimagecount",
     "save srt",
     "emptylatentimage",
     "emptyhunyuanlatentvideo",
     "wan22imagetovideolatent",
+    "wanimagetoimageapi",
+    "wantexttoimageapi",
     "imageonlycheckpointloader",
     "modelsamplingsd3",
     "svd_img2vid_conditioning",
@@ -92,6 +96,16 @@ KNOWN_NODE_TYPES = {
     "imagescaleto",
     "imageblur",
     "imagecompositemasked",
+    "imageblend",
+    "controlnetloader",
+    "controlnetapply",
+    "controlnetapplyadvanced",
+    "canny",
+    "depthanythingpreprocessor",
+    "depthanythingv2preprocessor",
+    "midas-depthmappreprocessor",
+    "zoe-depthmappreprocessor",
+    "zoe_depthanythingpreprocessor",
     # Video Helper Suite
     "vhs_batchmanager",
     "vhs_loadvideo",
@@ -247,9 +261,11 @@ class ComfyTemplateRegistry:
 
         override_category = str(payload.get("menu_category") or payload.get("category") or "").strip().lower()
         override_menu_parent = str(payload.get("menu_parent") or "").strip()
+        override_input_type = str(payload.get("input_type") or payload.get("source_type") or "").strip().lower()
         override_output_type = str(payload.get("output_type") or payload.get("media_output") or "").strip().lower()
         override_icon = str(payload.get("action_icon") or payload.get("icon") or "").strip()
         override_open_dialog = payload.get("open_dialog", None)
+        needs_reference_image = bool(payload.get("needs_reference_image", False))
 
         inferred_category = "unknown"
         requires_source = bool(input_types)
@@ -263,6 +279,8 @@ class ComfyTemplateRegistry:
                 )
         if override_category in ("create", "enhance", "unknown"):
             inferred_category = override_category
+        if override_input_type in ("image", "video", "audio"):
+            input_types = {override_input_type}
 
         template_id = str(payload.get("template_id") or payload.get("id") or "").strip()
         if not template_id:
@@ -308,6 +326,7 @@ class ComfyTemplateRegistry:
             "action_icon": override_icon,
             "open_dialog": open_dialog,
             "menu_parent": override_menu_parent,
+            "needs_reference_image": needs_reference_image,
         }
 
     def _primary_output_type(self, output_types):

--- a/src/classes/generation_service.py
+++ b/src/classes/generation_service.py
@@ -204,7 +204,7 @@ class GenerationService(QObject):
 
         source_path = source_file.data.get("path", "")
         media_type = source_file.data.get("media_type")
-        if template_id not in ("img2img-basic", "upscale-realesrgan-x4", "img2video-svd") or media_type != "image":
+        if template_id not in ("img2img-basic", "upscale-realesrgan-x4", "img2video-wan") or media_type != "image":
             return source_path
 
         if is_supported_img2img_path(source_path):
@@ -385,6 +385,7 @@ class GenerationService(QObject):
         prompt_text,
         source_file,
         source_path,
+        reference_image_path="",
         coordinates_positive_text="",
         coordinates_negative_text="",
         rectangles_positive_text="",
@@ -481,6 +482,14 @@ class GenerationService(QObject):
         def _is_placeholder_value(path_text):
             path_text = str(path_text or "").strip().lower()
             return path_text in ("__openshot_input__", "{{openshot_input}}", "$openshot_input")
+
+        def _is_reference_image_placeholder_value(path_text):
+            path_text = str(path_text or "").strip().lower()
+            return path_text in (
+                "__openshot_reference_image__",
+                "{{openshot_reference_image}}",
+                "$openshot_reference_image",
+            )
 
         def _is_prompt_placeholder_value(text_value):
             text_value = str(text_value or "").strip().lower()
@@ -620,10 +629,12 @@ class GenerationService(QObject):
 
             # Resolve generic OpenShot source placeholders in any string input
             # (custom nodes may use keys like `video_path` instead of `video`/`file`).
-            if source_path:
+            if source_path or reference_image_path:
                 for input_key, input_value in list(inputs.items()):
-                    if isinstance(input_value, str) and _is_placeholder_value(input_value):
+                    if isinstance(input_value, str) and source_path and _is_placeholder_value(input_value):
                         inputs[input_key] = source_path
+                    elif isinstance(input_value, str) and reference_image_path and _is_reference_image_placeholder_value(input_value):
+                        inputs[input_key] = reference_image_path
 
             if "filename_prefix" in inputs:
                 prefix_value = str(inputs.get("filename_prefix", "")).strip()
@@ -954,6 +965,12 @@ class GenerationService(QObject):
                 "OpenShot could not convert this image into PNG for ComfyUI.\n\n{}".format(ex),
             )
             return
+        reference_image_path = ""
+        reference_image_file_id = str(payload.get("reference_image_file_id") or "").strip()
+        if reference_image_file_id:
+            reference_image_file = File.get(id=reference_image_file_id)
+            if reference_image_file and isinstance(reference_image_file.data, dict):
+                reference_image_path = str(reference_image_file.data.get("path", "") or "").strip()
         try:
             workflow = self._prepare_template_workflow(
                 template_meta,
@@ -961,6 +978,7 @@ class GenerationService(QObject):
                 prompt_text=payload.get("prompt"),
                 source_file=source_file,
                 source_path=source_path,
+                reference_image_path=reference_image_path,
                 coordinates_positive_text=payload.get("coordinates_positive"),
                 coordinates_negative_text=payload.get("coordinates_negative"),
                 rectangles_positive_text=payload.get("rectangles_positive"),

--- a/src/comfyui/image-extract-depth.json
+++ b/src/comfyui/image-extract-depth.json
@@ -1,0 +1,37 @@
+{
+  "action_icon": "ai-action-extract-depth.svg",
+  "menu_category": "enhance",
+  "menu_order": 54,
+  "menu_parent": "extract",
+  "name": "Depth",
+  "open_dialog": false,
+  "output_type": "image",
+  "template_id": "image-extract-depth",
+  "workflow": {
+    "1": {
+      "class_type": "LoadImage",
+      "inputs": {
+        "image": "__openshot_input__"
+      }
+    },
+    "2": {
+      "class_type": "DepthAnythingV2Preprocessor",
+      "inputs": {
+        "image": [
+          "1",
+          0
+        ]
+      }
+    },
+    "3": {
+      "class_type": "SaveImage",
+      "inputs": {
+        "images": [
+          "2",
+          0
+        ],
+        "filename_prefix": "openshot_depth"
+      }
+    }
+  }
+}

--- a/src/comfyui/image-extract-lines.json
+++ b/src/comfyui/image-extract-lines.json
@@ -1,0 +1,39 @@
+{
+  "action_icon": "ai-action-extract-lines.svg",
+  "menu_category": "enhance",
+  "menu_order": 53,
+  "menu_parent": "extract",
+  "name": "Lines",
+  "open_dialog": false,
+  "output_type": "image",
+  "template_id": "image-extract-lines",
+  "workflow": {
+    "1": {
+      "class_type": "LoadImage",
+      "inputs": {
+        "image": "__openshot_input__"
+      }
+    },
+    "2": {
+      "class_type": "LineArtPreprocessor",
+      "inputs": {
+        "image": [
+          "1",
+          0
+        ],
+        "coarse": "enable",
+        "resolution": 1024
+      }
+    },
+    "3": {
+      "class_type": "SaveImage",
+      "inputs": {
+        "images": [
+          "2",
+          0
+        ],
+        "filename_prefix": "openshot_lines"
+      }
+    }
+  }
+}

--- a/src/comfyui/img2video-wan.json
+++ b/src/comfyui/img2video-wan.json
@@ -5,7 +5,7 @@
   "name": "Image to Video...",
   "open_dialog": true,
   "output_type": "video",
-  "template_id": "img2video-svd",
+  "template_id": "img2video-wan",
   "workflow": {
     "2": {
       "class_type": "LoadImage",

--- a/src/comfyui/video-extract-depth.json
+++ b/src/comfyui/video-extract-depth.json
@@ -1,0 +1,61 @@
+{
+  "action_icon": "ai-action-extract-depth.svg",
+  "menu_category": "enhance",
+  "menu_order": 55,
+  "menu_parent": "extract",
+  "name": "Depth",
+  "open_dialog": false,
+  "output_type": "video",
+  "template_id": "video-extract-depth",
+  "workflow": {
+    "1": {
+      "class_type": "LoadVideo",
+      "inputs": {
+        "file": "__openshot_input__"
+      }
+    },
+    "2": {
+      "class_type": "GetVideoComponents",
+      "inputs": {
+        "video": [
+          "1",
+          0
+        ]
+      }
+    },
+    "3": {
+      "class_type": "DepthAnythingV2Preprocessor",
+      "inputs": {
+        "image": [
+          "2",
+          0
+        ]
+      }
+    },
+    "4": {
+      "class_type": "CreateVideo",
+      "inputs": {
+        "images": [
+          "3",
+          0
+        ],
+        "fps": [
+          "2",
+          2
+        ]
+      }
+    },
+    "5": {
+      "class_type": "SaveVideo",
+      "inputs": {
+        "video": [
+          "4",
+          0
+        ],
+        "filename_prefix": "video/openshot_depth",
+        "format": "auto",
+        "codec": "auto"
+      }
+    }
+  }
+}

--- a/src/comfyui/video-extract-lines.json
+++ b/src/comfyui/video-extract-lines.json
@@ -1,0 +1,63 @@
+{
+  "action_icon": "ai-action-extract-lines.svg",
+  "menu_category": "enhance",
+  "menu_order": 56,
+  "menu_parent": "extract",
+  "name": "Lines",
+  "open_dialog": false,
+  "output_type": "video",
+  "template_id": "video-extract-lines",
+  "workflow": {
+    "1": {
+      "class_type": "LoadVideo",
+      "inputs": {
+        "file": "__openshot_input__"
+      }
+    },
+    "2": {
+      "class_type": "GetVideoComponents",
+      "inputs": {
+        "video": [
+          "1",
+          0
+        ]
+      }
+    },
+    "3": {
+      "class_type": "LineArtPreprocessor",
+      "inputs": {
+        "image": [
+          "2",
+          0
+        ],
+        "coarse": "enable",
+        "resolution": 1024
+      }
+    },
+    "4": {
+      "class_type": "CreateVideo",
+      "inputs": {
+        "images": [
+          "3",
+          0
+        ],
+        "fps": [
+          "2",
+          2
+        ]
+      }
+    },
+    "5": {
+      "class_type": "SaveVideo",
+      "inputs": {
+        "video": [
+          "4",
+          0
+        ],
+        "filename_prefix": "video/openshot_lines",
+        "format": "auto",
+        "codec": "auto"
+      }
+    }
+  }
+}

--- a/src/comfyui/video2video-basic.json
+++ b/src/comfyui/video2video-basic.json
@@ -4,50 +4,20 @@
   "menu_order": 50,
   "name": "Change Video Style...",
   "open_dialog": true,
+  "input_type": "video",
   "output_type": "video",
   "template_id": "video2video-basic",
+  "needs_reference_image": true,
   "workflow": {
     "1": {
       "class_type": "LoadVideo",
       "inputs": {
-        "file": "/tmp/input.mp4"
-      }
-    },
-    "10": {
-      "class_type": "CreateVideo",
-      "inputs": {
-        "audio": [
-          "3",
-          1
-        ],
-        "fps": [
-          "3",
-          2
-        ],
-        "images": [
-          "9",
-          0
-        ]
-      }
-    },
-    "11": {
-      "class_type": "SaveVideo",
-      "inputs": {
-        "codec": "auto",
-        "filename_prefix": "video/openshot_gen",
-        "format": "auto",
-        "video": [
-          "10",
-          0
-        ]
+        "file": "__openshot_input__"
       }
     },
     "2": {
-      "class_type": "Video Slice",
+      "class_type": "GetVideoComponents",
       "inputs": {
-        "duration": 10.0,
-        "start_time": 0.0,
-        "strict_duration": false,
         "video": [
           "1",
           0
@@ -55,91 +25,234 @@
       }
     },
     "3": {
-      "class_type": "GetVideoComponents",
+      "class_type": "GetImageSize",
       "inputs": {
-        "video": [
+        "image": [
           "2",
           0
         ]
       }
     },
     "4": {
-      "class_type": "CheckpointLoaderSimple",
+      "class_type": "VHS_GetImageCount",
       "inputs": {
-        "ckpt_name": "sd_xl_base_1.0.safetensors"
+        "images": [
+          "2",
+          0
+        ]
       }
     },
     "5": {
-      "class_type": "CLIPTextEncode",
+      "class_type": "LoadImage",
       "inputs": {
-        "clip": [
-          "4",
-          1
-        ],
-        "text": "cinematic shot, highly detailed"
+        "image": "__openshot_reference_image__"
       }
     },
     "6": {
-      "class_type": "CLIPTextEncode",
+      "class_type": "DepthAnythingV2Preprocessor",
       "inputs": {
-        "clip": [
-          "4",
-          1
-        ],
-        "text": "low quality, blurry"
+        "image": [
+          "2",
+          0
+        ]
       }
     },
     "7": {
-      "class_type": "VAEEncode",
+      "class_type": "Canny",
       "inputs": {
-        "pixels": [
-          "3",
+        "image": [
+          "2",
           0
         ],
-        "vae": [
-          "4",
-          2
-        ]
+        "low_threshold": 0.35,
+        "high_threshold": 0.75
       }
     },
     "8": {
-      "class_type": "KSampler",
+      "class_type": "ImageBlend",
       "inputs": {
-        "cfg": 6.0,
-        "denoise": 0.55,
-        "latent_image": [
-          "7",
-          0
-        ],
-        "model": [
-          "4",
-          0
-        ],
-        "negative": [
+        "image1": [
           "6",
           0
         ],
-        "positive": [
-          "5",
+        "image2": [
+          "7",
           0
         ],
-        "sampler_name": "euler",
-        "scheduler": "normal",
-        "seed": 147747579,
-        "steps": 16
+        "blend_factor": 0.3,
+        "blend_mode": "overlay"
       }
     },
     "9": {
-      "class_type": "VAEDecode",
+      "class_type": "UNETLoader",
       "inputs": {
-        "samples": [
-          "8",
+        "unet_name": "wan2.1_vace_1.3B_fp16.safetensors",
+        "weight_dtype": "default"
+      }
+    },
+    "10": {
+      "class_type": "ModelSamplingSD3",
+      "inputs": {
+        "model": [
+          "9",
+          0
+        ],
+        "shift": 8.0
+      }
+    },
+    "11": {
+      "class_type": "CLIPLoader",
+      "inputs": {
+        "clip_name": "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+        "type": "wan",
+        "device": "default"
+      }
+    },
+    "12": {
+      "class_type": "CLIPTextEncode",
+      "inputs": {
+        "text": "__openshot_prompt__",
+        "clip": [
+          "11",
+          0
+        ]
+      }
+    },
+    "13": {
+      "class_type": "CLIPTextEncode",
+      "inputs": {
+        "text": "overexposed, static shot, blurry details, subtitles, watermark, logo, text overlay, worst quality, low quality, jpeg artifacts, ugly, deformed, bad hands, bad face, extra fingers, fused fingers, chaotic background, frozen frame",
+        "clip": [
+          "11",
+          0
+        ]
+      }
+    },
+    "14": {
+      "class_type": "VAELoader",
+      "inputs": {
+        "vae_name": "wan_2.1_vae.safetensors"
+      }
+    },
+    "15": {
+      "class_type": "WanVaceToVideo",
+      "inputs": {
+        "positive": [
+          "12",
+          0
+        ],
+        "negative": [
+          "13",
           0
         ],
         "vae": [
+          "14",
+          0
+        ],
+        "control_video": [
+          "8",
+          0
+        ],
+        "reference_image": [
+          "5",
+          0
+        ],
+        "width": [
+          "3",
+          0
+        ],
+        "height": [
+          "3",
+          1
+        ],
+        "length": [
           "4",
+          0
+        ],
+        "batch_size": 1,
+        "strength": 0.85
+      }
+    },
+    "16": {
+      "class_type": "KSampler",
+      "inputs": {
+        "model": [
+          "10",
+          0
+        ],
+        "seed": 654654950714624,
+        "steps": 8,
+        "cfg": 1.0,
+        "sampler_name": "uni_pc",
+        "scheduler": "simple",
+        "positive": [
+          "15",
+          0
+        ],
+        "negative": [
+          "15",
+          1
+        ],
+        "latent_image": [
+          "15",
+          2
+        ],
+        "denoise": 1.0
+      }
+    },
+    "17": {
+      "class_type": "TrimVideoLatent",
+      "inputs": {
+        "samples": [
+          "16",
+          0
+        ],
+        "trim_amount": [
+          "15",
+          3
+        ]
+      }
+    },
+    "18": {
+      "class_type": "VAEDecode",
+      "inputs": {
+        "samples": [
+          "17",
+          0
+        ],
+        "vae": [
+          "14",
+          0
+        ]
+      }
+    },
+    "19": {
+      "class_type": "CreateVideo",
+      "inputs": {
+        "images": [
+          "18",
+          0
+        ],
+        "audio": [
+          "2",
+          1
+        ],
+        "fps": [
+          "2",
           2
         ]
+      }
+    },
+    "20": {
+      "class_type": "SaveVideo",
+      "inputs": {
+        "video": [
+          "19",
+          0
+        ],
+        "filename_prefix": "video/openshot_gen",
+        "format": "auto",
+        "codec": "auto"
       }
     }
   }

--- a/src/themes/cosmic/images/ai-action-extract-depth.svg
+++ b/src/themes/cosmic/images/ai-action-extract-depth.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <rect x="2.5" y="3" width="11" height="10" rx="1.8" stroke="#9EC8F7" stroke-width="1.3"/>
+  <path d="M4.2 10.7C5.15 9.7 6.24 9.18 7.45 9.18C8.56 9.18 9.53 9.47 10.42 10.04C10.95 10.38 11.46 10.56 12.15 10.67" stroke="#9EC8F7" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M4.1 8.6C5.1 7.92 6.18 7.58 7.26 7.58C8.35 7.58 9.45 7.86 11.02 8.47" stroke="#9EC8F7" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round" opacity=".8"/>
+  <path d="M4.4 6.35C5.05 5.98 5.78 5.79 6.52 5.79C7.29 5.79 8.07 5.99 8.92 6.38" stroke="#9EC8F7" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round" opacity=".55"/>
+</svg>

--- a/src/themes/cosmic/images/ai-action-extract-lines.svg
+++ b/src/themes/cosmic/images/ai-action-extract-lines.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M2.2 4.2 6 2.8l2.2 1.1 2.6-1.3 3 1.1" fill="none" stroke="#91A4B9" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M2.2 7.4 5.7 6.1l2.5 1.2 2.4-1.2 3.2 1.1" fill="none" stroke="#6F8398" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M2.2 10.6 5.9 9.4l2.3 1.1 2.6-1.2 3 1.1" fill="none" stroke="#4A5F75" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M2.2 13 5.8 11.8l2.4 1.1 2.4-1.2 3.2 1.1" fill="none" stroke="#2D3E51" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/windows/generate.py
+++ b/src/windows/generate.py
@@ -29,7 +29,7 @@ import os
 import json
 import functools
 
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QSize
 from PyQt5.QtGui import QIcon, QPixmap, QColor
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QFormLayout, QLabel, QLineEdit,
@@ -40,6 +40,7 @@ from PyQt5.QtWidgets import (
 from classes import info
 from classes.logger import log
 from classes.thumbnail import GetThumbPath
+from classes.query import File
 from windows.region import SelectRegion
 from windows.color_picker import ColorPicker
 
@@ -61,6 +62,10 @@ class GenerateMediaDialog(QDialog):
         super().__init__(parent)
         self.source_file = source_file
         self.templates = templates or []
+        self.template_map = {
+            str(t.get("id", "")).strip(): (t.get("template") or {})
+            for t in self.templates
+        }
         self.preselected_template_id = str(preselected_template_id or "").strip()
         self._coordinates_positive_text = ""
         self._coordinates_negative_text = ""
@@ -82,9 +87,11 @@ class GenerateMediaDialog(QDialog):
         self.tabs = QTabWidget(self)
         self.tabs.setObjectName("generateTabs")
         self.page_prompt = self._build_prompt_tab()
+        self.page_reference = self._build_reference_tab()
         self.page_points = self._build_points_tab()
         self.page_highlight = self._build_highlight_tab()
         self.prompt_tab_index = self.tabs.addTab(self.page_prompt, "Prompt")
+        self.reference_tab_index = self.tabs.addTab(self.page_reference, "Reference")
         self.points_tab_index = self.tabs.addTab(self.page_points, "Tracking")
         self.highlight_tab_index = self.tabs.addTab(self.page_highlight, "Highlight")
         root.addWidget(self.tabs, 1)
@@ -137,6 +144,7 @@ class GenerateMediaDialog(QDialog):
             "name": self.name_edit.text().strip(),
             "template_id": self.template_combo.currentData() or self.template_combo.currentText(),
             "prompt": prompt_text,
+            "reference_image_file_id": self.reference_image_combo.currentData() if hasattr(self, "reference_image_combo") else "",
             "coordinates_positive": coordinates_positive,
             "coordinates_negative": coordinates_negative,
             "rectangles_positive": rects_positive,
@@ -191,16 +199,26 @@ class GenerateMediaDialog(QDialog):
         self.template_combo.currentIndexChanged.connect(self._on_template_changed)
         setup_form.addRow("Template", self.template_combo)
 
-        if self.source_file:
-            source_path = self.source_file.data.get("path", "")
-            source_label = QLabel(os.path.basename(source_path))
-            source_label.setToolTip(source_path)
-            setup_form.addRow("Source", source_label)
-
         right_container = QWidget(self)
         right_container.setLayout(setup_form)
         block.addWidget(right_container, 1)
         return block
+
+    def _build_reference_tab(self):
+        tab = QWidget(self)
+        tab.setObjectName("pageReference")
+        layout = QVBoxLayout(tab)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(10)
+
+        self.reference_image_combo = QComboBox()
+        self.reference_image_combo.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLengthWithIcon)
+        self.reference_image_combo.setIconSize(QSize(96, 96))
+        self.reference_image_combo.addItem("Choose reference image...", "")
+        self._populate_reference_image_combo()
+        layout.addWidget(self.reference_image_combo)
+        layout.addStretch(1)
+        return tab
 
     def _build_prompt_tab(self):
         tab = QWidget(self)
@@ -356,6 +374,14 @@ class GenerateMediaDialog(QDialog):
         if not self.name_edit.text().strip():
             self.name_edit.setFocus(Qt.TabFocusReason)
             return
+        if self._needs_reference_image() and not str(self.reference_image_combo.currentData() or "").strip():
+            QMessageBox.warning(
+                self,
+                "Missing Reference Image",
+                "Choose a reference image from Project Files.",
+            )
+            self.reference_image_combo.setFocus(Qt.TabFocusReason)
+            return
         if self._is_track_object_template():
             coordinates_positive, _coordinates_negative, rects_positive, _rects_negative, auto_mode, _tracking_payload, prompt_text = self._current_coordinates_text()
             if (not auto_mode) and (not coordinates_positive) and (not rects_positive) and (not str(prompt_text or "").strip()):
@@ -383,10 +409,20 @@ class GenerateMediaDialog(QDialog):
         template_id = str(self.template_combo.currentData() or "").strip().lower()
         return template_id in ("video-highlight-anything-sam2", "image-highlight-anything-sam2")
 
+    def _current_template(self):
+        template_id = str(self.template_combo.currentData() or "").strip()
+        return self.template_map.get(template_id, {})
+
+    def _needs_reference_image(self):
+        return bool(self._current_template().get("needs_reference_image", False))
+
     def _on_template_changed(self, index):
         _ = index
         is_track_template = self._is_track_object_template()
         is_highlight_template = self._is_highlight_template()
+        needs_inputs = self._needs_reference_image()
+        self.reference_image_combo.setVisible(needs_inputs)
+        self._set_tab_visible(self.reference_tab_index, needs_inputs)
         self._set_tab_visible(self.prompt_tab_index, is_track_template)
         self._set_tab_visible(self.points_tab_index, is_track_template)
         self._set_tab_visible(self.highlight_tab_index, is_track_template and is_highlight_template)
@@ -400,6 +436,31 @@ class GenerateMediaDialog(QDialog):
             self._set_tab_visible(self.points_tab_index, False)
             self._set_tab_visible(self.highlight_tab_index, False)
             self.tabs.setCurrentWidget(self.page_prompt)
+
+    def _populate_reference_image_combo(self):
+        current_id = str(self.reference_image_combo.currentData() or "").strip()
+        image_files = []
+        for file_obj in File.filter():
+            data = file_obj.data if isinstance(getattr(file_obj, "data", None), dict) else {}
+            if str(data.get("media_type", "")).strip().lower() != "image":
+                continue
+            image_files.append(file_obj)
+
+        image_files.sort(key=lambda f: str((f.data or {}).get("name") or os.path.basename((f.data or {}).get("path", ""))).lower())
+        for file_obj in image_files:
+            data = file_obj.data if isinstance(file_obj.data, dict) else {}
+            display_name = str(data.get("name") or os.path.basename(data.get("path", "")) or "Image").strip()
+            icon = QIcon()
+            thumb_path = GetThumbPath(file_obj.id, 1)
+            if thumb_path and os.path.exists(thumb_path):
+                icon = QIcon(thumb_path)
+            self.reference_image_combo.addItem(icon, display_name, file_obj.id)
+            self.reference_image_combo.setItemData(self.reference_image_combo.count() - 1, str(data.get("path", "")), Qt.ToolTipRole)
+
+        if current_id:
+            index = self.reference_image_combo.findData(current_id)
+            if index >= 0:
+                self.reference_image_combo.setCurrentIndex(index)
 
     def _choose_tracking_clicked(self):
         if not self.source_file:

--- a/src/windows/views/ai_tools_menu.py
+++ b/src/windows/views/ai_tools_menu.py
@@ -50,6 +50,11 @@ def add_ai_tools_menu(win, parent_menu, source_file=None):
 
         parent_labels = {
             "track_object": _("Track an Object"),
+            "extract": _("Extract"),
+        }
+        parent_icons = {
+            "track_object": "tool-generate-sparkle.svg",
+            "extract": "ai-action-create-image.svg",
         }
         parent_menus = {}
 
@@ -74,7 +79,7 @@ def add_ai_tools_menu(win, parent_menu, source_file=None):
                 if template_parent not in parent_menus:
                     submenu_title = parent_labels.get(template_parent, template_parent.replace("_", " ").title())
                     submenu = StyledContextMenu(title=submenu_title, parent=ai_menu)
-                    submenu.setIcon(_icon("tool-generate-sparkle.svg"))
+                    submenu.setIcon(_icon(parent_icons.get(template_parent, "tool-generate-sparkle.svg")))
                     ai_menu.addMenu(submenu)
                     parent_menus[template_parent] = submenu
                 target_menu = parent_menus[template_parent]


### PR DESCRIPTION
<img width="768" height="512" alt="snow-ref-image_gen_001" src="https://github.com/user-attachments/assets/e7bde1ab-c37f-488a-9cb7-767f0836f77d" />

"Change Video Style" workflow now uses control nodes on depth and lines, to inform the generation of a new video. It works really well, to match the depth and general composition of the original video (camera motion, key details, etc...).

"Extract->Depth|Lines" allows you to quickly generate a depth map (or line drawing) of any image of video, which is also very cool, and can be used with our `Mask: Source` on any effect.