### PR TITLE
Tracked Objects menu for Mask: Source + New Margin Editing for Many Effects

### DIFF
--- a/doc/effects.rst
+++ b/doc/effects.rst
@@ -615,7 +615,9 @@ Blur
 """"
 The Blur effect softens the image, reducing detail and texture. This can be used to create a sense of depth,
 draw attention to specific parts of the frame, or simply to apply a stylistic choice for aesthetic purposes.
-The intensity of the blur can be adjusted to achieve the desired level of softness.
+The intensity of the blur can be adjusted to achieve the desired level of softness. Use the ``left``, ``right``,
+``top``, and ``bottom`` margin properties to limit the blur to a rectangular area, such as a corner, logo, or
+static part of the screen.
 
 .. table::
    :widths: 26 80
@@ -623,9 +625,13 @@ The intensity of the blur can be adjusted to achieve the desired level of softne
    ==========================  ============
    Property Name               Description
    ==========================  ============
+   bottom                      ``(float, 0 to 1)`` The curve to adjust the bottom margin size
    horizontal_radius           ``(float, 0 to 100)`` Horizontal blur radius keyframe. The size of the horizontal blur operation in pixels.
    iterations                  ``(float, 0 to 100)`` Iterations keyframe. The # of blur iterations per pixel. 3 iterations = Gaussian.
+   left                        ``(float, 0 to 1)`` The curve to adjust the left margin size
+   right                       ``(float, 0 to 1)`` The curve to adjust the right margin size
    sigma                       ``(float, 0 to 100)`` Sigma keyframe. The amount of spread in the blur operation. Should be larger than radius.
+   top                         ``(float, 0 to 1)`` The curve to adjust the top margin size
    vertical_radius             ``(float, 0 to 100)`` Vertical blur radius keyframe. The size of the vertical blur operation in pixels.
    ==========================  ============
 

--- a/doc/effects.rst
+++ b/doc/effects.rst
@@ -55,8 +55,15 @@ How to use effect masks:
 
 1. Add an effect to a clip.
 2. Open the effect :guilabel:`Properties`.
-3. Choose a mask source (static image or animated mask video).
+3. Choose a :guilabel:`Mask: Source` (static image, animated mask video, :guilabel:`Tracker`, or
+   :guilabel:`Object Detector`).
 4. Adjust :guilabel:`Mask Mode` (for example, *Limit to Mask* or *Vary Strength*).
+
+For quick rectangular masks, add a :guilabel:`Tracker` effect to the clip, draw a box around the area you want to
+affect, then choose that tracker as the :guilabel:`Mask: Source` for another effect, such as
+:guilabel:`Blur` or :guilabel:`Pixelate`. The tracker box can be moved or resized directly in the video preview while
+the Tracker effect is selected, and those box changes can be keyframed over time. Tracker boxes also work on static
+photos, so the same workflow can limit an effect to one region of an image.
 
 High-quality animated masks can also be generated with Advanced AI workflows.
 In many cases, you can click one or more subjects and let tracking build a mask
@@ -326,7 +333,7 @@ more information on individual effects and their unique properties.
    Mask: Invert            Bool        Invert the mask source so light areas become dark and dark areas become light.
    Mask: Loop              Bool        Loop an animated mask source when the effect is longer than the source.
    Mask Mode               Enum        Controls how the mask limits or varies the strength of the effect.
-   Mask: Source            Reader      The image, image sequence, or video used as the effect's grayscale mask source.
+   Mask: Source            Reader      The image, image sequence, video, Tracker, or Object Detector used as the effect's grayscale mask source.
    Mask: Time Mode         Enum        Controls how OpenShot maps effect time to an animated mask source.
    Parent                  String      The parent object to this effect, which makes many of these keyframe values initialize to the parent value.
    Position                Float       The position of the effect on the timeline (in seconds). This property is hidden when an effect belongs to a clip.
@@ -357,8 +364,10 @@ Mask Properties
 """""""""""""""
 The :guilabel:`Mask: Source`, :guilabel:`Mask Mode`, :guilabel:`Mask: Time Mode`, :guilabel:`Mask: Loop`, and
 :guilabel:`Mask: Invert` properties limit where an effect is applied. The mask source can be a static image, image
