### PR TITLE
Fix tiny 1080p video output caused by capped media metadata

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -116,6 +116,80 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         if updated:
             log.info("Updated %s optimized reader path(s) to use %s", updated, optimized_path)
 
+    def _repair_capped_media_dimensions(self):
+        """Repair media imported while metadata readers were decode-size capped."""
+        repaired = 0
+        files_by_id = {}
+
+        for file_data in self._data.get("files", []):
+            if not isinstance(file_data, dict):
+                continue
+            files_by_id[file_data.get("id")] = file_data
+
+            if not file_data.get("has_video"):
+                continue
+
+            try:
+                width = int(file_data.get("width") or 0)
+                height = int(file_data.get("height") or 0)
+            except (TypeError, ValueError):
+                continue
+
+            if width <= 0 or height <= 0 or max(width, height) > 128:
+                continue
+
+            path = file_data.get("path")
+            if not path or not os.path.exists(path):
+                continue
+
+            reader = openshot.Clip.CreateReader(path, False)
+            if not reader:
+                continue
+
+            try:
+                reader.Open()
+                original_data = json.loads(reader.Json())
+            except Exception:
+                log.warning("Unable to repair capped media dimensions for %s", path, exc_info=1)
+                continue
+            finally:
+                try:
+                    reader.Close()
+                except Exception:
+                    pass
+
+            try:
+                original_width = int(original_data.get("width") or 0)
+                original_height = int(original_data.get("height") or 0)
+            except (TypeError, ValueError):
+                continue
+
+            if max(original_width, original_height) <= max(width, height):
+                continue
+
+            for key in (
+                "width", "height", "display_ratio", "pixel_ratio", "fps",
+                "video_length", "duration", "has_video", "has_audio",
+            ):
+                if key in original_data:
+                    file_data[key] = original_data[key]
+            repaired += 1
+
+        if not repaired:
+            return
+
+        for clip in self._data.get("clips", []):
+            if not isinstance(clip, dict):
+                continue
+            reader_data = clip.get("reader")
+            if not isinstance(reader_data, dict):
+                continue
+            file_data = files_by_id.get(reader_data.get("id"))
+            if file_data:
+                clip["reader"] = copy.deepcopy(file_data)
+
+        log.info("Repaired capped dimensions for %s imported media file(s)", repaired)
+
     def _drop_obsolete_effect_resource(self, effect):
         """Remove legacy resource paths once a reader payload is available."""
         if not isinstance(effect, dict):
@@ -486,6 +560,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
             # Check if paths are all valid
             self.check_if_paths_are_valid()
+            self._repair_capped_media_dimensions()
 
             # Clear old thumbnails
             openshot_thumbnails = info.get_default_path("THUMBNAIL_PATH")

--- a/src/classes/proxy_service.py
+++ b/src/classes/proxy_service.py
@@ -361,6 +361,13 @@ class ProxyService(QObject):
                  return True
          return False
 
+     def uses_global_hidden_proxy_root(self):
+         """Return True when optimized files are stored in .openshot_qt/optimized."""
+         try:
+             return os.path.abspath(str(self._proxy_root() or "")) == os.path.abspath(str(info.PROXY_PATH or ""))
+         except Exception:
+             return False
+
      def delete_internal_project_proxy_files(self):
          proxy_root = os.path.abspath(str(self._proxy_root() or ""))
          proxy_root_prefix = proxy_root + os.sep if proxy_root else ""
@@ -701,31 +708,38 @@ class ProxyService(QObject):
                  target_width, target_height = self._scaled_dimensions(width, height, max_width, max_height)
                  fps = source_reader.get("fps", {"num": 30, "den": 1})
                  pixel_ratio = source_reader.get("pixel_ratio", {"num": 1, "den": 1})
+                 encoder_settings = self._proxy_encoder_settings()
                  writer = openshot.FFmpegWriter(output_path)
                  writer.SetVideoOptions(
                      True,
-                     "libx264",
+                     encoder_settings["video_codec"],
                      openshot.Fraction(int(fps.get("num", 30)), int(fps.get("den", 1))),
                      target_width,
                      target_height,
                      openshot.Fraction(int(pixel_ratio.get("num", 1)), int(pixel_ratio.get("den", 1))),
                      False,
                      False,
-                     28,
+                     int(encoder_settings["video_bitrate"]),
                  )
