### PR TITLE
Export Files menu failed to export animated titles (i.e. image sequences)

### DIFF
--- a/src/tests/test_export_clips.py
+++ b/src/tests/test_export_clips.py
@@ -1,0 +1,108 @@
+"""
+ @file
+ @brief Targeted unit tests for Project Files export helpers.
+"""
+
+import importlib
+import os
+import sys
+import types
+import unittest
+
+
+PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+if PATH not in sys.path:
+    sys.path.append(PATH)
+
+from qt_api import QApplication
+from qt_test_app import ensure_app_state, get_or_create_app
+
+
+class DummySettings:
+    pass
+
+
+class DummyApp(QApplication):
+    def __init__(self):
+        super().__init__([])
+
+    def _tr(self, text):
+        return text
+
+
+class ExportClipsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        app, cls._owns_app = get_or_create_app(DummyApp)
+        cls.app = ensure_app_state(app, DummySettings)
+        cls.export_clips = importlib.import_module("windows.export_clips")
+
+    def test_image_sequence_detection_matches_printf_pattern(self):
+        sequence = types.SimpleNamespace(data={"path": os.path.join("titles", "Title%04d.png")})
+        normal_file = types.SimpleNamespace(data={"path": os.path.join("titles", "Title0001.png")})
+
+        self.assertTrue(self.export_clips.isImageSequence(sequence))
+        self.assertFalse(self.export_clips.isImageSequence(normal_file))
+
+    def test_image_sequence_export_name_is_single_mp4(self):
+        file_obj = types.SimpleNamespace(data={
+            "path": os.path.join("titles", "Title%04d.png"),
+            "fps": {"num": 25, "den": 1},
+            "video_length": 300,
+        })
+
+        self.assertEqual(
+            self.export_clips.nameOfImageSequenceExport(file_obj),
+            "title [0.00 - 12.00].mp4",
+        )
+
+    def test_image_sequence_as_clip_sets_full_duration_range(self):
+        file_obj = types.SimpleNamespace(data={
+            "path": os.path.join("titles", "Title%04d.png"),
+            "fps": {"num": 25, "den": 1},
+            "video_length": 300,
+            "width": 1920,
+        })
+
+        clip_obj = self.export_clips.imageSequenceAsClip(file_obj)
+
+        self.assertEqual(clip_obj.data["start"], 0.0)
+        self.assertEqual(clip_obj.data["end"], 12.0)
+        self.assertEqual(clip_obj.data["path"], os.path.join("titles", "Title%04d.png"))
+        self.assertEqual(clip_obj.data["width"], 1920)
+
+    def test_setup_writer_disables_audio_for_silent_image_sequence(self):
+        clip_obj = types.SimpleNamespace(data={
+            "path": os.path.join("titles", "Title%04d.png"),
+            "fps": {"num": 25, "den": 1},
+            "pixel_ratio": {"num": 1, "den": 1},
+            "width": 1920,
+            "height": 1080,
+            "has_audio": False,
+            "sample_rate": 0,
+            "channels": 0,
+            "channel_layout": 0,
+        })
+        writer = types.SimpleNamespace(
+            audio_options=None,
+            video_options=None,
+            prepare_count=0,
+            opened=False,
+        )
+        writer.SetVideoOptions = lambda *args: setattr(writer, "video_options", args)
+        writer.SetAudioOptions = lambda *args: setattr(writer, "audio_options", args)
+        writer.PrepareStreams = lambda: setattr(writer, "prepare_count", writer.prepare_count + 1)
+        writer.Open = lambda: setattr(writer, "opened", True)
+
+        self.export_clips.setupWriter(clip_obj, writer)
+
+        self.assertFalse(writer.audio_options[0])
+        self.assertEqual(writer.audio_options[2], 48000)
+        self.assertEqual(writer.audio_options[3], 2)
+        self.assertEqual(writer.audio_options[4], 3)
+        self.assertEqual(writer.prepare_count, 2)
+        self.assertTrue(writer.opened)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/windows/export_clips.py
+++ b/src/windows/export_clips.py
@@ -50,14 +50,26 @@ def makeLegalFileName(s: str):
     s = re.sub(r'[^\w\s-]', '', s.lower())
     return s.strip() #clean leading or trailing spaces
 