-sequence, or video. Light areas of the mask usually apply more of the effect, while dark areas apply less; use
-:guilabel:`Mask: Invert` when you need the opposite result.
+sequence, video, :guilabel:`Tracker`, or :guilabel:`Object Detector`. Light areas of the mask usually apply more of
+the effect, while dark areas apply less; use :guilabel:`Mask: Invert` when you need the opposite result. Tracker and
+Object Detector sources use their bounding boxes as the masked region, which is useful for limiting effects such as
+blur, pixelation, color correction, or sharpening to a specific subject.
 
 Track
 """""
@@ -1532,9 +1541,19 @@ Tracker
 """""""
 The Tracker effect allows for the tracking of a specific object or area within the video frame across multiple frames.
 This can be used for motion tracking, adding effects or annotations that follow the movement of objects, or for
-stabilizing footage based on a tracked point.When tracking an object, be sure to select the entire object, which is
+stabilizing footage based on a tracked point. When tracking an object, be sure to select the entire object, which is
 visible at the start of a clip, and choose one of the following ``Tracking Type`` algorithms. The tracking algorithm
 then follows this object from frame to frame, recording its position, scale, and sometimes rotation.
+
+The tracked box can also be used as a live mask source for any other effect. For example, add a
+:guilabel:`Tracker` effect, draw a box around a face or license plate, add a :guilabel:`Blur` or
+:guilabel:`Pixelate` effect to the same clip, and set that effect's :guilabel:`Mask: Source` to the tracker. The blur
+or pixelation is then limited to the tracked box and updates in the video preview as you adjust it.
+
+Tracker boxes are not limited to moving video. You can add a Tracker effect to a static photo, use its box as the
+:guilabel:`Mask: Source` for another effect, and keyframe the box position or size if the masked region should move
+over time. Select the Tracker effect, then use the video preview transform handles to move or resize the box; OpenShot
+updates the box properties such as ``x1``, ``y1``, ``x2``, and ``y2`` so the masked effect follows the adjusted region.
 
 Tracking Type
 ^^^^^^^^^^^^^

--- a/doc/effects.rst
+++ b/doc/effects.rst
@@ -82,6 +82,13 @@ To adjust a property:
 - Double-click to enter precise values.
 - Right/double-click for non-numerical options.
 
+Effects with ``Margin: Left``, ``Margin: Top``, ``Margin: Right``, and ``Margin: Bottom`` controls can also be
+adjusted directly in the video preview. Select the effect, then drag the preview rectangle to move the affected
+area, resize its handles, or draw a new rectangle inside the clip.
+
+The same preview rectangle can be used to position Caption text. Select a Caption effect, then move or resize the
+white rectangle in the video preview to adjust the Caption margins.
+
 Effect properties are integral to the :ref:`animation_ref` system. When you modify an effect property, a
 keyframe is generated at the current playhead position. For a property to span the entire clip,
 position the playhead at or before the clip's start before making adjustments. A convenient way to
@@ -662,6 +669,14 @@ effect can even animate the text fading in/out, and supports any font, size, col
 easy-to-use Caption editor, where you can quickly insert captions at the playhead position, or edit all your caption
 text in one place.
 
+The Caption editor's insert button (the plus icon) creates a complete caption cue at the current playhead position,
+using a three-second default duration when possible, and selects the placeholder caption text so you can start typing
+immediately. Caption text updates are previewed while you type.
+
+To set a caption's end time from the playhead, remove the existing end timestamp from the cue line, leaving the start
+timestamp and arrow. Move the playhead to the desired end time, place the text cursor on that incomplete timestamp line,
+and press the plus icon again. OpenShot inserts the current playhead timestamp as the cue's end time.
+
 .. code-block:: console
 
    :caption: Show a caption, starting at 5 seconds and ending at 10 seconds.
@@ -682,6 +697,7 @@ text in one place.
    caption_font                ``(font)`` Font name or family name
    caption_text                ``(caption)`` VTT/Subrip formatted caption text (multi-line)
    color                       ``(color)`` Color of caption text
+   bottom                      ``(float, 0 to 1)`` Size of bottom margin
    fade_in                     ``(float, 0 to 3)`` Fade in per caption (# of seconds)
    fade_out                    ``(float, 0 to 3)`` Fade out per caption (# of seconds)
    font_alpha                  ``(float, 0 to 1)`` Font color alpha

--- a/src/tests/test_video_widget_transform.py
+++ b/src/tests/test_video_widget_transform.py
@@ -150,6 +150,32 @@ class VideoWidgetTransformTests(unittest.TestCase):
             self.assertLessEqual(top.y() + top.height(), 0.0)
             self.assertGreaterEqual(bottom.y(), self.viewport.height())
 
+    def test_margin_box_norm_converts_effect_margins_to_region(self):
+        raw = {
+            "left": {"value": 0.10},
+            "top": {"value": 0.20},
+            "right": {"value": 0.30},
+            "bottom": {"value": 0.40},
+        }
+
+        self.assertEqual(VideoWidget._margin_box_norm(raw), (0.10, 0.20, 0.70, 0.60))
+
+    def test_margin_box_clamp_preserves_opposing_edge(self):
+        left, top, right, bottom = VideoWidget._clamp_margin_values(
+            0.90, 0.90, 0.30, 0.30, prefer_left=True, prefer_top=True)
+
+        self.assertAlmostEqual(left, 0.70)
+        self.assertAlmostEqual(top, 0.70)
+        self.assertAlmostEqual(right, 0.30)
+        self.assertAlmostEqual(bottom, 0.30)
+
+    def test_effect_has_margin_box_from_class_name(self):
+        self.widget.transforming_effect = None
+        self.widget.transforming_effect_object = types.SimpleNamespace(
+            info=types.SimpleNamespace(class_name="Blur"))
+
+        self.assertTrue(VideoWidget._effect_has_margin_box(self.widget))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -130,6 +130,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
     ThumbnailUpdated = pyqtSignal(str, int)
     FileUpdated = pyqtSignal(str)
     CaptionTextUpdated = pyqtSignal(str, object)
+    CaptionTextCommitted = pyqtSignal(object)
     CaptionTextLoaded = pyqtSignal(str, object)
     TimelineZoom = pyqtSignal(float)     # Signal to zoom into timeline from zoom slider
     TimelineScrolled = pyqtSignal(list)  # Scrollbar changed signal from timeline
@@ -3288,10 +3289,11 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def actionInsertTimestamp_trigger(self, event):
         """Insert the current timestamp into the caption editor
-        In the format: 00:00:23,000 --> 00:00:24,500. first click to set the initial timestamp,
-        move the playehad, second click to set the end timestamp.
+        In the format: 00:00:23:000 --> 00:00:26:000.
 
