### PR TITLE
Rename macOS hardware decoder label to "Apple VideoToolbox"

### DIFF
--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -585,7 +585,7 @@
       },
       {
         "value": "5",
-        "name": "MacOS"
+        "name": "Apple VideoToolbox"
       },
       {
         "value": "6",

--- a/src/windows/about.py
+++ b/src/windows/about.py
@@ -358,7 +358,7 @@ class About(QDialog):
             "2": "NVDEC",
             "3": "D3D9",
             "4": "D3D11",
-            "5": "MacOS",
+            "5": "VideoToolbox",
             "6": "VDPAU",
             "7": "QSV",
         }

--- a/src/windows/preferences.py
+++ b/src/windows/preferences.py
@@ -455,7 +455,7 @@ class Preferences(QDialog):
                             icon = QIcon(":/hw/hw-accel-dx.svg")
                         elif k == "Windows D3D11" or i == 4:
                             icon = QIcon(":/hw/hw-accel-dx.svg")
-                        elif k == "MacOS" or i == 5:
+                        elif k == "Apple VideoToolbox" or i == 5:
                             icon = QIcon(":/hw/hw-accel-vtb.svg")
                         elif k == "Intel QSV" or i == 7:
                             icon = QIcon(":/hw/hw-accel-qsv.svg")


### PR DESCRIPTION
The macOS entry in the Hardware Decoder Mode dropdown is labelled simply
"MacOS", which is inconsistent with the other platform labels ("Linux VA-API",
"Nvidia NVDEC", "Windows D3D11", "Intel QSV", ...). This renames it to
"Apple VideoToolbox" and updates the two places that match on the English
label (preferences.py icon map, about.py short performance-line label).

The underlying `hw-decoder` integer (5) is unchanged, so existing user settings
continue to resolve to the same VideoToolbox path in libopenshot.

Scope is intentionally small to stay easy to review; this is the first in a
planned series of small Apple Silicon PRs (next: arch-aware DMG naming in
installer/build_server.py, and replacing the hard-coded /usr/local/Cellar
Python 3.7 path in installer/build-mac-dmg.sh).

Note for follow-up: the icon-matching block at preferences.py:448+ has a
latent bug - it checks `i == <int>` as a fallback, but no hw-decoder value
in _default.settings actually carries an "icon" field, so icons only resolve
by English label. Worth a separate PR to add "icon" fields to the settings
entries.