### PR TITLE
New Threading Preferences Clamping/Logging, Improved "Copy Version Info" feature

### DIFF
--- a/doc/locale/preferences.pot
+++ b/doc/locale/preferences.pot
@@ -467,19 +467,19 @@ msgid "Choose which GPU device is used for hardware encoding."
 msgstr ""
 
 #: ../preferences.rst:237
-msgid "OMP Threads (0 = Default)"
+msgid "OMP Threads"
 msgstr ""
 
 #: ../preferences.rst:238
-msgid "Number of OpenMP worker threads used by performance-sensitive processing. Use ``0`` to let OpenShot choose automatically."
+msgid "Number of OpenMP worker threads used by performance-sensitive processing."
 msgstr ""
 
 #: ../preferences.rst:239
-msgid "FFmpeg Threads (0 = Default)"
+msgid "FFmpeg Threads"
 msgstr ""
 
 #: ../preferences.rst:240
-msgid "Number of FFmpeg threads used for decoding/encoding. Use ``0`` for automatic thread selection."
+msgid "Number of FFmpeg threads used for decoding/encoding."
 msgstr ""
 
 #: ../preferences.rst:241

--- a/doc/preferences.rst
+++ b/doc/preferences.rst
@@ -234,10 +234,10 @@ NOTE: On systems with older graphics cards, hardware acceleration may not always
      - Choose which GPU device is used for hardware decoding.
    * - Hardware Encoder Graphics Card
      - Choose which GPU device is used for hardware encoding.
-   * - OMP Threads (0 = Default)
-     - Number of OpenMP worker threads used by performance-sensitive processing. Use ``0`` to let OpenShot choose automatically.
-   * - FFmpeg Threads (0 = Default)
-     - Number of FFmpeg threads used for decoding/encoding. Use ``0`` for automatic thread selection.
+   * - OMP Threads
+     - Number of OpenMP worker threads used by performance-sensitive processing.
+   * - FFmpeg Threads
+     - Number of FFmpeg threads used for decoding/encoding.
    * - Hardware Decoder Max Width (0 = Default)
      - Optional maximum width for hardware decoding. Use ``0`` for no explicit limit.
    * - Hardware Decoder Max Height (0 = Default)

--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -35,6 +35,7 @@ from classes import info
 from classes.app import get_app
 from classes.logger import log
 from classes.json_data import JsonDataStore
+import openshot
 
 
 class SettingStore(JsonDataStore):
@@ -61,6 +62,38 @@ class SettingStore(JsonDataStore):
         self.data_type = "user settings"
         self.settings_filename = "openshot.settings"
         self.defaults_path = os.path.join(info.PATH, 'settings', '_default.settings')
+
+    def _apply_runtime_defaults(self, settings_list):
+        """Overlay runtime-detected libopenshot defaults onto selected settings."""
+        lib_settings = openshot.Settings.Instance()
+        runtime_defaults = {
+            "omp_threads_number": lib_settings.DefaultOMPThreads(),
+            "ff_threads_number": lib_settings.DefaultFFThreads(),
+        }
+
+        for item in settings_list:
+            setting_name = item.get("setting")
+            if setting_name in runtime_defaults:
+                item["value"] = runtime_defaults[setting_name]
+
+        return settings_list
+
+    def has_user_value(self, key):
+        """Return True when the user settings file contains an explicit value for key."""
+        key = key.lower()
+        file_path = os.path.join(info.USER_PATH, self.settings_filename)
+        if not os.path.exists(os.fsencode(file_path)):
+            return False
+
+        try:
+            user_settings = self.read_from_file(file_path)
+        except Exception:
+            return False
+
+        for item in user_settings:
+            if item.get("setting", "").lower() == key and "value" in item:
+                return True
+        return False
 
     def get_all_settings(self):
         """ Get the entire list of settings (with all metadata) """