-        If beginning and ending timestamps would be the same, add 5 seconds to the second.
+        When the cursor is on an incomplete timestamp line, use the current playhead position
+        as the missing end timestamp. Otherwise, insert a complete caption cue using a short
+        default duration.
         """
         # Get translation function
         app = get_app()
@@ -3313,10 +3315,10 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 if effect.get("id") == effect_id:
                     clip_data = clip.data
                     break
-            if clip_data != None:
+            if clip_data is not None:
                 break
 
-        if clip_data == None:
+        if clip_data is None:
             log.info("No clip owns this caption effect")
             return
 
@@ -3324,70 +3326,150 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             return
 
         # Calculate fps / current seconds
+        default_caption_duration = 3.0
         fps = get_app().project.get("fps")
         fps_float = float(fps["num"]) / float(fps["den"])
         current_position = (self.preview_thread.current_frame - 1) / fps_float
         relative_position = current_position - clip_data.get("position") + clip_data.get("start")
 
         # Prevent captions before or after the clip
-        relative_position = max(clip_data.get('start'), relative_position)
+        clip_start = clip_data.get('start')
+        clip_end = clip_data.get('end')
+        relative_position = max(clip_start, relative_position)
         clip_seconds = clip_data.get("end") - clip_data.get("start")
-        relative_position = min(clip_data.get('end'), relative_position)
+        relative_position = min(clip_end, relative_position)
 
         # Get cursor / current line of text (where cursor is located)
         cursor = self.captionTextEdit.textCursor()
-        self.captionTextEdit.moveCursor(QTextCursor.StartOfLine)
+        cursor.movePosition(QTextCursor.StartOfLine)
         line_text = cursor.block().text()
-        self.captionTextEdit.moveCursor(QTextCursor.EndOfLine)
+        cursor.movePosition(QTextCursor.EndOfLine)
+        self.captionTextEdit.setTextCursor(cursor)
 
         # Convert time in seconds to hours:minutes:seconds:milliseconds
         current_timestamp = secondsToTimecode(relative_position, fps["num"], fps["den"], use_milliseconds=True)
 
-        # If this line only has one timestamp, and both timestamps are the same, default to 5 second duration
-        if "-->"  in line_text and line_text.count(':') == 3 and current_timestamp in line_text:
-            # prevent caption with 0 duration
-            relative_position += 5.0
-            # recalculate the timestamp string
-            current_timestamp = secondsToTimecode(relative_position, fps["num"], fps["den"], use_milliseconds=True)
-
         if "-->" in line_text and line_text.count(':') == 3:
             # Current line has only one timestamp. Add the second and go to the line below it.
+            timestamp_parts = line_text.split("-->", 1)
+            starting_timestamp = timestamp_parts[0].strip()
+            if starting_timestamp == current_timestamp:
+                relative_position = min(relative_position + default_caption_duration, clip_end)
+                current_timestamp = secondsToTimecode(relative_position, fps["num"], fps["den"], use_milliseconds=True)
             self.captionTextEdit.insertPlainText(current_timestamp)
             self.captionTextEdit.moveCursor(QTextCursor.Down)
             self.captionTextEdit.moveCursor(QTextCursor.EndOfLine)
         else:
             # Current line isn't a starting timestamp, so add a starting timestamp
+            caption_start = relative_position
+            caption_end = min(caption_start + default_caption_duration, clip_end)
+            if caption_end <= caption_start:
+                caption_start = max(clip_start, clip_end - min(default_caption_duration, clip_seconds))
+                caption_end = clip_end
+                current_timestamp = secondsToTimecode(caption_start, fps["num"], fps["den"], use_milliseconds=True)
+            end_timestamp = secondsToTimecode(caption_end, fps["num"], fps["den"], use_milliseconds=True)
 
-            # If the current line isn't blank, go to end and add two blank lines
-            if (self.captionTextEdit.textCursor().block().text().strip() != ""):
-                self.captionTextEdit.moveCursor(QTextCursor.End)
-                self.captionTextEdit.insertPlainText("\n\n")
-            # Add timestamp, and placeholder caption
-            self.captionTextEdit.insertPlainText("%s --> \n%s" % (current_timestamp, _("Enter caption text...")))
-            # Return to timestamp line, to await ending timestamp
-            self.captionTextEdit.moveCursor(QTextCursor.Up)
+            placeholder_text = _("Enter caption text...")
+            cue_header = "%s --> %s\n" % (current_timestamp, end_timestamp)
+
+            if self.captionTextEdit.textCursor().block().text().strip() != "":
+                cursor.movePosition(QTextCursor.End)
+                cursor.insertText("\n\n")
+
+            placeholder_start = cursor.position() + len(cue_header)
+            cursor.insertText("%s%s" % (cue_header, placeholder_text))
+            cursor.setPosition(placeholder_start)
+            cursor.setPosition(placeholder_start + len(placeholder_text), QTextCursor.KeepAnchor)
+            self.captionTextEdit.setTextCursor(cursor)
+
+        self._focus_caption_editor()
 
     def captionTextEdit_TextChanged(self):
         """Caption text was edited, start the save timer (to prevent spamming saves)"""
         self.caption_save_timer.start()
+        self.caption_commit_timer.start()
 
     def caption_editor_save(self):
         """Emit the CaptionTextUpdated signal (and if that property is active/selected, it will be saved)"""
         self.CaptionTextUpdated.emit(self.captionTextEdit.toPlainText(), self.caption_model_row)
 
+    def caption_editor_commit(self):
+        """Finalize the current caption edit as a single undoable transaction."""
+        self.caption_save_timer.stop()
+        self.caption_editor_save()
+        self.CaptionTextCommitted.emit(self.caption_model_row)
+
+    def _configure_caption_editor(self, editable):
+        """Apply the Caption dock's editable/read-only state in one place."""
+        focus_widgets = [self.captionTextEdit]
+        viewport = self.captionTextEdit.viewport()
+        if viewport is not None:
+            focus_widgets.append(viewport)
+        for widget in focus_widgets:
+            widget.setEnabled(True)
+            widget.setFocusPolicy(Qt.StrongFocus)
+            widget.setProperty("_original_focus_policy", None)
+        self.captionTextEdit.setTextInteractionFlags(Qt.TextEditorInteraction)
+        self.captionTextEdit.setReadOnly(not editable)
+
+    def _focus_caption_editor(self):
+        """Return keyboard focus to the Caption text editor after toolbar actions."""
+        self.captionTextEdit.setFocus(Qt.OtherFocusReason)
+        QTimer.singleShot(0, lambda: self.captionTextEdit.setFocus(Qt.OtherFocusReason))
+
+    def _caption_editor_has_focus(self):
+        """Return True if the Caption editor or its viewport currently owns focus."""
+        viewport = self.captionTextEdit.viewport()
+        return self.captionTextEdit.hasFocus() or (viewport is not None and viewport.hasFocus())
+
+    def _same_caption_model_row(self, first_row, second_row):
+        """Return True when two Caption model row handles reference the same property."""
+        if first_row is None or second_row is None:
+            return first_row is second_row
+        return bool(first_row and second_row and first_row[0] is second_row[0])
+
     def caption_editor_load(self, new_caption_text, caption_model_row):
         """Load the caption editor with text, or disable it if empty string detected"""
