### PR TITLE
Add native Windows Arm64 application readiness

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,6 +149,60 @@ win-x64:
   tags:
     - windows
 
+win-arm64:
+  stage: build
+  artifacts:
+    when: always
+    expire_in: 2 weeks
+    paths:
+    - build\*.exe
+    - build\*.torrent
+    - build\install-arm64\share\*.env
+    - build\install-arm64\share\*.log
+    - build\build-server.log
+    - build\arm64-architecture-report.json
+    - build\frozen-arm64-architecture-report.json
+  script:
+    - $PSVersionTable
+    - $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
+    - try { Invoke-WebRequest -Uri "https://gitlab.openshot.org/OpenShot/libopenshot/-/jobs/artifacts/$CI_COMMIT_REF_NAME/download?job=windows-builder-arm64" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" } catch { $_.Exception.Response.StatusCode.Value__ }
+    - if (-not (Test-Path "artifacts.zip")) { Invoke-WebRequest -Uri "https://gitlab.openshot.org/OpenShot/libopenshot/-/jobs/artifacts/develop/download?job=windows-builder-arm64" -Headers @{"PRIVATE-TOKEN"="$ACCESS_TOKEN"} -OutFile "artifacts.zip" }
+    - Expand-Archive -Path artifacts.zip -DestinationPath .
+    - Copy-Item "$CI_PROJECT_DIR/build/install-arm64/python/*" -Destination "$CI_PROJECT_DIR"
+    - $env:MSYSTEM = "CLANGARM64"
+    - $env:OPENSHOT_QT_API = "pyqt6"
+    - $originalPath = $env:Path
+    - $PY_ABI = (python3 -c "import sysconfig; print(sysconfig.get_config_var('py_version_short'))")
+    - $PathSegments = @("$CI_PROJECT_DIR\build\install-arm64\bin", "$CI_PROJECT_DIR\build\install-arm64\python", "C:\msys64\clangarm64\bin", "C:\msys64\usr\bin", "C:\msys64\clangarm64\lib\python$PY_ABI", "C:\msys64\clangarm64\lib\python$PY_ABI\site-packages", "C:\msys64\clangarm64\lib\python$PY_ABI\site-packages\PyQt6")
+    - $env:Path = ($PathSegments -join ";") + ";" + $originalPath
+    - $env:PYTHONPATH = "$CI_PROJECT_DIR\build\install-arm64\python;C:\msys64\clangarm64\lib\python" + $PY_ABI + "\site-packages\PyQt6;"
+    - python3 -m unittest discover -s ci -p "test_*.py" -v
+    - python3 -m unittest discover -s src\tests -t src\tests -p test_native_arm64_process_oracle.py -v
+    - python3 ci\validate_arm64_architecture.py --require-native-arm64 --package-lock ci\windows-arm64-packages.lock --payload-root "$CI_PROJECT_DIR\build\install-arm64" --require-payload --json-report build\arm64-architecture-report.json
+    - $VERSION=(python3 src/launch.py -V)
+    - New-Item -path "build/install-arm64/share/" -Name "$CI_PROJECT_NAME.env" -Value "CI_PROJECT_NAME:$CI_PROJECT_NAME`nCI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME`nCI_COMMIT_SHA:$CI_COMMIT_SHA`nCI_JOB_ID:$CI_JOB_ID`nCI_PIPELINE_ID:$env:CI_PIPELINE_ID`nVERSION:$VERSION" -ItemType file -force
+    - $PREV_GIT_LABEL=(git describe --tags --abbrev=0 '@^')
+    - git log "$PREV_GIT_LABEL..@" --oneline --pretty=format:"- %C(auto,yellow)%h%C(auto,magenta)% %C(auto,blue)%>(12,trunc)%ad %C(auto,green)%<(25,trunc)%aN%C(auto,reset)%s%C(auto,red)% gD% D" --date=short > "build/install-arm64/share/$CI_PROJECT_NAME.log"
+    - python3 -u freeze.py build --git-branch=$CI_COMMIT_REF_NAME
+    - $EXE_PATH = "$CI_PROJECT_DIR\build\exe.mingw-" + $PY_ABI + "\openshot-qt.exe"
+    - python3 ci\validate_arm64_architecture.py --require-native-arm64 --payload-root "$CI_PROJECT_DIR\build\exe.mingw-$PY_ABI" --require-payload --json-report build\frozen-arm64-architecture-report.json
+    - $manifestPath = "installer/windows.manifest"
+    - (Get-Content $manifestPath) -creplace "ARCHITECTURE", "arm64" | Set-Content $manifestPath
+    - mt.exe -manifest installer/windows.manifest -validate_manifest
+    - mt.exe  -manifest installer/windows.manifest -outputresource:$EXE_PATH;1
+    - python3 -u installer/build_server.py "$SLACK_TOKEN" "$GITHUB_USER" "$GITHUB_PASS" "arm64" "$CI_COMMIT_REF_NAME" "$MAC_PASSWORD" "build-only"
+  when: always
+  rules:
+    - if: '$ENABLE_WINDOWS_ARM64 == "1" && $CI_COMMIT_TAG == null'
+    - when: never
+  tags:
+    - windows-arm64
+  # Requires PR B's published windows-builder-arm64 artifact/digest and a
+  # native/virtual Windows Arm64 GitLab runner (design-spec.md
+  # release-infrastructure surface). Does not weaken or replace the
+  # existing win-x64/win-x86 jobs above.
+  allow_failure: true
+
 win-x86:
   stage: build
   artifacts:
@@ -256,6 +310,60 @@ win-sign-x86:
   - tags
   tags:
     - code-sign
+
+windows:msix:package:arm64:
+  stage: msix-package
+  artifacts:
+    when: always
+    expire_in: 2 weeks
+    paths:
+    - build\msix\*.msix
+  dependencies:
+    - win-arm64
+  script:
+    - $PSVersionTable
+    - powershell.exe -NoProfile -ExecutionPolicy Bypass -File installer\package_msix.ps1 -Architecture arm64
+  when: on_success
+  rules:
+    - if: '$ENABLE_WINDOWS_ARM64 == "1" && $CI_COMMIT_TAG == null'
+    - when: never
+  tags:
+    - code-sign-arm64
+  # Requires an Arm64-capable MSIX packaging/signing runner tagged
+  # code-sign-arm64 and the release-owned MSIX template
+  # (C:\OpenShot-MSIX\OpenShotTemplate\OpenShot_template.xml) generated with
+  # ProcessorArchitecture="arm64" per design-spec.md G10-G12. Does not
+  # weaken or replace the existing windows:msix:package (x64) job above.
+  allow_failure: true
+
+win-sign-arm64:
+  stage: sign
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+    - build\*-arm64.exe
+    - build\msix\*.msix
+    - build\build-server.log
+  dependencies:
+    - win-arm64
+    - windows:msix:package:arm64
+  script:
+    - $PSVersionTable
+    - $env:Path = $env:Path + ";C:\msys64\usr\local\bin;C:\msys64\usr\bin"
+    - if (-not (Get-ChildItem -Path "build\*-arm64.exe" -ErrorAction SilentlyContinue)) { throw "No arm64 Windows installer found in build\\*-arm64.exe" }
+    - if (-not (Get-ChildItem -Path "build\msix\*.msix" -ErrorAction SilentlyContinue)) { throw "No arm64 MSIX package found in build\\msix\\*.msix" }
+    - py -3 -m pip install defusedxml
+    - py -3 -u installer/build_server.py "$SLACK_TOKEN" "$GITHUB_USER" "$GITHUB_PASS" "arm64" "$CI_COMMIT_REF_NAME" "$MAC_PASSWORD" "sign-upload-only"
+  when: on_success
+  rules:
+    - if: '$ENABLE_WINDOWS_ARM64 == "1" && $CI_COMMIT_TAG == null'
+    - when: never
+  tags:
+    - code-sign-arm64
+  # Requires signing credentials/tooling capable of signing an Arm64 PE
+  # payload and a code-sign-arm64 runner (design-spec.md G12). Does not
+  # weaken or replace the existing win-sign-x64/win-sign-x86 jobs above.
+  allow_failure: true
 
 re-init-builders:
   stage: deploy

--- a/ci/test_package_msix_staging.py
+++ b/ci/test_package_msix_staging.py
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: 2026 OpenShot Studios, LLC
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+import json
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "installer" / "package_msix.ps1"
+BUILD_DIR = REPO_ROOT / "build"
+MSIX_DIR = BUILD_DIR / "msix"
+FIXTURE_DIR = BUILD_DIR / "test-package-msix-staging"
+INSTALLER_PATH = FIXTURE_DIR / "OpenShot-msix-staging-arm64.exe"
+TEMPLATE_PATH = FIXTURE_DIR / "OpenShot_template.xml"
+REPORT_PATH = MSIX_DIR / "prepare-report.json"
+WORKING_TEMPLATE_PATH = MSIX_DIR / "OpenShot_template.generated.xml"
+STAGED_INSTALLER_PATH = MSIX_DIR / "installer-source" / INSTALLER_PATH.name
+VERSION_FILE = BUILD_DIR / "install-arm64" / "share" / "openshot-qt.env"
+INSTALL_ARM64_DIR = BUILD_DIR / "install-arm64"
+
+
+def remove_path(path):
+    if path.is_dir():
+        shutil.rmtree(path, ignore_errors=True)
+    elif path.exists():
+        path.unlink()
+
+
+# Exact set of paths this suite creates/manages. setUp and tearDown must only
+# ever touch these paths so that unrelated, pre-existing files under
+# build/msix (for example real packaging outputs dropped there by a prior,
+# non-test packaging run) are never destroyed. Do not recursively wipe
+# MSIX_DIR itself: only remove it afterwards if it happens to be empty.
+OWNED_PATHS = (
+    REPORT_PATH,
+    WORKING_TEMPLATE_PATH,
+    STAGED_INSTALLER_PATH,
+    MSIX_DIR / "installer-source",
+    MSIX_DIR / "old-package.msix",
+    MSIX_DIR / "msix-packaging-tool.log",
+    FIXTURE_DIR,
+    VERSION_FILE,
+)
+
+
+class PackageMsixStagingTests(unittest.TestCase):
+    def setUp(self):
+        for path in OWNED_PATHS:
+            remove_path(path)
+
+        FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
+        MSIX_DIR.mkdir(parents=True, exist_ok=True)
+        VERSION_FILE.parent.mkdir(parents=True, exist_ok=True)
+        VERSION_FILE.write_text("VERSION:4.0.0\n", encoding="utf-8")
+
+    def tearDown(self):
+        for path in OWNED_PATHS:
+            remove_path(path)
+        # VERSION_FILE lives under build/install-arm64/share/. That directory
+        # can also hold a real, non-test installed payload (from `cmake
+        # --install`), so never rmtree it wholesale -- only remove the
+        # now-empty directories this suite itself created.
+        if VERSION_FILE.parent.exists() and not any(VERSION_FILE.parent.iterdir()):
+            VERSION_FILE.parent.rmdir()
+        if INSTALL_ARM64_DIR.exists() and not any(INSTALL_ARM64_DIR.iterdir()):
+            INSTALL_ARM64_DIR.rmdir()
+        if MSIX_DIR.exists() and not any(MSIX_DIR.iterdir()):
+            MSIX_DIR.rmdir()
+        if BUILD_DIR.exists() and not any(BUILD_DIR.iterdir()):
+            BUILD_DIR.rmdir()
+
+    def test_prepare_only_preserves_existing_packaging_outputs_and_refreshes_owned_staging(self):
+        INSTALLER_PATH.write_bytes(b"fresh-arm64-installer")
+        TEMPLATE_PATH.write_text(
+            "\n".join(
+                [
+                    "<MsixPackagingToolTemplate>",
+                    '  <SaveLocation PackagePath="C:\\OpenShot-MSIX\\OpenShot.msix" TemplatePath="C:\\OpenShot-MSIX\\OpenShot-template.xml" />',
+                    '  <Installer Path="C:\\OpenShot-MSIX\\source\\OpenShot-original-arm64.exe" Arguments="/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-" InstallLocation="C:\\Program Files\\OpenShot Video Editor" />',
+                    '  <PackageInformation PackageName="Old.Name" PublisherName="CN=Old Publisher" PublisherDisplayName="Old Publisher" Version="1.0.0.0">',
+                    "    <Applications />",
+                    "  </PackageInformation>",
+                    "</MsixPackagingToolTemplate>",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        stale_msix = MSIX_DIR / "old-package.msix"
+        stale_msix.write_bytes(b"stale-msix")
+        stale_log = MSIX_DIR / "msix-packaging-tool.log"
+        stale_log.write_text("stale-log", encoding="utf-8")
+        stale_report = REPORT_PATH
+        stale_report.write_text('{"stale": true}', encoding="utf-8")
+        stale_working_template = WORKING_TEMPLATE_PATH
+        stale_working_template.write_text("stale-template", encoding="utf-8")
+        stale_source_dir = MSIX_DIR / "installer-source"
+        stale_source_dir.mkdir(parents=True, exist_ok=True)
+        (stale_source_dir / "stale.txt").write_text("stale", encoding="utf-8")
+        (stale_source_dir / INSTALLER_PATH.name).write_bytes(b"old-installer")
+
+        completed = subprocess.run(
+            [
+                "powershell.exe",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(SCRIPT_PATH),
+                "-Architecture",
+                "arm64",
+                "-InstallerPath",
+                str(INSTALLER_PATH),
+                "-TemplatePath",
+                str(TEMPLATE_PATH),
+                "-PrepareOnly",
+                "-PreparationReportPath",
+                str(REPORT_PATH),
+            ],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(
+            completed.returncode,
+            0,
+            msg=f"stdout:\n{completed.stdout}\n\nstderr:\n{completed.stderr}",
+        )
+
+        self.assertTrue(stale_msix.exists())
+        self.assertEqual(stale_msix.read_bytes(), b"stale-msix")
+        self.assertTrue(stale_log.exists())
+        self.assertEqual(stale_log.read_text(encoding="utf-8"), "stale-log")
+        self.assertFalse((stale_source_dir / "stale.txt").exists())
+
+        self.assertTrue(STAGED_INSTALLER_PATH.exists())
+        self.assertEqual(STAGED_INSTALLER_PATH.read_bytes(), INSTALLER_PATH.read_bytes())
+
+        self.assertTrue(REPORT_PATH.exists())
+        report = json.loads(REPORT_PATH.read_text(encoding="utf-8-sig"))
+        self.assertNotEqual(REPORT_PATH.read_text(encoding="utf-8-sig"), '{"stale": true}')
+        self.assertEqual(report["output_dir"], str(MSIX_DIR))
+        self.assertEqual(report["source_installer_dir"], str(MSIX_DIR / "installer-source"))
+        self.assertEqual(report["source_installer_path"], str(STAGED_INSTALLER_PATH))
+        self.assertEqual(report["working_template_path"], str(WORKING_TEMPLATE_PATH))
+        self.assertEqual(report["processor_architecture"], "arm64")
+        self.assertEqual(report["publisher"], "CN=5FE34B8B-A62B-4594-911F-0D6CFC87D00F")
+        self.assertEqual(report["publisher_display_name"], "OpenShot Studios")
+
+        self.assertTrue(WORKING_TEMPLATE_PATH.exists())
+        working_template = WORKING_TEMPLATE_PATH.read_text(encoding="utf-8")
+        self.assertNotEqual(working_template, "stale-template")
+        self.assertIn(str(STAGED_INSTALLER_PATH), working_template)
+        self.assertNotIn(r"C:\OpenShot-MSIX\source\OpenShot-original-arm64.exe", working_template)
+        template_xml = ElementTree.fromstring(working_template)
+        package_info = template_xml.find(".//PackageInformation")
+        self.assertEqual(package_info.attrib["Version"], "4.0.0.0")
+        self.assertEqual(package_info.attrib["PackageName"], "OpenShotStudios.OpenShotforWindows")
+        self.assertEqual(
+            package_info.attrib["PublisherName"],
+            "CN=5FE34B8B-A62B-4594-911F-0D6CFC87D00F",
+        )
+        self.assertEqual(package_info.attrib["PublisherDisplayName"], "OpenShot Studios")
+
+    def test_teardown_preserves_unrelated_preexisting_build_msix_output(self):
+        """Regression for OSQT-MSIX-TEARDOWN-001.
+
+        tearDown() must remove only the exact paths this suite owns
+        (OWNED_PATHS, plus VERSION_FILE's now-empty parent directories) and
+        must never recursively delete build/msix or build/install-arm64
+        wholesale, because a real (non-test) packaging/install run can leave
+        genuine artifacts in either directory. This proves sentinel files
+        that setUp/tearDown do not own survive a full tearDown() pass, while
+        owned fixture paths are still cleaned up.
+        """
+        sentinel_path = MSIX_DIR / "sentinel-real-packaging-output.msix"
+        sentinel_path.write_bytes(b"real-signed-msix-package-not-owned-by-tests")
+
+        unrelated_subdir = MSIX_DIR / "unrelated-real-output"
+        unrelated_subdir.mkdir(parents=True, exist_ok=True)
+        (unrelated_subdir / "notes.txt").write_text("not owned by tests", encoding="utf-8")
+
+        owned_source_dir = MSIX_DIR / "installer-source"
+        owned_source_dir.mkdir(parents=True, exist_ok=True)
+        (owned_source_dir / "owned.txt").write_text("owned", encoding="utf-8")
+        REPORT_PATH.write_text('{"owned": true}', encoding="utf-8")
+
+        # Use a test-unique filename (never the real production binary name)
+        # so this fixture cannot collide with, and overwrite, a genuine
+        # installed openshot-qt.exe.
+        install_sentinel = (
+            INSTALL_ARM64_DIR / "bin" / "unrelated-real-preexisting-payload.bin"
+        )
+        install_sentinel.parent.mkdir(parents=True, exist_ok=True)
+        install_sentinel.write_bytes(b"real-installed-arm64-binary-not-owned-by-tests")
+
+        real_payload = (
+            INSTALL_ARM64_DIR / "lib" / "unrelated-real-preexisting-lib-fixture.bin"
+        )
+        real_payload.parent.mkdir(parents=True, exist_ok=True)
+        real_payload.write_bytes(b"real-preexisting-lib-payload-not-owned-by-tests")
+
+        try:
+            self.tearDown()
+
+            self.assertTrue(
+                sentinel_path.exists(),
+                "tearDown must not delete unrelated pre-existing build/msix output",
+            )
+            self.assertEqual(
+                sentinel_path.read_bytes(),
+                b"real-signed-msix-package-not-owned-by-tests",
+            )
+            self.assertTrue(unrelated_subdir.exists())
+            self.assertTrue((unrelated_subdir / "notes.txt").exists())
+
+            self.assertTrue(
+                install_sentinel.exists(),
+                "tearDown must not delete unrelated pre-existing build/install-arm64 output",
+            )
+            self.assertEqual(
+                install_sentinel.read_bytes(),
+                b"real-installed-arm64-binary-not-owned-by-tests",
+            )
+            self.assertTrue(
+                real_payload.exists(),
+                "tearDown must not delete unrelated pre-existing build/install-arm64 payload",
+            )
+            self.assertEqual(
+                real_payload.read_bytes(),
+                b"real-preexisting-lib-payload-not-owned-by-tests",
+            )
+
+            self.assertFalse(owned_source_dir.exists())
+            self.assertFalse(REPORT_PATH.exists())
+            self.assertFalse(VERSION_FILE.exists())
+        finally:
+            # Remove only the exact fixture paths this test itself created;
+            # never recursively delete INSTALL_ARM64_DIR, which may still
+            # hold the unrelated real payload this test just proved survives.
+            remove_path(sentinel_path)
+            remove_path(unrelated_subdir)
+            remove_path(install_sentinel)
+            if install_sentinel.parent.exists() and not any(install_sentinel.parent.iterdir()):
+                install_sentinel.parent.rmdir()
+            remove_path(real_payload)
+            if real_payload.parent.exists() and not any(real_payload.parent.iterdir()):
+                real_payload.parent.rmdir()
+            if INSTALL_ARM64_DIR.exists() and not any(INSTALL_ARM64_DIR.iterdir()):
+                INSTALL_ARM64_DIR.rmdir()
+            # Restore MSIX_DIR so the outer, real tearDown() (invoked again by
+            # the test runner after this method returns) has a directory to
+            # operate on, matching the fixture state other tests expect.
+            MSIX_DIR.mkdir(parents=True, exist_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/test_validate_arm64_architecture.py
+++ b/ci/test_validate_arm64_architecture.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2026 OpenShot Studios, LLC
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+import contextlib
+import importlib.util
+import io
+import os
+import struct
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+VALIDATOR_PATH = os.path.join(os.path.dirname(__file__), "validate_arm64_architecture.py")
+SPEC = importlib.util.spec_from_file_location("validate_arm64_architecture", VALIDATOR_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("Unable to load validator from %s" % VALIDATOR_PATH)
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+def write_pe(path, machine):
+    data = bytearray(0x80)
+    data[:2] = b"MZ"
+    struct.pack_into("<I", data, 0x3C, 0x40)
+    data[0x40:0x44] = b"PE\0\0"
+    struct.pack_into("<H", data, 0x44, machine)
+    with open(path, "wb") as stream:
+        stream.write(data)
+
+
+class Arm64ArchitectureValidatorTests(unittest.TestCase):
+    def test_package_lock_reports_missing_file(self):
+        verified, failures = validator.verify_package_lock("missing-package-lock.txt")
+        self.assertEqual(verified, [])
+        self.assertIn("Unable to read package lock", failures[0])
+
+    def test_payload_scan_accepts_arm64_and_rejects_amd64(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_pe(os.path.join(root, "native.dll"), validator.IMAGE_FILE_MACHINE_ARM64)
+            results, failures = validator.scan_payload_architecture(root)
+            self.assertEqual(len(results), 1)
+            self.assertEqual(failures, [])
+
+            write_pe(os.path.join(root, "foreign.pyd"), validator.IMAGE_FILE_MACHINE_AMD64)
+            results, failures = validator.scan_payload_architecture(root)
+            self.assertEqual(len(results), 2)
+            self.assertEqual(len(failures), 1)
+
+    def test_required_native_host_fails_closed(self):
+        oracle = {
+            "checked": True,
+            "process_machine": validator.IMAGE_FILE_MACHINE_UNKNOWN,
+            "native_machine": validator.IMAGE_FILE_MACHINE_AMD64,
+            "is_wow_or_emulated": False,
+            "native_arm64_ok": False,
+            "reason": None,
+        }
+        with mock.patch.object(validator, "read_native_process_oracle", return_value=oracle):
+            with mock.patch.object(sys, "argv", ["validator", "--require-native-arm64"]):
+                with contextlib.redirect_stdout(io.StringIO()):
+                    self.assertEqual(validator.main(), 1)
+
+    def test_package_lock_detects_version_drift(self):
+        with tempfile.NamedTemporaryFile("w", delete=False) as lock:
+            lock.write("example-package=1.2.3,UNVERIFIED-NO-SIGNED-SNAPSHOT\n")
+            lock_path = lock.name
+        try:
+            completed = mock.Mock(returncode=0, stdout="example-package 1.2.4\n")
+            with mock.patch.object(validator.subprocess, "run", return_value=completed):
+                verified, failures = validator.verify_package_lock(lock_path)
+            self.assertEqual(verified[0]["version"], "1.2.4")
+            self.assertEqual(len(failures), 1)
+        finally:
+            os.unlink(lock_path)
+
+    def test_package_lock_reports_missing_pacman(self):
+        with tempfile.NamedTemporaryFile("w", delete=False) as lock:
+            lock.write("example-package=1.2.3,UNVERIFIED-NO-SIGNED-SNAPSHOT\n")
+            lock_path = lock.name
+        try:
+            with mock.patch.object(
+                validator.subprocess, "run", side_effect=FileNotFoundError("pacman")
+            ):
+                verified, failures = validator.verify_package_lock(lock_path)
+            self.assertEqual(verified, [])
+            self.assertIn("Unable to run pacman", failures[0])
+        finally:
+            os.unlink(lock_path)
+
+    def test_package_lock_reports_malformed_entry(self):
+        with tempfile.NamedTemporaryFile("w", delete=False) as lock:
+            lock.write("malformed-entry\n")
+            lock_path = lock.name
+        try:
+            verified, failures = validator.verify_package_lock(lock_path)
+            self.assertEqual(verified, [])
+            self.assertEqual(failures, ["Malformed package lock entry: malformed-entry"])
+        finally:
+            os.unlink(lock_path)
+
+    def test_package_lock_rejects_unsafe_package_name(self):
+        with tempfile.NamedTemporaryFile("w", delete=False) as lock:
+            lock.write("-unsafe=1.2.3,UNVERIFIED-NO-SIGNED-SNAPSHOT\n")
+            lock_path = lock.name
+        try:
+            verified, failures = validator.verify_package_lock(lock_path)
+            self.assertEqual(verified, [])
+            self.assertEqual(failures, ["Invalid package name in lock: '-unsafe'"])
+        finally:
+            os.unlink(lock_path)
+
+    def test_package_lock_rejects_unexpected_pacman_output(self):
+        with tempfile.NamedTemporaryFile("w", delete=False) as lock:
+            lock.write("example-package=1.2.3,UNVERIFIED-NO-SIGNED-SNAPSHOT\n")
+            lock_path = lock.name
+        try:
+            completed = mock.Mock(returncode=0, stdout="warning only\n")
+            with mock.patch.object(validator.subprocess, "run", return_value=completed):
+                verified, failures = validator.verify_package_lock(lock_path)
+            self.assertEqual(verified, [])
+            self.assertIn("Unexpected pacman output", failures[0])
+        finally:
+            os.unlink(lock_path)
+
+    def test_package_lock_rejects_unverified_real_hash(self):
+        with tempfile.NamedTemporaryFile("w", delete=False) as lock:
+            lock.write("example-package=1.2.3,abc123\n")
+            lock_path = lock.name
+        try:
+            completed = mock.Mock(returncode=0, stdout="example-package 1.2.3\n")
+            with mock.patch.object(validator.subprocess, "run", return_value=completed):
+                _verified, failures = validator.verify_package_lock(lock_path)
+            self.assertIn("hash verification is not implemented", failures[0])
+        finally:
+            os.unlink(lock_path)
+
+    def test_require_payload_rejects_missing_root(self):
+        with mock.patch.object(sys, "argv", ["validator", "--require-payload"]):
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(validator.main(), 1)
+
+    def test_require_payload_rejects_directory_without_valid_pe(self):
+        with tempfile.TemporaryDirectory() as root:
+            with open(os.path.join(root, "stub.exe"), "w", encoding="utf-8") as stream:
+                stream.write("not a PE")
+            with mock.patch.object(
+                sys, "argv", ["validator", "--payload-root", root, "--require-payload"]
+            ):
+                with contextlib.redirect_stdout(io.StringIO()):
+                    self.assertEqual(validator.main(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/validate_arm64_architecture.py
+++ b/ci/validate_arm64_architecture.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 OpenShot Studios, LLC
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+"""
+@file
+@brief Reusable Windows Arm64 architecture validator (design-spec.md
+       G2/G3/G8/G11) implementing design-amendment-A1 native-process
+       semantics.
+
+This script is shared, byte-for-byte, across libopenshot-audio (PR A),
+libopenshot (PR B), and openshot-qt (PR C). It performs two independent
+checks, exactly as required by design-amendment-A1:
+
+1. Native-process oracle (host evidence): calls IsWow64Process2 via ctypes on
+   the *currently running* Python process and asserts
+     - pNativeMachine == IMAGE_FILE_MACHINE_ARM64 (0xAA64)
+     - pProcessMachine == IMAGE_FILE_MACHINE_UNKNOWN (0x0)
+   Any nonzero pProcessMachine is WOW/emulated execution and fails this
+   check. This check only passes evidence when actually run under a native
+   Arm64 Python interpreter; on any other host it reports the real, honest
+   values it observed and does not fabricate a pass.
+
+2. Recursive static PE architecture scan (payload evidence): recursively
+   scans a given root directory for every .exe, .dll, and .pyd, reads the
+   COFF file header "Machine" field directly (no external tool dependency),
+   and asserts every one of them is IMAGE_FILE_MACHINE_ARM64 (0xAA64). This
+   check is independent of the host architecture and can run on any Python
+   3 interpreter, including this AMD64 documentation/implementation
+   workspace, against whatever candidate payload directory is supplied.
+
+The two checks are deliberately independent, per design-amendment-A1: a
+native process oracle failure does not imply a payload architecture
+failure, and vice versa. Callers (CI jobs) should run both and fail closed
+if either reports a problem, unless the repository/job intentionally only
+has one kind of evidence available (e.g. no payload directory yet).
+"""
+
+import argparse
+import ctypes
+import json
+import os
+import re
+import subprocess
+import struct
+import sys
+
+IMAGE_FILE_MACHINE_UNKNOWN = 0x0
+IMAGE_FILE_MACHINE_ARM64 = 0xAA64
+IMAGE_FILE_MACHINE_AMD64 = 0x8664
+IMAGE_FILE_MACHINE_I386 = 0x14C
+
+MACHINE_NAMES = {
+    IMAGE_FILE_MACHINE_UNKNOWN: "UNKNOWN (native, non-WOW64)",
+    IMAGE_FILE_MACHINE_ARM64: "ARM64",
+    IMAGE_FILE_MACHINE_AMD64: "AMD64",
+    IMAGE_FILE_MACHINE_I386: "I386",
+}
+
+
+def machine_name(value):
+    return MACHINE_NAMES.get(value, "0x%04X" % value)
+
+
+def read_native_process_oracle():
+    """
+    Query IsWow64Process2 for the current process. Returns a dict with the
+    exact observed pProcessMachine / pNativeMachine values, the derived
+    WOW/emulation state, and a pass/fail verdict against
+    design-amendment-A1's native-execution requirement.
+    """
+    result = {
+        "checked": False,
+        "process_machine": None,
+        "native_machine": None,
+        "is_wow_or_emulated": None,
+        "native_arm64_ok": False,
+        "reason": None,
+    }
+
+    if not sys.platform.startswith("win"):
+        result["reason"] = "IsWow64Process2 is a Windows-only API; not running on Windows."
+        return result
+
+    try:
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.GetCurrentProcess.restype = ctypes.c_void_p
+        is_wow64_process2 = getattr(kernel32, "IsWow64Process2", None)
+        if is_wow64_process2 is None:
+            result["reason"] = "IsWow64Process2 is unavailable on this Windows system."
+            return result
+        is_wow64_process2.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_ushort),
+            ctypes.POINTER(ctypes.c_ushort),
+        ]
+        is_wow64_process2.restype = ctypes.c_int
+        process_machine = ctypes.c_ushort(0)
+        native_machine = ctypes.c_ushort(0)
+        handle = kernel32.GetCurrentProcess()
+        ok = is_wow64_process2(
+            handle,
+            ctypes.byref(process_machine),
+            ctypes.byref(native_machine),
+        )
+        if not ok:
+            result["reason"] = (
+                "IsWow64Process2 returned failure (GetLastError=%s)."
+                % ctypes.get_last_error()
+            )
+            return result
+
+        result["checked"] = True
+        result["process_machine"] = process_machine.value
+        result["native_machine"] = native_machine.value
+        result["is_wow_or_emulated"] = process_machine.value != IMAGE_FILE_MACHINE_UNKNOWN
+        result["native_arm64_ok"] = (
+            native_machine.value == IMAGE_FILE_MACHINE_ARM64
+            and process_machine.value == IMAGE_FILE_MACHINE_UNKNOWN
+        )
+        return result
+    except Exception as exc:  # noqa: BLE001 - report, don't hide
+        result["reason"] = "IsWow64Process2 call failed: %r" % exc
+        return result
+
+
+def read_pe_machine(path):
+    """
+    Read the COFF "Machine" field directly from a PE file's file header,
+    without requiring llvm-readobj/dumpbin/objdump. Returns an int machine
+    value, or None if the file is not a valid PE (e.g. a script stub).
+    """
+    with open(path, "rb") as f:
+        dos_header = f.read(64)
+        if len(dos_header) < 64 or dos_header[0:2] != b"MZ":
+            return None
+        pe_offset = struct.unpack_from("<I", dos_header, 0x3C)[0]
+        f.seek(pe_offset)
+        pe_sig = f.read(4)
+        if pe_sig != b"PE\x00\x00":
+            return None
+        coff_header = f.read(20)
+        if len(coff_header) < 20:
+            return None
+        machine = struct.unpack_from("<H", coff_header, 0)[0]
+        return machine
+
+
+def scan_payload_architecture(root):
+    """
+    Recursively scan `root` for .exe/.dll/.pyd files and read each PE
+    Machine field. Returns (results, failures) where results is a list of
+    {"path", "machine", "machine_name"} and failures is a list of
+    human-readable problem strings (missing PE header, wrong architecture).
+    """
+    results = []
+    failures = []
+    if not os.path.isdir(root):
+        failures.append("Payload root does not exist: %s" % root)
+        return results, failures
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames.sort()
+        for filename in sorted(filenames):
+            ext = os.path.splitext(filename)[1].lower()
+            if ext not in (".exe", ".dll", ".pyd"):
+                continue
+            full_path = os.path.join(dirpath, filename)
+            try:
+                machine = read_pe_machine(full_path)
+            except OSError as exc:
+                failures.append("Could not read %s: %s" % (full_path, exc))
+                continue
+
+            if machine is None:
+                failures.append("Not a valid PE file (no MZ/PE header): %s" % full_path)
+                continue
+
+            results.append({
+                "path": full_path,
+                "machine": machine,
+                "machine_name": machine_name(machine),
+            })
+            if machine != IMAGE_FILE_MACHINE_ARM64:
+                failures.append(
+                    "Wrong architecture %s (expected ARM64/0xAA64): %s"
+                    % (machine_name(machine), full_path)
+                )
+
+    return results, failures
+
+
+def verify_package_lock(path):
+    failures = []
+    verified = []
+    try:
+        with open(path, encoding="utf-8") as stream:
+            entries = [
+                line.strip()
+                for line in stream
+                if line.strip() and not line.lstrip().startswith("#")
+            ]
+    except OSError as exc:
+        return verified, ["Unable to read package lock %s: %s" % (path, exc)]
+    for entry in entries:
+        if "=" not in entry or "," not in entry.split("=", 1)[1]:
+            failures.append("Malformed package lock entry: %s" % entry)
+            continue
+        package, remainder = entry.split("=", 1)
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9@._+:-]*", package):
+            failures.append("Invalid package name in lock: %r" % package)
+            continue
+        expected_version, expected_sha256 = (
+            value.strip() for value in remainder.split(",", 1)
+        )
+        if expected_sha256 != "UNVERIFIED-NO-SIGNED-SNAPSHOT":
+            failures.append(
+                "Package archive hash verification is not implemented for %s: %s"
+                % (package, expected_sha256)
+            )
+        try:
+            completed = subprocess.run(
+                ["pacman", "-Q", "--", package],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError as exc:
+            failures.append("Unable to run pacman for %s: %s" % (package, exc))
+            continue
+        if completed.returncode != 0:
+            failures.append("Package not installed: %s" % package)
+            continue
+        lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+        fields = lines[0].split() if lines else []
+        if len(fields) != 2 or fields[0] != package:
+            failures.append(
+                "Unexpected pacman output for %s: %r" % (package, completed.stdout)
+            )
+            continue
+        actual_version = fields[1]
+        verified.append({
+            "package": package,
+            "version": actual_version,
+            "expected_version": expected_version,
+            "expected_sha256": expected_sha256,
+        })
+        if actual_version != expected_version:
+            failures.append(
+                "Wrong package version for %s: %s (expected %s)"
+                % (package, actual_version, expected_version)
+            )
+    return verified, failures
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--payload-root",
+        default=None,
+        help="Directory to recursively scan for .exe/.dll/.pyd PE architecture. "
+             "If omitted, only the native-process oracle check runs.",
+    )
+    parser.add_argument(
+        "--require-payload",
+        action="store_true",
+        help="Fail if --payload-root is omitted or contains no valid PE candidate files.",
+    )
+    parser.add_argument(
+        "--require-native-arm64",
+        action="store_true",
+        help="Fail unless the current process is running natively on Windows Arm64.",
+    )
+    parser.add_argument(
+        "--json-report",
+        default=None,
+        help="Optional path to write the full machine-readable report.",
+    )
+    parser.add_argument(
+        "--package-lock",
+        default=None,
+        help="Verify installed pacman package versions against this lock file.",
+    )
+    args = parser.parse_args()
+
+    oracle = read_native_process_oracle()
+
+    payload_results = []
+    payload_failures = []
+    if args.payload_root:
+        payload_results, payload_failures = scan_payload_architecture(args.payload_root)
+        if args.require_payload and not payload_results:
+            payload_failures.append(
+                "No valid PE .exe/.dll/.pyd files were scanned under: %s" % args.payload_root
+            )
+    elif args.require_payload:
+        payload_failures.append("--require-payload was set but --payload-root was not provided.")
+
+    package_results = []
+    package_failures = []
+    if args.package_lock:
+        package_results, package_failures = verify_package_lock(args.package_lock)
+
+    report = {
+        "contract": "windows-arm64-clangarm64-v1",
+        "amendment": "A1",
+        "native_process_oracle": oracle,
+        "native_process_required": args.require_native_arm64,
+        "payload_root": args.payload_root,
+        "payload_files_scanned": len(payload_results),
+        "payload_failures": payload_failures,
+        "payload_results": payload_results,
+        "package_lock": args.package_lock,
+        "package_results": package_results,
+        "package_failures": package_failures,
+    }
+
+    print("== Native Arm64 process oracle (design-amendment-A1) ==")
+    if oracle["checked"]:
+        print("  process_machine = %s" % machine_name(oracle["process_machine"]))
+        print("  native_machine  = %s" % machine_name(oracle["native_machine"]))
+        print("  wow/emulated    = %s" % oracle["is_wow_or_emulated"])
+        print("  native ARM64 ok = %s" % oracle["native_arm64_ok"])
+    else:
+        print("  NOT AVAILABLE: %s" % oracle["reason"])
+
+    print("== Recursive payload PE architecture scan ==")
+    if args.payload_root:
+        print("  root = %s" % args.payload_root)
+        print("  files scanned = %d" % len(payload_results))
+        for failure in payload_failures:
+            print("  FAIL: %s" % failure)
+    else:
+        print("  SKIPPED: no --payload-root supplied")
+
+    print("== MSYS2 package lock ==")
+    if args.package_lock:
+        print("  lock = %s" % args.package_lock)
+        print("  packages verified = %d" % len(package_results))
+        for failure in package_failures:
+            print("  FAIL: %s" % failure)
+    else:
+        print("  SKIPPED: no --package-lock supplied")
+
+    if args.json_report:
+        with open(args.json_report, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+
+    if args.require_native_arm64 and not oracle["native_arm64_ok"]:
+        reason = oracle["reason"] or (
+            "observed process_machine=%s, native_machine=%s"
+            % (
+                machine_name(oracle["process_machine"]),
+                machine_name(oracle["native_machine"]),
+            )
+        )
+        print("RESULT: FAIL (native Windows Arm64 process required: %s)" % reason)
+        return 1
+
+    if payload_failures:
+        print("RESULT: FAIL (%d payload architecture problem(s))" % len(payload_failures))
+        return 1
+    if package_failures:
+        print("RESULT: FAIL (%d package lock problem(s))" % len(package_failures))
+        return 1
+
+    print("RESULT: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/windows-arm64-packages.lock
+++ b/ci/windows-arm64-packages.lock
@@ -1,0 +1,45 @@
+# Windows Arm64 MSYS2 CLANGARM64 package/provenance lock
+# SPDX-FileCopyrightText: 2026 OpenShot Studios, LLC
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+# Contract identity: windows-arm64-clangarm64-v1
+# Target: Windows 11 Arm64, PE/COFF Machine=ARM64 (0xAA64)
+# Environment: MSYS2 CLANGARM64 at C:\msys64\clangarm64, aarch64-w64-mingw32
+#
+# This file pins the exact MSYS2 CLANGARM64 package set/versions required to
+# build libopenshot-audio (and, transitively, libopenshot and openshot-qt) for
+# the native Windows Arm64 lane. It is consumed unchanged by PR A, PR B, and
+# PR C so that all three producer artifacts share one dependency snapshot.
+#
+# Populate the sha256 column from the signed MSYS2 CLANGARM64 repo database
+# (repo.db.sig) once release infrastructure publishes the mirrored/pinned
+# snapshot required by design-spec.md G1. Until that snapshot exists, this
+# lock records the exact package/version identity only; the sha256 column is
+# intentionally left as UNVERIFIED-NO-SIGNED-SNAPSHOT so no producer job can
+# silently claim checksum verification that has not actually happened.
+#
+# name=version-release,sha256
+mingw-w64-clang-aarch64-clang=22.1.8-2,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-libc++=22.1.8-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-compiler-rt=22.1.8-2,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-llvm-openmp=22.1.8-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-libwinpthread=14.0.0.r302.gd7f3c5201-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-cmake=4.4.2-2,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-ninja=1.13.2-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-swig=4.5.0-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-python=3.14.7-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-python-pyqt6=6.11.0-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-python-pyqt6-sip=13.12.0-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-qt6-base=6.11.2-2,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-qt6-svg=6.11.2-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-qt6-multimedia=6.11.2-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-qt6-imageformats=6.11.2-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-ffmpeg=9.0.1-3,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-opencv=5.0.0-3,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-protobuf=35.1-2,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-zeromq=4.3.5-5,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-cppzmq=4.11.0-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-babl=0.1.128-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-imagemagick=7.1.2.30-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-jsoncpp=1.9.8-1,UNVERIFIED-NO-SIGNED-SNAPSHOT
+mingw-w64-clang-aarch64-zlib=1.3.2-2,UNVERIFIED-NO-SIGNED-SNAPSHOT

--- a/freeze.py
+++ b/freeze.py
@@ -139,13 +139,22 @@ if os.path.exists(openshot_copy_path):
     sys.path.append(openshot_copy_path)
     print("Loaded modules from openshot_qt directory: %s" % openshot_copy_path)
 
-# Detect artifact folder (if any)
-artifact_path = os.path.join(PATH, "build", "install-x64")
-if not os.path.exists(artifact_path):
-    artifact_path = os.path.join(PATH, "build", "install-x86")
-if not os.path.exists(artifact_path):
-    # Default to user install path
-    artifact_path = ""
+# Detect artifact folder (if any). Prefer the active MSYS2 architecture, while
+# preserving the historical x64 -> x86 fallback when MSYSTEM is unset.
+msystem_artifact = {
+    "clangarm64": "install-arm64",
+    "mingw64": "install-x64",
+    "mingw32": "install-x86",
+}.get(os.getenv("MSYSTEM", "").lower())
+artifact_names = [msystem_artifact] if msystem_artifact else ["install-x64", "install-x86"]
+artifact_path = next(
+    (
+        os.path.join(PATH, "build", artifact_name)
+        for artifact_name in dict.fromkeys(artifact_names)
+        if os.path.exists(os.path.join(PATH, "build", artifact_name))
+    ),
+    "",
+)
 
 # Append possible build server paths
 if artifact_path:

--- a/installer/build_server.py
+++ b/installer/build_server.py
@@ -750,6 +750,8 @@ def prepare_windows_msix_artifacts():
 
 
 def main():
+    windows_arch = "x64"
+    windows_32bit = False
     # Only run this code when directly executing this script. Parts of this file
     # are also used in the deploy.py script.
     try:
@@ -775,8 +777,20 @@ def main():
             repo = gh.repository("OpenShot", "openshot-qt")
 
         if len(sys.argv) >= 5:
-            if sys.argv[4] == 'True':
+            arch_arg = sys.argv[4].strip().lower()
+            if arch_arg == 'arm64':
+                windows_arch = "arm64"
+                windows_32bit = False
+            elif arch_arg in ('x86', 'true'):
+                windows_arch = "x86"
                 windows_32bit = True
+            elif arch_arg in ('x64', 'false'):
+                windows_arch = "x64"
+                windows_32bit = False
+            else:
+                raise ValueError(
+                    "Unsupported Windows architecture %r; expected x86, x64, "
+                    "arm64, True, or False" % sys.argv[4])
 
         mac_password = ""
         if len(sys.argv) >= 7:
@@ -790,13 +804,29 @@ def main():
                 git_branch_name)
             )
 
-        # Detect artifact folder (if any)
-        artifact_path = os.path.join(PATH, "build", "install-x64")
-        if not os.path.exists(artifact_path):
-            artifact_path = os.path.join(PATH, "build", "install-x86")
-        if not os.path.exists(artifact_path):
-            # Default to user install path
-            artifact_path = ""
+        # Detect the artifact folder for the active Windows architecture.
+        # Preserve the historical x64/x86 fallback order on other platforms.
+        artifact_names = ["install-x64", "install-x86"]
+        if platform.system() == "Windows":
+            preferred_artifact = {
+                "x64": "install-x64",
+                "x86": "install-x86",
+                "arm64": "install-arm64",
+            }[windows_arch]
+            artifact_path = os.path.join(PATH, "build", preferred_artifact)
+            if not os.path.isdir(artifact_path):
+                raise FileNotFoundError(
+                    "Required %s artifact directory not found: %s"
+                    % (windows_arch, artifact_path))
+        else:
+            artifact_path = next(
+                (
+                    os.path.join(PATH, "build", artifact_name)
+                    for artifact_name in artifact_names
+                    if os.path.exists(os.path.join(PATH, "build", artifact_name))
+                ),
+                "",
+            )
 
         # Parse artifact version files (if found)
         for repo_name in ["libopenshot-audio", "libopenshot", "openshot-qt"]:
@@ -838,6 +868,9 @@ def main():
         elif platform.system() == "Darwin":
             app_name += "-x86_64.dmg"
             app_upload_bucket = "releases.openshot.org/mac"
+        elif platform.system() == "Windows" and windows_arch == "arm64":
+            app_name += "-arm64.exe"
+            app_upload_bucket = "releases.openshot.org/windows"
         elif platform.system() == "Windows" and not windows_32bit:
             app_name += "-x86_64.exe"
             app_upload_bucket = "releases.openshot.org/windows"
@@ -994,7 +1027,9 @@ def main():
 
         if platform.system() == "Windows":
             only_64_bit = "x64"
-            if windows_32bit:
+            if windows_arch == "arm64":
+                only_64_bit = "arm64"
+            elif windows_32bit:
                 only_64_bit = ""
 
             if windows_mode != "sign-upload-only":
@@ -1029,23 +1064,50 @@ def main():
                     else:
                         output("Invalid delete path: %s" % full_delete_path)
 
-                # Replace these folders (cx_Freeze messes this up, so this fixes it)
+                # Replace these folders (cx_Freeze messes this up, so this fixes it).
+                # windows-arm64-clangarm64-v1 uses Qt6/PyQt6 from the CLANGARM64
+                # prefix; the MinGW Qt5 plugin-copy quirk below only applies to
+                # the existing x64/x86 MinGW Qt5 lanes and is left unchanged.
                 paths_to_replace = ['imageformats', 'platforms']
-                for replace_name in paths_to_replace:
-                    if windows_32bit:
-                        shutil.copytree(
-                            os.path.join('C:\\msys64\\mingw32\\share\\qt5\\plugins', replace_name),
-                            os.path.join(exe_dir, replace_name))
-                    else:
-                        shutil.copytree(
-                            os.path.join('C:\\msys64\\mingw64\\share\\qt5\\plugins', replace_name),
-                            os.path.join(exe_dir, replace_name))
+                if windows_arch == "arm64":
+                    paths_to_replace.extend(['iconengines', 'multimedia'])
+                    for replace_name in paths_to_replace:
+                        arm64_plugin_src = os.path.join(
+                            'C:\\msys64\\clangarm64\\share\\qt6\\plugins', replace_name)
+                        if not os.path.isdir(arm64_plugin_src):
+                            raise FileNotFoundError(
+                                "Required Qt6 arm64 plugin directory not found: %s"
+                                % arm64_plugin_src)
+                        dest = os.path.join(exe_dir, replace_name)
+                        if os.path.exists(dest):
+                            shutil.rmtree(dest)
+                        shutil.copytree(arm64_plugin_src, dest)
+                else:
+                    for replace_name in paths_to_replace:
+                        if windows_32bit:
+                            shutil.copytree(
+                                os.path.join('C:\\msys64\\mingw32\\share\\qt5\\plugins', replace_name),
+                                os.path.join(exe_dir, replace_name))
+                        else:
+                            shutil.copytree(
+                                os.path.join('C:\\msys64\\mingw64\\share\\qt5\\plugins', replace_name),
+                                os.path.join(exe_dir, replace_name))
 
-                # Copy Qt5Core.dll, Qt5Svg.dll to root of frozen directory
-                paths_to_copy = [
-                    ("Qt5Core.dll", "C:\\msys64\\mingw64\\bin\\"),
-                    ("Qt5Svg.dll", "C:\\msys64\\mingw64\\bin\\"),
-                    ]
+                # Copy Qt5Core.dll, Qt5Svg.dll (or, for arm64, Qt6Core.dll/Qt6Svg.dll)
+                # to root of frozen directory
+                if windows_arch == "arm64":
+                    paths_to_copy = [
+                        ("Qt6Core.dll", "C:\\msys64\\clangarm64\\bin\\"),
+                        ("Qt6Gui.dll", "C:\\msys64\\clangarm64\\bin\\"),
+                        ("Qt6Widgets.dll", "C:\\msys64\\clangarm64\\bin\\"),
+                        ("Qt6Svg.dll", "C:\\msys64\\clangarm64\\bin\\"),
+                        ("Qt6Multimedia.dll", "C:\\msys64\\clangarm64\\bin\\"),
+                        ]
+                else:
+                    paths_to_copy = [
+                        ("Qt5Core.dll", "C:\\msys64\\mingw64\\bin\\"),
+                        ("Qt5Svg.dll", "C:\\msys64\\mingw64\\bin\\"),
+                        ]
                 if windows_32bit:
                     paths_to_copy = [
                         ("Qt5Core.dll", "C:\\msys64\\mingw32\\bin\\"),
@@ -1054,6 +1116,9 @@ def main():
                 for qt_file_name, qt_parent_path in paths_to_copy:
                     qt5_path = os.path.join(qt_parent_path, qt_file_name)
                     new_qt5_path = os.path.join(exe_dir, qt_file_name)
+                    if windows_arch == "arm64" and not os.path.isfile(qt5_path):
+                        raise FileNotFoundError(
+                            "Required Qt6 arm64 runtime DLL not found: %s" % qt5_path)
                     if os.path.exists(qt5_path) and not os.path.exists(new_qt5_path):
                         output("Copying %s to %s" % (qt5_path, new_qt5_path))
                         shutil.copy(qt5_path, new_qt5_path)

--- a/installer/deploy.py
+++ b/installer/deploy.py
@@ -43,7 +43,7 @@ from build_server import (
     version_info, parse_version_info)
 
 PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))  # Primary openshot folder
-RELEASE_NAME_REGEX = re.compile(r'^OpenShot-v.*?(-.*?)-x86[_64]*')
+RELEASE_NAME_REGEX = re.compile(r'^OpenShot-v.*?(-.*?)-(?:x86(?:_64)?|arm64)(?=$|[-.])')
 DOWNLOAD_PAGE_URLS = re.compile(r'"(//github.com/OpenShot/openshot-qt/releases/download/v.*?/OpenShot-.*?)"',
                                 re.MULTILINE)
 

--- a/installer/package_msix.ps1
+++ b/installer/package_msix.ps1
@@ -1,5 +1,36 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("x86_64", "x86", "arm64")]
+    [string] $Architecture = "x86_64",
+
+    [Parameter(Mandatory = $false)]
+    [string] $InstallerPath,
+
+    [Parameter(Mandatory = $false)]
+    [string] $TemplatePath,
+
+    [Parameter(Mandatory = $false)]
+    [switch] $PrepareOnly,
+
+    [Parameter(Mandatory = $false)]
+    [string] $PreparationReportPath
+)
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+$InstallerFilter = "OpenShot-*-$Architecture.exe"
+$InstallDirectoryName = @{
+    "x86_64" = "install-x64"
+    "x86" = "install-x86"
+    "arm64" = "install-arm64"
+}[$Architecture]
+$ProcessorArchitecture = @{
+    "x86_64" = "x64"
+    "x86" = "x86"
+    "arm64" = "arm64"
+}[$Architecture]
 
 function Test-Administrator {
     $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
@@ -148,7 +179,7 @@ function Get-MsixVersion {
         [string] $ArtifactRoot
     )
 
-    $versionFile = Join-Path $ArtifactRoot "build\install-x64\share\openshot-qt.env"
+    $versionFile = Join-Path $ArtifactRoot "build\$InstallDirectoryName\share\openshot-qt.env"
     if (-not (Test-Path -Path $versionFile -PathType Leaf)) {
         throw "OpenShot version metadata not found: $versionFile"
     }
@@ -184,7 +215,7 @@ function Assert-SourceInstallerNotPackaged {
             foreach ($entry in $archive.Entries) {
                 $normalizedName = $entry.FullName -replace '\\', '/'
                 if ($normalizedName -like "VFS/AppVPackageDrive/*/$sourceInstallerName" -or
-                    $normalizedName -like "VFS/AppVPackageDrive/*/OpenShot-*-x86_64.exe") {
+                    $normalizedName -like "VFS/AppVPackageDrive/*/$InstallerFilter") {
                     $entry.FullName
                 }
             }
@@ -258,50 +289,99 @@ function Resolve-MsixPackagingTool {
     throw "MSIX Packaging Tool CLI not found. Checked package-root path, app execution alias, manifest AppID Msix.App, and package executable search. Package executables found: $($allPackageExes -join ', ')"
 }
 
-if (-not (Test-Administrator)) {
+function Assert-PackageProcessorArchitecture {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $PackagePath,
+
+        [Parameter(Mandatory = $true)]
+        [string] $ExpectedArchitecture
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
+    try {
+        $manifestEntry = $archive.GetEntry("AppxManifest.xml")
+        if (-not $manifestEntry) {
+            throw "MSIX package has no AppxManifest.xml: $PackagePath"
+        }
+        $reader = New-Object System.IO.StreamReader($manifestEntry.Open())
+        try {
+            [xml] $manifestXml = $reader.ReadToEnd()
+        }
+        finally {
+            $reader.Dispose()
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+
+    $identity = $manifestXml.SelectSingleNode("//*[local-name()='Identity']")
+    if (-not $identity) {
+        throw "MSIX manifest has no Identity element: $PackagePath"
+    }
+    $actualArchitecture = $identity.GetAttribute("ProcessorArchitecture")
+    if ($actualArchitecture -ne $ExpectedArchitecture) {
+        throw "MSIX ProcessorArchitecture is '$actualArchitecture', expected '$ExpectedArchitecture'."
+    }
+}
+
+if (-not $PrepareOnly -and -not (Test-Administrator)) {
     throw "MSIX packaging requires an elevated/admin Windows runner."
 }
 
-$installerMatches = @(Get-ChildItem -Path "build" -Filter "OpenShot-*-x86_64.exe" -File)
-Assert-SingleArtifact -Artifacts $installerMatches -Description "build\OpenShot-*-x86_64.exe installer"
-$installerPath = $installerMatches[0].FullName
-Write-Information "Using Inno installer: $installerPath"
+if ($InstallerPath) {
+    $InstallerPath = (Resolve-Path -Path $InstallerPath).Path
+}
+else {
+    $installerMatches = @(Get-ChildItem -Path "build" -Filter $InstallerFilter -File)
+    Assert-SingleArtifact -Artifacts $installerMatches -Description "build\$InstallerFilter installer"
+    $InstallerPath = $installerMatches[0].FullName
+}
+Write-Information "Using Inno installer: $InstallerPath"
 
-$toolPackage = Get-AppxPackage Microsoft.MSIXPackagingTool
-if (-not $toolPackage) {
-    throw "Microsoft.MSIXPackagingTool is not installed."
+if (-not $PrepareOnly) {
+    $toolPackage = Get-AppxPackage Microsoft.MSIXPackagingTool
+    if (-not $toolPackage) {
+        throw "Microsoft.MSIXPackagingTool is not installed."
+    }
+
+    $ToolDir = $toolPackage.InstallLocation
+    $ToolExe = Resolve-MsixPackagingTool -ToolPackage $toolPackage
+    Write-Information "Using MSIX Packaging Tool: $ToolExe"
 }
 
-$ToolDir = $toolPackage.InstallLocation
-$ToolExe = Resolve-MsixPackagingTool -ToolPackage $toolPackage
-Write-Information "Using MSIX Packaging Tool: $ToolExe"
-
-$templatePath = Join-Path $PSScriptRoot "openshot-msix-template.xml"
-if (-not (Test-Path -Path $templatePath -PathType Leaf)) {
-    throw "MSIX template not found: $templatePath"
+if (-not $TemplatePath) {
+    $TemplatePath = Join-Path $PSScriptRoot "openshot-msix-template.xml"
+}
+if (-not (Test-Path -Path $TemplatePath -PathType Leaf)) {
+    throw "MSIX template not found: $TemplatePath"
 }
 
 $outputDir = Join-Path $PWD "build\msix"
 New-Item -Path $outputDir -ItemType Directory -Force | Out-Null
-Remove-Item -Path (Join-Path $outputDir "*.msix") -Force -ErrorAction SilentlyContinue
 $toolLogPath = Join-Path $outputDir "msix-packaging-tool.log"
-Remove-Item -Path $toolLogPath -Force -ErrorAction SilentlyContinue
+if (-not $PrepareOnly) {
+    Remove-Item -Path (Join-Path $outputDir "*.msix") -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path $toolLogPath -Force -ErrorAction SilentlyContinue
+}
 
-$templateText = Get-Content -Path $templatePath -Raw
+$templateText = Get-Content -Path $TemplatePath -Raw
 foreach ($arg in @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-")) {
     if ($templateText -notmatch [regex]::Escape($arg)) {
         throw "MSIX template is missing required Inno silent argument: $arg"
     }
 }
 
-$expectedInstallerPath = Get-TemplateInstallerPath -TemplatePath $templatePath
+$expectedInstallerPath = Get-TemplateInstallerPath -TemplatePath $TemplatePath
 Write-Information "MSIX template expects installer: $expectedInstallerPath"
 
-$sourceInstallerDir = Join-Path ([System.IO.Path]::GetTempPath()) "OpenShot-MSIX-InstallerSource"
+$sourceInstallerDir = Join-Path $outputDir "installer-source"
 Remove-Item -Path $sourceInstallerDir -Recurse -Force -ErrorAction SilentlyContinue
 New-Item -Path $sourceInstallerDir -ItemType Directory -Force | Out-Null
-$sourceInstallerPath = Join-Path $sourceInstallerDir ([System.IO.Path]::GetFileName($installerPath))
-Copy-Item -Path $installerPath -Destination $sourceInstallerPath -Force
+$sourceInstallerPath = Join-Path $sourceInstallerDir ([System.IO.Path]::GetFileName($InstallerPath))
+Copy-Item -Path $InstallerPath -Destination $sourceInstallerPath -Force
 Write-Information "Staged MSIX source installer: $sourceInstallerPath"
 
 $workingTemplatePath = Join-Path $outputDir "OpenShot_template.generated.xml"
@@ -335,6 +415,30 @@ Set-TemplateAttribute -TemplatePath $workingTemplatePath -ElementName "PackageIn
 Write-Information "Generated MSIX template publisher display name: $publisherDisplayName"
 Write-Information "Generated MSIX template: $workingTemplatePath"
 
+if ($PreparationReportPath) {
+    $reportDir = Split-Path -Path $PreparationReportPath -Parent
+    if ($reportDir) {
+        New-Item -Path $reportDir -ItemType Directory -Force | Out-Null
+    }
+    [ordered]@{
+        architecture = $Architecture
+        processor_architecture = $ProcessorArchitecture
+        output_dir = $outputDir
+        installer_path = $InstallerPath
+        source_installer_dir = $sourceInstallerDir
+        source_installer_path = $sourceInstallerPath
+        working_template_path = $workingTemplatePath
+        generated_package_path = $generatedPackagePath
+        publisher = $msixPublisher
+        publisher_display_name = $publisherDisplayName
+    } | ConvertTo-Json | Set-Content -Path $PreparationReportPath -Encoding UTF8
+}
+
+if ($PrepareOnly) {
+    Write-Information "MSIX preparation-only mode completed."
+    return
+}
+
 Write-Information "Running MSIX Packaging Tool. Full output will be saved to: $toolLogPath"
 & $ToolExe create-package --template $workingTemplatePath -v *> $toolLogPath
 if ($LASTEXITCODE -ne 0) {
@@ -350,8 +454,11 @@ if (-not (Test-Path -Path $generatedPackagePath -PathType Leaf)) {
     throw "MSIX Packaging Tool did not create the expected package: $generatedPackagePath"
 }
 Assert-SourceInstallerNotPackaged -PackagePath $generatedPackagePath -SourceInstallerPath $sourceInstallerPath
+Assert-PackageProcessorArchitecture `
+    -PackagePath $generatedPackagePath `
+    -ExpectedArchitecture $ProcessorArchitecture
 
-$artifactName = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetFileName($installerPath), ".msix")
+$artifactName = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetFileName($InstallerPath), ".msix")
 $artifactPath = Join-Path $outputDir $artifactName
 Move-Item -Path $generatedPackagePath -Destination $artifactPath -Force
 $publishedPackages = @(Get-ChildItem -Path $outputDir -Filter "*.msix" -File)

--- a/src/tests/test_native_arm64_process_oracle.py
+++ b/src/tests/test_native_arm64_process_oracle.py
@@ -1,0 +1,105 @@
+"""
+ @file
+ @brief Unit tests for the Windows native Arm64 process/payload
+        architecture oracle (design-spec.md G2/G3/G8/G11,
+        design-amendment-A1)
+ @author OpenShot Studios, LLC
+
+ @section LICENSE
+
+ Copyright (c) 2008-2026 OpenShot Studios, LLC
+ (http://www.openshotstudios.com). This file is part of
+ OpenShot Video Editor (http://www.openshot.org), an open-source project
+ dedicated to delivering high quality video editing and animation solutions
+ to the world.
+"""
+
+import importlib.util
+import sys
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+VALIDATOR_PATH = Path(__file__).resolve().parents[2] / "ci" / "validate_arm64_architecture.py"
+VALIDATOR_SPEC = importlib.util.spec_from_file_location(
+    "validate_arm64_architecture", VALIDATOR_PATH
+)
+if VALIDATOR_SPEC is None or VALIDATOR_SPEC.loader is None:
+    raise RuntimeError("Unable to load validator from %s" % VALIDATOR_PATH)
+validator = importlib.util.module_from_spec(VALIDATOR_SPEC)
+VALIDATOR_SPEC.loader.exec_module(validator)
+
+IMAGE_FILE_MACHINE_UNKNOWN = validator.IMAGE_FILE_MACHINE_UNKNOWN
+IMAGE_FILE_MACHINE_ARM64 = validator.IMAGE_FILE_MACHINE_ARM64
+read_native_process_oracle = validator.read_native_process_oracle
+
+
+class NativeArm64ProcessOracleTests(unittest.TestCase):
+    """
+    These tests exercise the exact design-amendment-A1 semantics against the
+    real, running interpreter. They deliberately do not assert host
+    architecture: on this AMD64 development/CI host, native_arm64_ok is
+    expected to be False (native_machine == AMD64, not ARM64), and that is
+    not a release claim. The tests only assert internal consistency of the
+    oracle's derived fields, which is true on every host.
+    """
+
+    def test_oracle_reports_consistent_wow_state(self):
+        oracle = read_native_process_oracle()
+        if not oracle["checked"]:
+            self.skipTest("IsWow64Process2 unavailable: %s" % oracle["reason"])
+        self.assertEqual(
+            oracle["is_wow_or_emulated"],
+            oracle["process_machine"] != IMAGE_FILE_MACHINE_UNKNOWN,
+        )
+
+    def test_native_arm64_ok_requires_both_fields(self):
+        oracle = read_native_process_oracle()
+        if not oracle["checked"]:
+            self.skipTest("IsWow64Process2 unavailable: %s" % oracle["reason"])
+        expected = (
+            oracle["native_machine"] == IMAGE_FILE_MACHINE_ARM64
+            and oracle["process_machine"] == IMAGE_FILE_MACHINE_UNKNOWN
+        )
+        self.assertEqual(oracle["native_arm64_ok"], expected)
+
+    def test_nonzero_process_machine_always_fails_native_arm64_ok(self):
+        oracle = read_native_process_oracle()
+        if not oracle["checked"]:
+            self.skipTest("IsWow64Process2 unavailable: %s" % oracle["reason"])
+        if oracle["process_machine"] != IMAGE_FILE_MACHINE_UNKNOWN:
+            self.assertFalse(oracle["native_arm64_ok"])
+
+    def test_validator_rejects_non_arm64_host_when_required(self):
+        observed = {
+            "checked": True,
+            "process_machine": IMAGE_FILE_MACHINE_UNKNOWN,
+            "native_machine": 0x8664,
+            "is_wow_or_emulated": False,
+            "native_arm64_ok": False,
+            "reason": None,
+        }
+        with mock.patch.object(validator, "read_native_process_oracle", return_value=observed):
+            with mock.patch.object(sys, "argv", ["validator", "--require-native-arm64"]):
+                with redirect_stdout(StringIO()):
+                    self.assertEqual(validator.main(), 1)
+
+    def test_validator_accepts_native_arm64_host_when_required(self):
+        observed = {
+            "checked": True,
+            "process_machine": IMAGE_FILE_MACHINE_UNKNOWN,
+            "native_machine": IMAGE_FILE_MACHINE_ARM64,
+            "is_wow_or_emulated": False,
+            "native_arm64_ok": True,
+            "reason": None,
+        }
+        with mock.patch.object(validator, "read_native_process_oracle", return_value=observed):
+            with mock.patch.object(sys, "argv", ["validator", "--require-native-arm64"]):
+                with redirect_stdout(StringIO()):
+                    self.assertEqual(validator.main(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope: Windows Arm64 pre-action readiness

This draft adds the application, freeze, installer, and MSIX plumbing needed to produce a native Windows Arm64 OpenShot candidate. It intentionally stops before maintainer-owned signing/publication.

### Changes
- Arm64 GitLab build, MSIX package, and signing-stage wiring
- architecture-aware dependency discovery, cx_Freeze, installer naming, and deployment parsing
- fail-closed native-host and recursive install/frozen PE validation
- current OpenShot 4.0 MSIX identity/version handling with repo-local preparation
- generated package verification requiring `AppxManifest.xml` `ProcessorArchitecture=arm64`
- targeted validator, process-oracle, and MSIX preparation tests

### Evidence
- current with upstream `develop` and mergeable
- native Arm64 process oracle passed on real hardware
- MSIX preparation/staging tests pass
- audio and library dependencies have native Arm64 build/test evidence

### Dependencies
- OpenShot/libopenshot-audio#171
- OpenShot/libopenshot#1089

### Exit from draft
Produce one end-to-end native candidate: `import openshot`, PyQt6/QWidget startup, cx_Freeze, deterministic export, Arm64 Inno/MSIX creation, package-manifest verification, install, GUI launch, export, and uninstall.

### Post-actions owned by maintainers
Signing credentials, official release publication, and support announcement.

AI assistance disclosure: implementation and review used GitHub Copilot CLI.