@@ -93,7 +126,9 @@ class SettingStore(JsonDataStore):
         Creates user settings if missing. """
 
         # try to load default settings, on failure will raise exception to caller
-        default_settings = self.read_from_file(self.defaults_path)
+        default_settings = self._apply_runtime_defaults(
+            self.read_from_file(self.defaults_path)
+        )
         self._data = default_settings
 
         # Try to find user settings dir, give up if it's not there
@@ -136,7 +171,9 @@ class SettingStore(JsonDataStore):
         requires_restart = False  # Track if any setting requires a restart
 
         try:
-            default_settings = self.read_from_file(self.defaults_path)
+            default_settings = self._apply_runtime_defaults(
+                self.read_from_file(self.defaults_path)
+            )
         except Exception as ex:
             log.error(f"Error loading default settings: {ex}")
             return False

--- a/src/language/OpenShot/OpenShot.pot
+++ b/src/language/OpenShot/OpenShot.pot
@@ -3903,11 +3903,11 @@ msgid "Hardware Encoder Graphics Card"
 msgstr ""
 
 #: Settings for omp_threads_number
-msgid "OMP Threads (0 = Default)"
+msgid "OMP Threads"
 msgstr ""
 
 #: Settings for ff_threads_number
-msgid "FFmpeg Threads (0 = Default)"
+msgid "FFmpeg Threads"
 msgstr ""
 
 #: Settings for decode_hw_max_width

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -551,20 +551,20 @@
     "restart": false
   },
   {
-    "min": 0,
+    "min": 2,
     "max": 128,
     "value": 12,
-    "title": "OMP Threads (0 = Default)",
+    "title": "OMP Threads",
     "type": "spinner-int",
     "restart": true,
     "category": "Performance",
     "setting": "omp_threads_number"
   },
   {
-    "min": 0,
+    "min": 2,
     "max": 16,
     "value": 8,
-    "title": "FFmpeg Threads (0 = Default)",
+    "title": "FFmpeg Threads",
     "type": "spinner-int",
     "restart": true,
     "category": "Performance",

--- a/src/windows/about.py
+++ b/src/windows/about.py
@@ -29,6 +29,8 @@
 import os
 import codecs
 import re
+import platform
+import ctypes
 
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QDialog
@@ -47,6 +49,11 @@ import json
 import datetime
 
 import openshot
+
+try:
+    import distro
+except ImportError:
+    distro = None
 
 
 def parse_changelog(changelog_path):
@@ -179,23 +186,183 @@ class About(QDialog):
             self.copy_version_info()
 
     def copy_version_info(self):
-        """Copy cleaned version info (without HTML <div> and unnecessary links) to clipboard."""
-        # Get the raw HTML text from txtversion
-        raw_html = self.txtversion.text()
-
-        # Step 1: Strip <div> tags
-        clean_text = re.sub(r'<div[^>]*>|</div>', '', raw_html).strip()
-
-        # Step 2: Replace <br/> with newline characters
-        clean_text = clean_text.replace("<br/>", "\n")
-
-        # Step 3: Remove the HTML link after 'Release Date: x-x-x |'
-        # Matches "Release Date: YYYY-MM-DD | <a href=...>Release Notes</a>" and keeps only "Release Date: YYYY-MM-DD"
-        clean_text = re.sub(r'(Release Date: \d{4}-\d{2}-\d{2}) \|.*', r'\1', clean_text)
-
-        # Copy the cleaned text to the clipboard
+        """Copy a compact markdown version info block to the clipboard."""
         clipboard = get_app().clipboard()
-        clipboard.setText(clean_text)
+        clipboard.setText(self.build_version_info_markdown())
+
+    def build_version_info_markdown(self):
+        """Return a compact markdown block with version, system, and performance info."""
+        lines = ["**OpenShot Version Info**"]
+
+        version_line = f"Version: {info.VERSION} | libopenshot: {openshot.OPENSHOT_VERSION_FULL}"
+        lines.append(version_line)
+
+        build_name, release_date = self.get_build_details()
+        build_parts = []
+        if build_name:
+            build_parts.append(f"Build: {build_name}")
+        if release_date:
+            build_parts.append(f"Released: {release_date}")
+        if build_parts:
+            lines.append(" | ".join(build_parts))
+
+        lines.append(f"OS: {self.get_os_details()}")
+
+        hardware_parts = []
+        cpu_name = self.get_cpu_details()
+        if cpu_name:
+            hardware_parts.append(f"CPU: {cpu_name}")
+        ram_total = self.get_ram_details()
+        if ram_total:
+            hardware_parts.append(f"RAM: {ram_total}")
+        if hardware_parts:
+            lines.append(" | ".join(hardware_parts))
+
+        lines.extend(self.get_performance_details())
+        return "\n".join(lines)
+
+    def get_build_details(self):
+        """Return build name and release date from version.json when available."""
+        version_path = os.path.join(info.PATH, "settings", "version.json")
+        if not os.path.exists(version_path):
+            return "", ""
+
+        try:
+            with open(version_path, "r", encoding="UTF-8") as f:
+                version_info = json.loads(f.read())
+        except Exception:
+            log.warning("Failed to parse build details from %s", version_path, exc_info=1)
+            return "", ""
+
+        build_name = version_info.get("build_name", "")
+        release_date = ""
+        version_date = version_info.get("date")
+        if version_date:
+            try:
+                date_obj = datetime.datetime.strptime(version_date, "%Y-%m-%d %H:%M")
+                release_date = date_obj.strftime("%Y-%m-%d")
+            except Exception:
+                log.warning("Failed to parse release date: %s", version_date, exc_info=1)
+        return build_name, release_date
+
+    def get_os_details(self):
+        """Return a compact OS name/version string."""
+        system_name = platform.system()
+        if system_name == "Linux" and distro:
+            distro_name = " ".join(part for part in distro.linux_distribution()[0:2] if part)
+            return distro_name or "Linux"
+        if system_name == "Windows":
+            version_parts = [part for part in platform.win32_ver()[0:2] if part]
+            return " ".join(version_parts) or "Windows"
+        if system_name == "Darwin":
+            mac_version = platform.mac_ver()[0]
+            return f"macOS {mac_version}" if mac_version else "macOS"
+        return platform.platform()
+
+    def get_cpu_details(self):
+        """Return a compact CPU description when available."""
+        system_name = platform.system()
+        cpu_name = ""
+
+        try:
+            if system_name == "Linux" and os.path.exists("/proc/cpuinfo"):
+                with open("/proc/cpuinfo", "r", encoding="utf-8", errors="ignore") as cpuinfo_file:
+                    for line in cpuinfo_file:
+                        if ":" in line and line.lower().startswith("model name"):
+                            cpu_name = line.split(":", 1)[1].strip()
+                            break
+            elif system_name == "Darwin":
+                cpu_name = platform.processor().strip()
+            elif system_name == "Windows":
+                cpu_name = platform.processor().strip()
+        except Exception:
+            log.warning("Failed to gather CPU details", exc_info=1)
+
+        cpu_name = cpu_name or platform.processor().strip() or platform.machine().strip()
+        cpu_count = os.cpu_count()
+        if cpu_name and cpu_count:
+            return f"{cpu_name} ({cpu_count} threads)"
+        return cpu_name
+
+    def get_ram_details(self):
+        """Return total system RAM in GB when available."""
+        total_bytes = 0
+        try:
+            if platform.system() == "Windows":
+                class MEMORYSTATUSEX(ctypes.Structure):
+                    _fields_ = [
+                        ("dwLength", ctypes.c_ulong),
+                        ("dwMemoryLoad", ctypes.c_ulong),
+                        ("ullTotalPhys", ctypes.c_ulonglong),
+                        ("ullAvailPhys", ctypes.c_ulonglong),
+                        ("ullTotalPageFile", ctypes.c_ulonglong),
+                        ("ullAvailPageFile", ctypes.c_ulonglong),
+                        ("ullTotalVirtual", ctypes.c_ulonglong),
+                        ("ullAvailVirtual", ctypes.c_ulonglong),
+                        ("sullAvailExtendedVirtual", ctypes.c_ulonglong),
+                    ]
+
+                memory_status = MEMORYSTATUSEX()
+                memory_status.dwLength = ctypes.sizeof(MEMORYSTATUSEX)
+                if ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(memory_status)):
+                    total_bytes = int(memory_status.ullTotalPhys)
+            else:
+                page_size = os.sysconf("SC_PAGE_SIZE")
+                phys_pages = os.sysconf("SC_PHYS_PAGES")
+                total_bytes = int(page_size * phys_pages)
+        except Exception:
+            log.warning("Failed to gather RAM details", exc_info=1)
+
+        if total_bytes <= 0:
+            return ""
+        return f"{round(total_bytes / float(1024 ** 3))} GB"
+
+    def get_performance_details(self):
+        """Return compact cache and thread settings."""
+        settings = get_app().get_settings()
+        cache_mode = settings.get("cache-mode") or "CacheMemory"
+        cache_mode_map = {
+            "CacheMemory": "Memory",
+            "CacheDisk": "Disk",
+        }
+        cache_limit = settings.get("cache-limit-mb")
+        cache_frames = settings.get("cache-max-frames")
+        cache_ahead = settings.get("cache-ahead-percent")
+        cache_preroll_min = settings.get("cache-preroll-min-frames")
+        cache_preroll_max = settings.get("cache-preroll-max-frames")
+        omp_threads = settings.get("omp_threads_number")
+        ff_threads = settings.get("ff_threads_number")
+        hw_decoder = self.get_hardware_decoder_name(settings.get("hw-decoder"))
+        hw_decode_card = settings.get("graca_number_de")
+        hw_encode_card = settings.get("graca_number_en")
+
+        cache_ahead_pct = int(round(float(cache_ahead) * 100))
+
+        return [
+            (
+                f"Cache: {cache_mode_map.get(cache_mode, cache_mode)}, "
+                f"{cache_limit} MB, {cache_frames} frames, "
+                f"ahead {cache_ahead_pct}%, pre-roll {cache_preroll_min}/{cache_preroll_max}"
+            ),
+            (
+                f"Performance: Threads: OMP {omp_threads} | FFmpeg {ff_threads}, "
+                f"Cards: Decode: {hw_decoder} ({hw_decode_card}) | Encode: {hw_encode_card}"
+            ),
+        ]
+
+    def get_hardware_decoder_name(self, decoder_value):
+        """Return a short hardware decoder label for the current setting value."""
+        decoder_map = {
+            "0": "None",
+            "1": "VA-API",
+            "2": "NVDEC",
+            "3": "D3D9",
+            "4": "D3D11",
+            "5": "MacOS",
+            "6": "VDPAU",
+            "7": "QSV",
+        }
+        return decoder_map.get(str(decoder_value), str(decoder_value))
 
     def display_release(self, version_text):
 

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -4383,19 +4383,30 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Set scaling mode to lower quality scaling (for faster previews)
         lib_settings.HIGH_QUALITY_SCALING = False
 
-        # Set use omp threads number environment variable
-        if s.get("omp_threads_number"):
-            lib_settings.OMP_THREADS = max(
-                2, int(str(s.get("omp_threads_number"))))
-        else:
-            lib_settings.OMP_THREADS = 12
+        # Apply user overrides when present, otherwise use runtime-detected libopenshot defaults.
+        omp_default = lib_settings.DefaultOMPThreads()
+        ff_default = lib_settings.DefaultFFThreads()
+        omp_min, omp_max = 2, max(2, omp_default * 3)
+        ff_min, ff_max = 2, max(2, ff_default * 3)
 
-        # Set use ffmpeg threads number environment variable
-        if s.get("ff_threads_number"):
-            lib_settings.FF_THREADS = max(
-                1, int(str(s.get("ff_threads_number"))))
+        omp_source = "libopenshot default"
+        if s.has_user_value("omp_threads_number"):
+            omp_value = int(str(s.get("omp_threads_number")))
+            lib_settings.OMP_THREADS = max(omp_min, min(omp_value, omp_max))
+            omp_source = "user setting"
         else:
-            lib_settings.FF_THREADS = 8
+            lib_settings.OMP_THREADS = omp_default
+        lib_settings.ApplyOpenMPSettings()
+        log.info("Initialized OMP threads to %s (%s)", lib_settings.OMP_THREADS, omp_source)
+
+        ff_source = "libopenshot default"
+        if s.has_user_value("ff_threads_number"):
+            ff_value = int(str(s.get("ff_threads_number")))
+            lib_settings.FF_THREADS = max(ff_min, min(ff_value, ff_max))
+            ff_source = "user setting"
+        else:
+            lib_settings.FF_THREADS = ff_default
+        log.info("Initialized FFmpeg threads to %s (%s)", lib_settings.FF_THREADS, ff_source)
 
         # Set use max width decode hw environment variable
         if s.get("decode_hw_max_width"):

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -263,9 +263,20 @@ class Preferences(QDialog):
                 if param["type"] == "spinner-int":
                     # create QDoubleSpinBox
                     widget = QSpinBox()
-                    widget.setMinimum(int(param["min"]))
-                    widget.setMaximum(int(param["max"]))
-                    widget.setValue(int(param["value"]))
+                    min_value = int(param["min"])
+                    max_value = int(param["max"])
+                    current_value = int(param["value"])
+                    thread_limits = self._get_thread_spinner_limits(param.get("setting"))
+                    if thread_limits:
+                        min_value, max_value = thread_limits
+                        clamped_value = max(min_value, min(current_value, max_value))
+                        if clamped_value != current_value:
+                            self.s.set(param["setting"], clamped_value)
+                            param["value"] = clamped_value
+                            current_value = clamped_value
+                    widget.setMinimum(min_value)
+                    widget.setMaximum(max_value)
+                    widget.setValue(current_value)
                     widget.setSingleStep(param.get("step", 1))
                     widget.setToolTip(param["title"])
                     widget.valueChanged.connect(functools.partial(self.spinner_value_changed, param))
@@ -605,6 +616,36 @@ class Preferences(QDialog):
         except Exception:
             log.warning("Failed to apply timeline thumbnail style live", exc_info=1)
 
+    def _get_thread_spinner_limits(self, setting_name):
+        """Return UI bounds for thread-related preference spinners."""
+        lib_settings = openshot.Settings.Instance()
+        if setting_name == "omp_threads_number":
+            default_value = int(lib_settings.DefaultOMPThreads())
+            min_value = 2
+        elif setting_name == "ff_threads_number":
+            default_value = int(lib_settings.DefaultFFThreads())
+            min_value = 2
+        else:
+            return None
+
+        max_value = max(min_value, default_value * 3)
+        return min_value, max_value
+
+    def _apply_thread_settings(self):
+        """Apply current thread preference values to libopenshot."""
+        lib_settings = openshot.Settings.Instance()
+        omp_value = int(str(self.s.get("omp_threads_number")))
+        ff_value = int(str(self.s.get("ff_threads_number")))
+        omp_min, omp_max = self._get_thread_spinner_limits("omp_threads_number")
+        ff_min, ff_max = self._get_thread_spinner_limits("ff_threads_number")
+        lib_settings.OMP_THREADS = max(omp_min, min(omp_value, omp_max))
+        lib_settings.ApplyOpenMPSettings()
+        lib_settings.FF_THREADS = max(ff_min, min(ff_value, ff_max))
+
+    def _apply_cache_settings(self):
+        """Apply current cache preference values to the active session."""
+        get_app().window.InitCacheSettings()
+
     def bool_value_changed(self, widget, param, state):
         # Save setting
         if state == Qt.Checked:
@@ -647,10 +688,17 @@ class Preferences(QDialog):
             get_app().window.auto_save_timer.setInterval(int(value * 1000 * 60))
 
         elif param["setting"] == "omp_threads_number":
-            openshot.Settings.Instance().OMP_THREADS = max(2, int(str(value)))
+            lib_settings = openshot.Settings.Instance()
+            value = int(str(value))
+            min_value, max_value = self._get_thread_spinner_limits("omp_threads_number")
+            lib_settings.OMP_THREADS = max(min_value, min(value, max_value))
+            lib_settings.ApplyOpenMPSettings()
 
         elif param["setting"] == "ff_threads_number":
-            openshot.Settings.Instance().FF_THREADS = int(str(value))
+            lib_settings = openshot.Settings.Instance()
+            value = int(str(value))
+            min_value, max_value = self._get_thread_spinner_limits("ff_threads_number")
+            lib_settings.FF_THREADS = max(min_value, min(value, max_value))
 
         elif param["setting"] == "decode_hw_max_width":
             openshot.Settings.Instance().DE_LIMIT_WIDTH_MAX = int(str(value))
@@ -951,6 +999,12 @@ class Preferences(QDialog):
             # Restore category settings
             self.requires_restart = self.s.restore(category_filter=category)
             self.settings_data = self.s.get_all_settings()
+
+            if category == "Performance":
+                self._apply_thread_settings()
+                self._apply_cache_settings()
+            elif category == "Cache":
+                self._apply_cache_settings()
 
             # Re-apply thumbnail style to the QWidget timeline if it changed
             self._apply_timeline_thumbnail_style()


### PR DESCRIPTION
Applying new thread preference clamps (2 to 3X cpu count), logging on thread init, and a more descriptive "Copy Version Info" context menu - with way more system info (and cache settings).

For example:

**OpenShot Version Info**
Version: 3.5.0-dev | libopenshot: 0.6.0
OS: Ubuntu 24.04
CPU: AMD Ryzen 7 8840HS w/ Radeon 780M Graphics (16 threads) | RAM: 15 GB Cache: Memory, 900 MB, 905 frames, ahead 50%, pre-roll 24/48 Performance: Threads: OMP 16 | FFmpeg 16, Cards: Decode: None (0) | Encode: 0