+        if (
+            self.caption_commit_timer.isActive()
+            and self.caption_model_row is not None
+            and not self._same_caption_model_row(self.caption_model_row, caption_model_row)
+        ):
+            self.caption_commit_timer.stop()
+            self.caption_editor_commit()
+
         self.caption_model_row = caption_model_row
         if self.captionTextEdit is None:
             self.captionTextEdit = QTextEdit(self.dockCaptionContents)
-            self.captionTextEdit.setReadOnly(True)
+            self._configure_caption_editor(False)
             self.tabCaptions.addWidget(self.captionTextEdit)
             self.captionTextEdit.textChanged.connect(self.captionTextEdit_TextChanged)
-        self.captionTextEdit.setPlainText(new_caption_text.strip())
-        if not caption_model_row:
-            self.captionTextEdit.setReadOnly(True)
+
+        new_caption_text = new_caption_text or ""
+        if self.captionTextEdit.toPlainText() != new_caption_text:
+            current_cursor = self.captionTextEdit.textCursor()
+            restore_cursor = caption_model_row is not None and self._caption_editor_has_focus()
+            cursor_position = current_cursor.position()
+            selection_start = current_cursor.selectionStart()
+            selection_end = current_cursor.selectionEnd()
+
+            self.captionTextEdit.blockSignals(True)
+            self.captionTextEdit.setPlainText(new_caption_text)
+            self.captionTextEdit.blockSignals(False)
+
+            if restore_cursor:
+                doc_length = len(new_caption_text)
+                cursor = self.captionTextEdit.textCursor()
+                cursor.setPosition(min(selection_start, doc_length))
+                cursor.setPosition(min(selection_end, doc_length), QTextCursor.KeepAnchor)
+                if selection_start == selection_end:
+                    cursor.setPosition(min(cursor_position, doc_length))
+                self.captionTextEdit.setTextCursor(cursor)
+
+        if caption_model_row is None:
+            self._configure_caption_editor(False)
         else:
-            self.captionTextEdit.setReadOnly(False)
+            self._configure_caption_editor(True)
 
             # Show this dock
             self.dockCaptionEditor.show()
@@ -3511,7 +3593,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
                 effect = Effect.get(id=sel["id"])
                 if effect and (
                     effect.data.get("has_tracked_object")
-                    or effect.data.get("class_name") == "Crop"
+                    or effect.data.get("class_name") in ("Bars", "Blur", "Caption", "Crop", "Pixelate")
+                    or all(prop in effect.data for prop in ("left", "top", "right", "bottom"))
                 ):
                     clip_id = effect.parent['id']
                     self.KeyFrameTransformSignal.emit(sel["id"], clip_id)
@@ -3887,7 +3970,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
         # Add Caption text editor widget
         self.captionTextEdit = QTextEdit(self.dockCaptionContents)
-        self.captionTextEdit.setReadOnly(True)
+        self.captionTextEdit.setObjectName("captionTextEdit")
+        self._configure_caption_editor(False)
 
         # Playback controls (centered)
         self.captionToolbar.addAction(self.actionInsertTimestamp)
@@ -3897,9 +3981,13 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Hook up caption editor signal
         self.captionTextEdit.textChanged.connect(self.captionTextEdit_TextChanged)
         self.caption_save_timer = QTimer(self)
-        self.caption_save_timer.setInterval(1000)
+        self.caption_save_timer.setInterval(250)
         self.caption_save_timer.setSingleShot(True)
         self.caption_save_timer.timeout.connect(self.caption_editor_save)
+        self.caption_commit_timer = QTimer(self)
+        self.caption_commit_timer.setInterval(2500)
+        self.caption_commit_timer.setSingleShot(True)
+        self.caption_commit_timer.timeout.connect(self.caption_editor_commit)
         self.CaptionTextLoaded.connect(self.caption_editor_load)
         self.caption_model_row = None
 

