### PR TITLE
Make fix_qt5_rpath.py test harness path discoverable (no hard-coded dev path)

### DIFF
--- a/installer/fix_qt5_rpath.py
+++ b/installer/fix_qt5_rpath.py
@@ -109,9 +109,27 @@ def print_min_versions(PATH):
 
 
 if __name__ == "__main__":
-    # Run these methods manually for testing
+    # Run these methods manually for testing.
+    # Usage: python3 fix_qt5_rpath.py [BUILD_PATH]
+    # With no argument, the most recent cx_Freeze build directory under
+    # <repo>/build/exe.macosx-* is used, which works on any architecture
+    # (arm64 or x86_64) and any Python / macOS SDK version.
+    import sys
+    import glob
 
-    # XXX: This path should be set programmatically, somehow
-    PATH = "/Users/jonathanthomas/apps/openshot-qt/build/exe.macosx-10.15-x86_64-3.7"
+    if len(sys.argv) > 1:
+        PATH = sys.argv[1]
+    else:
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        candidates = sorted(glob.glob(os.path.join(repo_root, "build", "exe.macosx-*")))
+        if not candidates:
+            sys.exit(
+                "Usage: python3 fix_qt5_rpath.py [BUILD_PATH]\n"
+                "No cx_Freeze build directory found under %s/build/exe.macosx-*"
+                % repo_root
+            )
+        PATH = candidates[-1]
+
+    print("Running fix_rpath and print_min_versions against: %s" % PATH)
     fix_rpath(PATH)
     print_min_versions(PATH)


### PR DESCRIPTION
The `__main__` block at the bottom of `installer/fix_qt5_rpath.py` has a
hard-coded default:

```python
# XXX: This path should be set programmatically, somehow
PATH = "/Users/jonathanthomas/apps/openshot-qt/build/exe.macosx-10.15-x86_64-3.7"
fix_rpath(PATH)
print_min_versions(PATH)
```

This path can only resolve on one developer's machine. It embeds:

* a specific home directory (`/Users/jonathanthomas/...`),
* the x86_64 architecture (wrong on Apple Silicon),
* Python 3.7 (EOL since June 2023),
* macOS SDK 10.15 (from 2019).

The functions `fix_rpath()` and `print_min_versions()` themselves are fine,
and the production build already invokes them from `freeze.py:571-572` with
a correct runtime path, so this only affects contributors who want to run
the script directly for testing or post-mortem analysis of a frozen bundle.

This PR replaces the hard-coded line with a small harness:

1. If an argument is passed on the command line, use it as the build path.
2. Otherwise, glob `<repo>/build/exe.macosx-*` (the directory pattern
   cx_Freeze produces) and pick the most recent match.
3. If neither resolves, print a usage message and exit non-zero.

That works on Apple Silicon and Intel Macs, any Python version, and any
macOS SDK. It also addresses the existing `XXX: This path should be set
programmatically, somehow` TODO comment on the same block.

No production code path is changed; this is purely the interactive /
developer-testing harness.

Fourth in a small series of Apple Silicon contributor PRs (following
#6003 label rename, #6004 arch-aware DMG naming, #6005 brew-prefix PATH
in `build-mac-dmg.sh`).