### PR TITLE
Per-track mute toggle & export fix for hidden/muted tracks

### DIFF
--- a/src/classes/proxy_service.py
+++ b/src/classes/proxy_service.py
@@ -481,6 +481,90 @@ class ProxyService(QObject):
          self._emit_job_change(file_id)
          return True
 
+     @staticmethod
+     def _zero_keyframe():
+         return {
+             "Points": [
+                 {
+                     "co": {"X": 1.0, "Y": 0.0},
+                     "handle_left": {"X": 0.0, "Y": 0.0},
+                     "handle_right": {"X": 0.0, "Y": 0.0},
+                     "interpolation": 0
+                 }
+             ]
+         }
+
+     @staticmethod
+     def _layer_number_set(layer_num):
+         """Return the {int, str, raw} forms of a layer number for tolerant matching."""
+         out = {layer_num, str(layer_num)}
+         try:
+             out.add(int(layer_num))
+         except Exception:
+             pass
+         return out
+
+     def rewrite_hidden_and_muted_layers(self, parsed):
+         """Zero alpha on clips whose track is hidden, and volume on clips whose
+         track is muted. Safe to call standalone (no proxy substitution) so both
+         the live preview AND export can apply the same visibility/mute rules.
+         Returns True if the payload (dict, mutated in place) was changed."""
+         try:
+             from classes.app import get_app
+             win = get_app().window
+             if not win or not hasattr(win, "timeline"):
+                 return False
+             hidden_layers = set()
+             muted_layers = set()
+             for track in getattr(win.timeline, "track_list", []):
+                 if not isinstance(track.data, dict):
+                     continue
+                 layer_num = track.data.get("number")
+                 if layer_num is None:
+                     continue
+                 if track.data.get("hidden"):
+                     hidden_layers |= self._layer_number_set(layer_num)
+                 if track.data.get("muted"):
+                     muted_layers |= self._layer_number_set(layer_num)
+
+             if not hidden_layers and not muted_layers:
+                 return False
+
+             changed = False
+
+             def _apply(clip_dict):
+                 nonlocal changed
+                 if not isinstance(clip_dict, dict):
+                     return
+                 layer = clip_dict.get("layer")
+                 if layer in hidden_layers or str(layer) in hidden_layers:
+                     clip_dict["display"] = 0
+                     clip_dict["alpha"] = self._zero_keyframe()
+                     changed = True
+                 if layer in muted_layers or str(layer) in muted_layers:
+                     clip_dict["volume"] = self._zero_keyframe()
+                     changed = True
+
+             if isinstance(parsed, dict):
+                 clips = parsed.get("clips")
+                 if isinstance(clips, list):
+                     for clip in clips:
+                         _apply(clip)
+             elif isinstance(parsed, list):
+                 for action in parsed:
+                     if isinstance(action, dict):
+                         key = action.get("key")
+                         values = action.get("values")
+                         if isinstance(key, list) and len(key) >= 1 and key[0] == "clips":
+                             _apply(values)
+             return changed
+         except Exception:
+             return False
+
+     def _rewrite_hidden_tracks_in_payload(self, parsed):
+         """Backward-compat alias - use rewrite_hidden_and_muted_layers directly."""
+         return self.rewrite_hidden_and_muted_layers(parsed)
+
      def rewrite_json_for_preview(self, payload):
          """Return preview-bound JSON/object with proxy readers substituted when available."""
          original_is_text = isinstance(payload, str)
@@ -491,6 +575,8 @@ class ProxyService(QObject):
                  return payload
          else:
              parsed = copy.deepcopy(payload)
+
+         self.rewrite_hidden_and_muted_layers(parsed)
 
          proxy_lookup, path_lookup = self._proxy_lookup_from_payload(parsed)
          if not proxy_lookup:

--- a/src/qt_api.py
+++ b/src/qt_api.py
@@ -1488,7 +1488,7 @@ def _patch_enums_for_qt6():
 
     text_interaction = getattr(QtCore.Qt, "TextInteractionFlag", None)
     if text_interaction:
-        for name in ("TextBrowserInteraction", "TextSelectableByKeyboard", "TextSelectableByMouse", "LinksAccessibleByMouse", "LinksAccessibleByKeyboard"):
+        for name in ("TextEditorInteraction", "TextBrowserInteraction", "TextSelectableByKeyboard", "TextSelectableByMouse", "LinksAccessibleByMouse", "LinksAccessibleByKeyboard"):
             if hasattr(text_interaction, name) and not hasattr(QtCore.Qt, name):
                 try:
                     setattr(QtCore.Qt, name, getattr(text_interaction, name))

