### PR TITLE
Preserve clip positions and transform alignment across the 4.0.0 upgrade

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -939,18 +939,30 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         ):
             self._migrate_legacy_crop_locations()
 
+        # OpenShot 4.0.0 saved non-Crop locations using libopenshot 1.0's
+        # temporary geometry-relative behavior. Convert those values back to
+        # canvas-relative units so the positions remain unchanged with the
+        # corrected libopenshot behavior.
+        if (
+            self._numeric_version(openshot_version) == (4, 0, 0)
+            and "-" not in openshot_version
+        ):
+            self._migrate_400_non_crop_locations()
+
         # Fix default project id (if found)
         if self._data.get("id") == "T0":
             self._data["id"] = self.generate_id()
 
     @staticmethod
-    def _version_at_most(version, cutoff):
-        """Compare the numeric components of release-like version strings."""
-        def numeric_version(value):
-            numbers = [int(part) for part in re.findall(r"\d+", str(value))[:3]]
-            return tuple((numbers + [0, 0, 0])[:3])
+    def _numeric_version(value):
+        """Return three numeric components from a release-like version."""
+        numbers = [int(part) for part in re.findall(r"\d+", str(value))[:3]]
+        return tuple((numbers + [0, 0, 0])[:3])
 
-        return numeric_version(version) <= numeric_version(cutoff)
+    @classmethod
+    def _version_at_most(cls, version, cutoff):
+        """Compare the numeric components of release-like version strings."""
+        return cls._numeric_version(version) <= cls._numeric_version(cutoff)
 
     @staticmethod
     def _keyframe_value(keyframe_data, frame, default):
@@ -1052,6 +1064,77 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                     "Migrating legacy SCALE_CROP location keyframes for clip %s",
                     clip.get("id", "<unknown>"),
                 )
+
+    def _migrate_400_non_crop_locations(self):
+        """Preserve non-Crop positions saved by the OpenShot 4.0.0 release."""
+        canvas_width = float(self._data.get("width") or 0.0)
+        canvas_height = float(self._data.get("height") or 0.0)
+        if canvas_width <= 0.0 or canvas_height <= 0.0:
+            return
+
+        files = {
+            file_data.get("id"): file_data
+            for file_data in self._data.get("files", [])
+            if isinstance(file_data, dict)
+        }
+        horizontal_alignment = {
+            openshot.GRAVITY_TOP_LEFT: "start", openshot.GRAVITY_LEFT: "start",
+            openshot.GRAVITY_BOTTOM_LEFT: "start", openshot.GRAVITY_TOP_RIGHT: "end",
+            openshot.GRAVITY_RIGHT: "end", openshot.GRAVITY_BOTTOM_RIGHT: "end",
+        }
+        vertical_alignment = {
+            openshot.GRAVITY_TOP_LEFT: "start", openshot.GRAVITY_TOP: "start",
+            openshot.GRAVITY_TOP_RIGHT: "start", openshot.GRAVITY_BOTTOM_LEFT: "end",
+            openshot.GRAVITY_BOTTOM: "end", openshot.GRAVITY_BOTTOM_RIGHT: "end",
+        }
+
+        for clip in self._data.get("clips", []):
+            scale_mode = clip.get("scale", openshot.SCALE_FIT)
+            if scale_mode == openshot.SCALE_CROP:
+                continue
+            reader = clip.get("reader") or files.get(clip.get("file_id"), {})
+            source_width = float(reader.get("width") or 0.0)
+            source_height = float(reader.get("height") or 0.0)
+            if source_width <= 0.0 or source_height <= 0.0:
+                continue
+
+            gravity = clip.get("gravity", openshot.GRAVITY_CENTER)
+            for property_name, canvas_size, source_size, alignment, scale_name in (
+                ("location_x", canvas_width, source_width,
+                 horizontal_alignment.get(gravity, "center"), "scale_x"),
+                ("location_y", canvas_height, source_height,
+                 vertical_alignment.get(gravity, "center"), "scale_y"),
+            ):
+                for point in clip.get(property_name, {}).get("Points", []):
+                    coordinate = point.get("co")
+                    if not isinstance(coordinate, dict) or "Y" not in coordinate:
+                        continue
+                    frame = coordinate.get("X", 1.0)
+                    value = coordinate["Y"]
+                    margin = self._keyframe_value(clip.get("margin"), frame, 0.0)
+                    margin_pixels = max(0.0, min(0.5, margin)) * min(
+                        canvas_width, canvas_height)
+                    layout_size = max(1.0, canvas_size - (2.0 * margin_pixels))
+
+                    if scale_mode == openshot.SCALE_STRETCH:
+                        base_size = layout_size
+                    elif scale_mode == openshot.SCALE_NONE:
+                        base_size = source_size
+                    else:
+                        fit_scale = min(
+                            (canvas_width - 2.0 * margin_pixels) / source_width,
+                            (canvas_height - 2.0 * margin_pixels) / source_height,
+                        )
+                        base_size = source_size * fit_scale
+
+                    clip_size = base_size * self._keyframe_value(
+                        clip.get(scale_name), frame, 1.0)
+                    factor = self._legacy_location_factor(
+                        value, layout_size, clip_size, alignment)
+                    if factor:
+                        # Undo old->new conversion, then account for the fact
+                        # that restored non-Crop coordinates use the full canvas.
+                        coordinate["Y"] = value * layout_size / (factor * canvas_size)
 
     def is_keyframe_valid(self, keyframe, default_value):
         """Check if a keyframe is not empty (i.e. > 1 point, or a non default_value)"""