-def copyFileToFolder(f , destination_folder: str):
+SEQUENCE_FORMAT_RE = re.compile(r"%(?:0\d+)?d")
+
+
+def isImageSequence(file_object) -> bool:
+    """Return whether a Project File path represents an image sequence."""
+    path = file_object.data.get("path")
+    if not path:
+        return False
+    return bool(SEQUENCE_FORMAT_RE.search(os.path.basename(path)))
+
+
+def copyFileToFolder(f, destination_folder: str):
     """Takes a file object, gives it a suffix, and copies it"""
+    source_path = f.data.get("path")
     new_file_path = nameOfExport(f)
     destination_path = os.path.join(destination_folder, new_file_path)
     if os.path.exists(destination_path):
         return
-    log.info(f"copying {f.data.get('path')} to {destination_path}")
-    shutil.copy(f.data.get("path"), destination_path)
+    log.info(f"copying {source_path} to {destination_path}")
+    shutil.copy(source_path, destination_path)
 
 def notClip(file_obj):
     return not isClip(file_obj)
@@ -67,6 +79,11 @@ def isClip(file_object) -> bool:
        and "end" in file_object.data:
         return True
     return False
+
+def fileDurationSeconds(file_obj) -> float:
+    fps = file_obj.data.get("fps")
+    fps = int(fps.get("num")) / int(fps.get("den"))
+    return int(file_obj.data.get("video_length", 0)) / fps
 
 def nameOfExport(file_obj) -> str:
     if isClip(file_obj):
@@ -81,11 +98,25 @@ def nameOfExport(file_obj) -> str:
     else:
         name, ext = os.path.splitext(os.path.split(file_obj.data.get("path"))[1])
         name = makeLegalFileName(name)
-        fps = file_obj.data.get("fps")
-        fps = int(fps.get("num")) / int(fps.get("den"))
-        length_in_seconds = int(file_obj.data.get("video_length",0)) / fps
+        length_in_seconds = fileDurationSeconds(file_obj)
         suffix = f"[0.00 - {format(length_in_seconds, '.2f')}]"
         return f"{name} {suffix}{ext}"
+
+def nameOfImageSequenceExport(file_obj) -> str:
+    name, _ = os.path.splitext(os.path.split(file_obj.data.get("path"))[1])
+    name = file_obj.data.get("name", name)
+    name, _ = os.path.splitext(name)
+    name = makeLegalFileName(SEQUENCE_FORMAT_RE.sub("", name))
+    length_in_seconds = fileDurationSeconds(file_obj)
+    suffix = f"[0.00 - {format(length_in_seconds, '.2f')}]"
+    return f"{name} {suffix}.mp4"
+
+def imageSequenceAsClip(file_obj):
+    clip_obj = type("ImageSequenceClip", (), {})()
+    clip_obj.data = dict(file_obj.data)
+    clip_obj.data["start"] = 0.0
+    clip_obj.data["end"] = fileDurationSeconds(file_obj)
+    return clip_obj
 
 def framesInClip(cl):
     start_frame, end_frame = startAndEndFrames(cl)
@@ -101,13 +132,20 @@ def startAndEndFrames(clip):
     end_frame = max(start_frame - 1, int(round(end_time * fps)))
     return (start_frame, end_frame)
 
+def positiveInt(value, default: int) -> int:
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
 def setupWriter(clip, writer):
-    # TODO: allow for audio clips
     # Set video options
     pr = clip.data.get("pixel_ratio", {"num": 1, "den": 1})
     pixel_ratio = openshot.Fraction(pr.get("num"), pr.get("den"))
     fps = clip.data.get("fps", {"num": 30, "den": 1})
     frames_per_second = openshot.Fraction(fps.get("num",1), fps.get("den",1))