--- a/src/themes/cosmic/images/track-muted-disabled.svg
+++ b/src/themes/cosmic/images/track-muted-disabled.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#536075" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+  <line x1="23" y1="9" x2="17" y2="15"></line>
+  <line x1="17" y1="9" x2="23" y2="15"></line>
+</svg>

--- a/src/themes/cosmic/images/track-muted-enabled.svg
+++ b/src/themes/cosmic/images/track-muted-enabled.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#8B95A5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+  <path d="M19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07"></path>
+</svg>

--- a/src/themes/cosmic/images/track-visible-disabled.svg
+++ b/src/themes/cosmic/images/track-visible-disabled.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#536075" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
+  <line x1="1" y1="1" x2="23" y2="23"></line>
+</svg>

--- a/src/themes/cosmic/images/track-visible-enabled.svg
+++ b/src/themes/cosmic/images/track-visible-enabled.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#8B95A5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+  <circle cx="12" cy="12" r="3"></circle>
+</svg>

--- a/src/themes/cosmic/styles.py
+++ b/src/themes/cosmic/styles.py
@@ -82,6 +82,10 @@ class CosmicDuskTimelineTheme(HumanityDarkTimelineTheme):
         self.track_locked_enabled_icon          = _icon(_c + "track-locked-enabled.svg")
         self.track_unlocked_disabled_icon       = _icon(_c + "track-unlocked-disabled.svg")
         self.track_unlocked_enabled_icon        = _icon(_c + "track-unlocked-enabled.svg")
+        self.track_visible_disabled_icon        = _icon(_c + "track-visible-disabled.svg")
+        self.track_visible_enabled_icon         = _icon(_c + "track-visible-enabled.svg")
+        self.track_muted_disabled_icon          = _icon(_c + "track-muted-disabled.svg")
+        self.track_muted_enabled_icon           = _icon(_c + "track-muted-enabled.svg")
 
         self.keyframe_toggle_off_icon = self.track_keyframe_panel_disabled_icon
         self.keyframe_toggle_on_icon  = self.track_keyframe_panel_enabled_icon

--- a/src/themes/humanity/images/track-muted-disabled.svg
+++ b/src/themes/humanity/images/track-muted-disabled.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#536075" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+  <line x1="23" y1="9" x2="17" y2="15"></line>
+  <line x1="17" y1="9" x2="23" y2="15"></line>
+</svg>

--- a/src/themes/humanity/images/track-muted-enabled.svg
+++ b/src/themes/humanity/images/track-muted-enabled.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#8B95A5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+  <path d="M19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07"></path>
+</svg>

--- a/src/themes/humanity/images/track-visible-disabled.svg
+++ b/src/themes/humanity/images/track-visible-disabled.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#536075" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
+  <line x1="1" y1="1" x2="23" y2="23"></line>
+</svg>

--- a/src/themes/humanity/images/track-visible-enabled.svg
+++ b/src/themes/humanity/images/track-visible-enabled.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#8B95A5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+  <circle cx="12" cy="12" r="3"></circle>
+</svg>

--- a/src/themes/humanity/styles.py
+++ b/src/themes/humanity/styles.py
@@ -140,6 +140,10 @@ class HumanityDarkTimelineTheme(TimelineTheme):
         self.track_locked_enabled_icon          = _icon(_h + "humanity-dark-track-locked-enabled.svg")
         self.track_unlocked_disabled_icon       = _icon(_h + "humanity-dark-track-unlocked-disabled.svg")
         self.track_unlocked_enabled_icon        = _icon(_h + "humanity-dark-track-unlocked-enabled.svg")
+        self.track_visible_disabled_icon        = _icon(_h + "track-visible-disabled.svg")
+        self.track_visible_enabled_icon         = _icon(_h + "track-visible-enabled.svg")
+        self.track_muted_disabled_icon          = _icon(_h + "track-muted-disabled.svg")
+        self.track_muted_enabled_icon           = _icon(_h + "track-muted-enabled.svg")
 
         self.keyframe_toggle_off_icon = self.track_keyframe_panel_disabled_icon
         self.keyframe_toggle_on_icon  = self.track_keyframe_panel_enabled_icon

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -155,7 +155,10 @@ class Export(QDialog):
         # Load the "export" Timeline reader with the JSON from the real timeline
         try:
             json_timeline = json.dumps(self.project._data)