--- a/src/tests/test_project_data.py
+++ b/src/tests/test_project_data.py
@@ -538,7 +538,9 @@ class ProjectDataTests(unittest.TestCase):
                 store = make_store()
                 store._data = {
                     "version": {
-                        "openshot-qt": "4.0.0",
+                        "openshot-qt": (
+                            "4.0.0" if scale_mode == openshot.SCALE_CROP else "3.5.1"
+                        ),
                         "libopenshot": libopenshot_version,
                     },
                     "id": "P1",
@@ -569,6 +571,81 @@ class ProjectDataTests(unittest.TestCase):
                 self.assertEqual(
                     clip["location_y"]["Points"][0]["co"]["Y"], -0.5
                 )
+
+    def test_upgrade_migrates_400_fit_location_to_restored_canvas_units(self):
+        store = make_store()
+        fitted_height = 720.0 * 178.0 / 266.0
+        scaled_height = fitted_height / 9.0
+        store._data = {
+            "version": {"openshot-qt": "4.0.0", "libopenshot": "1.0.0"},
+            "id": "P1",
+            "width": 720,
+            "height": 720,
+            "files": [],
+            "clips": [{
+                "id": "C1",
+                "scale": openshot.SCALE_FIT,
+                "gravity": openshot.GRAVITY_CENTER,
+                "reader": {"width": 266, "height": 178},
+                "scale_x": {"Points": [{"co": {"X": 30, "Y": 1.0 / 9.0}}]},
+                "scale_y": {"Points": [{"co": {"X": 30, "Y": 1.0 / 9.0}}]},
+                "location_x": {"Points": [{"co": {"X": 30, "Y": -0.75}}]},
+                "location_y": {"Points": [{"co": {
+                    "X": 30,
+                    "Y": -310.0 / ((720.0 + scaled_height) / 2.0),
+                }}]},
+                "effects": [],
+            }],
+        }
+
+        ProjectDataStore.upgrade_project_data_structures(store)
+
+        clip = store._data["clips"][0]
+        self.assertAlmostEqual(
+            clip["location_x"]["Points"][0]["co"]["Y"], -5.0 / 12.0)
+        self.assertAlmostEqual(
+            clip["location_y"]["Points"][0]["co"]["Y"], -31.0 / 72.0)
+
+    def test_upgrade_migrates_400_non_crop_modes_with_gravity_margin_and_scale(self):
+        expected_locations = {
+            openshot.SCALE_FIT: (0.16, -0.18),
+            openshot.SCALE_STRETCH: (0.18, -0.18),
+            openshot.SCALE_NONE: (0.08, -0.09),
+        }
+        for scale_mode, expected in expected_locations.items():
+            with self.subTest(scale_mode=scale_mode):
+                store = make_store()
+                store._data = {
+                    "version": {"openshot-qt": "4.0.0", "libopenshot": "1.0.0"},
+                    "id": "P1", "width": 200, "height": 100, "files": [],
+                    "clips": [{
+                        "id": "C1", "scale": scale_mode,
+                        "gravity": openshot.GRAVITY_TOP_RIGHT,
+                        "reader": {"width": 80, "height": 40},
+                        "margin": {"Points": [{"co": {"X": 10, "Y": 0.1}}]},
+                        "scale_x": {"Points": [{"co": {"X": 10, "Y": 0.5}}]},
+                        "scale_y": {"Points": [{"co": {"X": 10, "Y": 0.75}}]},
+                        "location_x": {"Points": [{"co": {"X": 10, "Y": 0.4}}]},
+                        "location_y": {"Points": [{"co": {"X": 10, "Y": -0.3}}]},
+                        "effects": [],
+                    }],
+                }
+
+                ProjectDataStore.upgrade_project_data_structures(store)
+                clip = store._data["clips"][0]
+                x = clip["location_x"]["Points"][0]["co"]["Y"]
+                y = clip["location_y"]["Points"][0]["co"]["Y"]
+                self.assertAlmostEqual(x, expected[0])
+                self.assertAlmostEqual(y, expected[1])
+
+                # Re-running migration must not touch a project once its saved
+                # version advances beyond the affected 4.0.0 release.
+                store._data["version"]["openshot-qt"] = "4.0.1"
+                ProjectDataStore.upgrade_project_data_structures(store)
+                self.assertEqual(
+                    clip["location_x"]["Points"][0]["co"]["Y"], x)
+                self.assertEqual(
+                    clip["location_y"]["Points"][0]["co"]["Y"], y)
 
     def test_upgrade_does_not_remigrate_development_project(self):
         store = make_store()

--- a/src/tests/test_video_widget_transform.py
+++ b/src/tests/test_video_widget_transform.py
@@ -161,6 +161,41 @@ class VideoWidgetTransformTests(unittest.TestCase):
                 self.assertLessEqual(left.x() + left.width(), 0.0)
                 self.assertGreaterEqual(right.x(), self.viewport.width())
 
+    def test_non_crop_locations_remain_canvas_relative(self):
+        for scale_mode in (
+            openshot.SCALE_FIT,
+            openshot.SCALE_STRETCH,
+            openshot.SCALE_NONE,
+        ):
+            with self.subTest(scale_mode=scale_mode):
+                anchored = self.rect_for(scale_mode)
+                moved = self.rect_for(
+                    scale_mode, location_x=-0.25, location_y=0.25)
+
+                self.assertAlmostEqual(moved.x() - anchored.x(), -40.0)
+                self.assertAlmostEqual(moved.y() - anchored.y(), 22.5)
+
+    def test_fit_handles_match_reported_legacy_project_position(self):
+        viewport = QRect(0, 0, 720, 720)
+        rect = VideoWidget._clip_display_rect(
+            self.widget,
+            266,
+            178,
+            clip_with(openshot.SCALE_FIT),
+            props(
+                location_x=-5.0 / 12.0,
+                location_y=-31.0 / 72.0,
+                scale_x=1.0 / 9.0,
+                scale_y=1.0 / 9.0,
+            ),
+            viewport,
+        )
+
+        self.assertAlmostEqual(rect.x(), 20.0, places=5)
+        self.assertAlmostEqual(rect.y(), 23.233083, places=5)
+        self.assertAlmostEqual(rect.width(), 720.0)
+        self.assertAlmostEqual(rect.height(), 481.804511, places=5)
+
     def test_clip_margin_offsets_edge_gravity_handle_rect(self):
         project_values = {"width": 160, "height": 90}
         app = types.SimpleNamespace(project=types.SimpleNamespace(

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -1522,17 +1522,21 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                         layout_height) = self._clip_location_geometry(
                             base_w, base_h, self.transforming_clip, raw_properties, viewport_rect)
 
-                    # Convert from screen-pixel motion to libopenshot's normalized
-                    # location coordinates, which are relative to the gravity anchor
-                    # and the distance to the offscreen edge.
-                    current_x_offset = self._location_offset(
-                        location_x, anchored_x - layout_x, layout_width, scaled_w)
-                    current_y_offset = self._location_offset(
-                        location_y, anchored_y - layout_y, layout_height, scaled_h)
-                    location_x = self._location_value_from_offset(
-                        current_x_offset + x_motion, anchored_x - layout_x, layout_width, scaled_w)
-                    location_y = self._location_value_from_offset(
-                        current_y_offset + y_motion, anchored_y - layout_y, layout_height, scaled_h)
+                    # Match libopenshot's location contract: Crop uses the
+                    # distance to the offscreen edge, while all other scale
+                    # modes retain canvas-relative coordinates.
+                    if self.transforming_clip.data['scale'] == openshot.SCALE_CROP:
+                        current_x_offset = self._location_offset(
+                            location_x, anchored_x - layout_x, layout_width, scaled_w)
+                        current_y_offset = self._location_offset(
+                            location_y, anchored_y - layout_y, layout_height, scaled_h)
+                        location_x = self._location_value_from_offset(
+                            current_x_offset + x_motion, anchored_x - layout_x, layout_width, scaled_w)
+                        location_y = self._location_value_from_offset(
+                            current_y_offset + y_motion, anchored_y - layout_y, layout_height, scaled_h)
+                    else:
+                        location_x += x_motion / viewport_rect.width()
+                        location_y += y_motion / viewport_rect.height()
 
                     # Update keyframe value (or create new one)
                     self.updateClipProperty(
@@ -2528,8 +2532,12 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
         location_x = float(raw_properties.get('location_x', {}).get('value', 0.0))
         location_y = float(raw_properties.get('location_y', {}).get('value', 0.0))
-        x += self._location_offset(location_x, anchored_x - layout_x, layout_width, scaled_width)
-        y += self._location_offset(location_y, anchored_y - layout_y, layout_height, scaled_height)
+        if clip.data['scale'] == openshot.SCALE_CROP:
+            x += self._location_offset(location_x, anchored_x - layout_x, layout_width, scaled_width)
+            y += self._location_offset(location_y, anchored_y - layout_y, layout_height, scaled_height)
+        else:
+            x += player_width * location_x
+            y += player_height * location_y
 
         return QRectF(x, y, source_width, source_height)
 


### PR DESCRIPTION
Related to https://github.com/OpenShot/libopenshot/pull/1093

This complements the libopenshot location fix by keeping OpenShot’s transform handles, rendered output, and saved projects consistent.

  ### Changes

  - Use geometry-aware positioning only for Crop clips.
  - Restore canvas-relative transform positioning for Fit, Stretch, and None.
  - Preserve the existing migration for legacy Crop projects.
  - Convert affected non-Crop projects saved by the official 4.0.0 release once, preserving their 4.0.0 visual
    positions.

  - Avoid repeated conversion when those projects are reopened in 4.0.1 or later.

  ### Compatibility

  - Projects last saved in 3.5.1 and earlier retain their original positions.
  - Projects adjusted and saved in 4.0.0 do not jump again after upgrading.
  - Transform handles now match libopenshot’s rendered clip positions.

  Tests cover legacy projects, exact 4.0.0 migration, 4.0.1 reopening, all relevant scale modes, keyframed values, gravity, margins, and reported customer geometry.