--- a/src/windows/models/properties_model.py
+++ b/src/windows/models/properties_model.py
@@ -950,6 +950,14 @@ class PropertiesModel(updates.UpdateInterface):
                         log.debug("No clip data found for this object id")
                         return
 
+                if (
+                    property_key not in clip_data
+                    and item_type == "effect"
+                    and property_key in {"left", "top", "right", "bottom"}
+                    and property_type == "float"
+                ):
+                    clip_data[property_key] = {"Points": []}
+
                 # Update clip attribute
                 if property_key in clip_data:
                     log_id = "{}/{}".format(item_id, object_id) if object_id else item_id
@@ -1306,8 +1314,6 @@ class PropertiesModel(updates.UpdateInterface):
             elif type == "caption":
                 # Use caption value
                 col.setText(memo)
-                # Load caption editor also
-                get_app().window.CaptionTextLoaded.emit(memo, row)
             elif type == "bool":
                 # Use boolean value
                 if value:
@@ -1383,6 +1389,9 @@ class PropertiesModel(updates.UpdateInterface):
 
             # Append ROW to MODEL (if does not already exist in model)
             self.model.appendRow(row)
+            if type == "caption":
+                # Load caption editor after both label/value cells exist.
+                get_app().window.CaptionTextLoaded.emit(memo, row)
 
         elif name in self.items and self.items[name]["row"]:
             # Update the value of the existing model
@@ -1486,6 +1495,9 @@ class PropertiesModel(updates.UpdateInterface):
 
             # Update helper dictionary
             row.append(col)
+            if type == "caption":
+                # Keep the editor enabled and synchronized on property refreshes.
+                get_app().window.CaptionTextLoaded.emit(memo, row)
 
         # Keep track of items in a dictionary (for quick look up)
         self.items[name] = {"row": row, "property": property}

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -1619,10 +1619,10 @@
      <normaloff>:/icons/Humanity/actions/16/list-add.svg</normaloff>:/icons/Humanity/actions/16/list-add.svg</iconset>
    </property>
    <property name="text">
-    <string>Insert Timestamp</string>
+    <string>Insert Caption</string>
    </property>
    <property name="toolTip">
-    <string>Insert Timestamp</string>
+    <string>Insert Caption</string>
    </property>
   </action>
   <action name="actionClearWaveformData">

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -48,6 +48,8 @@ from classes.logger import log
 from classes.app import get_app
 from classes.query import Clip, Effect
 
+MARGIN_BOX_EFFECTS = {"Bars", "Blur", "Caption", "Crop", "Pixelate"}
+
 
 class VideoWidget(QWidget, updates.UpdateInterface):
     """ A QWidget used on the video display widget """
@@ -203,6 +205,56 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         origin_screen = t.map(QPointF(local_origin_x, local_origin_y))
         return t, (sx, sy, rot, shx, shy, ox, oy), origin_screen
 
+    def _effect_has_margin_box(self, raw_properties=None):
+        """Return True when an effect exposes a left/top/right/bottom margin rectangle."""
+        if raw_properties is not None:
+            return all(prop in raw_properties for prop in ("left", "top", "right", "bottom"))
+        if self.transforming_effect_object:
+            class_name = getattr(self.transforming_effect_object.info, 'class_name', '')
+            if class_name in MARGIN_BOX_EFFECTS:
+                return True
+        if self.transforming_effect:
+            if self.transforming_effect.data.get("class_name") in MARGIN_BOX_EFFECTS:
+                return True
+            return all(prop in self.transforming_effect.data for prop in ("left", "top", "right", "bottom"))
+        return False
+
+    @staticmethod
+    def _margin_box_norm(raw_properties):
+        """Return normalized x1/y1/x2/y2 from left/top/right/bottom margin properties."""
+        left = float(raw_properties.get('left', {}).get('value', 0.0))
+        top = float(raw_properties.get('top', {}).get('value', 0.0))
+        right = float(raw_properties.get('right', {}).get('value', 0.0))
+        bottom = float(raw_properties.get('bottom', {}).get('value', 0.0))
+        left = min(max(left, 0.0), 1.0)
+        top = min(max(top, 0.0), 1.0)
+        right = min(max(right, 0.0), 1.0)
+        bottom = min(max(bottom, 0.0), 1.0)
+        if left + right > 1.0:
+            right = 1.0 - left
+        if top + bottom > 1.0:
+            bottom = 1.0 - top
+        return left, top, 1.0 - right, 1.0 - bottom
+
+    @staticmethod
+    def _clamp_margin_values(left, top, right, bottom, prefer_left=False, prefer_top=False):
+        """Clamp margin values while preserving the dragged edge when opposing margins collide."""
+        left = min(max(float(left), 0.0), 1.0)
+        top = min(max(float(top), 0.0), 1.0)
+        right = min(max(float(right), 0.0), 1.0)
+        bottom = min(max(float(bottom), 0.0), 1.0)
+        if left + right > 1.0:
+            if prefer_left:
+                left = 1.0 - right
+            else:
+                right = 1.0 - left
+        if top + bottom > 1.0:
+            if prefer_top:
+                top = 1.0 - bottom
+            else:
+                bottom = 1.0 - top
+        return left, top, right, bottom
+
     # This method is invoked by the UpdateManager each time a change happens (i.e UpdateInterface)
     def changed(self, action):
         # Handle change