-                 writer.PrepareStreams()
 
                  if source_reader.get("has_audio"):
                      channel_layout = openshot.LAYOUT_STEREO if int(source_reader.get("channels", 2) or 2) > 1 else openshot.LAYOUT_MONO
                      writer.SetAudioOptions(
                          True,
-                         "aac",
+                         "pcm_s16le",
                          48000,
                          2 if channel_layout == openshot.LAYOUT_STEREO else 1,
                          channel_layout,
-                         128000,
+                         1536000,
                      )
-                     writer.PrepareStreams()
+
+                 writer.PrepareStreams()
+                 try:
+                     for option_name, option_value in encoder_settings["video_options"].items():
+                         writer.SetOption(openshot.VIDEO_STREAM, option_name, option_value)
+                     writer.SetOption(openshot.VIDEO_STREAM, "muxing_preset", "mp4_faststart")
+                 except Exception:
+                     log.debug("Optimize Preview writer options unavailable", exc_info=1)
 
                  writer.Open()
                  try:
@@ -967,12 +981,18 @@ class ProxyService(QObject):
          default_filename = self._preferred_proxy_filename(file_id, file_data, proxy_root, existing_names=set())
          default_path = os.path.join(proxy_root, default_filename)
          source_stem = os.path.splitext(os.path.basename(absolute_media_path((file_data or {}).get("path")) or ""))[0]
-         specific_path = os.path.join(proxy_root, "{}_{}.mp4".format(self._proxy_filename_stem(source_stem), str(file_id or "")))
+         specific_path = os.path.join(proxy_root, "{}_{}.mov".format(self._proxy_filename_stem(source_stem), str(file_id or "")))
+         legacy_default_path = os.path.splitext(default_path)[0] + ".mp4"
+         legacy_specific_path = os.path.join(proxy_root, "{}_{}.mp4".format(self._proxy_filename_stem(source_stem), str(file_id or "")))
 
          if os.path.exists(specific_path):
              return specific_path
          if os.path.exists(default_path):
              return default_path
+         if os.path.exists(legacy_specific_path):
+             return legacy_specific_path
+         if os.path.exists(legacy_default_path):
+             return legacy_default_path
          return None
 
      def _reserve_proxy_output_path(self, file_id, file_data):
@@ -1002,7 +1022,7 @@ class ProxyService(QObject):
          source_path = absolute_media_path(data.get("path"))
          source_stem = os.path.splitext(os.path.basename(source_path or ""))[0]
          base_stem = self._proxy_filename_stem(source_stem)
-         default_name = "{}.mp4".format(base_stem)
+         default_name = "{}.mov".format(base_stem)
 
          if existing_names is None:
              try:
@@ -1013,7 +1033,7 @@ class ProxyService(QObject):
 
          if default_name.lower() not in existing_names_lower:
              return default_name
-         return "{}_{}.mp4".format(base_stem, file_id)
+         return "{}_{}.mov".format(base_stem, file_id)
 
      @staticmethod
      def _proxy_filename_stem(source_stem):
@@ -1225,6 +1245,28 @@ class ProxyService(QObject):
              return width, height
          except (AttributeError, TypeError, ValueError):
              return 1280, 720
