### PR TITLE
Use reader-applied orientation in preview, region, thumbnails (i.e. let libopenshot rotate videos/photos)

### DIFF
--- a/src/classes/proxy_service.py
+++ b/src/classes/proxy_service.py
@@ -732,7 +732,6 @@ class ProxyService(QObject):
                      max_frame = int(source_reader.get("video_length", 0) or 0)
                      if max_frame <= 0:
                          raise RuntimeError("invalid source frame count")
-                     rotate = self._rotation_for_reader(reader)
                      prewarm_frames = self._thumbnail_prewarm_frames(
                          file_id,
                          max_frame,
@@ -747,7 +746,7 @@ class ProxyService(QObject):
                          while prewarm_index < len(prewarm_frames) and prewarm_frames[prewarm_index] < frame_number:
                              prewarm_index += 1
                          if prewarm_index < len(prewarm_frames) and prewarm_frames[prewarm_index] == frame_number:
-                             self._save_prewarmed_thumbnail(frame, file_id, frame_number, rotate)
+                             self._save_prewarmed_thumbnail(frame, file_id, frame_number, 0.0)
                              prewarm_index += 1
                          self._trim_optimize_caches(clip, reader, frame_number)
                          if frame_number == 1 or frame_number == max_frame or frame_number % max(1, min(12, max_frame // 40 or 1)) == 0:
@@ -1151,15 +1150,6 @@ class ProxyService(QObject):
              cache_object.Clear()
          except Exception:
              log.debug("Optimize Preview cache clear failed", exc_info=1)
-
-     @staticmethod
-     def _rotation_for_reader(reader):
-         try:
-             if reader.info.metadata.count("rotate"):
-                 return float(reader.info.metadata["rotate"])
-         except Exception:
-             pass
-         return 0.0
 
      def _create_optimize_timeline(self, width, height):
          width = max(2, int(width or 2))

--- a/src/classes/thumbnail.py
+++ b/src/classes/thumbnail.py
@@ -210,7 +210,7 @@ def GetThumbPath(file_id, thumbnail_frame, clear_cache=False, attempts=1):
 
 
 def GenerateThumbnail(file_path, thumb_path, thumbnail_frame, width, height, mask, overlay):
-    """Create thumbnail image, and check for rotate metadata (if any)"""
+    """Create thumbnail image."""
     try:
         scale = GetThumbDeviceScale()
     except Exception:
@@ -235,17 +235,6 @@ def GenerateThumbnail(file_path, thumb_path, thumbnail_frame, width, height, mas
             reader.SetMaxDecodeSize(decode_width, decode_height)
         reader.Open()
 
-        # Get the 'rotate' metadata (if any)
-        rotate = 0.0
-        try:
-            if reader.info.metadata.count("rotate"):
-                rotate_data = reader.info.metadata["rotate"]
-                rotate = float(rotate_data)
-        except ValueError as ex:
-            log.warning("Could not parse rotation value {}: {}".format(rotate_data, ex))
-        except Exception:
-            log.warning("Error reading rotation metadata from {}".format(file_path), exc_info=1)
-
         reader.GetFrame(thumbnail_frame).Thumbnail(
             thumb_path,
             thumb_width,
@@ -256,7 +245,7 @@ def GenerateThumbnail(file_path, thumb_path, thumbnail_frame, width, height, mas
             False,
             "png",
             85,
-            rotate,
+            0.0,
             openshot.SCALE_CROP,
         )
     except RuntimeError:

--- a/src/tests/test_dialog_preview_resize.py
+++ b/src/tests/test_dialog_preview_resize.py
@@ -2,6 +2,7 @@ import os
 import sys
 import types
 import unittest
+import json
 from unittest.mock import patch
 
 from qt_api import QRect, QSize
@@ -58,6 +59,7 @@ class DummySignal:
 class DummyVideoPreview:
     def __init__(self, viewport):
         self._viewport = viewport
+        self.aspect_ratio = None
 
     def centeredViewport(self, width, height):
         _ = (width, height)
@@ -68,6 +70,15 @@ class DummyVideoPreview:
 
     def height(self):
         return self._viewport.height()
+
+
+class DummyFraction:
+    def __init__(self, num, den):
+        self.num = num
+        self.den = den
+
+    def Reduce(self):
+        return None
 
 
 class DialogPreviewResizeTests(unittest.TestCase):
@@ -314,6 +325,9 @@ class DialogPreviewResizeTests(unittest.TestCase):
             def SetJson(self, payload):
                 self.payload = payload
 
+            def Open(self):
+                pass
+
             def Start(self, value):
                 self.start = value
 
@@ -332,6 +346,7 @@ class DialogPreviewResizeTests(unittest.TestCase):
             channels=2,
             channel_layout=3,
             file=types.SimpleNamespace(absolute_path=lambda: "/source.mp4", data={"start": 0.0, "duration": 5.0}),
+            videoPreview=DummyVideoPreview(QRect(0, 0, 640, 360)),
             video_length=150,
             source_reader_data={"path": "/source.mp4"},
             proxy_reader_data={"path": ""},
@@ -339,12 +354,16 @@ class DialogPreviewResizeTests(unittest.TestCase):
 
         with patch("windows.cutting.openshot.Timeline", FakeTimeline), \
              patch("windows.cutting.openshot.Clip", FakeClip), \
-             patch("windows.cutting.openshot.Fraction", side_effect=lambda num, den: (num, den)), \
+             patch("windows.cutting.openshot.Fraction", DummyFraction), \
              patch("windows.cutting.openshot.FRAME_DISPLAY_CLIP", 7):
             Cutting._build_preview_timeline(fake, {"path": "/source.mp4"}, QSize(640, 360))
 
         self.assertEqual(timeline_args[0][0:2], (3840, 2160))
         self.assertEqual(timeline_setmax, [(640, 360)])
+        self.assertEqual(json.loads(fake.clip.payload), {
+            "reader_orientation_mode": "reader",
+            "reader": {"path": "/source.mp4"},
+        })
 
     def test_cutting_build_preview_timeline_uses_project_floor_for_single_image_media(self):
         timeline_args = []
@@ -381,6 +400,9 @@ class DialogPreviewResizeTests(unittest.TestCase):
                 clip_payloads.append(payload)
                 self.payload = payload
 
+            def Open(self):
+                pass
+
             def Start(self, value):
                 self.start = value
 
@@ -402,6 +424,7 @@ class DialogPreviewResizeTests(unittest.TestCase):
                 absolute_path=lambda: "/emoji.svg",
                 data={"start": 0.0, "duration": 5.0, "media_type": "image"},
             ),
+            videoPreview=DummyVideoPreview(QRect(0, 0, 640, 360)),
             video_length=150,
             source_reader_data={"path": "/emoji.svg", "media_type": "image"},
             proxy_reader_data={"path": ""},
@@ -410,7 +433,7 @@ class DialogPreviewResizeTests(unittest.TestCase):
 
         with patch("windows.cutting.openshot.Timeline", FakeTimeline), \
              patch("windows.cutting.openshot.Clip", FakeClip), \
-             patch("windows.cutting.openshot.Fraction", side_effect=lambda num, den: (num, den)), \
+             patch("windows.cutting.openshot.Fraction", DummyFraction), \
              patch("windows.cutting.openshot.FRAME_DISPLAY_CLIP", 7), \
              patch("windows.cutting.get_app", return_value=fake_app):
             Cutting._build_preview_timeline(fake, {"path": "/emoji.svg", "media_type": "image"}, QSize(640, 360))

--- a/src/tests/test_proxy_service.py
+++ b/src/tests/test_proxy_service.py
@@ -426,6 +426,7 @@ class ProxyServiceTests(unittest.TestCase):
          self.assertIsNone(clip_obj.parent_timeline_calls[-1])
          self.assertEqual(writer_obj.frames, ["frame-1", "frame-2", "frame-3"])
          self.assertEqual([os.path.basename(call[1]) for call in thumbnail_calls], ["1.png", "3.png"])
+         self.assertEqual([call[4] for call in thumbnail_calls], [0.0, 0.0])
          self.assertEqual(clip_cache.max_bytes, [self.service.OPTIMIZE_CACHE_MAX_BYTES])
          self.assertEqual(reader_cache.max_bytes, [self.service.OPTIMIZE_CACHE_MAX_BYTES])
          self.assertGreaterEqual(clip_cache.clears, 2)

--- a/src/windows/cutting.py
+++ b/src/windows/cutting.py
@@ -313,13 +313,38 @@ class Cutting(QDialog):
             int(reader_data.get("height", 0) or 0),
         )
 
-        base_width = max(2, int(getattr(self, "width", 0) or max_size.width() or 2))
-        base_height = max(2, int(getattr(self, "height", 0) or max_size.height() or 2))
+        self.clip = openshot.Clip(self.file_path)
+        if not is_single_image:
+            self.clip.SetJson(json.dumps({
+                "reader_orientation_mode": "reader",
+                "reader": self.reader_data,
+            }))
+        self.clip.Open()
+
+        c_info = self.clip.Reader().info
+        self.width = int(getattr(c_info, "width", self.width))
+        self.height = int(getattr(c_info, "height", self.height))
+        fps_info = getattr(c_info, "fps", None)
+        self.fps_num = int(getattr(fps_info, "num", self.fps_num))
+        self.fps_den = int(getattr(fps_info, "den", self.fps_den))
+        self.fps = float(self.fps_num) / float(self.fps_den or 1)
+        self.sample_rate = int(getattr(c_info, "sample_rate", self.sample_rate))
+        self.channels = int(getattr(c_info, "channels", self.channels))
+        self.channel_layout = int(getattr(c_info, "channel_layout", self.channel_layout))
+
+        base_width = max(2, int(self.width or max_size.width() or 2))
+        base_height = max(2, int(self.height or max_size.height() or 2))
         if is_single_image:
             project = getattr(get_app(), "project", None)
             if project:
                 base_width = max(base_width, int(project.get("width") or 0))
                 base_height = max(base_height, int(project.get("height") or 0))
+
+        aspect_ratio = openshot.Fraction(base_width, base_height)
+        aspect_ratio.Reduce()
+        self.videoPreview.aspect_ratio = aspect_ratio
+        viewport_rect = self.videoPreview.centeredViewport(self.videoPreview.width(), self.videoPreview.height())
+        max_size = QSize(max(2, int(viewport_rect.width())), max(2, int(viewport_rect.height())))
 
         self.r = openshot.Timeline(
             base_width,
@@ -331,9 +356,6 @@ class Cutting(QDialog):
         self.r.info.channel_layout = self.channel_layout
         self.r.SetMaxSize(max_size.width(), max_size.height())
 
-        self.clip = openshot.Clip(self.file_path)
-        if not is_single_image:
-            self.clip.SetJson(json.dumps({"reader": self.reader_data}))
         self.clip.Start(self.file.data.get("start", 0.0))
         self.clip.End(self.file.data.get("end", self.file.data.get("duration", 0.0)))
 
@@ -779,7 +801,6 @@ class Cutting(QDialog):
 
         if getattr(self, "preview_thread", None):
             try:
-                self.initialized = False
                 self.PauseSignal.emit()
                 self.StopSignal.emit()
             except Exception:
@@ -794,11 +815,15 @@ class Cutting(QDialog):
                     pass
                 background.finished.connect(self._on_preview_stopped)
                 try:
-                    # Non-blocking stop to avoid visible UI lag when closing with ESC.
                     self.preview_parent.Stop(wait_for_thread=False)
                     return
                 except Exception:
                     pass
+
+            try:
+                self.preview_parent.Stop(wait_for_thread=True)
+            except Exception:
+                pass
 
         self._on_preview_stopped()
 

--- a/src/windows/preview_thread.py
+++ b/src/windows/preview_thread.py
@@ -661,7 +661,7 @@ class PlayerWorker(QObject):
         """ Stop the video player and terminate the playback threads """
 
         # Stop playback
-        if self.parent.initialized:
+        if getattr(self, "player", None):
             self.player.Stop()
 
     def queue_seek(self, number, start_preroll=True):

--- a/src/windows/region.py
+++ b/src/windows/region.py
@@ -257,7 +257,10 @@ class SelectRegion(QDialog):
             if self.file_path:
                 self.clip = openshot.Clip(self.file_path)
                 if not is_single_image:
-                    self.clip.SetJson(json.dumps({"reader": self.reader_data}))
+                    self.clip.SetJson(json.dumps({
+                        "reader_orientation_mode": "reader",
+                        "reader": self.reader_data,
+                    }))
             else:
                 self.clip = openshot.Clip(clip.Reader())
             self.clip.Open()
@@ -273,7 +276,10 @@ class SelectRegion(QDialog):
                     source_path = str(getattr(file, "data", {}).get("path", ""))
             self.clip = openshot.Clip(source_path)
             if self.reader_data and not is_single_image:
-                self.clip.SetJson(json.dumps({"reader": self.reader_data}))
+                self.clip.SetJson(json.dumps({
+                    "reader_orientation_mode": "reader",
+                    "reader": self.reader_data,
+                }))
             self.clip.Open()
         self.clip.Id(get_app().project.generate_id())
 


### PR DESCRIPTION
Use reader-applied orientation in preview, region, thumbnails, and proxy paths (source media is now rotated prior to Clip)

- Pass the internal reader_orientation_mode flag when creating temporary preview and region clips, remove duplicate thumbnail/proxy rotation handling, and update preview dialog sizing from oriented reader dimensions.

- Also make preview shutdown wait for the worker/player stop path to avoid crashes when closing the dialog during playback.

Related to https://github.com/OpenShot/libopenshot/pull/1073