@@ -253,10 +305,12 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.transform_mode = None
         self.transform = None
         self.clipBounds = None
+        self.marginBoxFullBounds = None
         self.originHandle = None
         self.original_effect_data = None
         self.hover_transform_mode = None
         self.rotation_drag_value = None
+        self.margin_box_drag_anchor = None
         self.hover_cursor = Qt.ArrowCursor
         self.setCursor(Qt.ArrowCursor)
         self.update()
@@ -276,6 +330,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
         # Accept 0.0 values; only treat None as missing
         has_crop_box = (x1 is not None and y1 is not None and x2 is not None and y2 is not None)
+        self.marginBoxFullBounds = QRectF(0.0, 0.0, source_width, source_height)
 
         # Build bounds in local (clip) coords
         if has_crop_box:
@@ -406,6 +461,8 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         elif (self.transforming_effect and self.transforming_effect_object and
                 getattr(self.transforming_effect_object.info, 'class_name', '') == 'Crop'):
             transform_label = _("Crop")
+        elif self.transforming_effect and self._effect_has_margin_box():
+            transform_label = _("Region")
         elif self.transforming_effect or self.transforming_clips:
             transform_label = _("Transform")
 
@@ -511,6 +568,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
             crop_params = None
             crop_norm = None
+            margin_box_norm = None
 
             # Effect overlays
             if (self.transforming_effect
@@ -585,6 +643,12 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
                     first_props = clip_props
                     crop_params = (left, top, right, bottom, resize, x_off, y_off, frame_w, frame_h)
+                    margin_box_norm = crop_norm
+
+                elif self._effect_has_margin_box(raw_eff):
+                    margin_box_norm = self._margin_box_norm(raw_eff)
+                    union_rect = clip_rect
+                    first_props = clip_props
 
             # Draw handler(s)
             if union_rect and first_props and not self.region_enabled:
@@ -607,11 +671,13 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                 is_crop = crop_params is not None
                 if is_crop and crop_norm:
                     x1, y1, x2, y2 = crop_norm
+                elif margin_box_norm:
+                    x1, y1, x2, y2 = margin_box_norm
                 else:
                     x1 = y1 = x2 = y2 = None
                 self.drawTransformHandler(
                     painter, sx, sy, sw, sh, ox, oy,
-                    x1, y1, x2, y2, skip_origin=is_crop
+                    x1, y1, x2, y2, skip_origin=(is_crop or margin_box_norm is not None)
                 )
 
                 # Crop origin glyph (screen space; constant size; with opacity)
@@ -809,6 +875,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.mouse_position = event.pos()
         self.transform_mode = None if self.region_enabled else self.hover_transform_mode
         self.rotation_drag_value = None
+        self.margin_box_drag_anchor = None
         self.setCursor(Qt.CrossCursor if self.region_enabled else self.hover_cursor)
 
         if self.region_enabled and self.region_selection_mode not in ("point", "annotate") and event.button() == Qt.LeftButton:
@@ -882,6 +949,8 @@ class VideoWidget(QWidget, updates.UpdateInterface):
             self.original_clip_data_map = {c.id: json.loads(json.dumps(c.data)) for c in self.transforming_clips} if self.transforming_clips else {}
             self.original_effect_data = json.loads(json.dumps(self.transforming_effect.data)) if self.transforming_effect else None
             get_app().updates.transaction_id = self.transaction_id
+            if self.transform_mode == 'draw_margin_box' and self.transform:
+                self.margin_box_drag_anchor = self.transform.inverted()[0].map(event.pos())
         else:
             self.transaction_id = None
             self.original_clip_data_map = {}
@@ -906,6 +975,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.mouse_dragging = False
         self.transform_mode = None
         self.rotation_drag_value = None
+        self.margin_box_drag_anchor = None
 
         if self.region_enabled and self.region_selection_mode == "annotate":
             if self.region_rect_drag_start is not None and self.region_rect_drag_current is not None:
@@ -1069,10 +1139,21 @@ class VideoWidget(QWidget, updates.UpdateInterface):
             "outside": {"mode": 'rotation', "cursor": "rotate"},
         }
 
-        if (self.transforming_effect and self.transforming_effect_object and
-            getattr(self.transforming_effect_object.info, 'class_name', '') == 'Crop'):
+        effect_class_name = (
+            getattr(self.transforming_effect_object.info, 'class_name', '')
+            if self.transforming_effect_object else ''
+        )
+        is_margin_box_effect = (
+            self.transforming_effect and self.transforming_effect_object
+            and self._effect_has_margin_box()
+        )
+        is_crop_effect = effect_class_name == 'Crop'
+        if is_margin_box_effect:
             handle_uis = [h for h in handle_uis if not h["mode"].startswith('shear_') and h["mode"] != 'origin']
-            non_handle_uis["outside"] = {"mode": None, "cursor": None}
+            non_handle_uis["outside"] = (
+                {"mode": None, "cursor": None}
+                if is_crop_effect else {"mode": 'draw_margin_box', "cursor": "cross"}
+            )
 
         # Ignore any handles that were not drawn
         handle_uis = [h for h in handle_uis if h["handle"]]
@@ -1103,14 +1184,24 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                 self.setCursor(cursor)
                 return
 
-        # If not over any handles, determine inside/outside clip rectangle
+        # If not over any handles, determine inside/outside active rectangle
         r = non_handle_uis.get("region")
         if self.transform.mapToPolygon(r.toRect()).containsPoint(event.pos(), Qt.OddEvenFill):
             nh = non_handle_uis.get("inside", {})
         else:
             nh = non_handle_uis.get("outside", {})