+
+     def _proxy_encoder_settings(self):
+         mode = str(self._setting_value("optimize-preview-encoder", "mjpeg") or "mjpeg").strip().lower()
+         if mode in ("dnxhr", "dnxhr_lb", "dnxhr-lb"):
+             return {
+                 "video_codec": "dnxhd",
+                 "video_bitrate": 36 * 1000 * 1000,
+                 "video_options": {
+                     "profile": "dnxhr_lb",
+                     "pix_fmt": "yuv422p",
+                 },
+             }
+         return {
+             "video_codec": "mjpeg",
+             "video_bitrate": 1,
+             "video_options": {
+                 "qscale": "1",
+                 "qmin": "1",
+                 "qmax": "1",
+                 "pix_fmt": "yuvj420p",
+             },
+         }
 
      @staticmethod
      def _setting_value(name, default):

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -331,6 +331,23 @@
     ]
   },
   {
+    "title": "Optimized Preview Encoder",
+    "category": "Preview",
+    "setting": "optimize-preview-encoder",
+    "type": "dropdown",
+    "value": "mjpeg",
+    "values": [
+      {
+        "value": "mjpeg",
+        "name": "Fast and robust - MJPEG/PCM"
+      },
+      {
+        "value": "dnxhr_lb",
+        "name": "Compact professional - DNxHR LB"
+      }
+    ]
+  },
+  {
     "max": 12,
     "title": "Thumbnail Preload Rate / second",
     "category": "Preview",

--- a/src/tests/test_files_model_import.py
+++ b/src/tests/test_files_model_import.py
@@ -80,8 +80,8 @@ class FilesModelImportTests(unittest.TestCase):
             file_data, duration = self.files_model_module.inspect_media("example.flac", 128, 72)
 
         self.assertEqual(create_reader_calls, [("example.flac", False), ("example.flac", True)])
-        self.assertEqual(first_reader.max_decode_sizes, [(128, 72)])
-        self.assertEqual(second_reader.max_decode_sizes, [(128, 72)])
+        self.assertEqual(first_reader.max_decode_sizes, [])
+        self.assertEqual(second_reader.max_decode_sizes, [])
         self.assertEqual(first_reader.open_calls, 1)
         self.assertEqual(first_reader.close_calls, 0)
         self.assertEqual(second_reader.open_calls, 1)
@@ -96,11 +96,24 @@ class FilesModelImportTests(unittest.TestCase):
             file_data, duration = self.files_model_module.inspect_media("example.wav", 64, 64)
 
         create_reader.assert_called_once_with("example.wav", False)
-        self.assertEqual(reader.max_decode_sizes, [(64, 64)])
+        self.assertEqual(reader.max_decode_sizes, [])
         self.assertEqual(reader.open_calls, 1)
         self.assertEqual(reader.close_calls, 1)
         self.assertEqual(file_data, {"media": "ok"})
         self.assertEqual(duration, 3.0)
+
+    def test_inspect_media_preserves_reader_reported_dimensions_when_max_size_requested(self):
+        reader = ReaderStub(
+            json_text='{"media":"ok","width":1920,"height":1080}',
+            duration=3.0,
+        )
+
+        with patch.object(self.files_model_module.openshot.Clip, "CreateReader", return_value=reader):
+            file_data, _duration = self.files_model_module.inspect_media("example.mp4", 128, 128)
+
+        self.assertEqual(reader.max_decode_sizes, [])
+        self.assertEqual(file_data["width"], 1920)
+        self.assertEqual(file_data["height"], 1080)
 
 
 if __name__ == "__main__":

--- a/src/tests/test_main_window.py
+++ b/src/tests/test_main_window.py
@@ -428,6 +428,39 @@ class MainWindowTests(unittest.TestCase):
         self.assertEqual(tracker, [False])
         self.assertTrue(fake_window.shutting_down)
 
+    def test_shutdown_cleans_global_hidden_optimized_files(self):
+        calls = []
+        tracker = []
+        fake_window = types.SimpleNamespace(
+            tutorial_manager=None,
+            shutting_down=False,
+            save_settings=lambda: calls.append("settings"),
+            StopSignal=SignalRecorder(),
+            http_server_thread=None,
+            generation_queue=None,
+            generation_service=None,
+            proxy_service=types.SimpleNamespace(
+                uses_global_hidden_proxy_root=lambda: True,
+                delete_internal_project_proxy_files=lambda: calls.append("delete_proxy"),
+                shutdown=lambda: calls.append("proxy_shutdown"),
+            ),
+            preview_thread=None,
+            preview_parent=None,
+            videoPreview=None,
+            timeline_sync=None,
+            destroy_lock_file=lambda: calls.append("destroy_lock"),
+        )
+        self.app.logger_libopenshot = None
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(self.main_window_module, "track_metric_session", tracker.append))
+            stack.enter_context(patch.object(self.main_window_module.QCoreApplication, "processEvents", lambda: None))
+            self.main_window_module.MainWindow._shutdown(fake_window)
+
+        self.assertIn("delete_proxy", calls)
+        self.assertIn("proxy_shutdown", calls)
+        self.assertEqual(tracker, [False])
+
     def test_clear_optimized_files_cancel_does_nothing(self):
         proxy_calls = []
         fake_window = types.SimpleNamespace(

--- a/src/tests/test_project_data.py
+++ b/src/tests/test_project_data.py
@@ -104,6 +104,22 @@ class DummyAction:
         self.enabled = value
 
 
+class ReaderStub:
+    def __init__(self, json_text):
+        self.json_text = json_text
+        self.open_calls = 0
+        self.close_calls = 0
+
+    def Open(self):
+        self.open_calls += 1
+
+    def Json(self):
+        return self.json_text
+
+    def Close(self):
+        self.close_calls += 1
+
+
 def make_store():
     store = ProjectDataStore.__new__(ProjectDataStore)
     store.data_type = "project data"
@@ -182,6 +198,53 @@ class ProjectDataTests(unittest.TestCase):
         self.assertEqual(store._data["history"], {"undo": [], "redo": []})
         self.assertTrue(clear_waveform_action.enabled)
         self.assertEqual(loaded_payloads, [store._data])
+
+    def test_repair_capped_media_dimensions_updates_file_and_clip_reader(self):
+        store = make_store()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_path = os.path.join(tmpdir, "source.mp4")
+            with open(media_path, "wb") as handle:
+                handle.write(b"video")
+
+            store._data = {
+                "files": [{
+                    "id": "F1",
+                    "path": media_path,
+                    "has_video": True,
+                    "has_audio": True,
+                    "width": 128,
+                    "height": 72,
+                    "display_ratio": {"num": 16, "den": 9},
+                    "pixel_ratio": {"num": 1, "den": 1},
+                }],
+                "clips": [{
+                    "id": "C1",
+                    "reader": {
+                        "id": "F1",
+                        "path": media_path,
+                        "width": 128,
+                        "height": 72,
+                    },
+                }],
+            }
+            reader = ReaderStub(
+                '{"id":"F1","path":"%s","has_video":true,"has_audio":true,'
+                '"width":1920,"height":1080,'
+                '"display_ratio":{"num":16,"den":9},'
+                '"pixel_ratio":{"num":1,"den":1},'
+                '"fps":{"num":30000,"den":1001},'
+                '"video_length":300,"duration":10.0}' % media_path.replace("\\", "\\\\")
+            )
+
+            with patch("classes.project_data.openshot.Clip.CreateReader", return_value=reader):
+                ProjectDataStore._repair_capped_media_dimensions(store)
+
+        self.assertEqual(reader.open_calls, 1)
+        self.assertEqual(reader.close_calls, 1)
+        self.assertEqual(store._data["files"][0]["width"], 1920)
+        self.assertEqual(store._data["files"][0]["height"], 1080)
+        self.assertEqual(store._data["clips"][0]["reader"]["width"], 1920)
+        self.assertEqual(store._data["clips"][0]["reader"]["height"], 1080)
 
     def test_load_migrates_flat_thumbnails_into_per_file_folders(self):
         store = make_store()

--- a/src/tests/test_proxy_service.py
+++ b/src/tests/test_proxy_service.py
@@ -355,7 +355,8 @@ class ProxyServiceTests(unittest.TestCase):
                      "fps": {"num": 30, "den": 1},
                      "pixel_ratio": {"num": 1, "den": 1},
                      "video_length": 3,
-                     "has_audio": False,
+                     "has_audio": True,
+                     "channels": 2,
                  }
              ),
              GetFrame="frame-{}".format,