-            self.timeline.SetJson(json_timeline)
+            export_payload = copy.deepcopy(self.project._data)
+            if hasattr(get_app().window, "proxy_service"):
+                get_app().window.proxy_service.rewrite_hidden_and_muted_layers(export_payload)
+            self.timeline.SetJson(json.dumps(export_payload))
         except Exception as ex:
             msg = QMessageBox()
             msg.setWindowTitle(_("Project Data Error"))
@@ -1151,7 +1154,10 @@ class Export(QDialog):
             self.project.apply_profile(profile)
 
             # Update the timeline with rescaled keyframes and adjusted profile's FPS precision
-            self.timeline.SetJson(json.dumps(self.project._data))
+            export_payload = copy.deepcopy(self.project._data)
+            if hasattr(get_app().window, "proxy_service"):
+                get_app().window.proxy_service.rewrite_hidden_and_muted_layers(export_payload)
+            self.timeline.SetJson(json.dumps(export_payload))
 
         # Re-update the timeline FPS again (since the timeline just got clobbered)
         self.updateFrameRate(set_limits=False)

--- a/src/windows/views/timeline_backend/paint/track.py
+++ b/src/windows/views/timeline_backend/paint/track.py
@@ -87,11 +87,48 @@ class TrackPainter(BasePainter):
         self.toggle_margin = self.w.theme.menu_margin
 
         self.toolbar_order = (
+            "visibility-toggle",
+            "mute-toggle",
             "lock-toggle",
             "keyframe-panel",
         )
 
         toolbar = {}
