### PR TITLE
Preserve import selection order

### DIFF
--- a/src/tests/test_files_model_import.py
+++ b/src/tests/test_files_model_import.py
@@ -102,6 +102,94 @@ class FilesModelImportTests(unittest.TestCase):
         self.assertEqual(file_data, {"media": "ok"})
         self.assertEqual(duration, 3.0)
 
+    def test_process_urls_preserves_original_url_order_for_import(self):
+        files_model_cls = self.files_model_module.FilesModel
+        fake_self = types.SimpleNamespace()
+        captured = {}
+
+        def record_add_files(paths, quiet=False, prevent_image_seq=False):
+            captured["paths"] = list(paths)
+            captured["quiet"] = quiet
+            captured["prevent_image_seq"] = prevent_image_seq
+
+        fake_self.add_files = record_add_files
+
+        fake_app = types.SimpleNamespace(
+            updates=types.SimpleNamespace(transaction_id=None),
+            window=types.SimpleNamespace(OpenProjectSignal=types.SimpleNamespace(emit=lambda *_args, **_kwargs: None)),
+        )
+
+        urls = [
+            types.SimpleNamespace(toLocalFile=lambda: "/tmp/zeta.mp4"),
+            types.SimpleNamespace(toLocalFile=lambda: "/tmp/alpha.mp4"),
+        ]
+
+        with patch.object(self.files_model_module.os.path, "exists", return_value=True), \
+                patch.object(self.files_model_module.os.path, "isdir", return_value=False), \
+                patch.object(self.files_model_module.os.path, "isfile", return_value=True), \
+                patch.object(self.files_model_module, "get_app", return_value=fake_app):
+            files_model_cls.process_urls(fake_self, urls)
+
+        self.assertEqual(captured["paths"], ["/tmp/zeta.mp4", "/tmp/alpha.mp4"])
+
+    def test_process_urls_sorts_directory_contents_in_place(self):
+        files_model_cls = self.files_model_module.FilesModel
+        fake_self = types.SimpleNamespace()
+        captured = {}
+
+        def record_add_files(paths, quiet=False, prevent_image_seq=False):
+            captured["paths"] = list(paths)
+            captured["quiet"] = quiet
+            captured["prevent_image_seq"] = prevent_image_seq
+
+        fake_self.add_files = record_add_files
+
+        fake_app = types.SimpleNamespace(
+            updates=types.SimpleNamespace(transaction_id=None),
+            window=types.SimpleNamespace(OpenProjectSignal=types.SimpleNamespace(emit=lambda *_args, **_kwargs: None)),
+        )
+
+        urls = [
+            types.SimpleNamespace(toLocalFile=lambda: "/tmp/zeta.mp4"),
+            types.SimpleNamespace(toLocalFile=lambda: "/tmp/imports"),
+            types.SimpleNamespace(toLocalFile=lambda: "/tmp/alpha.mp4"),
+        ]
+
+        def fake_isdir(path):
+            return path == "/tmp/imports"
+
+        def fake_isfile(path):
+            return not fake_isdir(path)
+
+        def fake_walk(path):
+            dirs = ["scene_b", "scene_a"]
+            yield path, dirs, ["clip_b.mp4", "clip_a.mp4"]
+            for dirname in dirs:
+                filenames = {
+                    "scene_a": ["take_4.mp4", "take_3.mp4"],
+                    "scene_b": ["take_2.mp4", "take_1.mp4"],
+                }[dirname]
+                yield os.path.join(path, dirname), [], filenames
+
+        with patch.object(self.files_model_module.os.path, "exists", return_value=True), \
+                patch.object(self.files_model_module.os.path, "isdir", side_effect=fake_isdir), \
+                patch.object(self.files_model_module.os.path, "isfile", side_effect=fake_isfile), \
+                patch.object(self.files_model_module.os, "walk", side_effect=fake_walk), \
+                patch.object(self.files_model_module, "get_app", return_value=fake_app):
+            files_model_cls.process_urls(fake_self, urls)
+
+        self.assertEqual(captured["paths"], [
+            "/tmp/zeta.mp4",
+            "/tmp/imports/clip_a.mp4",
+            "/tmp/imports/clip_b.mp4",
+            "/tmp/imports/scene_a/take_3.mp4",
+            "/tmp/imports/scene_a/take_4.mp4",
+            "/tmp/imports/scene_b/take_1.mp4",
+            "/tmp/imports/scene_b/take_2.mp4",
+            "/tmp/alpha.mp4",
+        ])
+        self.assertTrue(captured["quiet"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/windows/models/files_model.py
+++ b/src/windows/models/files_model.py
@@ -665,9 +665,10 @@ class FilesModel(QObject, updates.UpdateInterface):
                 import_quietly = True
                 log.info("Recursively importing {}".format(filepath))
                 try:
-                    for r, _, f in os.walk(filepath):
+                    for r, dirs, f in os.walk(filepath):
+                        dirs.sort()
                         media_paths.extend(
-                            [os.path.join(r, p) for p in f])
+                            [os.path.join(r, p) for p in sorted(f)])
                 except OSError:
                     log.warning("Directory recursion failed", exc_info=1)
             elif os.path.isfile(filepath):
@@ -677,7 +678,8 @@ class FilesModel(QObject, updates.UpdateInterface):
                 get_app().updates.transaction_id = None
             return
         # Import all new media files
-        media_paths.sort()
+        # Preserve the incoming path order (selection/drop order) instead of
+        # forcing filename sorting.
         log.debug("Importing file list: {}".format(media_paths))
         self.add_files(media_paths, quiet=import_quietly, prevent_image_seq=prevent_image_seq)
         if owns_transaction:

--- a/src/windows/views/files_listview.py
+++ b/src/windows/views/files_listview.py
@@ -422,7 +422,8 @@ class FilesListView(QListView):
         set_proxy_filter(self.files_model.proxy_model, regex)
 
         col = self.files_model.proxy_model.sortColumn()
-        self.files_model.proxy_model.sort(col)
+        if col >= 0:
+            self.files_model.proxy_model.sort(col)
 
     def resize_contents(self):
         pass

--- a/src/windows/views/files_treeview.py
+++ b/src/windows/views/files_treeview.py
@@ -469,6 +469,10 @@ class FilesTreeView(QTreeView):
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.setSelectionModel(self.files_model.selection_model)
         self.setSortingEnabled(True)
+        # Keep "sortable" behavior available from the header, but do not apply
+        # an initial forced sort so new imports keep insertion order by default.
+        self.header().setSortIndicator(-1, Qt.AscendingOrder)
+        self.files_model.proxy_model.sort(-1)
         self.setItemDelegate(FilesTreeProgressDelegate(self))
 
         self.setAcceptDrops(True)


### PR DESCRIPTION
- Keep top-level file URL import order intact instead of globally sorting all paths.
- Sort recursively imported directory names and filenames during os.walk() for deterministic directory imports.
- Add regression coverage for mixed file/directory imports to ensure directory contents expand in place.
- Guard thumbnail view refresh sorting when the files proxy is intentionally unsorted.