@@ -389,9 +390,13 @@ class ProxyServiceTests(unittest.TestCase):
              opened=False,
              closed=False,
              frames=[],
-             SetVideoOptions=lambda *args: None,
+             video_options=[],
+             audio_options=[],
+             stream_options=[],
+             SetVideoOptions=lambda *args: writer_obj.video_options.append(args),
              PrepareStreams=lambda: None,
-             SetAudioOptions=lambda *args: None,
+             SetAudioOptions=lambda *args: writer_obj.audio_options.append(args),
+             SetOption=lambda *args: writer_obj.stream_options.append(args),
              Open=lambda: setattr(writer_obj, "opened", True),
              Close=lambda: setattr(writer_obj, "closed", True),
              WriteFrame=lambda frame: writer_obj.frames.append(frame),
@@ -412,7 +417,7 @@ class ProxyServiceTests(unittest.TestCase):
               patch("classes.proxy_service.openshot.Fraction", side_effect=lambda num, den: (num, den)), \
               patch("classes.proxy_service.GenerateThumbnailFromFrame", side_effect=lambda frame, path, width, height, mask, overlay, rotate=0.0: thumbnail_calls.append((frame, path, width, height, rotate))), \
               patch.object(self.service, "_proxy_root", return_value="/project/optimized"), \