+            if is_margin_box_effect and not is_crop_effect:
+                try:
+                    local_point = self.transform.inverted()[0].map(event.pos())
+                    full_bounds = getattr(self, "marginBoxFullBounds", None)
+                    if not full_bounds or not full_bounds.contains(local_point):
+                        nh = {"mode": None, "cursor": None}
+                except Exception:
+                    nh = {"mode": None, "cursor": None}
         cursor_name = nh.get("cursor")
-        if cursor_name:
+        if cursor_name == "cross":
+            cursor = Qt.CrossCursor
+        elif cursor_name:
             cursor = self.rotateCursor(self.cursors.get(cursor_name), rotation, shear_x, shear_y)
         else:
             cursor = Qt.ArrowCursor
@@ -1772,6 +1863,118 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                             refresh=(i == len(updates) - 1),
                         )
 
+            elif self._effect_has_margin_box():
+                raw_properties = json.loads(
+                    self.transforming_effect_object.PropertiesJSON(clip_frame_number))
+                if not self._effect_has_margin_box(raw_properties):
+                    self.mouse_position = event.pos()
+                    self.mutex.unlock()
+                    return
+
+                clip_props_for_cursors = json.loads(self.transforming_clip_object.PropertiesJSON(clip_frame_number))
+                clip_rot = clip_props_for_cursors.get('rotation', {}).get('value', 0.0)
+                clip_sx = clip_props_for_cursors.get('shear_x', {}).get('value', 0.0)
+                clip_sy = clip_props_for_cursors.get('shear_y', {}).get('value', 0.0)
+
+                margin_left = raw_properties.get('left', {}).get('value', 0.0)
+                margin_top = raw_properties.get('top', {}).get('value', 0.0)
+                margin_right = raw_properties.get('right', {}).get('value', 0.0)
+                margin_bottom = raw_properties.get('bottom', {}).get('value', 0.0)
+
+                self.checkTransformMode(clip_rot, clip_sx, clip_sy, event)
+
+                if self.transform_mode:
+                    full_bounds = getattr(self, "marginBoxFullBounds", None)
+                    if not full_bounds:
+                        self.mouse_position = event.pos()
+                        self.mutex.unlock()
+                        return
+                    inverted_transform = self.transform.inverted()[0]
+                    current = inverted_transform.map(event.pos())
+                    previous = inverted_transform.map(self.mouse_position)
+                    x_motion = current.x() - previous.x()
+                    y_motion = current.y() - previous.y()
+                    width = max(full_bounds.width(), 0.0001)
+                    height = max(full_bounds.height(), 0.0001)
+
+                    eff_id = self.transforming_effect.id
+
+                    new_left = margin_left
+                    new_top = margin_top
+                    new_right = margin_right
+                    new_bottom = margin_bottom
+
+                    if self.transform_mode == 'draw_margin_box':
+                        if self.margin_box_drag_anchor is None:
+                            self.margin_box_drag_anchor = previous
+                        anchor = self.margin_box_drag_anchor
+                        left_px = min(max(min(anchor.x(), current.x()), 0.0), width)
+                        top_px = min(max(min(anchor.y(), current.y()), 0.0), height)
+                        right_px = min(max(max(anchor.x(), current.x()), 0.0), width)
+                        bottom_px = min(max(max(anchor.y(), current.y()), 0.0), height)
+                        new_left = left_px / width
+                        new_top = top_px / height
+                        new_right = 1.0 - (right_px / width)
+                        new_bottom = 1.0 - (bottom_px / height)
+                    elif self.transform_mode == 'location':
+                        dx = x_motion / width
+                        dy = y_motion / height
+                        dx = max(-margin_left, min(dx, margin_right))
+                        dy = max(-margin_top, min(dy, margin_bottom))
+                        new_left += dx
+                        new_top += dy
+                        new_right -= dx
+                        new_bottom -= dy
+                    elif self.transform_mode == 'scale_left':
+                        new_left += x_motion / width
+                    elif self.transform_mode == 'scale_right':
+                        new_right -= x_motion / width
+                    elif self.transform_mode == 'scale_top':
+                        new_top += y_motion / height
+                    elif self.transform_mode == 'scale_bottom':
+                        new_bottom -= y_motion / height
+                    elif self.transform_mode == 'scale_top_left':
+                        new_left += x_motion / width
+                        new_top += y_motion / height
+                    elif self.transform_mode == 'scale_top_right':
+                        new_top += y_motion / height
+                        new_right -= x_motion / width
+                    elif self.transform_mode == 'scale_bottom_left':
+                        new_left += x_motion / width
+                        new_bottom -= y_motion / height
+                    elif self.transform_mode == 'scale_bottom_right':
+                        new_right -= x_motion / width
+                        new_bottom -= y_motion / height
+
+                    new_left, new_top, new_right, new_bottom = self._clamp_margin_values(
+                        new_left,
+                        new_top,
+                        new_right,
+                        new_bottom,
+                        prefer_left=('left' in self.transform_mode or self.transform_mode == 'location'),
+                        prefer_top=('top' in self.transform_mode or self.transform_mode == 'location'),
+                    )
+
+                    updates = {}
+                    if abs(new_left - margin_left) > 0.0001:
+                        updates['left'] = new_left
+                    if abs(new_top - margin_top) > 0.0001:
+                        updates['top'] = new_top
+                    if abs(new_right - margin_right) > 0.0001:
+                        updates['right'] = new_right
+                    if abs(new_bottom - margin_bottom) > 0.0001:
+                        updates['bottom'] = new_bottom
+
+                    for i, (prop, val) in enumerate(updates.items()):
+                        self.updateEffectProperty(
+                            eff_id,
+                            clip_frame_number,
+                            None,
+                            prop,
+                            val,
+                            refresh=(i == len(updates) - 1),
+                        )
+
             # Force re-paint
             self.update()
             # ==================================================================================
