### PR TITLE
Use brew --prefix for PATH in build-mac-dmg.sh (Apple Silicon support)

### DIFF
--- a/installer/build-mac-dmg.sh
+++ b/installer/build-mac-dmg.sh
@@ -1,8 +1,15 @@
 #!/bin/sh
 
-# XXX: These paths should be set using `brew prefix` commands,
-#      for future-proofing against upgrades
-PATH=/usr/local/Cellar/python@3.7/3.7.9_2/Frameworks/Python.framework/Versions/3.7/bin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/qt5/5.5/clang_64/bin:/opt/X11/bin
+# Detect Homebrew prefix so this script works on both Apple Silicon
+# (/opt/homebrew) and Intel (/usr/local) Macs without hard-coded paths.
+if [ -x /opt/homebrew/bin/brew ]; then
+    BREW_PREFIX="$(/opt/homebrew/bin/brew --prefix)"
+elif [ -x /usr/local/bin/brew ]; then
+    BREW_PREFIX="$(/usr/local/bin/brew --prefix)"
+else
+    BREW_PREFIX="/usr/local"
+fi
+PATH="${BREW_PREFIX}/bin:${BREW_PREFIX}/sbin:/opt/local/bin:/opt/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin"
 MAC_NOTARIZE_PASSWORD=$1
 
 # Get Version


### PR DESCRIPTION
`installer/build-mac-dmg.sh` currently starts with:

```sh
# XXX: These paths should be set using `brew prefix` commands,
#      for future-proofing against upgrades
PATH=/usr/local/Cellar/python@3.7/3.7.9_2/Frameworks/Python.framework/Versions/3.7/bin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/qt5/5.5/clang_64/bin:/opt/X11/bin
```

Two problems:

1. The `/usr/local/Cellar/python@3.7/3.7.9_2/...` path is wrong on **any**
   Apple Silicon Mac (Homebrew there lives at `/opt/homebrew`), so the script
   cannot run end-to-end on an arm64 runner. Python 3.7 itself has also been
   EOL since June 2023.
2. The `/usr/local/qt5/5.5/clang_64/bin` entry is similarly stale; Qt 5.5
   was released in 2015, and the rest of the project actually uses Qt 5.15
   (see `freeze.py:477`).

Neither of those entries is actually used by this script: a grep confirms
`build-mac-dmg.sh` never invokes `python`, `qmake`, or any Qt tool. The only
thing it needs on PATH is Homebrew's `bin` for `appdmg`; all of `codesign`,
`xcrun`, `spctl`, `stapler`, and the coreutils are under `/usr/bin` and
`/bin` already.

This PR replaces the hard-coded line with a small `brew --prefix` probe that:

* resolves to `/opt/homebrew` on Apple Silicon,
* resolves to `/usr/local` on Intel Macs (so existing Intel Mac build
  pipelines produce a byte-identical PATH, with no behavioural change),
* falls back to `/usr/local` if Homebrew is not installed at all.

It also resolves the existing `# XXX: These paths should be set using
`brew prefix` commands` TODO comment in the file.

This is the third in a small series of Apple Silicon contributor PRs
(following #6003 "Apple VideoToolbox" label rename, and #6004 arch-aware
DMG naming). The next planned change is the `/Users/jonathanthomas/...`
hard-coded developer path in `installer/fix_qt5_rpath.py:115`.