-              patch.object(self.service, "_reader_json_for_path", return_value={"id": "F1", "path": "/project/optimized/source_proxy.mp4"}):
+              patch.object(self.service, "_reader_json_for_path", return_value={"id": "F1", "path": "/project/optimized/source_proxy.mov"}):
              result = self.service._build_proxy_reader("F1", {"path": "/media/source.mp4", "media_type": "video"})
 
          self.assertTrue(clip_obj.opened)
@@ -424,13 +429,17 @@ class ProxyServiceTests(unittest.TestCase):
          self.assertEqual(created_timelines[0].preview_height, 720)
          self.assertEqual(clip_obj.parent_timeline_calls[0], created_timelines[0])
          self.assertIsNone(clip_obj.parent_timeline_calls[-1])
+         self.assertEqual(writer_obj.video_options[0][1], "mjpeg")
+         self.assertEqual(writer_obj.audio_options[0][1], "pcm_s16le")
+         self.assertEqual(writer_obj.audio_options[0][2], 48000)
+         self.assertTrue(any(option[1:] == ("qscale", "1") for option in writer_obj.stream_options))
          self.assertEqual(writer_obj.frames, ["frame-1", "frame-2", "frame-3"])
          self.assertEqual([os.path.basename(call[1]) for call in thumbnail_calls], ["1.png", "3.png"])
          self.assertEqual(clip_cache.max_bytes, [self.service.OPTIMIZE_CACHE_MAX_BYTES])
          self.assertEqual(reader_cache.max_bytes, [self.service.OPTIMIZE_CACHE_MAX_BYTES])
          self.assertGreaterEqual(clip_cache.clears, 2)
          self.assertGreaterEqual(reader_cache.clears, 2)
-         self.assertEqual(result["path"], "/project/optimized/source_proxy.mp4")
+         self.assertEqual(result["path"], "/project/optimized/source_proxy.mov")
 
      def test_thumbnail_prewarm_frames_uses_coarse_4fps_grid(self):
          with patch.object(self.service, "_thumbnail_prewarm_rate", return_value=4):
@@ -449,6 +458,7 @@ class ProxyServiceTests(unittest.TestCase):
          self.app.settings.values["optimize-preview-jobs"] = 3
          self.app.settings.values["optimize-preview-max-size"] = "1920x1080"
          self.app.settings.values["optimize-preview-thumbnails"] = 5
+         self.app.settings.values["optimize-preview-encoder"] = "dnxhr_lb"
 
          self.service._jobs.clear()
          self.service._ensure_executor()
@@ -456,6 +466,13 @@ class ProxyServiceTests(unittest.TestCase):
          self.assertEqual(self.service._executor._max_workers, 3)
          self.assertEqual(self.service._max_optimize_bounds(), (1920, 1080))
          self.assertEqual(self.service._thumbnail_prewarm_rate(), 5)
