### PR TITLE
Support qt_api imports on Python 3.6

### DIFF
--- a/src/qt_api.py
+++ b/src/qt_api.py
@@ -2488,6 +2488,13 @@ def _select_binding() -> str:
                 )
                 if m is not None
             ]
+            # Python 3.6 does not support module-level __getattr__ (PEP 562),
+            # so expose Qt types eagerly as well as through the lazy fallback
+            # below. Preserve the same module precedence used by __getattr__.
+            for module in _MODULES:
+                for name in dir(module):
+                    if not name.startswith("_"):
+                        globals().setdefault(name, getattr(module, name))
             _patch_enums_for_qt6()
             QByteArray = getattr(QtCore, "QByteArray", None)
             QDir = getattr(QtCore, "QDir", None)

--- a/src/tests/test_qt_api.py
+++ b/src/tests/test_qt_api.py
@@ -1,0 +1,25 @@
+"""Tests for the centralized Qt binding loader."""
+
+import os
+import sys
+import unittest
+
+
+PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+if PATH not in sys.path:
+    sys.path.append(PATH)
+
+import qt_api
+
+
+class QtApiTests(unittest.TestCase):
+    def test_common_qt_types_are_eagerly_exported(self):
+        """Python 3.6 cannot use the module-level __getattr__ fallback."""
+        for name in ("QCoreApplication", "QPointF", "QRectF", "Qt"):
+            with self.subTest(name=name):
+                self.assertIn(name, vars(qt_api))
+                self.assertIsNotNone(vars(qt_api)[name])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is also breaking on older, Bionic build servers (Launchpad PPA)