@@ -1869,6 +2072,8 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                 props = c.data['objects'][obj_id]
             else:
                 props = c.data
+            if property_key not in props and property_key in {'left', 'top', 'right', 'bottom'}:
+                props[property_key] = {"Points": []}
             points_list = props[property_key]["Points"]
         except (TypeError, KeyError):
             log.error("Corrupted project data!", exc_info=1)
@@ -2582,6 +2787,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.rightShearHandle = None
         self.bottomShearHandle = None
         self.clipBounds = None
+        self.marginBoxFullBounds = None
         self.originHandle = None
         self.mouse_pressed = False
         self.mouse_dragging = False
@@ -2589,6 +2795,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         self.transform_mode = None
         self.hover_transform_mode = None
         self.rotation_drag_value = None
+        self.margin_box_drag_anchor = None
         self.hover_cursor = Qt.ArrowCursor
         self.original_clip_data = None
         self.original_clip_data_map = {}

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -1589,6 +1589,61 @@ class PropertiesTableView(QTableView):
                             "icon": None
                         })
 
+                # Handle generated mask source effect options
+                if property_key == "mask_source_id" and not self.choices:
+                    tracked_effect_choices = []
+
+                    for clip in Clip.filter():
+                        file_id = clip.data.get("file_id")
+
+                        clip_icon = None
+                        for row in range(self.files_model.rowCount()):
+                            idx = self.files_model.index(row, 0)
+                            if idx.sibling(row, 5).data() == file_id:
+                                clip_icon = idx.data(Qt.DecorationRole)
+                                break
+
+                        effect_choices = []
+                        for effect in clip.data.get("effects", []):
+                            effect_id = effect.get("id")
+                            if not effect_id:
+                                continue
+                            if effect_id == item_id:
+                                continue
+                            if not effect.get("has_tracked_object"):
+                                continue
+
+                            effect_class = effect.get("class_name", "")
+                            effect_name = effect.get("name") or effect_class or effect.get("id")
+                            effect_icon = None
+                            if effect_class:
+                                effect_icon = QIcon(QPixmap(os.path.join(
+                                    info.PATH, "effects", "icons", "%s.png" % effect_class.lower())))
+
+                            effect_choices.append({
+                                "name": f"{_(effect_name)} ({effect_id})",
+                                "value": effect_id,
+                                "selected": False,
+                                "icon": effect_icon
+                            })
+
+                        if effect_choices:
+                            tracked_effect_choices.append({
+                                "name": clip.data["title"],
+                                "value": effect_choices,
+                                "selected": False,
+                                "icon": clip_icon
+                            })
+
+                    self.choices.append({"name": _("None"), "value": "", "selected": False, "icon": None})
+                    if tracked_effect_choices:
+                        self.choices.append({
+                            "name": _("Tracked Objects"),
+                            "value": tracked_effect_choices,
+                            "selected": False,
+                            "icon": None
+                        })
+
             # Handle reader type values
             if self.property_type == "reader" and not self.choices:
                 # Add all files

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -1327,7 +1327,7 @@ class PropertiesTableView(QTableView):
 
     def caption_text_updated(self, new_caption_text, caption_model_row):
         """Caption text has been updated in the caption editor, and needs saving"""
-        if not caption_model_row:
+        if caption_model_row is None:
             # Ignore blank selections
             return
 
@@ -1349,8 +1349,13 @@ class PropertiesTableView(QTableView):
             self.start_transaction(caption_model_value)
             self.update_in_progress = True
             self.clip_properties_model.value_updated(caption_model_value, value=new_caption_text)
-            if not self.mouse_pressed:
-                self.finalize_transaction()
+
+    def caption_text_committed(self, caption_model_row):
+        """Finalize a batch of live Caption editor updates into one undo action."""
+        if caption_model_row is None:
+            return
+        if self.update_in_progress:
+            self.finalize_transaction()
 
     def select_item(self, selection):
         """Update the selected items in the properties window"""
@@ -2051,6 +2056,7 @@ class PropertiesTableView(QTableView):
         self.doubleClicked.connect(self.doubleClickedCB)
         self.loadProperties.connect(self.select_item)
         get_app().window.CaptionTextUpdated.connect(self.caption_text_updated)
+        get_app().window.CaptionTextCommitted.connect(self.caption_text_committed)
 
         self.color_grade_wheels_dock = QDockWidget(get_app()._tr("Color Wheels"), self.win)
         self.color_grade_wheels_dock.setObjectName("dockColorGradeWheels")


### PR DESCRIPTION
Tracked Objects now in Mask:Source menu
- Group choices by clip like tracked-object parenting
- Save selected source into mask_source_id

New real-time Rectangle Editor for the following effects with margins:
- Bars
- Blur
- Caption
- Crop
- Pixelate

Improvements / Fixes for Caption Editor
- Insert button now uses a 3.0 sec default
- Fixed editing carrot and focus issues
- Improved UNDO/REDO support
- Show faster updates in the video preview window


Related to https://github.com/OpenShot/libopenshot/pull/1074