### PR TITLE
Add one-click plus button to effects and transitions

### DIFF
--- a/src/tests/test_thumbnail_action_overlay.py
+++ b/src/tests/test_thumbnail_action_overlay.py
@@ -1,0 +1,399 @@
+"""
+@file
+@brief Tests for hover '+' button overlay and one-click timeline insertion for Effects and Transitions.
+"""
+
+import os
+import sys
+import types
+import unittest
+
+PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+if PATH not in sys.path:
+    sys.path.append(PATH)
+
+from qt_api import (
+    QCoreApplication, Qt, QRect, QRectF, QPoint, QPointF,
+    QApplication, QStandardItemModel, QStandardItem,
+    QMouseEvent, QEvent, QPainter, QPixmap, QStyleOptionViewItem,
+)
+
+from tests.qt_test_app import ensure_app_state as ensure_qt_app_state, get_or_create_app
+from windows.views.thumbnail_action_overlay import (
+    get_thumbnail_decoration_rect,
+    calculate_button_rect,
+    paint_plus_overlay_button,
+    ThumbnailActionDelegate,
+    ThumbnailActionViewMixin,
+)
+
+QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts, True)
+
+
+class DummySettings:
+    def __init__(self):
+        self.values = {
+            "default-profile": "HD 720p 30 fps",
+            "default-samplerate": 48000,
+            "default-channels": 2,
+            "default-transition-length": 5.0,
+        }
+
+    def get(self, key):
+        return self.values.get(key)
+
+
+class DummyApp(QApplication):
+    def __init__(self):
+        super().__init__([])
+        self.settings = DummySettings()
+        self.window = None
+
+    def get_settings(self):
+        return self.settings
+
+    def _tr(self, text):
+        return text
+
+
+def ensure_app_state(app):
+    return ensure_qt_app_state(app, DummySettings)
+
+
+class Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+
+class ThumbnailActionOverlayTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        app, cls._owns_app = get_or_create_app(DummyApp)
+        cls.app = ensure_app_state(app)
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "_owns_app", False) and cls.app:
+            cls.app.quit()
+
+    def setUp(self):
+        self.orig_window = getattr(self.app, "window", None)
+
+    def tearDown(self):
+        self.app.window = self.orig_window
+
+    def test_calculate_button_rect(self):
+        deco = QRectF(10, 20, 100, 60)
+        btn = calculate_button_rect(deco, button_size=28.0)
+        self.assertEqual(btn.width(), 28.0)
+        self.assertEqual(btn.height(), 28.0)
+        self.assertAlmostEqual(btn.center().x(), deco.center().x())
+        self.assertAlmostEqual(btn.center().y(), deco.center().y())
+
+        empty_btn = calculate_button_rect(QRectF())
+        self.assertFalse(empty_btn.isValid())
+
+    def test_paint_plus_overlay_button_executes_cleanly(self):
+        pix = QPixmap(100, 100)
+        painter = QPainter(pix)
+        try:
+            btn_rect = QRectF(20, 20, 28, 28)
+            # Test all 3 visual states
+            paint_plus_overlay_button(painter, btn_rect, is_button_hovered=False, is_button_pressed=False)
+            paint_plus_overlay_button(painter, btn_rect, is_button_hovered=True, is_button_pressed=False)
+            paint_plus_overlay_button(painter, btn_rect, is_button_hovered=True, is_button_pressed=True)
+        finally:
+            painter.end()
+
+    def test_effects_listview_add_item_to_timeline_selected_clips(self):
+        from windows.views.effects_listview import EffectsListView
+        from windows.models.effects_model import EffectsModel
+        from classes.query import Clip
+
+        apply_effect_to_clip_rec = Recorder()
+        timeline = types.SimpleNamespace(
+            _apply_effect_to_clip=apply_effect_to_clip_rec,
+        )
+
+        win = types.SimpleNamespace(
+            timeline=timeline,
+            selected_clips=["clip-101"],
+            effectsFilter=types.SimpleNamespace(
+                text=lambda: "",
+                textChanged=types.SimpleNamespace(connect=lambda fn: None),
+            ),
+            refreshEffectsSignal=types.SimpleNamespace(connect=lambda fn: None),
+            actionEffectsShowAll=types.SimpleNamespace(isChecked=lambda: True),
+            actionEffectsShowVideo=types.SimpleNamespace(isChecked=lambda: False),
+        )
+        self.app.window = win
+
+        # Build mock model with row: [Thumb, Name, Desc, Category, Effect]
+        model = EffectsModel()
+        model.model.clear()
+        row = [
+            QStandardItem("Blur"),
+            QStandardItem("Blur"),
+            QStandardItem("Blur description"),
+            QStandardItem("Video"),
+            QStandardItem("Blur"),
+        ]
+        model.model.appendRow(row)
+
+        view = EffectsListView(model)
+        view.win = win
+
+        # Proxy map index
+        idx = model.list_proxy_model.index(0, 0)
+        self.assertTrue(idx.isValid())
+
+        # Mock Clip.get
+        dummy_clip = types.SimpleNamespace(id="clip-101", data={"layer": 1, "position": 0.0})
+        orig_get = Clip.get
+        try:
+            Clip.get = classmethod(lambda cls, id=None: dummy_clip if id == "clip-101" else None)
+            view.add_item_to_timeline(idx)
+        finally:
+            Clip.get = orig_get
+
+        self.assertEqual(len(apply_effect_to_clip_rec.calls), 1)
+        self.assertEqual(apply_effect_to_clip_rec.calls[0][0], (dummy_clip, "Blur"))
+
+    def test_effects_listview_add_item_to_timeline_playhead_clip(self):
+        from windows.views.effects_listview import EffectsListView
+        from windows.models.effects_model import EffectsModel
+        from classes.query import Clip
+
+        apply_effect_to_clip_rec = Recorder()
+        timeline = types.SimpleNamespace(
+            _apply_effect_to_clip=apply_effect_to_clip_rec,
+        )
+
+        win = types.SimpleNamespace(
+            timeline=timeline,
+            selected_clips=[],
+            _current_timeline_seconds=lambda: 3.5,
+            effectsFilter=types.SimpleNamespace(
+                text=lambda: "",
+                textChanged=types.SimpleNamespace(connect=lambda fn: None),
+            ),
+            refreshEffectsSignal=types.SimpleNamespace(connect=lambda fn: None),
+            actionEffectsShowAll=types.SimpleNamespace(isChecked=lambda: True),
+            actionEffectsShowVideo=types.SimpleNamespace(isChecked=lambda: False),
+        )
+        self.app.window = win
+
+        model = EffectsModel()
+        model.model.clear()
+        row = [
+            QStandardItem("Color"),
+            QStandardItem("Color"),
+            QStandardItem("Color description"),
+            QStandardItem("Video"),
+            QStandardItem("Color"),
+        ]
+        model.model.appendRow(row)
+
+        view = EffectsListView(model)
+        view.win = win
+
+        idx = model.list_proxy_model.index(0, 0)
+        self.assertTrue(idx.isValid())
+
+        clip_low = types.SimpleNamespace(id="c-low", data={"layer": 1, "position": 0.0, "start": 0.0, "end": 10.0})
+        clip_high = types.SimpleNamespace(id="c-high", data={"layer": 3, "position": 2.0, "start": 0.0, "end": 8.0})
+
+        orig_filter = Clip.filter
+        try:
+            Clip.filter = classmethod(lambda cls, intersect=None: [clip_low, clip_high] if intersect == 3.5 else [])
+            view.add_item_to_timeline(idx)
+        finally:
+            Clip.filter = orig_filter
+
+        self.assertEqual(len(apply_effect_to_clip_rec.calls), 1)
+        # Should pick the top-most layer (c-high on layer 3)
+        self.assertEqual(apply_effect_to_clip_rec.calls[0][0], (clip_high, "Color"))
+
+    def test_transitions_listview_add_item_to_timeline(self):
+        from windows.views.transitions_listview import TransitionsListView
+        from windows.models.transition_model import TransitionsModel
+
+        add_trans_rec = Recorder()
+        select_added_rec = Recorder()
+        timeline = types.SimpleNamespace(
+            addTransition=add_trans_rec,
+            _select_added_items=select_added_rec,
+            _nearest_unlocked_track_number=lambda track: track,
+            track_list=[types.SimpleNamespace(data={"number": 2})],
+        )
+
+        win = types.SimpleNamespace(
+            timeline=timeline,
+            selected_clips=[],
+            selected_transitions=[],
+            _current_timeline_seconds=lambda: 4.0,
+            transitionsFilter=types.SimpleNamespace(
+                text=lambda: "",
+                textChanged=types.SimpleNamespace(connect=lambda fn: None),
+            ),
+            refreshTransitionsSignal=types.SimpleNamespace(connect=lambda fn: None),
+            actionTransitionsShowCommon=types.SimpleNamespace(isChecked=lambda: False),
+        )
+        self.app.window = win
+
+        model = TransitionsModel()
+        model.model.clear()
+        row = [
+            QStandardItem("Fade In"),
+            QStandardItem("Fade In"),
+            QStandardItem("common"),
+            QStandardItem("/dummy/path/fade.svg"),
+        ]
+        model.model.appendRow(row)
+
+        view = TransitionsListView(model)
+        view.win = win
+
+        idx = model.list_proxy_model.index(0, 0)
+        self.assertTrue(idx.isValid())
+
+        add_trans_rec.calls.clear()
+        def mock_add_trans(path, pos, track, ignore_refresh=False, call_manual_move=False):
+            return {"id": "T1", "layer": track, "position": pos.x()}
+        timeline.addTransition = mock_add_trans
+
+        view.add_item_to_timeline(idx)
+
+        self.assertEqual(select_added_rec.calls, [(("transition",), {})])
+
+    def test_view_mixin_mouse_events(self):
+        from windows.views.effects_listview import EffectsListView
+        from windows.models.effects_model import EffectsModel
+
+        win = types.SimpleNamespace(
+            timeline=types.SimpleNamespace(_apply_effect_to_clip=Recorder()),
+            selected_clips=[],
+            effectsFilter=types.SimpleNamespace(
+                text=lambda: "",
+                textChanged=types.SimpleNamespace(connect=lambda fn: None),
+            ),
+            refreshEffectsSignal=types.SimpleNamespace(connect=lambda fn: None),
+            actionEffectsShowAll=types.SimpleNamespace(isChecked=lambda: True),
+            actionEffectsShowVideo=types.SimpleNamespace(isChecked=lambda: False),
+        )
+        self.app.window = win
+
+        model = EffectsModel()
+        model.model.clear()
+        row = [
+            QStandardItem("Blur"),
+            QStandardItem("Blur"),
+            QStandardItem("Blur description"),
+            QStandardItem("Video"),
+            QStandardItem("Blur"),
+        ]
+        model.model.appendRow(row)
+
+        view = EffectsListView(model)
+        view.win = win
+        added_items = []
+        view.add_item_to_timeline = lambda idx: added_items.append(idx)
+
+        idx = model.list_proxy_model.index(0, 0)
+        # Mock indexAt and _button_rect_for_index
+        view.indexAt = lambda pos: idx if pos.x() < 100 else model.list_proxy_model.index(-1, -1)
+        btn_rect = QRectF(30, 20, 28, 28)
+        view._button_rect_for_index = lambda i: btn_rect
+
+        # 1. Mouse move inside button
+        move_event = QMouseEvent(QEvent.MouseMove, QPointF(40, 30), Qt.NoButton, Qt.NoButton, Qt.NoModifier)
+        view.mouseMoveEvent(move_event)
+        self.assertTrue(view._button_hovered)
+        self.assertEqual(view.cursor().shape(), Qt.PointingHandCursor)
+
+        # 2. Mouse move outside button but on item
+        move_event2 = QMouseEvent(QEvent.MouseMove, QPointF(5, 5), Qt.NoButton, Qt.NoButton, Qt.NoModifier)
+        view.mouseMoveEvent(move_event2)
+        self.assertFalse(view._button_hovered)
+        self.assertNotEqual(view.cursor().shape(), Qt.PointingHandCursor)
+
+        # 3. Mouse press on button
+        press_event = QMouseEvent(QEvent.MouseButtonPress, QPointF(40, 30), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
+        view.mousePressEvent(press_event)
+        self.assertTrue(view._button_pressed)
+
+        # 4. Mouse release on button triggers add_item_to_timeline
+        release_event = QMouseEvent(QEvent.MouseButtonRelease, QPointF(40, 30), Qt.LeftButton, Qt.NoButton, Qt.NoModifier)
+        view.mouseReleaseEvent(release_event)
+        self.assertFalse(view._button_pressed)
+        self.assertEqual(len(added_items), 1)
+
+        # 5. Leave event clears hover
+        leave_event = QEvent(QEvent.Leave)
+        view.leaveEvent(leave_event)
+        self.assertIsNone(view._hovered_index)
+        self.assertFalse(view._button_hovered)
+
+    def test_emoji_list_view_add_item_to_timeline(self):
+        from windows.views.emojis_listview import EmojisListView
+        from windows.models.emoji_model import EmojisModel
+
+        add_clip_rec = Recorder()
+        select_added_rec = Recorder()
+        timeline = types.SimpleNamespace(
+            addClip=add_clip_rec,
+            _select_added_items=select_added_rec,
+            _nearest_unlocked_track_number=lambda t: t,
+            track_list=[types.SimpleNamespace(data={"number": 2})],
+        )
+
+        win = types.SimpleNamespace(
+            timeline=timeline,
+            selected_clips=[],
+            selected_transitions=[],
+            _current_timeline_seconds=lambda: 3.5,
+            emojisFilter=types.SimpleNamespace(
+                text=lambda: "",
+                textChanged=types.SimpleNamespace(connect=lambda fn: None),
+            ),
+            emojiFilterGroup=types.SimpleNamespace(
+                clear=lambda: None,
+                addItem=lambda *a: None,
+                currentIndexChanged=types.SimpleNamespace(connect=lambda fn: None),
+                setCurrentIndex=lambda i: None,
+            ),
+            statusBar=types.SimpleNamespace(showMessage=lambda msg, timeout=0: None),
+        )
+        self.app.window = win
+
+        model = EmojisModel()
+        model.model.clear()
+        col = QStandardItem("Smile")
+        col.setData("/dummy/path/smile.svg")
+        model.model.appendRow([
+            col,
+            QStandardItem("Smileys"),
+            QStandardItem("smileys-emotion"),
+        ])
+
+        view = EmojisListView(model)
+        view.win = win
+        view.add_file = lambda path, name: types.SimpleNamespace(id="F_EMOJI", absolute_path=lambda: path, data={"path": path})
+
+        idx = model.proxy_model.index(0, 0)
+        self.assertTrue(idx.isValid())
+
+        def mock_add_clip(file_id, pos, track, ignore_refresh=False, call_manual_move=False, auto_transition=False):
+            return {"id": "C_EMOJI", "layer": track, "position": pos.x()}
+        timeline.addClip = mock_add_clip
+
+        view.add_item_to_timeline(idx)
+        self.assertEqual(select_added_rec.calls, [(("clip",), {})])
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/src/windows/views/effects_listview.py
+++ b/src/windows/views/effects_listview.py
@@ -34,9 +34,10 @@ from classes import info
 from classes.app import get_app
 from classes.logger import log
 from .menu import StyledContextMenu, add_bound_action
+from .thumbnail_action_overlay import ThumbnailActionViewMixin
 
 
-class EffectsListView(QListView):
+class EffectsListView(ThumbnailActionViewMixin, QListView):
     """ A TreeView QWidget used on the main window """
     drag_item_size = QSize(48, 48)
     drag_item_center = QPoint(24, 24)
@@ -94,6 +95,103 @@ class EffectsListView(QListView):
         self.effects_model.proxy_model.setFilterCaseSensitivity(Qt.CaseInsensitive)
         self.effects_model.proxy_model.sort(0, Qt.AscendingOrder)
 
+    def add_item_to_timeline(self, index):
+        """Add the effect at index to the timeline."""
+        if not index.isValid():
+            log.warning("add_item_to_timeline called with invalid index")
+            return
+
+        # Map list_proxy_model -> proxy_model -> source model
+        proxy_index = self.effects_model.list_proxy_model.mapToSource(index)
+        if not proxy_index or not proxy_index.isValid():
+            log.warning("add_item_to_timeline failed to map list_proxy_model index to proxy_index")
+            return
+        source_index = self.effects_model.proxy_model.mapToSource(proxy_index)
+        if not source_index or not source_index.isValid():
+            log.warning("add_item_to_timeline failed to map proxy_index to source_index")
+            return
+
+        # Column 4 contains the effect class_name (e.g. "Blur", "Color")
+        effect_name_item = source_index.sibling(source_index.row(), 4)
+        effect_name = effect_name_item.data(Qt.DisplayRole) or effect_name_item.data()
+        if not effect_name:
+            log.warning("No effect name found for row %s", source_index.row())
+            return
+
+        timeline = getattr(self.win, "timeline", None)
+        if not timeline:
+            log.warning("No timeline found in window")
+            return
+
+        from classes.query import Clip
+        log.info("One-click adding effect '%s' to timeline", effect_name)
+
+        # 1. If clips are selected on the timeline, apply effect to each selected clip
+        selected_clip_ids = list(getattr(self.win, "selected_clips", []) or [])
+        applied = False
+        if selected_clip_ids:
+            log.info("Applying effect '%s' to %d selected clips: %s", effect_name, len(selected_clip_ids), selected_clip_ids)
+            for clip_id in selected_clip_ids:
+                clip = Clip.get(id=clip_id)
+                if clip:
+                    timeline._apply_effect_to_clip(clip, effect_name)
+                    applied = True
+            if applied and hasattr(self.win, "statusBar") and self.win.statusBar:
+                self.win.statusBar.showMessage(get_app()._tr(f"Applied {effect_name} effect to selected clip(s)"), 3000)
+            return
+
+        # 2. Check for clips under the current playhead position
+        pos_seconds = 0.0
+        if hasattr(self.win, "_current_timeline_seconds"):
+            pos_seconds = self.win._current_timeline_seconds()
+        elif hasattr(self.win, "preview_thread"):
+            fps = get_app().project.get("fps")
+            fps_float = float(fps["num"]) / float(fps["den"])
+            cur_frame = getattr(self.win.preview_thread, "current_frame", None)
+            if cur_frame is None and hasattr(self.win.preview_thread, "player") and self.win.preview_thread.player:
+                cur_frame = self.win.preview_thread.player.Position()
+            if cur_frame:
+                pos_seconds = max(0.0, float(cur_frame - 1) / fps_float)
+
+        intersecting_clips = Clip.filter(intersect=pos_seconds)
+        if intersecting_clips:
+            # Sort by layer descending so the top-most visual clip is targeted
+            sorted_clips = sorted(
+                intersecting_clips,
+                key=lambda c: int(c.data.get("layer", 0) if isinstance(c.data, dict) else 0),
+                reverse=True,
+            )
+            target_clip = sorted_clips[0]
+            log.info("Applying effect '%s' to clip under playhead (id=%s, layer=%s)", effect_name, target_clip.id, target_clip.data.get("layer"))
+            timeline._apply_effect_to_clip(target_clip, effect_name)
+            if hasattr(self.win, "statusBar") and self.win.statusBar:
+                self.win.statusBar.showMessage(get_app()._tr(f"Applied {effect_name} effect to clip"), 3000)
+            return
+
+        # 3. Fallback: if no clip at playhead, find the nearest clip on the timeline
+        all_clips = Clip.filter()
+        if all_clips:
+            def clip_dist(c):
+                data = c.data if isinstance(c.data, dict) else {}
+                c_pos = float(data.get("position", 0.0) or 0.0)
+                c_start = float(data.get("start", 0.0) or 0.0)
+                c_end = float(data.get("end", c_start) or c_start)
+                c_finish = c_pos + (c_end - c_start)
+                if c_pos <= pos_seconds <= c_finish:
+                    return 0.0
+                return min(abs(pos_seconds - c_pos), abs(pos_seconds - c_finish))
+
+            nearest_clip = min(all_clips, key=clip_dist)
+            log.info("Applying effect '%s' to nearest clip on timeline (id=%s, layer=%s)", effect_name, nearest_clip.id, nearest_clip.data.get("layer"))
+            timeline._apply_effect_to_clip(nearest_clip, effect_name)
+            if hasattr(self.win, "statusBar") and self.win.statusBar:
+                self.win.statusBar.showMessage(get_app()._tr(f"Applied {effect_name} effect to clip"), 3000)
+            return
+
+        log.warning("Cannot add effect '%s': No clips found on timeline. Add a clip first.", effect_name)
+        if hasattr(self.win, "statusBar") and self.win.statusBar:
+            self.win.statusBar.showMessage(get_app()._tr("Please add a clip to the timeline before applying effects"), 4000)
+
     def __init__(self, model):
         # Invoke parent init
         QListView.__init__(self)
@@ -128,6 +226,9 @@ class EffectsListView(QListView):
         self.setUniformItemSizes(True)
         self.setWordWrap(False)
         self.setTextElideMode(Qt.ElideRight)
+
+        # Initialize thumbnail hover '+' button overlay and mouse tracking
+        self.init_thumbnail_action_overlay()
 
         # setup filter events
         app.window.effectsFilter.textChanged.connect(self.filter_changed)

--- a/src/windows/views/emojis_listview.py
+++ b/src/windows/views/emojis_listview.py
@@ -25,7 +25,7 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-from qt_api import QMimeData, QSize, QPoint, Qt, QUrl, pyqtSlot
+from qt_api import QMimeData, QSize, QPoint, QPointF, Qt, QUrl, pyqtSlot
 from qt_api import clear_override_cursor
 from qt_api import QDrag, QListView
 import openshot  # Python module for libopenshot (required video editing module installed separately)
@@ -33,11 +33,12 @@ from classes import info
 from classes.query import File
 from classes.app import get_app
 from classes.logger import log
+from .thumbnail_action_overlay import ThumbnailActionViewMixin
 import json
 import uuid
 
 
-class EmojisListView(QListView):
+class EmojisListView(ThumbnailActionViewMixin, QListView):
     """ A QListView QWidget used on the main window """
     drag_item_size = QSize(48, 48)
     drag_item_center = QPoint(24, 24)
@@ -180,6 +181,126 @@ class EmojisListView(QListView):
         info.EMOJI_PATH = file_path
         info.EMOJI_ICON = file_path
 
+    def add_item_to_timeline(self, index):
+        """Add the emoji at index as a clip to the timeline."""
+        if not index or not index.isValid():
+            log.warning("add_item_to_timeline called with invalid index")
+            return
+
+        from .thumbnail_action_overlay import to_qmodelindex
+        index = to_qmodelindex(index)
+
+        # Map through proxy_model -> group_model -> standard model
+        group_index = self.model.mapToSource(index)
+        if not group_index or not group_index.isValid():
+            log.warning("Failed to map index to group_index in EmojisListView")
+            return
+        source_index = self.group_model.mapToSource(group_index)
+        if not source_index or not source_index.isValid():
+            log.warning("Failed to map group_index to source_index in EmojisListView")
+            return
+
+        selected_item = self.emojis_model.model.itemFromIndex(source_index)
+        emoji_name = selected_item.text() if selected_item else "Emoji"
+        emoji_path = selected_item.data() if selected_item else None
+        if not emoji_path:
+            emoji_path = source_index.data(Qt.UserRole + 1)
+        if not emoji_path:
+            log.warning("No emoji path found for index %s", index.row())
+            return
+
+        timeline = getattr(self.win, "timeline", None)
+        if not timeline:
+            log.warning("No timeline found in window")
+            return
+
+        from classes.query import Clip, Transition
+        log.info("One-click adding emoji '%s' (%s) to timeline", emoji_name, emoji_path)
+
+        # 1. Determine position (playhead position in seconds)
+        pos_seconds = 0.0
+        if hasattr(self.win, "_current_timeline_seconds"):
+            pos_seconds = self.win._current_timeline_seconds()
+        elif hasattr(self.win, "preview_thread"):
+            fps = get_app().project.get("fps")
+            fps_float = float(fps["num"]) / float(fps["den"])
+            cur_frame = getattr(self.win.preview_thread, "current_frame", None)
+            if cur_frame is None and hasattr(self.win.preview_thread, "player") and self.win.preview_thread.player:
+                cur_frame = self.win.preview_thread.player.Position()
+            if cur_frame:
+                pos_seconds = max(0.0, float(cur_frame - 1) / fps_float)
+
+        # 2. Determine target track layer
+        track_num = None
+        selected_clips = list(getattr(self.win, "selected_clips", []) or [])
+        selected_trans = list(getattr(self.win, "selected_transitions", []) or [])
+        if selected_clips:
+            first_clip = Clip.get(id=selected_clips[0])
+            if first_clip and isinstance(first_clip.data, dict):
+                track_num = first_clip.data.get("layer")
+        elif selected_trans:
+            first_tran = Transition.get(id=selected_trans[0])
+            if first_tran and isinstance(first_tran.data, dict):
+                track_num = first_tran.data.get("layer")
+
+        if track_num is None:
+            intersecting_clips = Clip.filter(intersect=pos_seconds)
+            if intersecting_clips:
+                sorted_clips = sorted(
+                    intersecting_clips,
+                    key=lambda c: int(c.data.get("layer", 0) if isinstance(c.data, dict) else 0),
+                    reverse=True,
+                )
+                track_num = sorted_clips[0].data.get("layer")
+
+        if track_num is not None:
+            try:
+                track_num = int(track_num)
+            except (TypeError, ValueError):
+                track_num = None
+
+        if hasattr(timeline, "_nearest_unlocked_track_number"):
+            if track_num is not None:
+                track_num = timeline._nearest_unlocked_track_number(track_num)
+            if track_num is None and hasattr(timeline, "track_list") and timeline.track_list:
+                track_num = timeline._nearest_unlocked_track_number(
+                    timeline.track_list[0].data.get("number")
+                )
+
+        if track_num is None:
+            track_num = 1
+
+        log.info("Adding emoji '%s' clip at position %.2fs on track %s", emoji_name, pos_seconds, track_num)
+
+        # 3. Create File + Clip wrapped in a transaction for undo
+        tid = str(uuid.uuid4())
+        get_app().updates.transaction_id = tid
+        try:
+            file = self.add_file(emoji_path, emoji_name)
+            if not file:
+                log.warning("Failed to add emoji file: %s", emoji_path)
+                return
+
+            clip = timeline.addClip(
+                file.id,
+                QPointF(pos_seconds, 0),
+                track_num,
+                ignore_refresh=False,
+                call_manual_move=False,
+                auto_transition=False,
+            )
+
+            # Auto-select added emoji clip
+            if clip and hasattr(timeline, "_select_added_items"):
+                timeline._select_added_items("clip")
+            elif clip and clip.get("id"):
+                self.win.addSelection(str(clip.get("id")), "clip", clear_existing=True)
+
+            if hasattr(self.win, "statusBar") and self.win.statusBar:
+                self.win.statusBar.showMessage(get_app()._tr(f"Added {emoji_name} to timeline"), 3000)
+        finally:
+            get_app().updates.transaction_id = None
+
     def __init__(self, model, *args):
         # Invoke parent init
         super().__init__(*args)
@@ -212,6 +333,9 @@ class EmojisListView(QListView):
         self.setUniformItemSizes(True)
         self.setWordWrap(False)
         self.setTextElideMode(Qt.ElideRight)
+
+        # Initialize thumbnail hover '+' button overlay and mouse tracking
+        self.init_thumbnail_action_overlay()
 
         self.emojis_model.ModelRefreshed.connect(self.refresh_view)
         # Activate filter and group selection

--- a/src/windows/views/thumbnail_action_overlay.py
+++ b/src/windows/views/thumbnail_action_overlay.py
@@ -1,0 +1,274 @@
+"""
+@file
+@brief Reusable thumbnail action overlay delegate and interaction mixin for item list views.
+"""
+
+from qt_api import (
+    QPoint, QPointF, QRect, QRectF, Qt,
+    QColor, QPen, QBrush, QPainter,
+    QStyledItemDelegate, QStyleOptionViewItem, QStyle,
+    QPersistentModelIndex, QModelIndex,
+)
+from classes.logger import log
+
+
+def to_qmodelindex(index):
+    """Safely convert QPersistentModelIndex or QModelIndex to QModelIndex."""
+    if isinstance(index, QPersistentModelIndex):
+        return QModelIndex(index)
+    return index
+
+
+def get_thumbnail_decoration_rect(option, widget=None):
+    """Return the decoration (thumbnail) rect for a given style option."""
+    if widget and hasattr(widget, "style"):
+        style = widget.style()
+        if style:
+            deco_rect = style.subElementRect(QStyle.SE_ItemViewItemDecoration, option, widget)
+            if deco_rect.isValid() and deco_rect.width() > 0 and deco_rect.height() > 0:
+                return QRectF(deco_rect)
+
+    r = option.rect
+    target_w = 100.0
+    target_h = 65.0
+    if widget and hasattr(widget, "iconSize"):
+        isz = widget.iconSize()
+        if isz.isValid():
+            target_w = float(isz.width())
+            target_h = float(isz.height())
+
+    icon_w = min(target_w, float(r.width()))
+    icon_h = min(target_h, float(r.height()))
+    icon_x = float(r.center().x()) - (icon_w / 2.0)
+    icon_y = float(r.top())
+    return QRectF(icon_x, icon_y, icon_w, icon_h)
+
+
+def calculate_button_rect(deco_rect, button_size=28.0):
+    """Return a centered square QRectF for the action button inside the decoration rect."""
+    if not deco_rect or not deco_rect.isValid() or deco_rect.width() <= 0 or deco_rect.height() <= 0:
+        return QRectF()
+    cx = float(deco_rect.center().x())
+    cy = float(deco_rect.center().y())
+    return QRectF(cx - (button_size / 2.0), cy - (button_size / 2.0), button_size, button_size)
+
+
+def paint_plus_overlay_button(painter, btn_rect, is_button_hovered=False, is_button_pressed=False):
+    """Draw a modern, crisp circular '+' action button with hover and pressed states."""
+    if not btn_rect or not btn_rect.isValid():
+        return
+
+    painter.save()
+    painter.setRenderHint(QPainter.Antialiasing, True)
+
+    if is_button_pressed:
+        bg_color = QColor(24, 90, 160, 245)
+        border_color = QColor(255, 255, 255, 180)
+        border_width = 1.5
+        plus_color = QColor(230, 230, 230, 255)
+        plus_width = 2.0
+    elif is_button_hovered:
+        bg_color = QColor(42, 130, 218, 235)  # OpenShot vibrant blue
+        border_color = QColor(255, 255, 255, 220)
+        border_width = 1.5
+        plus_color = QColor(255, 255, 255, 255)
+        plus_width = 2.2
+    else:
+        bg_color = QColor(20, 26, 38, 190)  # Dark translucent
+        border_color = QColor(255, 255, 255, 120)
+        border_width = 1.2
+        plus_color = QColor(255, 255, 255, 230)
+        plus_width = 2.0
+
+    painter.setPen(QPen(border_color, border_width))
+    painter.setBrush(QBrush(bg_color))
+    painter.drawEllipse(btn_rect)
+
+    cx = float(btn_rect.center().x())
+    cy = float(btn_rect.center().y())
+    glyph_radius = max(4.0, min(btn_rect.width(), btn_rect.height()) * 0.22)
+
+    plus_pen = QPen(plus_color, plus_width, Qt.SolidLine, Qt.RoundCap, Qt.RoundJoin)
+    painter.setPen(plus_pen)
+    painter.drawLine(QPointF(cx - glyph_radius, cy), QPointF(cx + glyph_radius, cy))
+    painter.drawLine(QPointF(cx, cy - glyph_radius), QPointF(cx, cy + glyph_radius))
+
+    painter.restore()
+
+
+class ThumbnailActionDelegate(QStyledItemDelegate):
+    """Item delegate that paints a '+' button overlay when an item is hovered."""
+
+    def __init__(self, view):
+        super().__init__(view)
+        self.view = view
+
+    def get_item_button_rect(self, index):
+        """Compute the button QRectF for an index using delegate styling."""
+        if not index.isValid():
+            return QRectF()
+        model_idx = to_qmodelindex(index)
+        opt = QStyleOptionViewItem()
+        opt.rect = self.view.visualRect(model_idx)
+        opt.widget = self.view
+        self.initStyleOption(opt, model_idx)
+        deco_rect = get_thumbnail_decoration_rect(opt, self.view)
+        return calculate_button_rect(deco_rect)
+
+    def paint(self, painter, option, index):
+        super().paint(painter, option, index)
+
+        if not index.isValid():
+            return
+
+        hovered_idx = getattr(self.view, "_hovered_index", None)
+        if not hovered_idx or not hovered_idx.isValid() or hovered_idx.row() != index.row():
+            return
+
+        opt = QStyleOptionViewItem(option)
+        self.initStyleOption(opt, index)
+        deco_rect = get_thumbnail_decoration_rect(opt, opt.widget or self.view)
+        if not deco_rect.isValid():
+            return
+
+        btn_rect = calculate_button_rect(deco_rect)
+        is_btn_hovered = getattr(self.view, "_button_hovered", False)
+        is_btn_pressed = getattr(self.view, "_button_pressed", False) and (
+            getattr(self.view, "_pressed_index", None) == hovered_idx
+        )
+
+        paint_plus_overlay_button(
+            painter,
+            btn_rect,
+            is_button_hovered=is_btn_hovered,
+            is_button_pressed=is_btn_pressed,
+        )
+
+
+class ThumbnailActionViewMixin:
+    """Mixin for QListView widgets to support hover '+' button overlay and click interaction."""
+
+    def init_thumbnail_action_overlay(self):
+        """Initialize overlay state and enable mouse tracking."""
+        self._hovered_index = None
+        self._button_hovered = False
+        self._button_pressed = False
+        self._pressed_index = None
+        self.setMouseTracking(True)
+        if self.viewport():
+            self.viewport().setMouseTracking(True)
+        self.setItemDelegate(ThumbnailActionDelegate(self))
+
+    def _button_rect_for_index(self, index):
+        """Compute the button QRectF for a given model index."""
+        if not index.isValid():
+            return QRectF()
+        model_idx = to_qmodelindex(index)
+        delegate = self.itemDelegate()
+        if delegate and hasattr(delegate, "get_item_button_rect"):
+            return delegate.get_item_button_rect(model_idx)
+        opt = QStyleOptionViewItem()
+        opt.rect = self.visualRect(model_idx)
+        opt.widget = self
+        deco_rect = get_thumbnail_decoration_rect(opt, self)
+        return calculate_button_rect(deco_rect)
+
+    def _trigger_repaint(self):
+        """Request a repaint of the view/viewport."""
+        if self.viewport():
+            self.viewport().update()
+        else:
+            self.update()
+
+    def mouseMoveEvent(self, event):
+        pos = event.pos()
+        index = self.indexAt(pos)
+
+        if index.isValid():
+            btn_rect = self._button_rect_for_index(index)
+            btn_hovered = btn_rect.adjusted(-2, -2, 2, 2).contains(QPointF(pos.x(), pos.y()))
+
+            if btn_hovered:
+                self.setCursor(Qt.PointingHandCursor)
+            else:
+                self.unsetCursor()
+
+            hover_changed = (
+                not self._hovered_index
+                or not self._hovered_index.isValid()
+                or self._hovered_index.row() != index.row()
+            )
+            state_changed = hover_changed or (self._button_hovered != btn_hovered)
+
+            if state_changed:
+                self._hovered_index = QPersistentModelIndex(index) if isinstance(index, QModelIndex) else index
+                self._button_hovered = btn_hovered
+                self._trigger_repaint()
+        else:
+            if self._hovered_index and self._hovered_index.isValid():
+                self._hovered_index = None
+                self._button_hovered = False
+                self.unsetCursor()
+                self._trigger_repaint()
+
+        super().mouseMoveEvent(event)
+
+    def leaveEvent(self, event):
+        if self._hovered_index and self._hovered_index.isValid():
+            self._hovered_index = None
+            self._button_hovered = False
+            self._button_pressed = False
+            self._pressed_index = None
+            self.unsetCursor()
+            self._trigger_repaint()
+        else:
+            self._button_hovered = False
+            self._button_pressed = False
+            self._pressed_index = None
+            self.unsetCursor()
+        super().leaveEvent(event)
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            pos = event.pos()
+            index = self.indexAt(pos)
+            if index.isValid():
+                btn_rect = self._button_rect_for_index(index)
+                if btn_rect.adjusted(-4, -4, 4, 4).contains(QPointF(pos.x(), pos.y())):
+                    log.info("Thumbnail '+' button mouse pressed for row %s", index.row())
+                    self._button_pressed = True
+                    self._pressed_index = QPersistentModelIndex(index) if isinstance(index, QModelIndex) else index
+                    self._trigger_repaint()
+                    event.accept()
+                    return
+
+        self._button_pressed = False
+        self._pressed_index = None
+        super().mousePressEvent(event)
+
+    def mouseReleaseEvent(self, event):
+        if event.button() == Qt.LeftButton and self._button_pressed:
+            pos = event.pos()
+            index = self.indexAt(pos)
+            was_pressed_index = self._pressed_index
+            self._button_pressed = False
+            self._pressed_index = None
+
+            self._trigger_repaint()
+
+            if was_pressed_index and was_pressed_index.isValid():
+                target_idx = to_qmodelindex(was_pressed_index)
+                btn_rect = self._button_rect_for_index(target_idx)
+                if btn_rect.adjusted(-8, -8, 8, 8).contains(QPointF(pos.x(), pos.y())) or (
+                    index.isValid() and index.row() == was_pressed_index.row()
+                ):
+                    log.info("Thumbnail '+' button clicked for row %s -> adding to timeline", was_pressed_index.row())
+                    self.add_item_to_timeline(target_idx)
+                    event.accept()
+                    return
+
+        super().mouseReleaseEvent(event)
+
+    def add_item_to_timeline(self, index):
+        """Subclasses should implement this method to insert item into the timeline."""
+        pass

--- a/src/windows/views/transitions_listview.py
+++ b/src/windows/views/transitions_listview.py
@@ -25,7 +25,9 @@
  along with OpenShot Library.  If not, see <http://www.gnu.org/licenses/>.
  """
 
-from qt_api import Qt, QSize, QPoint
+import os
+
+from qt_api import Qt, QSize, QPoint, QPointF
 from qt_api import clear_override_cursor
 from qt_api import QDrag
 from qt_api import QListView, QAbstractItemView
@@ -34,9 +36,10 @@ from classes import info
 from classes.app import get_app
 from classes.logger import log
 from .menu import StyledContextMenu, add_bound_action
+from .thumbnail_action_overlay import ThumbnailActionViewMixin
 
 
-class TransitionsListView(QListView):
+class TransitionsListView(ThumbnailActionViewMixin, QListView):
     """ A QListView QWidget used on the main window """
     drag_item_size = QSize(48, 48)
     drag_item_center = QPoint(24, 24)
@@ -95,6 +98,112 @@ class TransitionsListView(QListView):
         self.transition_model.proxy_model.setFilterCaseSensitivity(Qt.CaseInsensitive)
         self.transition_model.proxy_model.sort(0, Qt.AscendingOrder)
 
+    def add_item_to_timeline(self, index):
+        """Add the transition at index to the timeline."""
+        if not index.isValid():
+            log.warning("add_item_to_timeline called with invalid index")
+            return
+
+        # Map list_proxy_model -> proxy_model -> source model
+        proxy_index = self.transition_model.list_proxy_model.mapToSource(index)
+        if not proxy_index or not proxy_index.isValid():
+            log.warning("add_item_to_timeline failed to map list_proxy_model index to proxy_index")
+            return
+        source_index = self.transition_model.proxy_model.mapToSource(proxy_index)
+        if not source_index or not source_index.isValid():
+            log.warning("add_item_to_timeline failed to map proxy_index to source_index")
+            return
+
+        # Column 3 contains the transition file path
+        path_item = source_index.sibling(source_index.row(), 3)
+        trans_path = path_item.data(Qt.DisplayRole) or path_item.data()
+        if not trans_path:
+            log.warning("No transition path found for row %s", source_index.row())
+            return
+        trans_path = os.path.normpath(str(trans_path))
+
+        timeline = getattr(self.win, "timeline", None)
+        if not timeline:
+            log.warning("No timeline found in window")
+            return
+
+        from classes.query import Clip, Transition
+        log.info("One-click adding transition '%s' to timeline", trans_path)
+
+        # 1. Determine position (playhead position in seconds)
+        pos_seconds = 0.0
+        if hasattr(self.win, "_current_timeline_seconds"):
+            pos_seconds = self.win._current_timeline_seconds()
+        elif hasattr(self.win, "preview_thread"):
+            fps = get_app().project.get("fps")
+            fps_float = float(fps["num"]) / float(fps["den"])
+            cur_frame = getattr(self.win.preview_thread, "current_frame", None)
+            if cur_frame is None and hasattr(self.win.preview_thread, "player") and self.win.preview_thread.player:
+                cur_frame = self.win.preview_thread.player.Position()
+            if cur_frame:
+                pos_seconds = max(0.0, float(cur_frame - 1) / fps_float)
+
+        # 2. Determine target track layer
+        track_num = None
+        selected_clips = list(getattr(self.win, "selected_clips", []) or [])
+        selected_trans = list(getattr(self.win, "selected_transitions", []) or [])
+        if selected_clips:
+            first_clip = Clip.get(id=selected_clips[0])
+            if first_clip and isinstance(first_clip.data, dict):
+                track_num = first_clip.data.get("layer")
+        elif selected_trans:
+            first_tran = Transition.get(id=selected_trans[0])
+            if first_tran and isinstance(first_tran.data, dict):
+                track_num = first_tran.data.get("layer")
+
+        if track_num is None:
+            intersecting_clips = Clip.filter(intersect=pos_seconds)
+            if intersecting_clips:
+                sorted_clips = sorted(
+                    intersecting_clips,
+                    key=lambda c: int(c.data.get("layer", 0) if isinstance(c.data, dict) else 0),
+                    reverse=True,
+                )
+                track_num = sorted_clips[0].data.get("layer")
+
+        if track_num is not None:
+            try:
+                track_num = int(track_num)
+            except (TypeError, ValueError):
+                track_num = None
+
+        if hasattr(timeline, "_nearest_unlocked_track_number"):
+            if track_num is not None:
+                track_num = timeline._nearest_unlocked_track_number(track_num)
+            if track_num is None and hasattr(timeline, "track_list") and timeline.track_list:
+                track_num = timeline._nearest_unlocked_track_number(
+                    timeline.track_list[0].data.get("number")
+                )
+
+        if track_num is None:
+            track_num = 1
+
+        log.info("Adding transition '%s' at position %.2fs on track %s", trans_path, pos_seconds, track_num)
+
+        # 3. Call timeline.addTransition
+        item = timeline.addTransition(
+            trans_path,
+            QPointF(pos_seconds, 0),
+            track_num,
+            ignore_refresh=False,
+            call_manual_move=False,
+        )
+
+        # 4. Auto-select added transition
+        if item and hasattr(timeline, "_select_added_items"):
+            timeline._select_added_items("transition")
+        elif item and item.get("id"):
+            self.win.addSelection(str(item.get("id")), "transition", clear_existing=True)
+
+        if hasattr(self.win, "statusBar") and self.win.statusBar:
+            trans_title = source_index.sibling(source_index.row(), 1).data(Qt.DisplayRole) or "Transition"
+            self.win.statusBar.showMessage(get_app()._tr(f"Added {trans_title} transition to timeline"), 3000)
+
     def __init__(self, model):
         # Invoke parent init
         QListView.__init__(self)
@@ -129,6 +238,9 @@ class TransitionsListView(QListView):
         self.setUniformItemSizes(True)
         self.setWordWrap(False)
         self.setTextElideMode(Qt.ElideRight)
+
+        # Initialize thumbnail hover '+' button overlay and mouse tracking
+        self.init_thumbnail_action_overlay()
 
         # setup filter events
         app.window.transitionsFilter.textChanged.connect(self.filter_changed)


### PR DESCRIPTION
Adds a hover plus button to Effects and Transitions thumbnails. Clicking the button adds the selected item using the existing OpenShot insertion behavior while preserving drag-and-drop.