+         self.assertEqual(self.service._proxy_encoder_settings()["video_codec"], "dnxhd")
+
+     def test_proxy_encoder_defaults_to_mjpeg(self):
+         settings = self.service._proxy_encoder_settings()
+
+         self.assertEqual(settings["video_codec"], "mjpeg")
+         self.assertEqual(settings["video_options"]["pix_fmt"], "yuvj420p")
 
      def test_create_for_files_skips_already_optimized_files(self):
          ready_file = types.SimpleNamespace(
@@ -486,13 +503,13 @@ class ProxyServiceTests(unittest.TestCase):
          submitted = []
 
          with patch.object(self.service, "has_missing_proxy", return_value=False), \
-              patch.object(self.service, "_existing_proxy_output_path", return_value="/project/optimized/source_proxy.mp4"), \
-              patch.object(self.service, "_reader_json_for_path", return_value={"id": "F1", "path": "/project/optimized/source_proxy.mp4"}), \
+              patch.object(self.service, "_existing_proxy_output_path", return_value="/project/optimized/source_proxy.mov"), \
+              patch.object(self.service, "_reader_json_for_path", return_value={"id": "F1", "path": "/project/optimized/source_proxy.mov"}), \
               patch.object(self.service, "_save_proxy_reader", return_value=None) as save_proxy_reader, \
               patch.object(self.service._executor, "submit", side_effect=lambda *args: submitted.append(args)):
              self.service.create_for_files([file_obj])
 
-         save_proxy_reader.assert_called_once_with("F1", {"id": "F1", "path": "/project/optimized/source_proxy.mp4"})
+         save_proxy_reader.assert_called_once_with("F1", {"id": "F1", "path": "/project/optimized/source_proxy.mov"})
          self.assertEqual(submitted, [])
          self.assertEqual(self.win.status_messages[-1][0], "Optimize Preview: linked 1 item(s)")
 
@@ -504,18 +521,25 @@ class ProxyServiceTests(unittest.TestCase):
          submitted = []
 
          with patch.object(self.service, "has_missing_proxy", return_value=False), \
-              patch.object(self.service, "_existing_proxy_output_path", return_value="/project/optimized/source_proxy.mp4"), \
+              patch.object(self.service, "_existing_proxy_output_path", return_value="/project/optimized/source_proxy.mov"), \
               patch.object(self.service, "_reader_json_for_path", side_effect=RuntimeError("invalid proxy")), \
               patch("classes.proxy_service.os.remove") as remove_file, \
-              patch.object(self.service, "_reserve_proxy_output_path", return_value="/project/optimized/source_proxy.mp4"), \
+              patch.object(self.service, "_reserve_proxy_output_path", return_value="/project/optimized/source_proxy.mov"), \
               patch.object(self.service._executor, "submit", side_effect=lambda *args: submitted.append(args) or Mock(add_done_callback=lambda callback: None)):
              self.service.create_for_files([file_obj])
 
-         remove_file.assert_called_once_with("/project/optimized/source_proxy.mp4")
+         remove_file.assert_called_once_with("/project/optimized/source_proxy.mov")
          self.assertEqual(len(submitted), 1)
          self.assertEqual(submitted[0][1], "F1")
 
      def test_existing_proxy_output_path_reuses_default_name_when_file_exists(self):
+         with patch.object(self.service, "_proxy_root", return_value="/project/optimized"), \
+              patch("classes.proxy_service.os.path.exists", side_effect=lambda path: path == "/project/optimized/clip001_proxy.mov"):
+             existing_path = self.service._existing_proxy_output_path("F2", {"path": "/media/clip001.mov"})
+
+         self.assertEqual(existing_path, "/project/optimized/clip001_proxy.mov")
+
+     def test_existing_proxy_output_path_reuses_legacy_mp4_proxy_when_present(self):
          with patch.object(self.service, "_proxy_root", return_value="/project/optimized"), \
               patch("classes.proxy_service.os.path.exists", side_effect=lambda path: path == "/project/optimized/clip001_proxy.mp4"):
              existing_path = self.service._existing_proxy_output_path("F2", {"path": "/media/clip001.mov"})
@@ -565,7 +589,7 @@ class ProxyServiceTests(unittest.TestCase):
          self.assertEqual(saved[0], ("F1", {"id": "F1", "path": "/optimized/F1.mp4"}))
          self.assertEqual(saved[1][0], "F2")
          self.assertTrue(saved[1][1]["missing"])
-         self.assertEqual(saved[1][1]["path"], "/optimized/source-b_proxy.mp4")
+         self.assertEqual(saved[1][1]["path"], "/optimized/source-b_proxy.mov")
 
      def test_use_existing_for_files_skips_invalid_matches_without_crashing(self):
          file_one = types.SimpleNamespace(id="F1", data={"id": "F1", "path": "/media/source-a.mp4"})
@@ -667,17 +691,17 @@ class ProxyServiceTests(unittest.TestCase):
              existing_names={"other_proxy.mp4"},
          )
 
