### PR TITLE
Fix AppImage file dialogs silently failing to open via broken portal

### DIFF
--- a/installer/launch-linux.sh
+++ b/installer/launch-linux.sh
@@ -7,10 +7,17 @@ export LD_LIBRARY_PATH="${HERE}"
 # Set some environment variables
 export QT_PLUGIN_PATH="${HERE}"
 
-# Prefer native desktop file dialogs through XDG Desktop Portal. Respect an
-# explicit user override, and only select the theme when it was bundled.
+# Prefer native file dialogs via XDG Desktop Portal, but only if a portal
+# is actually reachable -- otherwise Qt's file dialogs silently fail to
+# open. Ping instead of checking NameHasOwner so portals that are merely
+# lazy-activated (not yet running) aren't skipped.
 if [[ -z "${QT_QPA_PLATFORMTHEME:-}" \
-      && -f "${HERE}/platformthemes/libqxdgdesktopportal.so" ]]; then
+      && -f "${HERE}/platformthemes/libqxdgdesktopportal.so" ]] \
+      && command -v dbus-send >/dev/null 2>&1 \
+      && timeout 2 dbus-send --session --print-reply \
+           --dest=org.freedesktop.portal.Desktop \
+           /org/freedesktop/portal/desktop \
+           org.freedesktop.DBus.Peer.Ping >/dev/null 2>&1; then
     export QT_QPA_PLATFORMTHEME="xdgdesktopportal"
 fi
 


### PR DESCRIPTION
Version: `v4.0.0-release-candidate-16662`

`launch-linux.sh` unconditionally sets `QT_QPA_PLATFORMTHEME=xdgdesktopportal` whenever the bundled portal plugin is present, with no check that a portal implementation is actually reachable.

On sessions where portal D-Bus activation is broken (e.g. no desktop-specific backend registered, common on window managers without a full desktop environment), this makes Qt's file dialogs (Import Files, Save Project, etc.) silently fail to open instead of falling back to the default theme.

Ping the portal's D-Bus name directly before opting in, which also triggers on-demand activation (rather than just checking NameHasOwner), so portals that are lazily activated but working aren't skipped.

Fixes #6084 