### PR TITLE
Make macOS DMG filename arch-aware (arm64 / x86_64)

### DIFF
--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -385,7 +385,10 @@ def main():
             app_name += "-x86_64.AppImage"
             app_upload_bucket = "releases.openshot.org/linux"
         elif platform.system() == "Darwin":
-            app_name += "-x86_64.dmg"
+            # Apple Silicon (arm64) and Intel (x86_64) Macs produce arch-suffixed
+            # DMGs so both can be published side-by-side to the mac release bucket.
+            mac_arch = "arm64" if platform.machine() == "arm64" else "x86_64"
+            app_name += "-%s.dmg" % mac_arch
             app_upload_bucket = "releases.openshot.org/mac"
         elif platform.system() == "Windows" and not windows_32bit:
             app_name += "-x86_64.exe"
@@ -506,7 +509,7 @@ def main():
                 os.remove(app_build_path)
 
         if platform.system() == "Darwin":
-            # Create DMG (OpenShot-%s-x86_64.DMG)
+            # Create DMG (OpenShot-%s-arm64.dmg or OpenShot-%s-x86_64.dmg)
             app_image_success = False
 
             # Build app.bundle and create DMG


### PR DESCRIPTION
The `Darwin` branch of `installer/build_server.py` currently hard-codes
`-x86_64.dmg` as the DMG suffix. That name is fine on Intel Macs but
mis-labels any Apple Silicon build, and (more importantly) would prevent an
arm64 and an Intel DMG from coexisting under `releases.openshot.org/mac/`.

This PR detects the arch via `platform.machine()`:

* `arm64` produces `OpenShot-<version>-arm64.dmg`.
* Anything else (including Rosetta-translated Python on Apple Silicon)
  produces `OpenShot-<version>-x86_64.dmg`, which is byte-identical to
  today's name.

So there is no observable change for existing Intel Mac build pipelines.
Once an Apple Silicon runner is available, it will produce a clearly
labelled `-arm64.dmg` artifact that can sit alongside the Intel one.

The Linux AppImage and Windows `.exe` suffixes are left untouched; they
are still `x86_64`-only in practice, and changing them is out of scope
for this PR.

This is the second in a small series of Apple Silicon PRs (following
#6003, the "Apple VideoToolbox" label rename). The next planned change
is replacing the hard-coded `/usr/local/Cellar/python@3.7/3.7.9_2/...`
PATH in `installer/build-mac-dmg.sh`, which is required before any arm64
Homebrew (`/opt/homebrew`) machine can run the mac packaging script
end-to-end.