-         self.assertEqual(filename, "clip001_proxy.mp4")
+         self.assertEqual(filename, "clip001_proxy.mov")
 
      def test_preferred_proxy_filename_appends_file_id_on_collision(self):
          filename = self.service._preferred_proxy_filename(
              "F1",
              {"path": "/media/clip001.mov"},
              "/project/optimized",
-             existing_names={"clip001_proxy.mp4"},
+             existing_names={"clip001_proxy.mov"},
          )
 
-         self.assertEqual(filename, "clip001_proxy_F1.mp4")
+         self.assertEqual(filename, "clip001_proxy_F1.mov")
 
      def test_reserve_proxy_output_path_avoids_collisions_with_already_reserved_jobs(self):
          self.service._jobs["F1"] = {
@@ -685,7 +709,7 @@ class ProxyServiceTests(unittest.TestCase):
              "status": "queued",
              "progress": 0,
              "cancel_requested": False,
-             "output_path": "/project/optimized/clip001_proxy.mp4",
+             "output_path": "/project/optimized/clip001_proxy.mov",
          }
 
          with patch.object(self.service, "_proxy_root", return_value="/project/optimized"), \
@@ -693,7 +717,7 @@ class ProxyServiceTests(unittest.TestCase):
               patch("classes.proxy_service.os.makedirs"):
              output_path = self.service._reserve_proxy_output_path("F2", {"path": "/media/clip001.mov"})
 
-         self.assertEqual(output_path, "/project/optimized/clip001_proxy_F2.mp4")
+         self.assertEqual(output_path, "/project/optimized/clip001_proxy_F2.mov")
 
      def test_index_existing_optimized_files_limits_matches_to_common_video_extensions(self):
          def fake_walk(_):

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -243,6 +243,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             self.generation_service.shutdown()
             self.generation_service.cleanup_temp_files()
         if getattr(self, "proxy_service", None):
+            if self.proxy_service.uses_global_hidden_proxy_root():
+                self.proxy_service.delete_internal_project_proxy_files()
             self.proxy_service.shutdown()
 
         # Stop ZMQ polling thread (if any)

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -57,14 +57,17 @@ IMPORT_READER_MAX_SIZE = 128
 
 
 def inspect_media(path, max_width=0, max_height=0):
-    """Inspect media using the shared libopenshot reader-selection logic."""
+    """Inspect media using the shared libopenshot reader-selection logic.
+
+    The max-size arguments are kept for API compatibility with older callers,
+    but are intentionally not applied during metadata inspection. Applying a
+    decode-size cap here can cause libopenshot to report preview dimensions in
+    reader.Json(), which then stores imported 1080p media as a tiny clip.
+    """
     def _inspect_with_reader(inspect_reader):
         reader = openshot.Clip.CreateReader(path, inspect_reader)
         if not reader:
             raise RuntimeError(f"No reader available for path: {path}")
-
-        if max_width > 0 and max_height > 0 and hasattr(reader, "SetMaxDecodeSize"):
-            reader.SetMaxDecodeSize(int(max_width), int(max_height))
 
         reader.Open()
         try:


### PR DESCRIPTION
What changed:

- Removed the metadata inspection decode-size cap so imported 1080p videos keep their real dimensions instead of preview-sized values like 128x72.
- Added a project-load repair step for projects that were already affected by this issue.
- Updated tests to cover metadata import and repairing linked clip readers.
Why:

In daily builds, some imported FHD videos could be stored with tiny dimensions.
When exporting as FHD 29.97 fps, those clips could appear very small inside the final 1920x1080 frame.
Keeping real source dimensions prevents incorrect scaling during export.
How to test:

Import a 1920x1080 video.
Confirm the imported file properties show 1920x1080.
Export using YouTube HD / FHD 1080p 29.97 fps.
Open the exported video and confirm it fills the 1080p frame correctly.
Optional: open an older affected project and confirm the same clip is repaired and exports at the correct size.

Checks
Ran Python syntax checks with py_compile.
Full unit tests could not be run in this environment because no Qt binding is installed (PyQt6, PySide6, or PyQt5).