### PR TITLE
Fix AppImage bundling missing/stale libsndfile dependencies

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -514,7 +514,8 @@ elif sys.platform == "linux":
     for lib_name in [
             os.path.join(libopenshot_path, "libopenshot.so"),
             "/usr/local/lib/libresvg.so",
-            ARCHLIB + "qt5/plugins/platforms/libqxcb.so"
+            ARCHLIB + "qt5/plugins/platforms/libqxcb.so",
+            sndfile_path,
             ]:
         if os.path.exists(lib_name):
             lib_list.append(lib_name)
@@ -561,6 +562,14 @@ elif sys.platform == "linux":
         "libXdmcp.so.6",
         "libpipewire-0.3.so.0",
         "libspa-0.2.so",
+        # libmpg123 must also stay host-provided. Our bundled libsndfile.so.1
+        # depends on it, but host ALSA plugins (e.g. the PulseAudio/PipeWire
+        # PCM plugin) dlopen the *host's* libsndfile.so.1 at runtime too, and
+        # LD_LIBRARY_PATH puts our bundled copy ahead of the host's own. A
+        # stale bundled libmpg123 (missing symbols newer libsndfile expects,
+        # e.g. mpg123_info2) breaks ALSA device enumeration for the whole
+        # process, not just OpenShot's own audio decoding (see issue #5825).
+        "libmpg123.so.0",
     }
     system_libs_to_skip.update(appimage_driver_libs)
 


### PR DESCRIPTION
Version: `OpenShot-v3.5.1-x86_64.AppImage`

Hi, human here. I wanted to try out OpenShot on my Arch Linux machine, but ran into [this issue](https://github.com/OpenShot/openshot-qt/issues/5825). I pointed my Claude at it, and tested it locally with success. Though I am unfamiliar with the project, the fix seems fairly straightforward. Below is the AI summary.

---

libsndfile.so.1 was bundled directly via external_so_files, bypassing the ldd-based dependency walk used for other libraries. This let cx_Freeze's auto-detection silently drop libFLAC.so.8 entirely, and pull in a stale build-host libmpg123.so.0 missing symbols (e.g. mpg123_info2) that newer host libsndfile builds require.

Both bugs break host ALSA plugins (e.g. the PulseAudio/PipeWire PCM plugin) that dlopen the host's own libsndfile.so.1 at runtime, since LD_LIBRARY_PATH puts the AppImage's incomplete/stale copies first. This can prevent ALSA from enumerating any working audio device, surfacing as "no channels" errors unrelated to OpenShot's own code.

Route libsndfile.so.1 through the existing lib_list/ldd walk so its real dependencies (including libFLAC) are bundled correctly, and add libmpg123.so.0 to the host-provided skip list alongside libasound and PipeWire, which are excluded for the same reason.

Fixes #5825