+    has_audio = bool(clip.data.get("has_audio", False))
 
     writer.SetVideoOptions(True,
                            "libx264",
@@ -120,12 +158,12 @@ def setupWriter(clip, writer):
                            22)
     writer.PrepareStreams()
     # Set audio options
-    writer.SetAudioOptions(True,
+    writer.SetAudioOptions(has_audio,
                            "aac",
-                           clip.data.get("sample_rate", 48000),
-                           clip.data.get("channels", 2),
-                           clip.data.get("channel_layout", 3),
-                           clip.data.get("audio_bit_rate", 192000) )
+                           positiveInt(clip.data.get("sample_rate"), 48000),
+                           positiveInt(clip.data.get("channels"), 2),
+                           positiveInt(clip.data.get("channel_layout"), 3),
+                           positiveInt(clip.data.get("audio_bit_rate"), 192000))
     writer.PrepareStreams()
     writer.Open()
 
@@ -149,12 +187,14 @@ class clipExportWindow(QDialog):
 
     def _getDestination(self):
         settings = get_app().get_settings()
-        fd = QFileDialog()
-        fd.setOption(QFileDialog.ShowDirsOnly)
-        fd.setDirectory(
-            settings.getDefaultPath(settings.actionType.EXPORT)
+        parent = get_app().window
+        default_path = settings.getDefaultPath(settings.actionType.EXPORT)
+        chosen_destination = QFileDialog.getExistingDirectory(
+            parent,
+            _("Choose Target Folder"),
+            default_path,
+            QFileDialog.ShowDirsOnly,
         )
-        chosen_destination = fd.getExistingDirectory()
 
         # if dialog is canceled, use default path
         if chosen_destination:
@@ -189,41 +229,86 @@ class clipExportWindow(QDialog):
 
     def _exportPressed(self):
         clips = list(filter(isClip, self.file_objs))
-        files = list(filter(notClip, self.file_objs))
+        sequence_files = list(filter(isImageSequence, filter(notClip, self.file_objs)))
+        files = [f for f in filter(notClip, self.file_objs) if not isImageSequence(f)]
         # Total number of frames
         self._updateDialogExportStarting()
         total_frames, frames_written = 0, 0
         for c in clips:
             total_frames += framesInClip(c)
+        for f in sequence_files:
+            total_frames += int(f.data.get("video_length",0))
         for f in files:
             total_frames += int(f.data.get("video_length",0))
         for f in files:
-            copyFileToFolder(f, self.export_destination)
-            frames_written+=int(f.data.get("video_length",0))
-        for c in clips:
-            export_path = os.path.join(self.export_destination, f"{nameOfExport(c)}")
-            if(os.path.exists(export_path)):
-                log.info("Export path exists. Skipping render")
-                frames_written += framesInClip(c)
-                self._updateProgressBar(frames_written, total_frames)
-                get_app().processEvents()
-                continue
-            w = openshot.FFmpegWriter(export_path)
             try:
-                setupWriter(c, w)
+                copyFileToFolder(f, self.export_destination)
             except Exception as ex:
-                log.error("Error Exporting Clip: "+str(ex))
-                QMessageBox.warning(self, _("Error Exporting Clip"),
-                                    _("The following error occurred while exporting this clip: \n%s") % str(ex))
-                log.info("Removing this clip from total_frames")
-                total_frames -= int(framesInClip(c))
-                if os.path.exists(export_path):
-                    log.info("Removing incomplete file %s" % export_path)
-                    os.remove(export_path)
+                log.error("Error Exporting File: %s", ex, exc_info=True)
+                QMessageBox.warning(self, _("Error Exporting File"),
+                                    _("The following error occurred while exporting this file: \n%s") % str(ex))
+                total_frames -= int(f.data.get("video_length", 0))
                 continue
+            frames_written += int(f.data.get("video_length", 0))
+            self._updateProgressBar(frames_written, total_frames)
+            get_app().processEvents()
+            if self.canceled:
+                log.info("Export Canceled. Exiting Dialog")
+                self.done(0)
+                return
+        for f in sequence_files:
+            export_path = os.path.join(self.export_destination, f"{nameOfImageSequenceExport(f)}")
+            frames_written, total_frames = self._exportClip(
+                imageSequenceAsClip(f),
+                export_path,
+                frames_written,
+                total_frames,
+            )
+            if self.canceled:
+                self.done(0)
+                return
+        for c in clips:
+            frames_written, total_frames = self._exportClip(
+                c,
+                os.path.join(self.export_destination, f"{nameOfExport(c)}"),
+                frames_written,
+                total_frames,
+            )
+            if self.canceled:
+                self.done(0)
+                return
+        log.info("Finished exporting")
+        self._updateProgressBar(frames_written, total_frames)
+        self._updateDialogExportFinished()
 
-            start_frame, end_frame = startAndEndFrames(c)
-            clip_reader = openshot.Clip(c.data.get("path"))
+    def _exportClip(self, clip, export_path: str, frames_written: int, total_frames: int):
+        if os.path.exists(export_path):
+            log.info("Export path exists. Skipping render")
+            frames_written += framesInClip(clip)
+            self._updateProgressBar(frames_written, total_frames)
+            get_app().processEvents()
+            return frames_written, total_frames
+
+        w = openshot.FFmpegWriter(export_path)
+        try:
+            setupWriter(clip, w)
+        except Exception as ex:
+            log.error("Error Exporting Clip: "+str(ex))
+            QMessageBox.warning(self, _("Error Exporting Clip"),
+                                _("The following error occurred while exporting this clip: \n%s") % str(ex))
+            log.info("Removing this clip from total_frames")
+            total_frames -= int(framesInClip(clip))
+            if os.path.exists(export_path):
+                log.info("Removing incomplete file %s" % export_path)
+                os.remove(export_path)
+            return frames_written, total_frames
+
+        clip_reader = None
+        export_error = False
+        remove_partial_export = False
+        try:
+            start_frame, end_frame = startAndEndFrames(clip)
+            clip_reader = openshot.Clip(clip.data.get("path"))
             clip_reader.Open()
 
             log.info(f"Starting to write frames to {export_path}")
@@ -235,19 +320,29 @@ class clipExportWindow(QDialog):
                 frames_written += 1
                 if self.canceled:
                     log.info("Export Canceled. Deleting partial export")
-                    if os.path.exists(export_path):
-                        os.remove(export_path)
+                    remove_partial_export = True
                     break
-            clip_reader.Close()
+        except Exception as ex:
+            log.error("Error Exporting Clip: %s", ex, exc_info=True)
+            QMessageBox.warning(self, _("Error Exporting Clip"),
+                                _("The following error occurred while exporting this clip: \n%s") % str(ex))
+            total_frames -= int(framesInClip(clip))
+            export_error = True
+            remove_partial_export = True
+        finally:
+            if clip_reader:
+                clip_reader.Close()
             w.Close()
-            if self.canceled:
-                log.info("Reader and Writer closed. Exiting Dialog")
-                self.done(0)
-                break
-            log.info("Finished Exporting Clip: %s" % export_path)
-        log.info("Finished exporting")
-        self._updateProgressBar(frames_written, total_frames)
-        self._updateDialogExportFinished()
+        if remove_partial_export and os.path.exists(export_path):
+            log.info("Removing incomplete file %s" % export_path)
+            os.remove(export_path)
+        if export_error:
+            return frames_written, total_frames
+        if self.canceled:
+            log.info("Reader and Writer closed. Exiting Dialog")
+            return frames_written, total_frames
+        log.info("Finished Exporting Clip: %s" % export_path)
+        return frames_written, total_frames
 
     def _updateProgressBar(self, count: int, total: int):
         if total==0:


### PR DESCRIPTION
Export Files menu failed to export animated titles (i.e. image sequences)

- Animated titles now export as a single MP4.
- Fixed silent title exports by disabling audio when no audio exists.
- Prevented export failures from leaving the dialog stuck.
- Fixed the target-folder chooser appearing behind the main window.
- Added focused regression tests.