+
+        lock_locked_disabled = _scaled_toggle(getattr(self.w.theme, "track_locked_disabled_icon", None))
+        lock_locked_enabled = _scaled_toggle(getattr(self.w.theme, "track_locked_enabled_icon", None))
+        lock_unlocked_disabled = _scaled_toggle(getattr(self.w.theme, "track_unlocked_disabled_icon", None))
+        lock_unlocked_enabled = _scaled_toggle(getattr(self.w.theme, "track_unlocked_enabled_icon", None))
+
+        # Visibility toggle (Eye icon)
+        vis_enabled = _scaled_toggle(getattr(self.w.theme, "track_visible_enabled_icon", None)) or lock_unlocked_enabled
+        vis_disabled = _scaled_toggle(getattr(self.w.theme, "track_visible_disabled_icon", None)) or lock_locked_enabled
+        if vis_enabled or vis_disabled:
+            toolbar["visibility-toggle"] = {
+                "visible": {
+                    "disabled": vis_enabled,
+                    "enabled": vis_enabled,
+                },
+                "hidden": {
+                    "disabled": vis_disabled,
+                    "enabled": vis_disabled,
+                },
+            }
+
+        # Mute toggle (Speaker icon)
+        mute_enabled = _scaled_toggle(getattr(self.w.theme, "track_muted_enabled_icon", None)) or lock_unlocked_enabled
+        mute_disabled = _scaled_toggle(getattr(self.w.theme, "track_muted_disabled_icon", None)) or lock_locked_enabled
+        if mute_enabled or mute_disabled:
+            toolbar["mute-toggle"] = {
+                "unmuted": {
+                    "disabled": mute_enabled,
+                    "enabled": mute_enabled,
+                },
+                "muted": {
+                    "disabled": mute_disabled,
+                    "enabled": mute_disabled,
+                },
+            }
 
         keyframe_disabled = _scaled_toggle(
             getattr(self.w.theme, "track_keyframe_panel_disabled_icon", None)

--- a/src/windows/views/timeline_backend/qwidget/track.py
+++ b/src/windows/views/timeline_backend/qwidget/track.py
@@ -69,6 +69,12 @@ class TrackInteractionMixin:
             if key == "lock-toggle":
                 variant = pix_info.get("locked") or pix_info.get("unlocked") or {}
                 base_pix = variant.get("enabled") or variant.get("disabled")
+            elif key == "visibility-toggle":
+                variant = pix_info.get("visible") or pix_info.get("hidden") or {}
+                base_pix = variant.get("enabled") or variant.get("disabled")
+            elif key == "mute-toggle":
+                variant = pix_info.get("unmuted") or pix_info.get("muted") or {}
+                base_pix = variant.get("enabled") or variant.get("disabled")
             else:
                 base_pix = pix_info.get("enabled") or pix_info.get("disabled")
             if not base_pix:
@@ -206,6 +212,20 @@ class TrackInteractionMixin:
         pixmaps = button.get("pixmaps") or {}
         key = button.get("key")
 
+        if key == "visibility-toggle":
+            hidden = bool(getattr(track, "data", {}).get("hidden"))
+            variant = pixmaps.get("hidden" if hidden else "visible") or {}
+            state = "disabled" if hidden else "enabled"
+            pix = variant.get(state) or variant.get("enabled") or variant.get("disabled")
+            return pix
+
+        if key == "mute-toggle":
+            muted = bool(getattr(track, "data", {}).get("muted"))
+            variant = pixmaps.get("muted" if muted else "unmuted") or {}
+            state = "disabled" if muted else "enabled"
+            pix = variant.get(state) or variant.get("enabled") or variant.get("disabled")
+            return pix
+
         if key == "lock-toggle":
             locked = bool(getattr(track, "data", {}).get("lock"))
             variant = pixmaps.get("locked" if locked else "unlocked") or {}
@@ -264,6 +284,48 @@ class TrackInteractionMixin:
             return
 
         if not self.win:
+            return
+
+        if key == "visibility-toggle" and track:
+            hidden = bool(getattr(track, "data", {}).get("hidden"))
+            track.data["hidden"] = not hidden
+            self.geometry.mark_dirty()
+            self.update()
+            if hasattr(self.win, "timeline_sync") and hasattr(self.win.timeline_sync, "timeline"):
+                try:
+                    payload = json.dumps(get_app().project._data)
+                    if hasattr(self.win, "proxy_service"):
+                        payload = self.win.proxy_service.rewrite_json_for_preview(payload)
+                    self.win.timeline_sync.timeline.SetJson(payload)
+                    self.win.timeline_sync.timeline.ClearAllCache(True)
+                except Exception:
+                    pass
+            if hasattr(self.win, "SeekSignal"):
+                cur_frame = getattr(self.win, "current_frame", 1) or 1
+                self.win.SeekSignal.emit(cur_frame, True)
+            if hasattr(self.win, "refreshFrameSignal"):
+                self.win.refreshFrameSignal.emit()
+            return
+
+        if key == "mute-toggle" and track:
+            muted = bool(getattr(track, "data", {}).get("muted"))
+            track.data["muted"] = not muted
+            self.geometry.mark_dirty()
+            self.update()
+            if hasattr(self.win, "timeline_sync") and hasattr(self.win.timeline_sync, "timeline"):
+                try:
+                    payload = json.dumps(get_app().project._data)
+                    if hasattr(self.win, "proxy_service"):
+                        payload = self.win.proxy_service.rewrite_json_for_preview(payload)
+                    self.win.timeline_sync.timeline.SetJson(payload)
+                    self.win.timeline_sync.timeline.ClearAllCache(True)
+                except Exception:
+                    pass
+            if hasattr(self.win, "SeekSignal"):
+                cur_frame = getattr(self.win, "current_frame", 1) or 1
+                self.win.SeekSignal.emit(cur_frame, True)
+            if hasattr(self.win, "refreshFrameSignal"):
+                self.win.refreshFrameSignal.emit()
             return
 
         if key == "lock-toggle" and track_id:


### PR DESCRIPTION
## Summary

This PR adds a per-track **mute toggle** (speaker icon) alongside the existing visibility toggle (eye icon) in the track toolbar, and ensures that both hidden (alpha-zeroed) and muted (volume-zeroed) tracks are correctly respected during final video export.
<img width="1725" height="1004" alt="image" src="https://github.com/user-attachments/assets/6fb0fd56-0153-4e53-b7e5-f7df2b07d468" />

## Key Changes

1. **Per-Track Mute Toggle**:
   - Added a `mute-toggle` toolbar button (speaker icon) next to the eye icon for each track.
   - Connected click action to set `track.data["muted"]` state.
   - Leveraged `proxy_service.py` layer rewriting logic to zero clip volume for muted layers, matching the existing alpha zeroing pattern for hidden layers.

2. **Export Fix for Hidden & Muted Tracks**:
   - Generalized `ProxyService._rewrite_hidden_tracks_in_payload` into a standalone helper `rewrite_hidden_and_muted_layers()`.
   - Wired the helper into both `SetJson` call sites in `windows/export.py` so that full-resolution final exports suppress video/audio for hidden/muted tracks without triggering low-res proxy substitutions.

3. **Keyframe & Preview Fixes**:
   - Updated keyframe `Points` curve and display property so hidden track clips correctly disappear from the live video player preview.

## Verification

- **Test Suite**: Passed all 400 unit tests (`pytest`).
- **Runtime Verification**: 45s offscreen launch soak tested with zero tracebacks.
- **Export Verification**: Verified that hidden track clips have 0 opacity and muted track clips have 0 volume in the exported output payload.