### PR TITLE
Improved screen dock/widget restoring (at > 100% screen scale)

### DIFF
--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -114,11 +114,11 @@ class SettingStore(JsonDataStore):
         if key in user_values:
             user_values[key].update({"value": value})
         else:
-            log.warn(
+            log.warning(
                 "{} key '{}' not valid. The following are valid: {}".format(
                     self.data_type,
                     key,
-                    list(self._data.keys()),
+                    list(user_values.keys()),
                 ))
 
     def load(self):

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -167,6 +167,13 @@
     "setting": "timeline_height"
   },
   {
+    "value": 0,
+    "title": "",
+    "type": "hidden",
+    "category": "Qt",
+    "setting": "video_dock_width"
+  },
+  {
     "value": [],
     "title": "",
     "type": "hidden",

--- a/src/tests/test_main_window.py
+++ b/src/tests/test_main_window.py
@@ -26,6 +26,7 @@
  """
 
 import importlib
+import json
 import os
 import sys
 import tempfile
@@ -43,10 +44,11 @@ PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 if PATH not in sys.path:
     sys.path.append(PATH)
 
-from qt_api import QCoreApplication, Qt
+from qt_api import QByteArray, QCoreApplication, Qt
 from qt_api import QApplication, QDockWidget, QMainWindow, QMenu, QStandardItem, QStandardItemModel
 
 from classes.project_data import ProjectDataStore
+from classes.settings import SettingStore
 from classes.updates import UpdateManager
 from qt_test_app import ensure_app_state as ensure_qt_app_state, get_or_create_app
 
@@ -109,6 +111,65 @@ class SignalRecorder:
 
     def emit(self, *args):
         self.calls.append(args)
+
+
+class FakeDock:
+    def __init__(self, name="", height=100, width=200, area=Qt.TopDockWidgetArea):
+        self._name = name
+        self._height = height
+        self._width = width
+        self._area = area
+        self._minimum_height = 0
+        self._maximum_height = 16777215
+        self._minimum_width = 0
+        self._maximum_width = 16777215
+        self.fixed_heights = []
+        self.fixed_widths = []
+
+    def objectName(self):
+        return self._name
+
+    def height(self):
+        return self._height
+
+    def width(self):
+        return self._width
+
+    def minimumHeight(self):
+        return self._minimum_height
+
+    def maximumHeight(self):
+        return self._maximum_height
+
+    def minimumWidth(self):
+        return self._minimum_width
+
+    def maximumWidth(self):
+        return self._maximum_width
+
+    def setFixedHeight(self, height):
+        self.fixed_heights.append(height)
+        self._height = height
+        self._minimum_height = height
+        self._maximum_height = height
+
+    def setFixedWidth(self, width):
+        self.fixed_widths.append(width)
+        self._width = width
+        self._minimum_width = width
+        self._maximum_width = width
+
+    def setMinimumHeight(self, height):
+        self._minimum_height = height
+
+    def setMaximumHeight(self, height):
+        self._maximum_height = height
+
+    def setMinimumWidth(self, width):
+        self._minimum_width = width
+
+    def setMaximumWidth(self, width):
+        self._maximum_width = width
 
 
 class MainWindowTests(unittest.TestCase):
@@ -226,6 +287,74 @@ class MainWindowTests(unittest.TestCase):
         self.main_window_module.MainWindow._on_dock_top_level_changed(fake_window, True)
 
         self.assertEqual(calls, ["interaction", ("style", {"delay": 0})])
+
+    def test_save_settings_persists_video_width_and_timeline_height(self):
+        timeline_dock = FakeDock("dockTimeline", height=240, area=Qt.BottomDockWidgetArea)
+        video_dock = FakeDock("dockVideo", height=360, width=520, area=Qt.TopDockWidgetArea)
+        fake_window = types.SimpleNamespace(
+            dockTimeline=timeline_dock,
+            dockVideo=video_dock,
+            saveState=lambda: QByteArray(b"state"),
+            saveGeometry=lambda: QByteArray(b"geometry"),
+            getDocks=lambda: [timeline_dock, video_dock],
+            dockWidgetArea=lambda dock: dock._area,
+        )
+
+        self.main_window_module.MainWindow.save_settings(fake_window)
+
+        self.assertEqual(self.app.settings.values["timeline_height"], 240)
+        self.assertEqual(self.app.settings.values["video_dock_width"], 520)
+
+    def test_default_settings_include_video_dock_width(self):
+        with open(os.path.join(PATH, "settings", "_default.settings"), encoding="utf-8") as fh:
+            settings = json.load(fh)
+
+        names = {item.get("setting") for item in settings}
+
+        self.assertIn("video_dock_width", names)
+
+    def test_setting_store_invalid_key_warns_without_crashing(self):
+        store = SettingStore()
+        store._data = [{"setting": "known", "value": 1}]
+
+        store.set("unknown", 2)
+
+        self.assertEqual(store.get("known"), 1)
+
+    def test_apply_saved_dock_sizes_restores_video_width_and_timeline_height(self):
+        timeline_dock = FakeDock("dockTimeline", height=140, area=Qt.BottomDockWidgetArea)
+        video_dock = FakeDock("dockVideo", height=180, width=260, area=Qt.TopDockWidgetArea)
+        fake_window = types.SimpleNamespace(
+            dockTimeline=timeline_dock,
+            dockVideo=video_dock,
+            saved_timeline_height=260,
+            saved_video_dock_width=640,
+            width=lambda: 1200,
+            height=lambda: 900,
+        )
+        fake_window._force_dock_extent_once = types.MethodType(
+            self.main_window_module.MainWindow._force_dock_extent_once,
+            fake_window)
+        fake_window._positive_int = self.main_window_module.MainWindow._positive_int
+
+        with patch.object(self.main_window_module.QTimer, "singleShot", lambda _delay, callback: callback()):
+            self.main_window_module.MainWindow._apply_saved_dock_sizes(fake_window)
+
+        self.assertEqual(timeline_dock.fixed_heights, [260])
+        self.assertEqual(video_dock.fixed_widths, [640])
+        self.assertEqual(timeline_dock.minimumHeight(), 0)
+        self.assertEqual(video_dock.maximumWidth(), 16777215)
+
+    def test_missing_video_dock_width_uses_initial_shown_layout_as_fallback(self):
+        video_dock = FakeDock("dockVideo", height=300, width=540, area=Qt.TopDockWidgetArea)
+        fake_window = types.SimpleNamespace(
+            dockVideo=video_dock,
+            saved_video_dock_width=None,
+        )
+
+        self.main_window_module.MainWindow._capture_missing_dock_size_fallbacks(fake_window)
+
+        self.assertEqual(fake_window.saved_video_dock_width, 540)
 
     def test_active_custom_view_setter_does_not_shadow_reader(self):
         fake_window = types.SimpleNamespace()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -3609,6 +3609,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         dock = getattr(self, "dockTimeline", None)
         if dock:
             s.set('timeline_height', dock.height())
+        dock = getattr(self, "dockVideo", None)
+        if dock:
+            s.set('video_dock_width', dock.width())
 
     # Get window settings from setting store
     def load_settings(self):
@@ -3620,14 +3623,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             self.saved_geometry = qt_types.str_to_bytes(s.get('window_geometry_v2'))
         if s.get('window_state_v2'):
             self.saved_state = qt_types.str_to_bytes(s.get('window_state_v2'))
-        timeline_height = s.get('timeline_height')
-        if timeline_height:
-            try:
-                height_value = int(timeline_height)
-            except (TypeError, ValueError):
-                height_value = None
-            if height_value and height_value > 0:
-                self.saved_timeline_height = height_value
+        self.saved_timeline_height = self._positive_int(s.get('timeline_height'))
+        self.saved_video_dock_width = self._positive_int(s.get('video_dock_width'))
 
         # Load Recent Projects
         self.load_recent_menu()
@@ -4069,40 +4066,80 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         if self._restored_saved_window:
             return
         self._restored_saved_window = True
+        self._capture_missing_dock_size_fallbacks()
         if self.saved_geometry:
             self.restoreGeometry(self.saved_geometry)
         if self.saved_state:
-            self._restore_state_and_timeline()
+            self._restore_state_and_dock_sizes()
 
-    def _restore_state_and_timeline(self):
-        """Restore saved dock state and then apply timeline height."""
+    def _capture_missing_dock_size_fallbacks(self):
+        """Use the initial shown layout as a fallback for newly introduced dock sizes."""
+        video_dock = getattr(self, "dockVideo", None)
+        if (video_dock
+                and not getattr(self, "saved_video_dock_width", None)
+                and video_dock.width() > 0):
+            self.saved_video_dock_width = video_dock.width()
+
+    def _restore_state_and_dock_sizes(self):
+        """Restore saved dock state and then apply stable logical dock sizes."""
         if self.saved_state:
             self.restoreState(self.saved_state)
         # Re-apply removed-dock state that Qt's saveState/restoreState doesn't preserve.
         hidden_names = get_app().get_settings().get('hidden_docks') or []
         self._restore_hidden_docks(hidden_names)
-        self._apply_saved_timeline_height()
+        self._apply_saved_dock_sizes()
+
+    @staticmethod
+    def _positive_int(value):
+        """Return value as a positive int, or None."""
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            return None
+        return value if value > 0 else None
+
+    def _force_dock_extent_once(self, dock, size, orientation):
+        """Force one saved logical dock splitter extent, then restore flexibility."""
+        if not dock:
+            return
+        size = self._positive_int(size)
+        if not size:
+            return
+        if orientation == Qt.Horizontal:
+            size = min(size, max(160, int(self.width() * 0.85)))
+            current = dock.width()
+            old_min = dock.minimumWidth()
+            old_max = dock.maximumWidth()
+            set_fixed = dock.setFixedWidth
+            restore = lambda: (dock.setMinimumWidth(old_min), dock.setMaximumWidth(old_max))
+        else:
+            size = min(size, max(100, int(self.height() * 0.85)))
+            current = dock.height()
+            old_min = dock.minimumHeight()
+            old_max = dock.maximumHeight()
+            set_fixed = dock.setFixedHeight
+            restore = lambda: (dock.setMinimumHeight(old_min), dock.setMaximumHeight(old_max))
+        if current != size:
+            set_fixed(size)
+            QTimer.singleShot(0, restore)
+
+    def _apply_saved_dock_sizes(self):
+        """Apply saved logical sizes for docks Qt state commonly drifts."""
+        self._force_dock_extent_once(
+            getattr(self, "dockTimeline", None),
+            self.saved_timeline_height,
+            Qt.Vertical)
+        self._force_dock_extent_once(
+            getattr(self, "dockVideo", None),
+            self.saved_video_dock_width,
+            Qt.Horizontal)
 
     def _apply_saved_timeline_height(self):
         """Apply the saved timeline dock height."""
-        if not self.saved_timeline_height:
-            return
-
-        dock = getattr(self, "dockTimeline", None)
-        if not dock:
-            return
-
-        # If height already matches, skip the resize to avoid an extra layout pass.
-        if dock.height() != self.saved_timeline_height:
-            # Force the height by temporarily constraining min/max
-            old_min = dock.minimumHeight()
-            old_max = dock.maximumHeight()
-            dock.setFixedHeight(self.saved_timeline_height)
-            # Restore flexibility after layout processes
-            def restore_flex():
-                dock.setMinimumHeight(old_min)
-                dock.setMaximumHeight(old_max)
-            QTimer.singleShot(0, restore_flex)
+        self._force_dock_extent_once(
+            getattr(self, "dockTimeline", None),
+            self.saved_timeline_height,
+            Qt.Vertical)
 
     def show_property_timeout(self):
         """Callback for show property timer"""
@@ -5135,6 +5172,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.saved_state = None
         self.saved_geometry = None
         self.saved_timeline_height = None
+        self.saved_video_dock_width = None
         self._restored_saved_window = False
         self.load_settings()
 
@@ -5300,8 +5338,9 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Save settings
         s.save()
 
-        # Re-apply timeline height after theme settles (theme changes dock sizes)
-        QTimer.singleShot(0, self._apply_saved_timeline_height)
+        # Re-apply saved logical dock sizes after theme settles (theme changes dock sizes)
+        QTimer.singleShot(0, self._apply_saved_dock_sizes)
+        QTimer.singleShot(250, self._apply_saved_dock_sizes)
 
         # Refresh frame
         QTimer.singleShot(100, lambda: self.refreshFrameSignal.emit())


### PR DESCRIPTION
Improved screen dock restoring at > 100% screen scales, regardless of OS scaling or OpenShot's internal scaling. The goal is to restore the screen as accurately as possible on launch, and without this change, the video widget kept getting smaller and smaller with each launch.