### PR TITLE
Add feedback and update notification banners

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -62,7 +62,7 @@ from shutil import copytree, rmtree, copy
 from cx_Freeze import setup, Executable
 import cx_Freeze
 import shutil
-from installer.version_parser import parse_version_info, parse_build_name
+from installer.version_parser import parse_version_info, parse_build_name, write_build_metadata
 
 PATH = os.path.dirname(os.path.realpath(__file__))  # Primary openshot folder
 sys.path.insert(0, os.path.join(PATH, "src"))
@@ -346,13 +346,12 @@ if artifact_path:
                     # No extension, parse version info
                     version_info.update(parse_version_info(git_log_filepath))
 
-# If version info found (create src/settings/version.json file)
+# Always write provenance, including when a local build has no CI version files.
 if version_info:
     # Calculate build name from version info
     version_info["build_name"] = parse_build_name(version_info, git_branch_name)
-    version_path = os.path.join(openshot_copy_path, "settings", "version.json")
-    with open(version_path, "w") as f:
-        f.write(json.dumps(version_info, indent=4))
+version_path = os.path.join(openshot_copy_path, "settings", "version.json")
+write_build_metadata(version_path, version_info)
 
 if sys.platform == "win32":
     # Define alternate terminal-based executable

--- a/installer/version_parser.py
+++ b/installer/version_parser.py
@@ -93,6 +93,22 @@ def parse_build_name(version_info, git_branch_name=""):
     return build_name
 
 
+def write_build_metadata(version_path, version_info, environ=None):
+    """Write provenance for this build, clearing any marker left by an earlier build.
+
+    Copying the CI configuration into a fork must not label its builds official.
+    This is a distribution label, not a cryptographic authenticity check.
+    """
+    environ = os.environ if environ is None else environ
+    metadata = dict(version_info)
+    metadata["official_distribution"] = (
+        environ.get("CI_SERVER_HOST") == "gitlab.openshot.org"
+        and environ.get("CI_PROJECT_PATH") == "OpenShot/openshot-qt"
+    )
+    with open(version_path, "w", encoding="utf-8") as stream:
+        json.dump(metadata, stream, indent=4)
+
+
 if __name__ == "__main__":
     """Run these methods manually for testing"""
     # Determine absolute PATH of OpenShot folder

--- a/src/classes/app.py
+++ b/src/classes/app.py
@@ -165,6 +165,8 @@ class OpenShotApp(QApplication):
             log.info("-" * 48)
 
             log.info("openshot-qt version: %s" % info.VERSION)
+            from classes.distribution import distribution_label
+            log.info("distribution: %s", distribution_label())
             log.info("libopenshot version: %s" % openshot.OPENSHOT_VERSION_FULL)
             log.info("platform: %s" % platform.platform())
             log.info("processor: %s" % platform.processor())

--- a/src/classes/distribution.py
+++ b/src/classes/distribution.py
@@ -1,0 +1,84 @@
+"""Local distribution metadata. Build markers describe provenance, not authenticity."""
+
+import ctypes
+import json
+import os
+import platform
+import sys
+from functools import lru_cache
+
+
+def windows_package_name():
+    """Return this process's package identity, or empty for an unpackaged process."""
+    try:
+        function = ctypes.WinDLL("kernel32").GetCurrentPackageFullName
+        function.argtypes = [ctypes.POINTER(ctypes.c_uint32), ctypes.c_wchar_p]
+        function.restype = ctypes.c_long
+        length = ctypes.c_uint32()
+        if function(ctypes.byref(length), None) != 122:  # ERROR_INSUFFICIENT_BUFFER
+            return ""
+        if not 0 < length.value <= 32768:
+            return ""
+        buffer = ctypes.create_unicode_buffer(length.value)
+        if function(ctypes.byref(length), buffer) == 0:
+            return buffer.value
+    except (AttributeError, OSError, ValueError):
+        pass
+    return ""
+
+
+def detect_distribution(metadata, system, executable, frozen, environ, package_name="",
+                        flatpak=False):
+    """Classify the running copy conservatively; downstream packages stay unofficial."""
+    kind = "unknown"
+    official = False
+    marked = metadata.get("official_distribution") is True
+    if flatpak or environ.get("FLATPAK_ID"):
+        kind = "flatpak"
+    elif environ.get("SNAP"):
+        kind = "snap"
+    elif system == "Windows" and package_name:
+        kind = "msix"
+        official = marked and frozen and package_name.split("_")[0] == "OpenShotStudios.OpenShotforWindows"
+    elif system == "Linux" and environ.get("APPIMAGE"):
+        kind = "appimage"
+        official = marked and frozen
+    elif system == "Windows" and frozen and executable.lower().endswith(".exe"):
+        kind = "exe"
+        official = marked
+    elif system == "Darwin" and frozen and ".app/Contents/MacOS/" in executable:
+        kind = "appbundle"
+        official = marked
+    return {"package_type": kind, "official": official}
+
+
+@lru_cache(maxsize=1)
+def get_distribution_info():
+    from classes import info
+    try:
+        with open(os.path.join(info.PATH, "settings", "version.json"), encoding="utf-8") as stream:
+            metadata = json.load(stream)
+        if not isinstance(metadata, dict):
+            metadata = {}
+    except (OSError, ValueError):
+        metadata = {}
+    system = platform.system()
+    package_name = windows_package_name() if system == "Windows" else ""
+    result = detect_distribution(
+        metadata, system, sys.executable, bool(getattr(sys, "frozen", False)), os.environ,
+        package_name,
+        os.path.isfile("/.flatpak-info"),
+    )
+    result.update(app_version=info.VERSION, platform=system.lower(),
+                  architecture=platform.machine())
+    if metadata.get("build_name"):
+        result["build_name"] = str(metadata["build_name"])
+    if package_name and len(package_name.split("_")) == 5:
+        result["package_version"] = package_name.split("_")[1]
+    return result
+
+
+def distribution_label():
+    data = get_distribution_info()
+    return "{} | Official distribution: {}".format(
+        data["package_type"], "yes" if data["official"] else "no")

--- a/src/classes/feedback.py
+++ b/src/classes/feedback.py
@@ -1,0 +1,57 @@
+"""One-time survey policy and URL metadata (no automatic network requests)."""
+
+import math
+from urllib.parse import urlencode
+
+# Provisional website endpoint; keep routing separate from the UI.
+SURVEY_URL = "https://www.openshot.org/survey/"
+FEEDBACK_DELAY_SECONDS = 30 * 60
+
+
+def survey_url(distribution, install_id):
+    params = dict(distribution)
+    params["official"] = "1" if params["official"] else "0"
+    params["guid"] = install_id
+    return SURVEY_URL + "?" + urlencode(params)
+
+
+class FeedbackPolicy:
+    """Persist use across sessions; consume only on dismissal or survey navigation."""
+
+    def __init__(self, settings):
+        self.settings = settings
+        self.unsaved_seconds = 0
+
+    @property
+    def shown(self):
+        # Keep the original settings key so previously dismissed prompts stay dismissed.
+        return bool(self.settings.get("feedback-shown"))
+
+    def advance(self, seconds):
+        if self.shown:
+            return False
+        try:
+            elapsed = float(self.settings.get("feedback-use-seconds") or 0)
+        except (TypeError, ValueError, OverflowError):
+            elapsed = 0
+        if not math.isfinite(elapsed) or elapsed < 0:
+            elapsed = 0
+        previous = elapsed
+        elapsed = min(FEEDBACK_DELAY_SECONDS, elapsed + max(0, seconds))
+        self.settings.set("feedback-use-seconds", elapsed)
+        self.unsaved_seconds += max(0, seconds)
+        if self.unsaved_seconds >= 60 or previous < FEEDBACK_DELAY_SECONDS <= elapsed:
+            self.settings.save()
+            self.unsaved_seconds = 0
+        return elapsed >= FEEDBACK_DELAY_SECONDS
+
+    def consume(self):
+        if self.shown:
+            return False
+        self.settings.set("feedback-shown", True)
+        try:
+            self.settings.save()
+        except Exception:
+            self.settings.set("feedback-shown", False)
+            raise
+        return True

--- a/src/classes/feedback.py
+++ b/src/classes/feedback.py
@@ -1,18 +1,48 @@
 """One-time survey policy and URL metadata (no automatic network requests)."""
 
+import base64
+import json
 import math
 from urllib.parse import urlencode
 
-# Provisional website endpoint; keep routing separate from the UI.
-SURVEY_URL = "https://www.openshot.org/survey/"
+SURVEY_URL = "https://www.openshot.org/feedback/"
 FEEDBACK_DELAY_SECONDS = 30 * 60
 
 
 def survey_url(distribution, install_id):
-    params = dict(distribution)
-    params["official"] = "1" if params["official"] else "0"
-    params["guid"] = install_id
-    return SURVEY_URL + "?" + urlencode(params)
+    """Encode the website's v1 context as unpadded URL-safe base64 UTF-8 JSON.
+
+    Official website packages use ``direct``; our official MSIX uses
+    ``microsoft-store``. Unidentified installs stay ``unknown`` until we can
+    reliably detect distro or Steam packaging.
+    """
+    kind = distribution.get("package_type", "unknown")
+    source = kind if kind in ("snap", "flatpak") else "unknown"
+    if distribution.get("official") and kind in ("exe", "appimage", "appbundle"):
+        source = "direct"
+    elif distribution.get("official") and kind == "msix":
+        source = "microsoft-store"
+    system = distribution.get("platform", "unknown").lower()
+    system = {"windows": "windows", "darwin": "macos", "macos": "macos",
+              "linux": "linux"}.get(system, "unknown")
+    # Website context contract (v=1):
+    # os: windows, macos, linux, unknown.
+    # source: direct, microsoft-store, steam, flatpak, snap, distro, unknown.
+    # direct means official website downloads; distro means distribution packages.
+    # steam/distro are reserved here until reliable detection is implemented.
+    # version is the OpenShot version string; install_uuid is the existing
+    # unique_install_id (installation/profile identifier, not a person-wide ID).
+    payload = {
+        "v": 1,
+        "version": distribution["app_version"],
+        "os": system,
+        "source": source,
+        "install_uuid": install_id,
+    }
+    context = base64.urlsafe_b64encode(
+        json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).decode("ascii").rstrip("=")
+    return SURVEY_URL + "?" + urlencode({"context": context})
 
 
 class FeedbackPolicy:

--- a/src/classes/info.py
+++ b/src/classes/info.py
@@ -112,6 +112,8 @@ BLENDER_MIN_VERSION = "5.0"
 
 # Data-model debugging enabler
 MODEL_TEST = False
+FEEDBACK_PREVIEW = False  # Launch-only preview; never stored in user settings.
+UPDATE_PREVIEW = False
 
 # Default/initial logging levels
 LOG_LEVEL_FILE = 'INFO'

--- a/src/classes/notifications.py
+++ b/src/classes/notifications.py
@@ -1,0 +1,21 @@
+"""Release notification policy, independent of the presentation and network check."""
+
+import re
+
+
+def release_version(value):
+    """Compare numeric public releases, including 4.10 versus 4.9 and trailing zeros."""
+    if not isinstance(value, str) or not re.fullmatch(r"\d+(?:\.\d+)*", value):
+        return None
+    parts = [int(part) for part in value.split(".")]
+    while len(parts) > 1 and parts[-1] == 0:
+        parts.pop()
+    return tuple(parts)
+
+
+def should_notify_update(version, current_version, dismissed_version):
+    available = release_version(version)
+    current = release_version(current_version)
+    dismissed = release_version(dismissed_version)
+    return bool(available is not None and current is not None and available > current
+                and (dismissed is None or available > dismissed))

--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -168,6 +168,8 @@ class SettingStore(JsonDataStore):
         log.info(f"Restoring defaults for category: {category_filter or 'all categories'}")
         preserve_keys = [
             'unique_install_id', 'tutorial_ids', 'tutorial_enabled', 'send_metrics',
+            'feedback-shown', 'feedback-use-seconds',
+            'dismissed-update-version',
             'recent_projects', 'custom_views', 'active_custom_view', 'active_builtin_view',
         ]
 

--- a/src/language/OpenShot/OpenShot.pot
+++ b/src/language/OpenShot/OpenShot.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenShot Video Editor (version: 4.0.0)\n"
 "Report-Msgid-Bugs-To: Jonathan Thomas <Jonathan.Oomph@gmail.com>\n"
-"POT-Creation-Date: 2026-08-14 23:03:59.739450\n"
+"POT-Creation-Date: 2026-09-08 18:41:16.520920\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Jonathan Thomas <Jonathan.Oomph@gmail.com>\n"
 "Language-Team: https://translations.launchpad.net/+groups/launchpad-translators\n"
@@ -16,81 +16,346 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: /home/jonathan/apps/openshot-qt/src/windows/animated_title.py:62
-msgid "Render"
+#: /home/jonathan/apps/openshot-qt-git/src/classes/importers/final_cut_pro.py:270
+msgid "Import XML..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/animated_title.py:64
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:94
-#: /home/jonathan/apps/openshot-qt/src/windows/views/optimized_preview_menu.py:84
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4620
-#: /home/jonathan/apps/openshot-qt/src/windows/export_clips.py:210
-#: /home/jonathan/apps/openshot-qt/src/windows/file_properties.py:80
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:466
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1361
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1477
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:445
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:131
+#: /home/jonathan/apps/openshot-qt-git/src/classes/importers/final_cut_pro.py:271
+#: /home/jonathan/apps/openshot-qt-git/src/classes/exporters/final_cut_pro.py:524
+msgid "Final Cut Pro (*.xml)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/importers/edl.py:300
+msgid "Import EDL..."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/importers/edl.py:302
+#: /home/jonathan/apps/openshot-qt-git/src/classes/importers/edl.py:303
+#: /home/jonathan/apps/openshot-qt-git/src/classes/exporters/edl.py:153
+msgid "Edit Decision List (*.edl)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/exporters/final_cut_pro.py:520
+#: /home/jonathan/apps/openshot-qt-git/src/classes/exporters/edl.py:149
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:179
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:880
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:945
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3781
+msgid "Untitled Project"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/exporters/final_cut_pro.py:523
+msgid "Export XML..."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/exporters/edl.py:152
+msgid "Export EDL..."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/tray_status.py:44
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2813
+msgid "Stop Recording"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/tray_status.py:49
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:6147
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:5456
+msgid "Recording"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/tray_status.py:60
+msgid "Stop Export"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/tray_status.py:73
+#, python-format
+msgid "Exporting %s%%"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/app.py:197
+msgid "Wrong Version of libopenshot Detected"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/app.py:198
+#, python-format
+msgid ""
+"<b>Version %(minimum_version)s is required</b>, but %(current_version)s was "
+"detected. Please update libopenshot or download our latest installer."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/app.py:253
+msgid "Permission Error"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/app.py:254
+#, python-format
+msgid "%(error)s. Please delete <b>%(path)s</b> and launch OpenShot again."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/app.py:317
+msgid "Settings Error"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/app.py:318
+#, python-format
+msgid "Error loading settings file: %(file_path)s. Settings will be reset."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/json_data.py:418
+msgid "Saved backup file {}"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/title_bar.py:106
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/about.ui:154
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/changelog.ui:134
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/credits.ui:134
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/license.ui:45
+msgid "Close"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/title_bar.py:110
+msgid "Dock"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/classes/title_bar.py:112
+msgid "Float"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/about.py:151
+msgid ""
+"OpenShot Video Editor is an Award-Winning, Free, and<br> Open-Source Video "
+"Editor for Linux, Mac, Chrome OS, and Windows."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/about.py:152
+#, python-format
+msgid "Copyright &copy; %(begin_year)s-%(current_year)s"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/about.py:175
+#: /home/jonathan/apps/openshot-qt-git/src/windows/about.py:224
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/about.ui:84
+msgid "Copy Version Info"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/about.py:176
+msgid "Version info copied to clipboard"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/about.py:178
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1443
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1598
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1607
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4834
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4843
+#: Settings for copyAll
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/about.ui:87
+msgid "Copy"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/about.py:491
+msgid "Release Date"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/about.py:492
+msgid "Release Notes"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/about.py:493
+msgid "Official"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/about.py:528
+#, python-format
+msgid "Version: %s"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/about.py:613
+msgid "Become a Supporter"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/about.py:638
+msgid "translator-credits"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/about.py:717
+msgid "OpenShot on GitHub"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:71
+msgid "The Title"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:72
+msgid "Sub-Title"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:73 Settings
+#: for actionTitle
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:161
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1083
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1086
+msgid "Title"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:74
+msgid "Header Text"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:75
+msgid "Footer Text"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:76
+msgid "Line 1"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:77
+msgid "Line 2"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:78
+msgid "Line 3"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:79
+msgid "Line 4"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:129
+msgid "Save"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:131
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:94
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/optimized_preview_menu.py:84
+#: /home/jonathan/apps/openshot-qt-git/src/windows/animated_title.py:64
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4609
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:466
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1361
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1477
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:445
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export_clips.py:210
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:80
 msgid "Cancel"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/video_widget.py:506
-msgid "Selection"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:398
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:1074
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:43
+msgid "File Name:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/video_widget.py:509
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1876
-#: libopenshot (Effect Metadata)
-msgid "Crop"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:414
+#, python-format
+msgid "TitleFileName (%d)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/video_widget.py:511
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:833
-#: effect_init (Effect parameter for Tracker)
-msgid "Region"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:464
+#, python-format
+msgid "Line %s:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/video_widget.py:513
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1855
-msgid "Transform"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:481
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:482
+msgid "Font:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/video_widget.py:515
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:257
-msgid "Video Preview"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:483
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:654
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1294
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1774
+msgid "Change Font"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/video_widget.py:520
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:488
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:489
+msgid "Text:"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:490
+#: libopenshot (Effect Properties)
+msgid "Text Color"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:495
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:496
+msgid "Background:"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:497
+#: libopenshot (Effect Properties)
+msgid "Background Color"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:502
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:503
+msgid "Advanced:"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:504
+msgid "Use Advanced Editor"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:628
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:643
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1286
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1784
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1934
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1547
+msgid "Select a Color"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:834
+msgid "Title Editor"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:835
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1097
 #, python-format
 msgid ""
-" (Speed: %(speed)sx, Paint: %(pfps)s FPS, Render: %(rfps)s FPS, "
-"%(width)sx%(height)s)"
+"%s already exists.\n"
+"Do you want to replace it?"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/video_widget.py:3053
-msgid "Reset Zoom"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:862
+msgid "Error launching editor"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:96
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1085
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1096
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1480 Settings for
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:864
+#, python-brace-format
+msgid ""
+"The editor did not launch: <b>{cmd}</b><br><br>If you used Snap or Flatpak, "
+"try installing the editor with your package manager."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/title_editor.py:868
+#, python-brace-format
+msgid ""
+"The editor did not launch: <b>{cmd}</b><br><br>Please check that the editor "
+"is installed and working."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:96
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1085
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1096
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1480 Settings for
 #: actionExportVideo
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:20
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:20
 msgid "Export Video"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:98
-#: /home/jonathan/apps/openshot-qt/src/windows/export_clips.py:208
-#: /home/jonathan/apps/openshot-qt/src/windows/export_clips.py:365
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:98
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export_clips.py:208
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export_clips.py:365
 msgid "Done"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:162
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:162
 msgid "Project Data Error"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:163
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:163
 #, python-format
 msgid ""
 "Sorry, an error was encountered while parsing your project data: \n"
@@ -99,614 +364,1443 @@ msgid ""
 "Please save your project and inspect in a JSON editor to repair."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:179
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:867
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:932
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3770
-#: /home/jonathan/apps/openshot-qt/src/classes/exporters/edl.py:149
-#: /home/jonathan/apps/openshot-qt/src/classes/exporters/final_cut_pro.py:520
-msgid "Untitled Project"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:191
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:659
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1093
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1186
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1200
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:191
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:659
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1093
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1186
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1200
 msgid "Video & Audio"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:191
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:659
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1093
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1186
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:191
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:659
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1093
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1186
 msgid "Video Only"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:191
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:660
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1093
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1200
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1221
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:191
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:660
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1093
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1200
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1221
 msgid "Audio Only"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:191
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:660
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1053
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1131
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1186
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:191
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:660
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1053
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1131
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1186
 msgid "Image Sequence"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:198
-#: /home/jonathan/apps/openshot-qt/src/windows/file_properties.py:153 Settings
-#: for default-channellayout
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:198
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:153
+#: Settings for default-channellayout
 msgid "Mono (1 Channel)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:199
-#: /home/jonathan/apps/openshot-qt/src/windows/file_properties.py:154 Settings
-#: for default-channellayout
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:199
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:154
+#: Settings for default-channellayout
 msgid "Stereo (2 Channel)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:200
-#: /home/jonathan/apps/openshot-qt/src/windows/file_properties.py:155 Settings
-#: for default-channellayout
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:200
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:155
+#: Settings for default-channellayout
 msgid "Surround (3 Channel)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:201
-#: /home/jonathan/apps/openshot-qt/src/windows/file_properties.py:156 Settings
-#: for default-channellayout
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:201
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:156
+#: Settings for default-channellayout
 msgid "Surround (5.1 Channel)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:202
-#: /home/jonathan/apps/openshot-qt/src/windows/file_properties.py:157 Settings
-#: for default-channellayout
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:202
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:157
+#: Settings for default-channellayout
 msgid "Surround (7.1 Channel)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:276
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1534
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp4_x264_hw.xml
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:276
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1534
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_webm_libvpx.xml
 msgid "All Formats"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:554
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp4_x264.xml
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:554
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mp4_x264.xml
 msgid "MP4 (h.264)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:584
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:594
-#: /home/jonathan/apps/openshot-qt/src/windows/file_properties.py:171
-#: /home/jonathan/apps/openshot-qt/src/windows/profile_edit.py:84
-#: /home/jonathan/apps/openshot-qt/src/windows/profile_edit.py:88
-#: /home/jonathan/apps/openshot-qt/src/windows/profile_edit.py:102
-#: /home/jonathan/apps/openshot-qt/src/windows/profile_edit.py:103
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:872
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:584
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:594
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:872
+#: /home/jonathan/apps/openshot-qt-git/src/windows/profile_edit.py:84
+#: /home/jonathan/apps/openshot-qt-git/src/windows/profile_edit.py:88
+#: /home/jonathan/apps/openshot-qt-git/src/windows/profile_edit.py:102
+#: /home/jonathan/apps/openshot-qt-git/src/windows/profile_edit.py:103
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:171
 #: libopenshot (Clip Properties)
 msgid "No"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:585
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:585
 msgid "Yes Top field first"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:586
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:586
 msgid "Yes Bottom field first"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:595
-#: /home/jonathan/apps/openshot-qt/src/windows/file_properties.py:170
-#: /home/jonathan/apps/openshot-qt/src/windows/profile_edit.py:83
-#: /home/jonathan/apps/openshot-qt/src/windows/profile_edit.py:87
-#: /home/jonathan/apps/openshot-qt/src/windows/profile_edit.py:102
-#: /home/jonathan/apps/openshot-qt/src/windows/profile_edit.py:103
-#: /home/jonathan/apps/openshot-qt/src/windows/profile_edit.py:181
-#: /home/jonathan/apps/openshot-qt/src/windows/profile_edit.py:188
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:871
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:595
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:871
+#: /home/jonathan/apps/openshot-qt-git/src/windows/profile_edit.py:83
+#: /home/jonathan/apps/openshot-qt-git/src/windows/profile_edit.py:87
+#: /home/jonathan/apps/openshot-qt-git/src/windows/profile_edit.py:102
+#: /home/jonathan/apps/openshot-qt-git/src/windows/profile_edit.py:103
+#: /home/jonathan/apps/openshot-qt-git/src/windows/profile_edit.py:181
+#: /home/jonathan/apps/openshot-qt-git/src/windows/profile_edit.py:188
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:170
 #: libopenshot (Clip Properties)
 msgid "Yes"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:673
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:681
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:749
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1545
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:673
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:681
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:749
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1545
 msgid "Low"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:673
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:681
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:751
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1545
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:673
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:681
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:751
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1545
 msgid "Med"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:673
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:681
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:753
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1545
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:673
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:681
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:753
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1545
 msgid "High"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:824
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:827
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:824
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:827
 msgid "Choose a Folder..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1033
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1359
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1033
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1359
 msgid "Export Error"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1034
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1034
 msgid "Sorry, please select a valid range of frames to export"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1086
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1086
 #, python-format
 msgid ""
 "%s is an input file.\n"
 "Please choose a different name."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1097
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:835
-#, python-format
-msgid ""
-"%s already exists.\n"
-"Do you want to replace it?"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1285
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1285
 msgid "Finalizing video export, please wait..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1360
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1360
 #, python-format
 msgid ""
 "Sorry, there was an error exporting your video: \n"
 "%s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/export.py:1481
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export.py:1481
 msgid "Are you sure you want to cancel the export?"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/credits_treeview.py:86
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/emojis_listview.py:275
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1613
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4849
+msgid "All"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/credits_treeview.py:86
 msgid "Copy E-mail"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/credits_treeview.py:89
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/credits_treeview.py:89
 msgid "View Website"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/track.py:330
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1766
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:781
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2986
-#: /home/jonathan/apps/openshot-qt/src/windows/models/properties_model.py:1384
-#: /home/jonathan/apps/openshot-qt/src/windows/models/properties_model.py:1491
-#: /home/jonathan/apps/openshot-qt/src/windows/add_to_timeline.py:535
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1745
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1771
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1776
-#, python-format
-msgid "Track %s"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:44
+msgid "Custom Repeat"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1641
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:162
-msgid "Ease (Default)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:48
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2086
+msgid "Loop"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1642
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:163
-msgid "Ease In"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:48
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2086
+msgid "Ping-Pong"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1643
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:164
-msgid "Ease Out"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:50
+msgid "Pattern"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1644
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:165
-msgid "Ease In/Out"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:53
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2068
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2088
+msgid "Forward"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1646
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:166
-msgid "Ease In (Quad)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:53
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2055
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2088
+msgid "Reverse"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1647
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:167
-msgid "Ease In (Cubic)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:55
+msgid "Direction"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1648
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:168
-msgid "Ease In (Quart)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:60
+msgid "Passes"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1649
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:169
-msgid "Ease In (Quint)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:67
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:90
+msgid "frames"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1650
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:170
-msgid "Ease In (Sine)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:67
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:92
+msgid "ms"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1651
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:171
-msgid "Ease In (Expo)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:67
+msgid "sec"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1652
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:172
-msgid "Ease In (Circ)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:70
+#: libopenshot (Effect Metadata)
+msgid "Delay"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1653
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:173
-msgid "Ease In (Back)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/repeat.py:75
+msgid "Speed Ramp (%)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1655
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:174
-msgid "Ease Out (Quad)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_treeview.py:188
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_listview.py:191
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:981 Settings
+#: for actionImportFiles
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:594
+msgid "Import Files..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1656
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:175
-msgid "Ease Out (Cubic)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_treeview.py:210
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_listview.py:216
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4590
+msgid "Cancel Job"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1657
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:176
-msgid "Ease Out (Quart)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_treeview.py:220
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/transitions_treeview.py:51
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/effects_treeview.py:53
+#: Settings for actionThumbnailView
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1151
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1154
+msgid "Thumbnail View"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1658
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:177
-msgid "Ease Out (Quint)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_treeview.py:239
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_listview.py:246
+#: Settings for actionEditTitle
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1516
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1519
+msgid "Edit Title"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1659
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:178
-msgid "Ease Out (Sine)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_treeview.py:240
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_listview.py:247
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/profiles_treeview.py:111
+#: Settings for actionDuplicate
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1540
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1543
+msgid "Duplicate"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1660
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:179
-msgid "Ease Out (Expo)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_treeview.py:243
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_listview.py:250
+#: Settings for actionPreview_File
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1303
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1306
+msgid "Preview File"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1661
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:180
-msgid "Ease Out (Circ)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_treeview.py:246
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_listview.py:253
+msgid "Split Clip"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1662
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:181
-msgid "Ease Out (Back)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_treeview.py:247
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_listview.py:254
+msgid "Export Selected Clips"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1664
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:182
-msgid "Ease In/Out (Quad)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_treeview.py:249
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_listview.py:256
+#: Settings for actionAdd_to_Timeline
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1291
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1294
+msgid "Add to Timeline"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1665
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:183
-msgid "Ease In/Out (Cubic)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_treeview.py:252
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_listview.py:259
+#: Settings for actionProfile
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1279
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1282
+msgid "Choose Profile"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1666
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:184
-msgid "Ease In/Out (Quart)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_treeview.py:263
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_listview.py:270
+#: /home/jonathan/apps/openshot-qt-git/src/windows/profile_edit.py:78
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/profile-edit.ui:14
+msgid "Create Profile"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1667
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:185
-msgid "Ease In/Out (Quint)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_treeview.py:267
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_listview.py:274
+#: Settings for actionFile_Properties
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:20
+msgid "File Properties"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1668
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:186
-msgid "Ease In/Out (Sine)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_treeview.py:269
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_listview.py:276
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1315
+msgid "Remove from Project"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1669
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:187
-msgid "Ease In/Out (Expo)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1670
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:188
-msgid "Ease In/Out (Circ)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/keyframe.py:1671
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:189
-msgid "Ease In/Out (Back)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/base.py:2816
-msgid "Unlock track"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/base.py:2816
-msgid "Lock track"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/base.py:2820
-msgid "Hide keyframes"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/base.py:2820
-msgid "Show keyframes"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/base.py:2836
-#, python-format
-msgid "Effect: %s"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/base.py:2837
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1444
-msgid "Effect"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/base.py:2843
-#, python-format
-msgid "Transition: %s"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/base.py:2844
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4844
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:341
-msgid "Transition"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/base.py:2855
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1608
-#: libopenshot (Clip Properties)
-msgid "Clip"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/base.py:2856
-#, python-format
-msgid "Clip: %s"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/base.py:3695
-msgid "Keyframe Properties"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline_backend/qwidget/base.py:3734
-msgid "No keyframes are avaialble"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:208
-msgid "Bezier"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:213
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:953
-msgid "Linear"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:216
-msgid "Constant"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/menu.py:221
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1810
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1838
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1864
-msgid "Remove Keyframe"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1286
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1784
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1934
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1547
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:628
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:643
-msgid "Select a Color"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1294
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1774
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:483
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:654
-msgid "Change Font"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1525
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1629
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1649
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1688
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1716
-#: /home/jonathan/apps/openshot-qt/src/windows/add_to_timeline.py:540
-#: /home/jonathan/apps/openshot-qt/src/windows/add_to_timeline.py:546
-#: /home/jonathan/apps/openshot-qt/src/windows/add_to_timeline.py:558
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1525
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1629
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1649
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1688
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1716
+#: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:540
+#: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:546
+#: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:558
 #: libopenshot (Clip Properties) Settings for timeline-thumbnail-style
 msgid "None"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1527
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1639
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1527
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1639
 msgid "Clips"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1533
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1553
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1533
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1553
 msgid "Tracked Classes"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1534
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/cutting.ui:162
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1534
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:162
 msgid "Clear"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1536
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1632
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1652
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1536
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1632
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1652
 msgid "Tracked Objects"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1693
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1693
 msgid "Files"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1713
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:284
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1713
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:286
 msgid "Transitions"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1754
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1754
 msgid "User-Defined"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1788
-#: /home/jonathan/apps/openshot-qt/src/windows/views/profiles_treeview.py:119
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1766
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:781
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/track.py:330
+#: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:535
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:1384
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:1491
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2997
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1757
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1783
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1788
+#, python-format
+msgid "Track %s"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1788
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/profiles_treeview.py:119
 msgid "Edit"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1791
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1124
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1869
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1902
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1962
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:664
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1791
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:664
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1124
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1869
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1902
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1962
 msgid "Reset"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:1808
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1835
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1861
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1808
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1835
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1861
 #: Settings for actionInsertKeyframe
 msgid "Insert Keyframe"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:2067
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:1810
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:221
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1838
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1864
+msgid "Remove Keyframe"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:2067
 #: libopenshot (Effect Properties)
 msgid "Color Wheels"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:2201
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:2356
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:2201
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:2356
 #, python-format
 msgid "%d selections"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:2355
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:2389
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:2355
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:2389
 msgid "Selection:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:2395
-#: /home/jonathan/apps/openshot-qt/src/windows/views/properties_tableview.py:2415
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:2395
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/properties_tableview.py:2415
 msgid "No Selection"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/ai_tools_menu.py:39
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/effects_listview.py:51
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/files_listview.py:226
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/transitions_listview.py:53
+#: Settings for actionDetailsView
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1163
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1166
+msgid "Details View"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/ai_tools_menu.py:39
 msgid "Enhance with AI"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/ai_tools_menu.py:39
-#: /home/jonathan/apps/openshot-qt/src/windows/views/ai_tools_menu.py:41
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/ai_tools_menu.py:39
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/ai_tools_menu.py:41
 msgid "Unknown AI"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/ai_tools_menu.py:41
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/ai_tools_menu.py:41
 msgid "Create with AI"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/ai_tools_menu.py:52
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/ai_tools_menu.py:52
 msgid "Track an Object"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/ai_tools_menu.py:53
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/ai_tools_menu.py:53
 msgid "Extract"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/ai_tools_menu.py:54
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/ai_tools_menu.py:54
 #: libopenshot (Effect Metadata)
 msgid "Noise"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/ai_tools_menu.py:55
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/ai_tools_menu.py:55
 msgid "Clarity"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/changelog_treeview.py:78
-msgid "Copy Hash"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/profiles_treeview.py:105
+msgid "Set as Default Profile"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/changelog_treeview.py:80
-msgid "View on GitHub"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/profiles_treeview.py:124
+msgid "Delete"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/transitions_treeview.py:51
-#: /home/jonathan/apps/openshot-qt/src/windows/views/effects_treeview.py:53
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_treeview.py:220
-#: Settings for actionThumbnailView
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1149
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1152
-msgid "Thumbnail View"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/tutorial.py:187
+msgid "Yes, I would like to improve OpenShot!"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/transitions_listview.py:53
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_listview.py:226
-#: /home/jonathan/apps/openshot-qt/src/windows/views/effects_listview.py:51
-#: Settings for actionDetailsView
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1161
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1164
-msgid "Details View"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/tutorial.py:200
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/tutorial.py:206
+msgid "Hide Tutorial"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/blender_listview.py:183
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/tutorial.py:212
+msgid "Next"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/tutorial.py:482
+msgid ""
+"<b>Welcome!</b> OpenShot Video Editor is an award-winning, open-source video "
+"editing application! This tutorial will walk you through the basics."
+"<br><br>Would you like to automatically send errors and metrics to help "
+"improve OpenShot?"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/tutorial.py:489
+msgid ""
+"<b>Project Files:</b> Get started with your project by adding video, audio, "
+"and image files here. Drag and drop files from your file system."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/tutorial.py:496
+msgid ""
+"<b>Timeline:</b> Arrange your clips on the timeline here. Overlap clips to "
+"create automatic transitions. Access lots of fun presets and options by "
+"right-clicking on clips."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/tutorial.py:503
+msgid ""
+"<b>Video Preview:</b> Watch your timeline video preview here. Use the "
+"buttons (play, rewind, fast-forward) to control the video playback."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/tutorial.py:509
+msgid ""
+"<b>Properties:</b> View and change advanced properties of clips and effects "
+"here. Right-clicking on clips is usually faster than manually changing "
+"properties."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/tutorial.py:516
+msgid ""
+"<b>Transitions:</b> Create a gradual fade from one clip to another. Drag and "
+"drop a transition onto the timeline and position it on top of a clip "
+"(usually at the beginning or ending)."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/tutorial.py:523
+msgid ""
+"<b>Effects:</b> Adjust brightness, contrast, saturation, and add exciting "
+"special effects. Drag and drop an effect onto the timeline and position it "
+"on top of a clip (or track)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/tutorial.py:530
+msgid ""
+"<b>Emojis:</b> Add exciting and colorful emojis to your project! Drag and "
+"drop an emoji onto the timeline. The emoji will become a new Clip when "
+"dropped on the Timeline."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/tutorial.py:537
+msgid ""
+"<b>Export Video:</b> When you are ready to create your finished video, click "
+"this button to export your timeline as a single video file."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1408
+msgid "Slice All"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1409
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2213
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4897
+msgid "Keep Both Sides"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1413
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2216
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4900
+msgid "Keep Left Side"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1417
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2219
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4903
+msgid "Keep Right Side"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1424
+#: Settings Category for Cache
+msgid "Cache"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1444
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/base.py:2837
+msgid "Effect"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1535
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1654
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4872
+#: Settings for pasteAll
+msgid "Paste"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1602
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1647
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4838
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4865
+#: Settings for cutAll
+msgid "Cut"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1608
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/base.py:2855
+#: libopenshot (Clip Properties)
+msgid "Clip"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1612
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4848
+msgid "Keyframes"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1617
+#: libopenshot (Clip Properties)
+msgid "Alpha"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1620
+#: libopenshot (Clip Properties)
+msgid "Scale"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1623
+msgid "Shear"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1626
+#: libopenshot (Clip Properties)
+msgid "Rotation"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1629
+#: Settings Category for Location
+msgid "Location"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1632
+#: libopenshot (Effect Properties)
+msgid "Time"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1635
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2130
+#: effect_init (Effect parameter for Example) Settings volume
+msgid "Volume"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1640
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:340
+msgid "Effects"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1661
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4879
+msgid "Align"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1662
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4880
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:947
+#: libopenshot (Clip Properties)
+msgid "Left"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1664
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4882
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:948
+#: libopenshot (Clip Properties)
+msgid "Right"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1671
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:240
+msgid "Fade"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1672
+msgid "No Fade"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1676
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2143
+#: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:541
+msgid "Fade In"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1677
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1684
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1691
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2144
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2151
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2158
+msgid "Fast"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1679
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1686
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1693
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2146
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2153
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2160
+msgid "Slow"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1683
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2150
+#: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:542
+msgid "Fade Out"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1690
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2157
+msgid "Fade In and Out"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1700
+msgid "Motion"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1701
+msgid "No Motion"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1716
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1817
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1828
+msgid "In"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1717
+msgid "Back In"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1718
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1726
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1734
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1741
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1750
+msgid "From Bottom"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1719
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1727
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1735
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1742
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1751
+msgid "From Left"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1720
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1728
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1736
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1743
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1752
+msgid "From Right"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1721
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1729
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1737
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1744
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1753
+msgid "From Top"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1723
+msgid "Blur In"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1724
+msgid "Bounce In"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1725
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1767
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:949
+#: libopenshot (Clip Properties)
+msgid "Center"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1731
+msgid "Focus Wipe In"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1732
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1748
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1774
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1790
+msgid "Circle Expand"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1733
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1749
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1775
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1791
+msgid "Circle Shrink"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1739
+msgid "Pop In"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1740
+msgid "Slide In"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1746
+msgid "Spiral In"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1747
+msgid "Wipe In"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1758
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1818
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1835
+msgid "Out"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1759
+msgid "Back Out"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1760
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1768
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1776
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1783
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1792
+msgid "To Bottom"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1761
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1769
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1777
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1784
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1793
+msgid "To Left"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1762
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1770
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1778
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1785
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1794
+msgid "To Right"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1763
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1771
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1779
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1786
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1795
+msgid "To Top"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1765
+msgid "Blur Out"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1766
+msgid "Bounce Out"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1773
+msgid "Focus Wipe Out"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1781
+msgid "Pop Out"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1782
+msgid "Slide Out"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1788
+msgid "Spiral Out"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1789
+msgid "Wipe Out"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1800
+msgid "Emphasis"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1801
+msgid "Bounce"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1802
+msgid "Flash"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1803
+msgid "Heartbeat"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1804
+msgid "Jello"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1805
+msgid "Pulse"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1806
+msgid "Rubber Band"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1807
+msgid "Shake X"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1808
+msgid "Shake Y"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1809
+msgid "Swing"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1810
+msgid "Tada"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1811
+msgid "Wobble"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1815
+msgid "Camera"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1816
+#: libopenshot (Effect Properties)
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:307
+msgid "Zoom"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1820
+msgid "Pan"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1821
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1829
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1836
+msgid "Auto Direction"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1822
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1830
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1837
+msgid "Left to Right"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1823
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1831
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1838
+msgid "Right to Left"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1824
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1832
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1839
+msgid "Top to Bottom"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1825
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1833
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1840
+msgid "Bottom to Top"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1827
+msgid "Zoom & Pan"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1846
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/about.ui:133
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/credits.ui:14
+msgid "Credits"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1847
+msgid "Scroll Up"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1848
+msgid "Scroll Down"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1855
+#: /home/jonathan/apps/openshot-qt-git/src/windows/video_widget.py:513
+msgid "Transform"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1856
+msgid "No Transform"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1860
+msgid "Rotate"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1861
+msgid "No Rotation"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1865
+msgid "Rotate 90 (Right)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1868
+msgid "Rotate 90 (Left)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1871
+msgid "Rotate 180 (Flip)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1876
+#: /home/jonathan/apps/openshot-qt-git/src/windows/video_widget.py:509
+#: libopenshot (Effect Metadata)
+msgid "Crop"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1877
+msgid "No Crop"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1880
+msgid "Crop (No Resize)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1882
+msgid "Crop (Resize)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1886
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:951
+msgid "Layout"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1887
+msgid "Reset Layout"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1891
+msgid "1/4 Size - Center"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1894
+msgid "1/4 Size - Top Left"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1897
+msgid "1/4 Size - Top Right"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1900
+msgid "1/4 Size - Bottom Left"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1903
+msgid "1/4 Size - Bottom Right"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1907
+msgid "Show All (Maintain Ratio)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1910
+msgid "Show All (Distort)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1920
+msgid "Look"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1921
+msgid "Reset Look"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1925
+#: libopenshot (Effect Properties)
+msgid "Color"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1926
+msgid "Auto Contrast"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1928
+msgid "Lift Shadows"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1930
+msgid "Warm Up"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1932
+msgid "Boost Color"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1936
+msgid "Film"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1937
+#: libopenshot (Effect Metadata)
+msgid "Film Grain"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1938
+msgid "No Film Grain"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1942
+msgid "35mm Fine"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1945
+msgid "35mm Classic"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1948
+msgid "35mm Gritty"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1951
+msgid "16mm Classic"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1954
+msgid "Super 8"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1957
+msgid "High ISO"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1964
+#: libopenshot (Effect Metadata)
+msgid "Analog Tape"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1966
+msgid "No Analog Tape"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1968
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1984
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2013
+msgid "Subtle"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1969
+msgid "VHS"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1970
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1998
+msgid "Heavy"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1977
+msgid "Focus"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1980
+#: libopenshot (Effect Metadata)
+msgid "Sharpen"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1982
+msgid "No Sharpen"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1985
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1997 AI
+#: model dropdown (cutie-models.json name)
+msgid "Medium"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1986
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2015
+msgid "Strong"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1992
+#: libopenshot (Effect Metadata)
+msgid "Blur"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1994
+msgid "No Blur"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:1996
+msgid "Soft Focus"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2006
+msgid "Lighting"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2009
+#: libopenshot (Effect Metadata)
+msgid "Shadow"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2011
+msgid "No Shadow"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2014
+msgid "Soft"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2016
+msgid "Long"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2022
+#: libopenshot (Effect Metadata)
+msgid "Glow"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2024
+msgid "No Glow"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2026
+msgid "Soft White"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2027
+msgid "Warm"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2028
+msgid "Neon"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2029
+msgid "Inner Glow"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2040
+msgid "Adjust Colors"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2044
+msgid "Analyze Colors"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2050
+msgid "Speed"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2051
+msgid "Reset Speed"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2062
+msgid "Speed Up"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2063
+msgid "Slow Down"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2069
+msgid "Backward"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2085
+#: /home/jonathan/apps/openshot-qt-git/src/windows/cutting.py:222
+msgid "Repeat"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2091
+msgid "{}X"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2096
+msgid "Custom"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2103
+msgid "Freeze"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2104
+msgid "Freeze && Zoom"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2110
+msgid "{} seconds"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2121
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:921
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:924
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1035
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1038
+msgid "Audio"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2125
+msgid "Record"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2131
+msgid "Reset Volume"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2135
+#: libopenshot (Effect Properties)
+msgid "Level"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2137
+#, python-brace-format
+msgid "Level {level}%"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2168
+msgid "Separate"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2169
+msgid "Single Clip (all channels)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2172
+msgid "Multiple Clips (each channel)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2185
+msgid "Hide Waveform"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2190
+msgid "Show Waveform"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2195
+msgid "Analyze Levels"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2212
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4896
+msgid "Slice"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2225
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4909
+msgid "Keep Left Side (Ripple)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2228
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4912
+msgid "Keep Right Side (Ripple)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2456
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2544
+#, python-format
+msgid "(channel %s)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:2506
+msgid "(all channels)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4844
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/base.py:2844
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:341
+msgid "Transition"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4853
+#: libopenshot (Effect Properties)
+msgid "Brightness"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4856
+#: libopenshot (Effect Properties)
+msgid "Contrast"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline.py:4919
+msgid "Reverse Transition"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/blender_listview.py:183
 msgid "No Files Found"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/blender_listview.py:353
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/blender_listview.py:353
 msgid "Generating"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/blender_listview.py:361
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/blender_listview.py:361
 msgid "Rendering"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/blender_listview.py:370
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/blender_listview.py:370
 msgid "Saved"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/blender_listview.py:377
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/blender_listview.py:377
 msgid "Initializing"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/blender_listview.py:536
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/blender_listview.py:536
 msgid "Version Detected: {}"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/blender_listview.py:540
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/blender_listview.py:540
 msgid ""
 "Error Output:\n"
 "{}"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/blender_listview.py:544
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/blender_listview.py:544
 msgid ""
 "\n"
 "Blender, the free open source 3D content creation suite, is required for "
@@ -722,2950 +1816,1908 @@ msgid ""
 "{}"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/blender_listview.py:1027
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/blender_listview.py:1027
 msgid "No frame was found in the output from Blender"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1408
-msgid "Slice All"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1409
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2213
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4897
-msgid "Keep Both Sides"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1413
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2216
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4900
-msgid "Keep Left Side"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1417
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2219
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4903
-msgid "Keep Right Side"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1424 Settings
-#: Category for Cache
-msgid "Cache"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1443
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1598
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1607
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4834
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4843
-#: /home/jonathan/apps/openshot-qt/src/windows/about.py:178 Settings for
-#: copyAll /home/jonathan/apps/openshot-qt/src/windows/ui/about.ui:87
-msgid "Copy"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1535
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1654
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4872 Settings
-#: for pasteAll
-msgid "Paste"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1602
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1647
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4838
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4865 Settings
-#: for cutAll
-msgid "Cut"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1612
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4848
-msgid "Keyframes"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1613
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4849
-#: /home/jonathan/apps/openshot-qt/src/windows/views/emojis_listview.py:275
-msgid "All"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1617
-#: libopenshot (Clip Properties)
-msgid "Alpha"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1620
-#: libopenshot (Clip Properties)
-msgid "Scale"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1623
-msgid "Shear"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1626
-#: libopenshot (Clip Properties)
-msgid "Rotation"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1629 Settings
-#: Category for Location
-msgid "Location"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1632
-#: libopenshot (Effect Properties)
-msgid "Time"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1635
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2130
-#: effect_init (Effect parameter for Example) Settings volume
-msgid "Volume"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1640
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:338
-msgid "Effects"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1661
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4879
-msgid "Align"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1662
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4880
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:947
-#: libopenshot (Clip Properties)
-msgid "Left"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1664
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4882
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:948
-#: libopenshot (Clip Properties)
-msgid "Right"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1671
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:240
-msgid "Fade"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1672
-msgid "No Fade"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1676
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2143
-#: /home/jonathan/apps/openshot-qt/src/windows/add_to_timeline.py:541
-msgid "Fade In"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1677
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1684
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1691
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2144
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2151
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2158
-msgid "Fast"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1679
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1686
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1693
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2146
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2153
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2160
-msgid "Slow"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1683
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2150
-#: /home/jonathan/apps/openshot-qt/src/windows/add_to_timeline.py:542
-msgid "Fade Out"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1690
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2157
-msgid "Fade In and Out"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1700
-msgid "Motion"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1701
-msgid "No Motion"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1716
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1817
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1828
-msgid "In"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1717
-msgid "Back In"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1718
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1726
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1734
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1741
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1750
-msgid "From Bottom"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1719
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1727
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1735
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1742
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1751
-msgid "From Left"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1720
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1728
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1736
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1743
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1752
-msgid "From Right"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1721
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1729
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1737
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1744
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1753
-msgid "From Top"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1723
-msgid "Blur In"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1724
-msgid "Bounce In"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1725
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1767
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:949
-#: libopenshot (Clip Properties)
-msgid "Center"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1731
-msgid "Focus Wipe In"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1732
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1748
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1774
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1790
-msgid "Circle Expand"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1733
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1749
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1775
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1791
-msgid "Circle Shrink"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1739
-msgid "Pop In"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1740
-msgid "Slide In"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1746
-msgid "Spiral In"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1747
-msgid "Wipe In"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1758
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1818
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1835
-msgid "Out"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1759
-msgid "Back Out"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1760
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1768
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1776
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1783
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1792
-msgid "To Bottom"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1761
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1769
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1777
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1784
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1793
-msgid "To Left"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1762
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1770
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1778
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1785
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1794
-msgid "To Right"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1763
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1771
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1779
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1786
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1795
-msgid "To Top"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1765
-msgid "Blur Out"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1766
-msgid "Bounce Out"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1773
-msgid "Focus Wipe Out"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1781
-msgid "Pop Out"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1782
-msgid "Slide Out"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1788
-msgid "Spiral Out"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1789
-msgid "Wipe Out"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1800
-msgid "Emphasis"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1801
-msgid "Bounce"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1802
-msgid "Flash"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1803
-msgid "Heartbeat"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1804
-msgid "Jello"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1805
-msgid "Pulse"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1806
-msgid "Rubber Band"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1807
-msgid "Shake X"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1808
-msgid "Shake Y"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1809
-msgid "Swing"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1810
-msgid "Tada"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1811
-msgid "Wobble"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1815
-msgid "Camera"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1816
-#: libopenshot (Effect Properties)
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:307
-msgid "Zoom"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1820
-msgid "Pan"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1821
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1829
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1836
-msgid "Auto Direction"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1822
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1830
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1837
-msgid "Left to Right"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1823
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1831
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1838
-msgid "Right to Left"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1824
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1832
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1839
-msgid "Top to Bottom"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1825
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1833
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1840
-msgid "Bottom to Top"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1827
-msgid "Zoom & Pan"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1846
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/about.ui:133
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/credits.ui:14
-msgid "Credits"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1847
-msgid "Scroll Up"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1848
-msgid "Scroll Down"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1856
-msgid "No Transform"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1860
-msgid "Rotate"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1861
-msgid "No Rotation"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1865
-msgid "Rotate 90 (Right)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1868
-msgid "Rotate 90 (Left)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1871
-msgid "Rotate 180 (Flip)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1877
-msgid "No Crop"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1880
-msgid "Crop (No Resize)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1882
-msgid "Crop (Resize)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1886
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:951
-msgid "Layout"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1887
-msgid "Reset Layout"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1891
-msgid "1/4 Size - Center"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1894
-msgid "1/4 Size - Top Left"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1897
-msgid "1/4 Size - Top Right"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1900
-msgid "1/4 Size - Bottom Left"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1903
-msgid "1/4 Size - Bottom Right"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1907
-msgid "Show All (Maintain Ratio)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1910
-msgid "Show All (Distort)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1920
-msgid "Look"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1921
-msgid "Reset Look"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1925
-#: libopenshot (Effect Properties)
-msgid "Color"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1926
-msgid "Auto Contrast"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1928
-msgid "Lift Shadows"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1930
-msgid "Warm Up"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1932
-msgid "Boost Color"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1936
-msgid "Film"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1937
-#: libopenshot (Effect Metadata)
-msgid "Film Grain"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1938
-msgid "No Film Grain"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1942
-msgid "35mm Fine"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1945
-msgid "35mm Classic"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1948
-msgid "35mm Gritty"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1951
-msgid "16mm Classic"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1954
-msgid "Super 8"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1957
-msgid "High ISO"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1964
-#: libopenshot (Effect Metadata)
-msgid "Analog Tape"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1966
-msgid "No Analog Tape"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1968
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1984
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2013
-msgid "Subtle"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1969
-msgid "VHS"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1970
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1998
-msgid "Heavy"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1977
-msgid "Focus"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1980
-#: libopenshot (Effect Metadata)
-msgid "Sharpen"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1982
-msgid "No Sharpen"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1985
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1997 AI model
-#: dropdown (cutie-models.json name)
-msgid "Medium"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1986
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2015
-msgid "Strong"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1992
-#: libopenshot (Effect Metadata)
-msgid "Blur"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1994
-msgid "No Blur"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:1996
-msgid "Soft Focus"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2006
-msgid "Lighting"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2009
-#: libopenshot (Effect Metadata)
-msgid "Shadow"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2011
-msgid "No Shadow"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2014
-msgid "Soft"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2016
-msgid "Long"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2022
-#: libopenshot (Effect Metadata)
-msgid "Glow"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2024
-msgid "No Glow"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2026
-msgid "Soft White"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2027
-msgid "Warm"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2028
-msgid "Neon"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2029
-msgid "Inner Glow"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2040
-msgid "Adjust Colors"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2044
-msgid "Analyze Colors"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2050
-msgid "Speed"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2051
-msgid "Reset Speed"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2055
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2088
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:53
-msgid "Reverse"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2062
-msgid "Speed Up"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2063
-msgid "Slow Down"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2068
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2088
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:53
-msgid "Forward"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2069
-msgid "Backward"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2085
-#: /home/jonathan/apps/openshot-qt/src/windows/cutting.py:222
-msgid "Repeat"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2086
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:48
-msgid "Loop"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2086
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:48
-msgid "Ping-Pong"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2091
-msgid "{}X"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2096
-msgid "Custom"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2103
-msgid "Freeze"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2104
-msgid "Freeze && Zoom"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2110
-msgid "{} seconds"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2121
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:919
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:922
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1033
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1036
-msgid "Audio"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2125
-msgid "Record"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2131
-msgid "Reset Volume"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2135
-#: libopenshot (Effect Properties)
-msgid "Level"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2137
-#, python-brace-format
-msgid "Level {level}%"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2168
-msgid "Separate"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2169
-msgid "Single Clip (all channels)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2172
-msgid "Multiple Clips (each channel)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2185
-msgid "Hide Waveform"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2190
-msgid "Show Waveform"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2195
-msgid "Analyze Levels"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2212
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4896
-msgid "Slice"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2225
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4909
-msgid "Keep Left Side (Ripple)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2228
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4912
-msgid "Keep Right Side (Ripple)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2456
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2544
-#, python-format
-msgid "(channel %s)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:2506
-msgid "(all channels)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4853
-#: libopenshot (Effect Properties)
-msgid "Brightness"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4856
-#: libopenshot (Effect Properties)
-msgid "Contrast"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:4919
-msgid "Reverse Transition"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/timeline.py:6147
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:5462
-#: /home/jonathan/apps/openshot-qt/src/classes/tray_status.py:49
-msgid "Recording"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_listview.py:191
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_treeview.py:188
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:968 Settings for
-#: actionImportFiles
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:592
-msgid "Import Files..."
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_listview.py:216
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_treeview.py:210
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4601
-msgid "Cancel Job"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_listview.py:246
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_treeview.py:239
-#: Settings for actionEditTitle
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1514
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1517
-msgid "Edit Title"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_listview.py:247
-#: /home/jonathan/apps/openshot-qt/src/windows/views/profiles_treeview.py:111
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_treeview.py:240
-#: Settings for actionDuplicate
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1538
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1541
-msgid "Duplicate"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_listview.py:250
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_treeview.py:243
-#: Settings for actionPreview_File
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1301
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1304
-msgid "Preview File"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_listview.py:253
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_treeview.py:246
-msgid "Split Clip"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_listview.py:254
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_treeview.py:247
-msgid "Export Selected Clips"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_listview.py:256
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_treeview.py:249
-#: Settings for actionAdd_to_Timeline
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1289
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1292
-msgid "Add to Timeline"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_listview.py:259
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_treeview.py:252
-#: Settings for actionProfile
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1277
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1280
-msgid "Choose Profile"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_listview.py:270
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_treeview.py:263
-#: /home/jonathan/apps/openshot-qt/src/windows/profile_edit.py:78
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/profile-edit.ui:14
-msgid "Create Profile"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_listview.py:274
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_treeview.py:267
-#: Settings for actionFile_Properties
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:20
-msgid "File Properties"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_listview.py:276
-#: /home/jonathan/apps/openshot-qt/src/windows/views/files_treeview.py:269
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1313
-msgid "Remove from Project"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:44
-msgid "Custom Repeat"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:50
-msgid "Pattern"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:55
-msgid "Direction"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:60
-msgid "Passes"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:67
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:90
-msgid "frames"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:67
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:92
-msgid "ms"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:67
-msgid "sec"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:70 libopenshot
-#: (Effect Metadata)
-msgid "Delay"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/repeat.py:75
-msgid "Speed Ramp (%)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/optimized_preview_menu.py:75
-#: /home/jonathan/apps/openshot-qt/src/windows/views/optimized_preview_menu.py:90
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4608
-msgid "Optimize Video"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/optimized_preview_menu.py:94
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4612
-msgid "Link to Existing..."
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/optimized_preview_menu.py:99
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4616
-msgid "Unlink"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/optimized_preview_menu.py:103
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4624
-msgid "Delete && Unlink"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/optimized_preview_menu.py:115
-msgid "Optimize"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/profiles_treeview.py:105
-msgid "Set as Default Profile"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/profiles_treeview.py:124
-msgid "Delete"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/views/find_file.py:74
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/find_file.py:74
 msgid "Locate Missing Files"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/find_file.py:82
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/find_file.py:82
 msgid "This file is missing. You can locate it or remove it from the project."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/find_file.py:107
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/find_file.py:107
 msgid "Remove All Missing"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/find_file.py:108
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1006
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:82
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/find_file.py:108
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1006
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:82
 msgid "Remove"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/find_file.py:109
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:293
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:1108
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:117
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/find_file.py:109
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:293
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:1108
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:117
 msgid "Browse..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/find_file.py:122
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/find_file.py:122
 #, python-format
 msgid "Locate folder containing: %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/tutorial.py:187
-msgid "Yes, I would like to improve OpenShot!"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:162
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1641
+msgid "Ease (Default)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/tutorial.py:200
-#: /home/jonathan/apps/openshot-qt/src/windows/views/tutorial.py:206
-msgid "Hide Tutorial"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:163
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1642
+msgid "Ease In"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/tutorial.py:212
-msgid "Next"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:164
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1643
+msgid "Ease Out"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/tutorial.py:482
-msgid ""
-"<b>Welcome!</b> OpenShot Video Editor is an award-winning, open-source video "
-"editing application! This tutorial will walk you through the basics."
-"<br><br>Would you like to automatically send errors and metrics to help "
-"improve OpenShot?"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:165
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1644
+msgid "Ease In/Out"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/tutorial.py:489
-msgid ""
-"<b>Project Files:</b> Get started with your project by adding video, audio, "
-"and image files here. Drag and drop files from your file system."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:166
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1646
+msgid "Ease In (Quad)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/tutorial.py:496
-msgid ""
-"<b>Timeline:</b> Arrange your clips on the timeline here. Overlap clips to "
-"create automatic transitions. Access lots of fun presets and options by "
-"right-clicking on clips."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:167
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1647
+msgid "Ease In (Cubic)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/tutorial.py:503
-msgid ""
-"<b>Video Preview:</b> Watch your timeline video preview here. Use the "
-"buttons (play, rewind, fast-forward) to control the video playback."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:168
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1648
+msgid "Ease In (Quart)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/tutorial.py:509
-msgid ""
-"<b>Properties:</b> View and change advanced properties of clips and effects "
-"here. Right-clicking on clips is usually faster than manually changing "
-"properties."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:169
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1649
+msgid "Ease In (Quint)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/tutorial.py:516
-msgid ""
-"<b>Transitions:</b> Create a gradual fade from one clip to another. Drag and "
-"drop a transition onto the timeline and position it on top of a clip "
-"(usually at the beginning or ending)."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:170
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1650
+msgid "Ease In (Sine)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/tutorial.py:523
-msgid ""
-"<b>Effects:</b> Adjust brightness, contrast, saturation, and add exciting "
-"special effects. Drag and drop an effect onto the timeline and position it "
-"on top of a clip (or track)"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:171
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1651
+msgid "Ease In (Expo)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/tutorial.py:530
-msgid ""
-"<b>Emojis:</b> Add exciting and colorful emojis to your project! Drag and "
-"drop an emoji onto the timeline. The emoji will become a new Clip when "
-"dropped on the Timeline."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:172
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1652
+msgid "Ease In (Circ)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/views/tutorial.py:537
-msgid ""
-"<b>Export Video:</b> When you are ready to create your finished video, click "
-"this button to export your timeline as a single video file."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:173
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1653
+msgid "Ease In (Back)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/recording_widgets.py:115
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:540
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:581 Settings
-#: Category for Advanced
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:275
-msgid "Advanced"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:174
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1655
+msgid "Ease Out (Quad)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/recording_widgets.py:330
-#: /home/jonathan/apps/openshot-qt/src/windows/recording_widgets.py:417
-msgid "All Screens"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:175
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1656
+msgid "Ease Out (Cubic)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/recording_widgets.py:348
-#: /home/jonathan/apps/openshot-qt/src/windows/recording_widgets.py:402
-#: /home/jonathan/apps/openshot-qt/src/windows/recording_widgets.py:858
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:176
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1657
+msgid "Ease Out (Quart)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:177
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1658
+msgid "Ease Out (Quint)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:178
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1659
+msgid "Ease Out (Sine)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:179
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1660
+msgid "Ease Out (Expo)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:180
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1661
+msgid "Ease Out (Circ)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:181
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1662
+msgid "Ease Out (Back)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:182
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1664
+msgid "Ease In/Out (Quad)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:183
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1665
+msgid "Ease In/Out (Cubic)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:184
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1666
+msgid "Ease In/Out (Quart)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:185
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1667
+msgid "Ease In/Out (Quint)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:186
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1668
+msgid "Ease In/Out (Sine)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:187
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1669
+msgid "Ease In/Out (Expo)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:188
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1670
+msgid "Ease In/Out (Circ)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:189
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/keyframe.py:1671
+msgid "Ease In/Out (Back)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:208
+msgid "Bezier"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:213
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:953
+msgid "Linear"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/menu.py:216
+msgid "Constant"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/changelog_treeview.py:78
+msgid "Copy Hash"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/changelog_treeview.py:80
+msgid "View on GitHub"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/optimized_preview_menu.py:75
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/optimized_preview_menu.py:90
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4597
+msgid "Optimize Video"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/optimized_preview_menu.py:94
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4601
+msgid "Link to Existing..."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/optimized_preview_menu.py:99
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4605
+msgid "Unlink"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/optimized_preview_menu.py:103
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4613
+msgid "Delete && Unlink"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/optimized_preview_menu.py:115
+msgid "Optimize"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/base.py:2816
+msgid "Unlock track"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/base.py:2816
+msgid "Lock track"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/base.py:2820
+msgid "Hide keyframes"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/base.py:2820
+msgid "Show keyframes"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/base.py:2836
 #, python-format
-msgid "Screen %s"
+msgid "Effect: %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/recording_widgets.py:369
-#: /home/jonathan/apps/openshot-qt/src/windows/recording_widgets.py:430
-msgid "Screen 1"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:297
-msgid "Check"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:344
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:203
-msgid "Search Profiles"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:378
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/base.py:2843
 #, python-format
-msgid "%d%% (Custom)"
+msgid "Transition: %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:399
-msgid "Default"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:420
-msgid "Test"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:431
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/base.py:2856
 #, python-format
-msgid "Graphics Card %s"
+msgid "Clip: %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:608
-msgid "Select executable file"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/base.py:3696
+msgid "Keyframe Properties"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:784
-msgid "ComfyUI URL is empty."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/views/timeline_backend/qwidget/base.py:3735
+msgid "No keyframes are avaialble"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:795
-msgid "Checking ComfyUI connection..."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/video_widget.py:506
+msgid "Selection"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:806
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:835
-msgid "Connection failed."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/video_widget.py:511
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:833
+#: effect_init (Effect parameter for Tracker)
+msgid "Region"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:819
-msgid "ComfyUI URL changed. Click Check to validate the new value."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/video_widget.py:515
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:259
+msgid "Video Preview"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:829
-msgid "Connection successful. AI menus are enabled."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/video_widget.py:520
+#, python-format
+msgid ""
+" (Speed: %(speed)sx, Paint: %(pfps)s FPS, Render: %(rfps)s FPS, %(width)sx"
+"%(height)s)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:835
-msgid "Connection failed: {}"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/video_widget.py:3061
+msgid "Reset Zoom"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:841
-msgid "AI menus are disabled until ComfyUI is reachable."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:543
+msgid "Fade In & Out"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:1011
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:48
-msgid "Restore Defaults"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:547
+#: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:559
+msgid "Random"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:1012
-#, python-brace-format
-msgid "Restore default values for {category}?"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:548
+#: Settings for actionTimelineZoomIn
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1059
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1062
+msgid "Zoom In"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:1095
-msgid "Restart Required"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/add_to_timeline.py:549
+#: Settings for actionTimelineZoomOut
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1071
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1074
+msgid "Zoom Out"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preferences.py:1096
-msgid "Please restart OpenShot for all preferences to take effect."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/animated_title.py:62
+msgid "Render"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1108
-msgid "Edit Color Curve"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:938
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:1362
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:1471
+msgid "False"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1114
-msgid "Drag to reshape. Right-click points for options."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:1310
+msgid "Transparency"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1118
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1170
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1956
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:2002
-msgid "Disable"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:1360
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:1469
+msgid "True"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1170
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:2002
-msgid "Enable"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:1631
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:1654
+msgid "Property"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1847
-msgid "Choose Color..."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:1631
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/properties_model.py:1654
+msgid "Value"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1883
-msgid "Edit Color Wheels"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/add_to_timeline_model.py:57
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/transition_model.py:167
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/blender_model.py:69
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/files_model.py:337
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/effects_model.py:128
+msgid "Thumb"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1892
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1943
-msgid "Global"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/add_to_timeline_model.py:57
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/transition_model.py:167
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/blender_model.py:69
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/credits_model.py:74
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/titles_model.py:91
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/files_model.py:337
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/emoji_model.py:84
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/effects_model.py:128
+msgid "Name"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1893
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1944
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/transition_model.py:248
+msgid "{} is not a valid transition file."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/credits_model.py:74
+msgid "Email"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/credits_model.py:74
+msgid "Website"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/credits_model.py:104
+msgid "Multiple Contributions!"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/credits_model.py:122
+msgid "PayPal Supporter!"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/credits_model.py:125
+msgid "Kickstarter Supporter!"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/credits_model.py:129
+msgid "Bitcoin Supporter!"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/credits_model.py:132
+msgid "Patreon Supporter!"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/credits_model.py:135
+msgid "Developer!"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/profiles_model.py:78
+msgid "Key"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/profiles_model.py:78
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/effects_model.py:128
+msgid "Description"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/profiles_model.py:78
 #: libopenshot (Effect Properties)
-msgid "Shadows"
+msgid "Width"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1894
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1945
-#: libopenshot (Effect Properties)
-msgid "Midtones"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/profiles_model.py:78
+msgid "Height"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1895
-#: /home/jonathan/apps/openshot-qt/src/windows/color_grade_editor.py:1946
-#: libopenshot (Effect Properties)
-msgid "Highlights"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/profiles_model.py:79
+msgid "FPS"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:173
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:380
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:705
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:838
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/profiles_model.py:79
+msgid "DAR"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/profiles_model.py:79
+msgid "SAR"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/profiles_model.py:79
+msgid "360°"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/changelog_model.py:70
+msgid "Hash"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/changelog_model.py:70
+msgid "Date"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/changelog_model.py:70
+msgid "Author"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/changelog_model.py:70
+msgid "Subject"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/titles_model.py:156
+#, python-format
+msgid "%s is not a valid image file."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/files_model.py:261
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/files_model.py:263
+msgid "(Optimized)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/files_model.py:337
+msgid "Tags"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/files_model.py:526
+#, python-format
+msgid "Importing %(count)d / %(total)d"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/files_model.py:568
+#, python-format
+msgid "Imported %(count)d files"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/models/emoji_model.py:154
+msgid "{} is not a valid image file."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:174
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:381
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:718
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:851
 msgid "Unsaved Changes"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:174
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:175
 msgid "Save changes to project before closing?"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:310
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:311
 msgid "Backup Recovered"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:311
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:312
 msgid "Your most recent unsaved project has been recovered."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:381
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:706
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:839
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:382
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:719
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:852
 msgid "Save changes to project first?"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:561
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:562
 msgid "Delete Optimized Videos?"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:562
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:563
 msgid "Delete optimized videos from this project's assets folder?"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:607
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:608
 msgid "Error Saving Project"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:754
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:697
+msgid "Invalid Project File"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:698
+msgid ""
+"Please select an OpenShot project (.osp). To add video, audio, or images, "
+"use Import Files."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:767
 #, python-format
 msgid ""
 "Project %s is missing (it may have been moved or deleted). It has been "
 "removed from the Recent Projects menu."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:769
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:782
 msgid "Error Opening Project"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:827 Settings for
-#: actionOpen /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:531
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:840 Settings
+#: for actionOpen
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:533
 msgid "Open Project..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:829
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:842
 msgid "OpenShot Project (*.osp)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:877
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:890
 msgid "Save Project..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:943 Settings for
-#: actionSaveAs
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:567
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:570
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:956 Settings
+#: for actionSaveAs
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:569
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:572
 msgid "Save Project As..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:994
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:1007
 #, python-format
 msgid "%s is not a valid video, audio, or image file."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:1013
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:607
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:1026
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:609
 msgid "Import Image Sequence"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:1014
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:1027
 #, python-format
 msgid "Would you like to import %s as an image sequence?"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:1699
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:1710
 msgid "Save Frame..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:1699
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:1710
 msgid "Image files (*.png)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:1703
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:1714
 msgid "Save Frame cancelled..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:1745
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:1756
 #, python-format
 msgid "Saved Frame to %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:1747
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:1758
 #, python-format
 msgid "Failed to save image to %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2071
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2072
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:838
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:841
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2082
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2083
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:840
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:843
 msgid "Disable Snapping"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2074
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2075
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2085
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2086
 msgid "Enable Snapping"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2085
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2086
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2096
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2097
 msgid "Disable Razor"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2088
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2089
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:805
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:808
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2099
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2100
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:807
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:810
 msgid "Enable Razor"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2099
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2100
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2110
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2111
 msgid "Disable Timing"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2102
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2103
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:820
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:823
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2113
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2114
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:822
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:825
 msgid "Enable Timing"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2439
-#: /home/jonathan/apps/openshot-qt/src/windows/profile_edit.py:213
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2450
+#: /home/jonathan/apps/openshot-qt-git/src/windows/profile_edit.py:213
 msgid "Profile Error"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2440
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2451
 msgid "You can not delete the <b>current</b> or <b>default</b> profile."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2913
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2924
 msgid "Error Removing Track"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2913
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2924
 msgid "You must keep at least 1 track"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2988
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1436
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1439
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2999
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1438
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1441
 msgid "Rename Track"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:2988
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:2999
 msgid "Track Name:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3150
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3161
 msgid "My Views"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3158
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3169
 msgid "Recording View"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3166
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3177
 msgid "Docks"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3169
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3180
 msgid "Scopes"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3271
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3282
 #, python-format
 msgid "Update \"%s\""
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3277
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3288
 #, python-format
 msgid "Delete \"%s\""
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3283
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3294
 msgid "Save Current View As..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3306
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3317
 msgid "Show All Scopes"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3306
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3317
 msgid "Close All Scopes"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3367
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3378
 msgid "Save Current View"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3368
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3379
 msgid "View Name:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3379
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3390
 msgid "Custom View Exists"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3380
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3391
 #, python-format
 msgid "A custom view named \"%s\" already exists."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3413
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3424
 msgid "Delete Custom View"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3414
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3425
 #, python-format
 msgid "Delete \"%s\"?"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3642
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3653
 msgid "Enter caption text..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3972
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3983
 msgid "Recent Projects"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:3984
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:3995
 msgid "No Recent Projects"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4021
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4032
 msgid "{} seconds ago"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4024
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4035
 msgid "{} minutes ago"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4027
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4038
 msgid "{} hours ago"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4030
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4041
 msgid "{} days ago"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4033
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4044
 msgid "{} weeks ago"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4036
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4047
 msgid "{} months ago"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4039
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4050
 msgid "{} years ago"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4048
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4059
 msgid "Recovery"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4072
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4083
 msgid "No Previous Versions Available"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4174
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4191
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4210
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4221
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:5482
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:429
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4185
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4202
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4221
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4232
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:5476
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:431
 msgid "Filter"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4237
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4248
 msgid "Caption Toolbar"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4315
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1448
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1451
-msgid "Update Available"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4316
-#, python-format
-msgid "Update Available: <b>%s</b>"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:4593
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:4582
 msgid "Generate..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:5354 Settings for
-#: actionFullscreen
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1108
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1111
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:5344 Settings
+#: for actionFullscreen
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1110
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1113
 msgid "Fullscreen"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:5355
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1235
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:5345
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1237
 msgid "Color View"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:5385
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:5379
 msgid "Error starting local HTTP server"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:5386
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:5380
 msgid "Failed multiple attempts to start server:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:5423
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:5417
 msgid "Luma Waveform"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:5433
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:5427
 msgid "Histogram"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:5444
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:5438
 msgid "Vectorscope"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/main_window.py:5453
+#: /home/jonathan/apps/openshot-qt-git/src/windows/main_window.py:5447
 msgid "Audio Levels"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/models/add_to_timeline_model.py:57
-#: /home/jonathan/apps/openshot-qt/src/windows/models/blender_model.py:69
-#: /home/jonathan/apps/openshot-qt/src/windows/models/transition_model.py:167
-#: /home/jonathan/apps/openshot-qt/src/windows/models/effects_model.py:128
-#: /home/jonathan/apps/openshot-qt/src/windows/models/files_model.py:337
-msgid "Thumb"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/add_to_timeline_model.py:57
-#: /home/jonathan/apps/openshot-qt/src/windows/models/blender_model.py:69
-#: /home/jonathan/apps/openshot-qt/src/windows/models/transition_model.py:167
-#: /home/jonathan/apps/openshot-qt/src/windows/models/credits_model.py:74
-#: /home/jonathan/apps/openshot-qt/src/windows/models/titles_model.py:91
-#: /home/jonathan/apps/openshot-qt/src/windows/models/emoji_model.py:84
-#: /home/jonathan/apps/openshot-qt/src/windows/models/effects_model.py:128
-#: /home/jonathan/apps/openshot-qt/src/windows/models/files_model.py:337
-msgid "Name"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/transition_model.py:248
-msgid "{} is not a valid transition file."
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/changelog_model.py:70
-msgid "Hash"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/changelog_model.py:70
-msgid "Date"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/changelog_model.py:70
-msgid "Author"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/changelog_model.py:70
-msgid "Subject"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/properties_model.py:938
-#: /home/jonathan/apps/openshot-qt/src/windows/models/properties_model.py:1362
-#: /home/jonathan/apps/openshot-qt/src/windows/models/properties_model.py:1471
-msgid "False"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/properties_model.py:1310
-msgid "Transparency"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/properties_model.py:1360
-#: /home/jonathan/apps/openshot-qt/src/windows/models/properties_model.py:1469
-msgid "True"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/properties_model.py:1631
-#: /home/jonathan/apps/openshot-qt/src/windows/models/properties_model.py:1654
-msgid "Property"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/properties_model.py:1631
-#: /home/jonathan/apps/openshot-qt/src/windows/models/properties_model.py:1654
-msgid "Value"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/credits_model.py:74
-msgid "Email"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/credits_model.py:74
-msgid "Website"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/credits_model.py:104
-msgid "Multiple Contributions!"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/credits_model.py:122
-msgid "PayPal Supporter!"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/credits_model.py:125
-msgid "Kickstarter Supporter!"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/credits_model.py:129
-msgid "Bitcoin Supporter!"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/credits_model.py:132
-msgid "Patreon Supporter!"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/credits_model.py:135
-msgid "Developer!"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/titles_model.py:156
-#, python-format
-msgid "%s is not a valid image file."
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/emoji_model.py:154
-msgid "{} is not a valid image file."
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/effects_model.py:128
-#: /home/jonathan/apps/openshot-qt/src/windows/models/profiles_model.py:78
-msgid "Description"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/profiles_model.py:78
-msgid "Key"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/profiles_model.py:78
-#: libopenshot (Effect Properties)
-msgid "Width"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/profiles_model.py:78
-msgid "Height"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/profiles_model.py:79
-msgid "FPS"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/profiles_model.py:79
-msgid "DAR"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/profiles_model.py:79
-msgid "SAR"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/profiles_model.py:79
-msgid "360°"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/files_model.py:261
-#: /home/jonathan/apps/openshot-qt/src/windows/models/files_model.py:263
-msgid "(Optimized)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/files_model.py:337
-msgid "Tags"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/files_model.py:526
-#, python-format
-msgid "Importing %(count)d / %(total)d"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/models/files_model.py:568
-#, python-format
-msgid "Imported %(count)d files"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/export_clips.py:194
-msgid "Choose Target Folder"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/export_clips.py:207
-#, python-format
-msgid "Export To %s"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/export_clips.py:248
-msgid "Error Exporting File"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/export_clips.py:249
-#, python-format
-msgid ""
-"The following error occurred while exporting this file: \n"
-"%s"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/export_clips.py:297
-#: /home/jonathan/apps/openshot-qt/src/windows/export_clips.py:327
-msgid "Error Exporting Clip"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/export_clips.py:298
-#: /home/jonathan/apps/openshot-qt/src/windows/export_clips.py:328
-#, python-format
-msgid ""
-"The following error occurred while exporting this clip: \n"
-"%s"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/export_clips.py:374
-msgid "Exporting"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/cutting.py:69
-#: /home/jonathan/apps/openshot-qt/src/windows/cutting.py:75
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:929 Settings
-#: Category for Preview
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animation.ui:341
-msgid "Preview"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/cutting.py:74
-#, python-format
-msgid "Preview: %s"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/cutting.py:639
-#: /home/jonathan/apps/openshot-qt/src/windows/cutting.py:676
-msgid "Please choose valid 'start' and 'end' values for your clip."
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/add_to_timeline.py:543
-msgid "Fade In & Out"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/add_to_timeline.py:547
-#: /home/jonathan/apps/openshot-qt/src/windows/add_to_timeline.py:559
-msgid "Random"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/add_to_timeline.py:548 Settings
-#: for actionTimelineZoomIn
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1057
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1060
-msgid "Zoom In"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/add_to_timeline.py:549 Settings
-#: for actionTimelineZoomOut
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1069
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1072
-msgid "Zoom Out"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/file_properties.py:78
-msgid "Update"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/file_properties.py:152
-msgid "Unknown"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/file_properties.py:262
-#, python-format
-msgid "Locate media file: %s"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:187
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:187
 msgid "Download"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:188
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:188
 #, python-format
 msgid "Download (%s MB)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:309
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:309
 msgid "Click to Select"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:323
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:323
 msgid "Select Point / Region"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:324
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:997
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:324
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:997
 msgid "Choose a positive point or rectangle, and optional negative points."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:329
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:329
 msgid "Point or region has not been selected."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:379
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:379
 msgid "File has not been validated yet."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:381
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:381
 msgid "Browse"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:382
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:382
 msgid "Choose a file from disk."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:454
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:454
 msgid "Status"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:467
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:467
 msgid "Process Effect"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:491
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:491
 msgid "Download selected YOLO model files."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:497
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:497
 msgid "Download selected Object Mask model files."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:536
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1063
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1095
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1099
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:536
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1063
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1095
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1099
 msgid "Not Downloaded"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:538
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1065
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1101
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:538
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1065
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1101
 msgid "Required model files are not downloaded."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:542
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:540
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:581
+#: /home/jonathan/apps/openshot-qt-git/src/windows/recording_widgets.py:115
+#: Settings Category for Advanced
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:275
+msgid "Advanced"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:542
 msgid "Show model file paths."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:581
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:581
 msgid "Hide Advanced"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:795
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:795
 #, python-format
 msgid "Choose %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:808
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:842
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1069
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:808
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:842
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1069
 msgid "File not found"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:821
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:859
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1004
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1091
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:821
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:859
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1004
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1091
 msgid "Ready"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:828
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:828
 #, python-format
 msgid "%(model)s requires an FP32 model file for this OpenCV build."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:838
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1069
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:838
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1069
 msgid "Required file"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:847
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:847
 msgid "Expected a model file."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:849
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:849
 msgid "Model file is empty."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:856
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:856
 msgid "Unable to read class names"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:858
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:858
 msgid "Class names file is empty"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:999
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1618
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:999
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1618
 msgid "Download valid Object Mask model files before selecting points."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1006
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1006
 msgid "Select a positive point or rectangle."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1008
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1008
 msgid "Object Mask model files are not ready."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1093
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1093
 msgid "All required model files are ready."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1097
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1097
 msgid "A model download is incomplete. Download again to finish installation."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1103
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1103
 msgid "Invalid"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1105
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1105
 msgid "One or more model files are invalid."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1305
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1308
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1305
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1308
 msgid "Downloaded model files are invalid."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1341
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1417
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1440
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1525
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1341
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1417
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1440
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1525
 msgid "Download Failed"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1341
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1341
 msgid "No YOLO models are available."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1354
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1366
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1354
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1366
 #, python-format
 msgid "Download %(model)s Files"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1355
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1355
 #, python-format
 msgid "The %(model)s files are already downloaded."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1360
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1360
 #, python-format
 msgid "Downloading %(model)s files..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1392
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1392
 #, python-format
 msgid "%(model)s files"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1397
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1404
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1397
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1404
 #, python-format
 msgid "Downloaded %(model)s files are invalid."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1440
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1440
 msgid "No Object Mask models are available."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1470
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1482
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1470
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1482
 msgid "Download Object Mask Files"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1471
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1471
 msgid "The Object Mask files are already downloaded."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1476
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1476
 msgid "Downloading Object Mask files..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1567
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:1147
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1567
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:1147
 msgid "Invalid Region"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1568
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1568
 msgid "Please draw a rectangle region before clicking Select Region."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1617
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1617
 msgid "Object Mask Models Not Ready"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1668
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:1155
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:1161
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:1190
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:1199
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1668
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:1155
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:1161
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:1190
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:1199
 msgid "Invalid Selection"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1669
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1669
 msgid "Please select a positive point or rectangle."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1688
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1688
 #, python-format
 msgid "Selection: %(include)s include, %(exclude)s exclude"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1690
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1690
 #, python-format
 msgid "Selection: %(include)s include"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1727
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1727
 msgid "Unable to process this effect. Check the model files and settings."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/process_effect.py:1732
+#: /home/jonathan/apps/openshot-qt-git/src/windows/process_effect.py:1732
 msgid "Processing Failed"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:371
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:371
 msgid ""
 "Click to add tracking point (SHIFT+Click for additional points, CTRL+Click "
 "for negative point)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:375
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:375
 msgid ""
 "Choose a tool and mark positive/negative points or rectangles. Scrub to edit "
 "selections by frame."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:378
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/region.ui:44
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:378
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/region.ui:44
 msgid "Draw a rectangle to select a region of the video frame."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:447
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/region.ui:14
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:447
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/region.ui:14
 msgid "Select Region"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:449
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:449
 msgid "Apply Selections"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:451
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:451
 msgid "Select Point(s)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:633
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:633
 msgid "Positive Point"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:634
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:634
 msgid "Negative Point"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:635
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:635
 msgid "Positive Rectangle"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:636
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:636
 msgid "Negative Rectangle"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:657
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:657
 msgid "Clear All Selections"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:669
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:669
 msgid "Preview Mask"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:670
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:670
 msgid ""
 "Preview the current seed-frame mask using the selected EfficientSAM model."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:675
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:675
 msgid "Preview requires an updated libopenshot Python module."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:679
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:679
 msgid "Preview requires a valid EfficientSAM model path."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:1041
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:1041
 msgid "Frames: {}"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:1148
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:1148
 msgid "Please choose a region at the beginning of the clip"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:1155
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:1155
 msgid "Please select at least one point."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:1161
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:1161
 msgid "Please draw a rectangle region."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:1190
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:1190
 msgid "Please select at least one point or rectangle."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/region.py:1200
+#: /home/jonathan/apps/openshot-qt-git/src/windows/region.py:1200
 msgid ""
 "Each Object Mask frame must include at least one positive point or rectangle."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:104
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:104
 msgid "Analyze selected preview region"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:862
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:946
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:862
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:946
 msgid "Luma"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:863
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:863
 msgid "RGB Overlay"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:864
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:864
 msgid "RGB Parade"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:865
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:947
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:865
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:947
 msgid "Red"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:866
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:870
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:948
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:866
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:870
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:948
 msgid "Green"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:867
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:949
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:867
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:949
 msgid "Blue"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:871
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:871
 msgid "White"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:872
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:872
 msgid "Orange"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:945
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:945
 msgid "All Channels"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:952
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:952
 msgid "Logarithmic"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:1010
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:1010
 msgid "Colorized"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:1011
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:1011
 msgid "Density"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/scope_panel.py:1012 libopenshot
-#: (Effect Properties)
+#: /home/jonathan/apps/openshot-qt-git/src/windows/scope_panel.py:1012
+#: libopenshot (Effect Properties)
 msgid "Intensity"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preview_thread.py:115
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:297
+msgid "Check"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:344
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:203
+msgid "Search Profiles"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:378
+#, python-format
+msgid "%d%% (Custom)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:399
+msgid "Default"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:420
+msgid "Test"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:431
+#, python-format
+msgid "Graphics Card %s"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:608
+msgid "Select executable file"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:784
+msgid "ComfyUI URL is empty."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:795
+msgid "Checking ComfyUI connection..."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:806
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:835
+msgid "Connection failed."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:819
+msgid "ComfyUI URL changed. Click Check to validate the new value."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:829
+msgid "Connection successful. AI menus are enabled."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:835
+msgid "Connection failed: {}"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:841
+msgid "AI menus are disabled until ComfyUI is reachable."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:1011
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:48
+msgid "Restore Defaults"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:1012
+#, python-brace-format
+msgid "Restore default values for {category}?"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:1095
+msgid "Restart Required"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preferences.py:1096
+msgid "Please restart OpenShot for all preferences to take effect."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/cutting.py:69
+#: /home/jonathan/apps/openshot-qt-git/src/windows/cutting.py:75
+#: /home/jonathan/apps/openshot-qt-git/src/windows/notifications.py:243
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:929
+#: Settings Category for Preview
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animation.ui:341
+msgid "Preview"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/cutting.py:74
+#, python-format
+msgid "Preview: %s"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/cutting.py:639
+#: /home/jonathan/apps/openshot-qt-git/src/windows/cutting.py:676
+msgid "Please choose valid 'start' and 'end' values for your clip."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/feedback.py:26
+msgid "Share Feedback…"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/feedback.py:76
+msgid "Help us make OpenShot even better!"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/feedback.py:76
+msgid "Share feedback"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/feedback.py:108
+#: /home/jonathan/apps/openshot-qt-git/src/windows/feedback.py:111
+#: /home/jonathan/apps/openshot-qt-git/src/windows/notifications.py:271
+#: /home/jonathan/apps/openshot-qt-git/src/windows/notifications.py:274
+msgid "Couldn’t open your browser. Please try again."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/feedback.py:110
+#: /home/jonathan/apps/openshot-qt-git/src/windows/notifications.py:273
+msgid "Unable to open browser"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1108
+msgid "Edit Color Curve"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1114
+msgid "Drag to reshape. Right-click points for options."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1118
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1170
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1956
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:2002
+msgid "Disable"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1170
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:2002
+msgid "Enable"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1847
+msgid "Choose Color..."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1883
+msgid "Edit Color Wheels"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1892
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1943
+msgid "Global"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1893
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1944
+#: libopenshot (Effect Properties)
+msgid "Shadows"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1894
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1945
+#: libopenshot (Effect Properties)
+msgid "Midtones"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1895
+#: /home/jonathan/apps/openshot-qt-git/src/windows/color_grade_editor.py:1946
+#: libopenshot (Effect Properties)
+msgid "Highlights"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/notifications.py:71
+#: /home/jonathan/apps/openshot-qt-git/src/windows/notifications.py:72
+msgid "Dismiss notification"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/notifications.py:231
+#: Settings for actionUpdate
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1450
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1453
+msgid "Update Available"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/notifications.py:232
+#: /home/jonathan/apps/openshot-qt-git/src/windows/notifications.py:243
+#, python-format
+msgid "Update Available: %s"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/notifications.py:241
+msgid "Upgrade to the latest version of OpenShot."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/notifications.py:241
+msgid "Upgrade"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/recording_widgets.py:356
+#: /home/jonathan/apps/openshot-qt-git/src/windows/recording_widgets.py:443
+msgid "All Screens"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/recording_widgets.py:374
+#: /home/jonathan/apps/openshot-qt-git/src/windows/recording_widgets.py:428
+#: /home/jonathan/apps/openshot-qt-git/src/windows/recording_widgets.py:884
+#, python-format
+msgid "Screen %s"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/recording_widgets.py:395
+#: /home/jonathan/apps/openshot-qt-git/src/windows/recording_widgets.py:456
+msgid "Screen 1"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preview_thread.py:115
 msgid "Audio Error"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/preview_thread.py:115
+#: /home/jonathan/apps/openshot-qt-git/src/windows/preview_thread.py:115
 #, python-format
 msgid ""
 "Please fix the following error and restart OpenShot\n"
 "%s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:71
-msgid "The Title"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:72
-msgid "Sub-Title"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:73 Settings for
-#: actionTitle
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:161
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1081
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1084
-msgid "Title"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:74
-msgid "Header Text"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:75
-msgid "Footer Text"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:76
-msgid "Line 1"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:77
-msgid "Line 2"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:78
-msgid "Line 3"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:79
-msgid "Line 4"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:129
-msgid "Save"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:398
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:1074
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:43
-msgid "File Name:"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:414
-#, python-format
-msgid "TitleFileName (%d)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:464
-#, python-format
-msgid "Line %s:"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:481
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:482
-msgid "Font:"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:488
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:489
-msgid "Text:"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:490 libopenshot
-#: (Effect Properties)
-msgid "Text Color"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:495
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:496
-msgid "Background:"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:497 libopenshot
-#: (Effect Properties)
-msgid "Background Color"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:502
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:503
-msgid "Advanced:"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:504
-msgid "Use Advanced Editor"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:834
-msgid "Title Editor"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:862
-msgid "Error launching editor"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:864
-#, python-brace-format
-msgid ""
-"The editor did not launch: <b>{cmd}</b><br><br>If you used Snap or Flatpak, "
-"try installing the editor with your package manager."
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/title_editor.py:868
-#, python-brace-format
-msgid ""
-"The editor did not launch: <b>{cmd}</b><br><br>Please check that the editor "
-"is installed and working."
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/about.py:151
-msgid ""
-"OpenShot Video Editor is an Award-Winning, Free, and<br> Open-Source Video "
-"Editor for Linux, Mac, Chrome OS, and Windows."
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/about.py:152
-#, python-format
-msgid "Copyright &copy; %(begin_year)s-%(current_year)s"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/about.py:175
-#: /home/jonathan/apps/openshot-qt/src/windows/about.py:224
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/about.ui:84
-msgid "Copy Version Info"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/about.py:176
-msgid "Version info copied to clipboard"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/about.py:489
-msgid "Release Date"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/about.py:490
-msgid "Release Notes"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/about.py:491
-msgid "Official"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/about.py:526
-#, python-format
-msgid "Version: %s"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/about.py:611
-msgid "Become a Supporter"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/about.py:636
-msgid "translator-credits"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/about.py:715
-msgid "OpenShot on GitHub"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/profile_edit.py:80
-msgid "Edit Profile"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/profile_edit.py:214
-msgid "Please enter a <b>unique</b> description for this profile."
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:454
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:454
 #, python-format
 msgid "Timed out opening %s capture device."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:770
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:779
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:770
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:779
 msgid "Mic"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:770
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:770
 msgid "Record your voice"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:771
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:826
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1255
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:771
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:826
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1255
 #: libopenshot (Clip Properties)
 msgid "Screen"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:771
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:771
 msgid "Capture your screen"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:772
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:928
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:772
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:928
 msgid "Webcam"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:772
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:772
 msgid "Record yourself"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:784
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:814
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:784
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:814
 msgid "Mono"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:785
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:815
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:785
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:815
 msgid "Stereo"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:816
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:968
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:816
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:968
 msgid "Input:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:818
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:818
 msgid "Format:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:820
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:929
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:688
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:820
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:929
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:688
 msgid "Sample Rate:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:822
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:822
 msgid "Channels:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:831
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:831
 msgid "Full Screen"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:832
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:172
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:832
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:172
 msgid "Window"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:843
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:843
 msgid "System Audio:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:845
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:868
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:845
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:868
 #: libopenshot (Clip Properties)
 msgid "On"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:846
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:869
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:992
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:846
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:869
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:992
 #: libopenshot (Clip Properties)
 msgid "Off"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:848
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:848
 msgid "Record sound playing through the system output in the screen recording."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:874
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:874
 msgid ""
 "Temporarily hide OpenShot while selecting or recording a window or region."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:888
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:888
 msgid "Screen:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:889
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:889
 msgid "Offset:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:890
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:976
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:890
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:976
 msgid "Size:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:891
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:891
 msgid "FPS:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:892
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:892
 msgid "Cursor:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:893
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:893
 msgid "Hide OpenShot:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:943
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:943
 #: libopenshot (Clip Properties)
 msgid "Bottom Right"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:944
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:944
 #: libopenshot (Clip Properties)
 msgid "Top Right"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:945
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:945
 #: libopenshot (Clip Properties)
 msgid "Bottom Left"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:946
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:946
 #: libopenshot (Clip Properties)
 msgid "Top Left"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:950
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:950
 msgid "Full Size"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:954
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:954
 msgid "Corner (20%)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:955
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:955
 msgid "Corner (30%)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:956
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:956
 msgid "Corner (40%)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:958
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:958
 #: libopenshot (Effect Properties)
 msgid "Size"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:961
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:961
 msgid "Rectangle"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:962
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:962
 msgid "Rounded"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:963
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:963
 msgid "Oval"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:964
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:964
 msgid "Corners"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:970
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:970
 msgid "Resolution:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:972
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:972
 msgid "Record FPS:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:974
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:974
 msgid "Layout:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:978
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:978
 msgid "Corners:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:986
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:986
 msgid ""
 "Choose the top track for recorded clips.\n"
 "Additional recording sources use tracks below it.\n"
 "Select No Track to add recordings to Project Files only."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:993
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:993
 msgid "Full"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:994
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:994
 msgid "Half"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:995
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:995
 msgid "Quarter"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:999
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:999
 msgid ""
 "Play the timeline while recording.\n"
 "Lower resolutions can improve recording performance."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1002
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1002
 msgid "Preview:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1008
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:2752
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1008
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2764
 msgid "Start Recording"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1114
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1114
 msgid "Audio recording is not available."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1117
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1854
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1117
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1866
 msgid ""
 "Screen recording is not available for this platform or libopenshot build."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1126
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1857
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1126
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1869
 msgid ""
 "Webcam recording is not available for this platform or libopenshot build."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1128
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1860
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:2149
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1128
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1872
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2161
 msgid "No webcam device was found."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1160
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1160
 msgid ""
 "System audio recording is not available for this platform or libopenshot "
 "build."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1164
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1341
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1352
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1164
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1341
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1352
 msgid "Your desktop will ask what to share when recording starts."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1167
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1167
 msgid ""
 "macOS screen recording uses full screen or cropped window and region bounds."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1170
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1170
 msgid "Windows screen recording uses full screen or numeric region bounds."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1296
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1296
 #, python-format
 msgid "All screens: %(width)sx%(height)s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1298
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1309
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1321
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1298
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1309
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1321
 #, python-format
 msgid "Full screen: %(width)sx%(height)s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1330
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1330
 msgid "Full screen"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1369
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1369
 #, python-format
 msgid "Window: %(width)sx%(height)s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1373
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1373
 msgid "Window selection canceled."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1377
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1377
 msgid "Region selection is not available for Wayland screen recording."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1394
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1406
 #, python-format
 msgid "Region: %(width)sx%(height)s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1397
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1409
 msgid "Region selection canceled."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1498
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1510
 msgid "Default input"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1581
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1615
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:2226
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1593
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1627
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2238
 msgid "No webcam found"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1739
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1751
 msgid "No Track"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1796
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:2760
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1808
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2772
 msgid "Select at least one recording source."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1842
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1854
 #, python-format
 msgid "Unable to prepare recording: %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1862
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1874
 #, python-format
 msgid "Webcam device was not found: %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1864
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1876
 #, python-format
 msgid "Webcam device is not accessible: %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1925
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:1937
 #, python-format
 msgid "Unable to start recording: %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:1992
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2004
 #, python-format
 msgid "Unable to finish recording: %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:2215
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2227
 #, python-format
 msgid "Recording stopped: %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:2285
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2297
 msgid "Preview unavailable"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:2386
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2398
 msgid "Screen Recording"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:2395
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2407
 msgid "Webcam Recording"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:2772
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2784
 msgid "Unavailable"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:2778
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2790
 msgid "Starting..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:2784
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2796
 msgid "Stopping..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:2792
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2804
 msgid "Saving..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:2801
-#: /home/jonathan/apps/openshot-qt/src/classes/tray_status.py:44
-msgid "Stop Recording"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/windows/audio_recording.py:2869
+#: /home/jonathan/apps/openshot-qt-git/src/windows/audio_recording.py:2881
 #, python-format
 msgid "Unable to monitor input: %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/classes/exporters/edl.py:152
-msgid "Export EDL..."
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export_clips.py:194
+msgid "Choose Target Folder"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/classes/exporters/edl.py:153
-#: /home/jonathan/apps/openshot-qt/src/classes/importers/edl.py:302
-#: /home/jonathan/apps/openshot-qt/src/classes/importers/edl.py:303
-msgid "Edit Decision List (*.edl)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/classes/exporters/final_cut_pro.py:523
-msgid "Export XML..."
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/classes/exporters/final_cut_pro.py:524
-#: /home/jonathan/apps/openshot-qt/src/classes/importers/final_cut_pro.py:271
-msgid "Final Cut Pro (*.xml)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/classes/importers/edl.py:300
-msgid "Import EDL..."
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/classes/importers/final_cut_pro.py:270
-msgid "Import XML..."
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/classes/tray_status.py:60
-msgid "Stop Export"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/classes/tray_status.py:73
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export_clips.py:207
 #, python-format
-msgid "Exporting %s%%"
+msgid "Export To %s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/classes/title_bar.py:106
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/about.ui:154
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/changelog.ui:134
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/credits.ui:134
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/license.ui:45
-msgid "Close"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export_clips.py:248
+msgid "Error Exporting File"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/classes/title_bar.py:110
-msgid "Dock"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/classes/title_bar.py:112
-msgid "Float"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/classes/app.py:195
-msgid "Wrong Version of libopenshot Detected"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/classes/app.py:196
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export_clips.py:249
 #, python-format
 msgid ""
-"<b>Version %(minimum_version)s is required</b>, but %(current_version)s was "
-"detected. Please update libopenshot or download our latest installer."
+"The following error occurred while exporting this file: \n"
+"%s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/classes/app.py:251
-msgid "Permission Error"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export_clips.py:297
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export_clips.py:327
+msgid "Error Exporting Clip"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/classes/app.py:252
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export_clips.py:298
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export_clips.py:328
 #, python-format
-msgid "%(error)s. Please delete <b>%(path)s</b> and launch OpenShot again."
+msgid ""
+"The following error occurred while exporting this clip: \n"
+"%s"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/classes/app.py:315
-msgid "Settings Error"
+#: /home/jonathan/apps/openshot-qt-git/src/windows/export_clips.py:374
+msgid "Exporting"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/classes/app.py:316
+#: /home/jonathan/apps/openshot-qt-git/src/windows/profile_edit.py:80
+msgid "Edit Profile"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/profile_edit.py:214
+msgid "Please enter a <b>unique</b> description for this profile."
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:78
+msgid "Update"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:152
+msgid "Unknown"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/windows/file_properties.py:262
 #, python-format
-msgid "Error loading settings file: %(file_path)s. Settings will be reset."
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/classes/json_data.py:418
-msgid "Saved backup file {}"
+msgid "Locate media file: %s"
 msgstr ""
 
 #: libopenshot (Clip Properties)
@@ -3737,7 +3789,7 @@ msgid "Frame Number"
 msgstr ""
 
 #: libopenshot (Clip Properties) Settings Category for Timeline
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:494
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:496
 msgid "Timeline"
 msgstr ""
 
@@ -3750,7 +3802,7 @@ msgid "Duration"
 msgstr ""
 
 #: libopenshot (Effect Properties)
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/cutting.ui:116
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:116
 msgid "End"
 msgstr ""
 
@@ -3851,7 +3903,7 @@ msgid "Shear Y"
 msgstr ""
 
 #: libopenshot (Effect Properties)
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/cutting.ui:97
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:97
 msgid "Start"
 msgstr ""
 
@@ -3860,7 +3912,7 @@ msgid "Wave Color"
 msgstr ""
 
 #: libopenshot (Clip Properties)
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1636
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1638
 msgid "Waveform"
 msgstr ""
 
@@ -4073,7 +4125,7 @@ msgid "Font"
 msgstr ""
 
 #: libopenshot (Effect Properties)
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:365
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:367
 msgid "Captions"
 msgstr ""
 
@@ -5013,15 +5065,207 @@ msgid "Create and draw a segmentation mask for a prompted object."
 msgstr ""
 
 #: ColorMap effect lookup (Category)
+msgid "Utility & Correction"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Clean & Denoise"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Warm Correction"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Protect Highlights"
+msgstr ""
+
+#: ColorMap effect lookup (Category)
+msgid "Teal & Orange Vibes"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Sunset Orange"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Teal Punch"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Western Sunset"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Moonlight Orange"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Tropical Teal"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Signature Teal & Orange"
+msgstr ""
+
+#: ColorMap effect lookup (Category)
+msgid "Cinematic & Blockbuster"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Sunlit Cinema"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Elegant Dark Cinema"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "City Neon Cinema"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Romantic Cinema"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Teal Cinema"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Warm Cinema"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Heroic Cinema"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Bold Red Cinema"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Cool Cinema"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Teal & Orange Cinema"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Dreamy Cinema"
+msgstr ""
+
+#: ColorMap effect lookup (Category)
+msgid "Film Stock & Vintage"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Emerald Film"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Faded Memories"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Green Film Pop"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Vintage 400 Film"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Warm Roast Film"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Golden Years Film"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Red Film"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Dark Orange Film"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Classic Film"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Vintage Green Film"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Low Key Film"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Golden Wood Film"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Standard Film"
+msgstr ""
+
+#: ColorMap effect lookup (Category)
+msgid "Dark & Moody"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Noir Era"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Spy Night"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Cool Haze"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Mystic Emerald Drama"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Dramatic Warmth"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Woodland Drama"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "City Night Film"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Retro Red Shadows"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Icy Drama"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Teal Horror"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Night Glow"
+msgstr ""
+
+#: ColorMap effect lookup (Name)
+msgid "Cold Shadows"
+msgstr ""
+
+#: ColorMap effect lookup (Category)
 msgid "Vibrant & Colorful"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Warm Pop"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Color Pop"
 msgstr ""
 
 #: ColorMap effect lookup (Name)
@@ -5036,456 +5280,264 @@ msgstr ""
 msgid "Photo Contrast"
 msgstr ""
 
-#: ColorMap effect lookup (Category)
-msgid "Dark & Moody"
+#: ColorMap effect lookup (Name)
+msgid "Warm Pop"
 msgstr ""
 
 #: ColorMap effect lookup (Name)
-msgid "Woodland Drama"
+msgid "Color Pop"
 msgstr ""
 
-#: ColorMap effect lookup (Name)
-msgid "Cool Haze"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "City Night Film"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Retro Red Shadows"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Cold Shadows"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Mystic Emerald Drama"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Spy Night"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Teal Horror"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Night Glow"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Noir Era"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Dramatic Warmth"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Icy Drama"
-msgstr ""
-
-#: ColorMap effect lookup (Category)
-msgid "Cinematic & Blockbuster"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Romantic Cinema"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Sunlit Cinema"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Warm Cinema"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "City Neon Cinema"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Bold Red Cinema"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Cool Cinema"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Heroic Cinema"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Elegant Dark Cinema"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Dreamy Cinema"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Teal & Orange Cinema"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Teal Cinema"
-msgstr ""
-
-#: ColorMap effect lookup (Category)
-msgid "Teal & Orange Vibes"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Signature Teal & Orange"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Western Sunset"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Tropical Teal"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Moonlight Orange"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Teal Punch"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Sunset Orange"
-msgstr ""
-
-#: ColorMap effect lookup (Category)
-msgid "Utility & Correction"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Warm Correction"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Clean & Denoise"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Protect Highlights"
-msgstr ""
-
-#: ColorMap effect lookup (Category)
-msgid "Film Stock & Vintage"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Vintage 400 Film"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Golden Years Film"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Dark Orange Film"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Low Key Film"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Green Film Pop"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Golden Wood Film"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Emerald Film"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Warm Roast Film"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Standard Film"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Classic Film"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Vintage Green Film"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Faded Memories"
-msgstr ""
-
-#: ColorMap effect lookup (Name)
-msgid "Red Film"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mov_mpeg2.xml
-msgid "MOV (mpeg2)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mkv_x265.xml
-msgid "MKV (h.265)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp3.xml
-msgid "MP3 (audio only)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/apple_tv.xml
-msgid "Device"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/nokia_nHD.xml
-msgid "Nokia nHD"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp4_x264_qsv.xml
-msgid "MP4 (h.264 qsv)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/twitter.xml
-msgid "Web"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/youtube_4K.xml
-msgid "YouTube (4K)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_ogg_libvorbis.xml
-msgid "OGG (theora/vorbis)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_gif.xml
-msgid "GIF (animated)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mov_x264.xml
-msgid "MOV (h.264)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp4_hevc_hw.xml
-msgid "MP4 (HEVC va)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp4_libsvtav1.xml
-msgid "MP4 (AV1 svt)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/chromebook.xml
-msgid "Chromebook"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp4_x265_crf.xml
-msgid "MP4 (h.265)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/flickr_HD.xml
-msgid "Flickr"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/tiktok.xml
-msgid "TikTok"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/avchd.xml
-msgid "Blu-Ray/AVCHD"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/avchd.xml
-msgid "AVCHD Disks"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mkv_x264_vtb.xml
-msgid "MKV (h.264 videotoolbox)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/picasa.xml
-msgid "Picasa"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/linkedin.xml
-msgid "LinkedIn"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp4_x264_vtb.xml
-msgid "MP4 (h.264 videotoolbox)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp4_mpeg4.xml
-msgid "MP4 (mpeg4)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/vimeo_HD.xml
-msgid "Vimeo"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mov_prores.xml
-msgid "MOV (ProRes 422)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/xbox360.xml
-msgid "Xbox 360"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp4_x264_lossless.xml
-msgid "MP4 (h.264) lossless"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mov_mpeg4.xml
-msgid "MOV (mpeg4)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/snapchat.xml
-msgid "Snapchat"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/facebook.xml
-msgid "Facebook"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_avi_mp4.xml
-msgid "AVI (mpeg4)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_avi_mpeg2.xml
-msgid "AVI (mpeg2)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/youtube_HD.xml
-msgid "YouTube"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_webm_libvp9.xml
-msgid "WEBM (vp9)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/youtube_8K.xml
-msgid "YouTube (8K)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_ogg_flac.xml
-msgid "OGG (theora/flac)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_webm_vp9_hw.xml
-msgid "WEBP (vp9 va)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/metacafe.xml
-msgid "Metacafe"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mkv_x264_dx.xml
-msgid "MKV (h.264 dx)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/instagram_reels.xml
-msgid "Instagram Reels"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mkv_x264_hw.xml
-msgid "MKV (h.264 va)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/dvd_pal.xml
-msgid "DVD"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/dvd_ntsc.xml
-msgid "DVD-NTSC"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_webm_libvp9_lossless.xml
-msgid "WEBM (vp9) lossless"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/wikipedia.xml
-msgid "Wikipedia"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_avi_x264.xml
-msgid "AVI (h.264)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp4_xvid.xml
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mp4_xvid.xml
 msgid "MP4 (Xvid)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp4_x264_dx.xml
-msgid "MP4 (h.264 dx)"
+#: /home/jonathan/apps/openshot-qt-git/src/presets/snapchat.xml
+msgid "Web"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mkv_x264_nv.xml
-msgid "MKV (h.264 nv)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/youtube_shorts.xml
+#: /home/jonathan/apps/openshot-qt-git/src/presets/youtube_shorts.xml
 msgid "YouTube Shorts"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mkv_x264.xml
-msgid "MKV (h.264)"
+#: /home/jonathan/apps/openshot-qt-git/src/presets/linkedin.xml
+msgid "LinkedIn"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mpeg_mpeg2.xml
-msgid "MPEG (mpeg2)"
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mp4_mpeg4.xml
+msgid "MP4 (mpeg4)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/presets/apple_tv.xml
-msgid "Apple TV"
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mov_x264.xml
+msgid "MOV (h.264)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/presets/youtube_2K.xml
-msgid "YouTube (2K)"
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mov_mpeg2.xml
+msgid "MOV (mpeg2)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/presets/format_webm_libvpx.xml
-msgid "WEBM (vpx)"
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_avi_x264.xml
+msgid "AVI (h.264)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/presets/dvd_pal.xml
-msgid "DVD-PAL"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp4_x264_nv.xml
-msgid "MP4 (h.264 nv)"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/instagram.xml
-msgid "Instagram"
-msgstr ""
-
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp4_librav1e.xml
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mp4_librav1e.xml
 msgid "MP4 (AV1 rav1e)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mkv_x264_qsv.xml
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_webm_vp9_hw.xml
+msgid "WEBP (vp9 va)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mp4_x265_crf.xml
+msgid "MP4 (h.265)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_avi_mp4.xml
+msgid "AVI (mpeg4)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/chromebook.xml
+msgid "Device"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/xbox360.xml
+msgid "Xbox 360"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mkv_x264.xml
+msgid "MKV (h.264)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mp3.xml
+msgid "MP3 (audio only)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/twitter.xml
+msgid "Twitter / X"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mkv_x264_qsv.xml
 msgid "MKV (h.264 qsv)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/presets/format_mp4_x264_hw.xml
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mov_mpeg4.xml
+msgid "MOV (mpeg4)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/facebook.xml
+msgid "Facebook"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/dvd_pal.xml
+msgid "DVD"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/dvd_ntsc.xml
+msgid "DVD-NTSC"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mp4_x264_dx.xml
+msgid "MP4 (h.264 dx)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mkv_x264_nv.xml
+msgid "MKV (h.264 nv)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mp4_x264_hw.xml
 msgid "MP4 (h.264 va)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/presets/twitter.xml
-msgid "Twitter / X"
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mkv_x264_dx.xml
+msgid "MKV (h.264 dx)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mp4_x264_qsv.xml
+msgid "MP4 (h.264 qsv)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mp4_libsvtav1.xml
+msgid "MP4 (AV1 svt)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mp4_x264_nv.xml
+msgid "MP4 (h.264 nv)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mp4_hevc_hw.xml
+msgid "MP4 (HEVC va)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mp4_x264_vtb.xml
+msgid "MP4 (h.264 videotoolbox)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mkv_x264_hw.xml
+msgid "MKV (h.264 va)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_gif.xml
+msgid "GIF (animated)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/dvd_pal.xml
+msgid "DVD-PAL"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_avi_mpeg2.xml
+msgid "AVI (mpeg2)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_ogg_libvorbis.xml
+msgid "OGG (theora/vorbis)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mkv_x265.xml
+msgid "MKV (h.265)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/youtube_HD.xml
+msgid "YouTube"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/instagram_reels.xml
+msgid "Instagram Reels"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mkv_x264_vtb.xml
+msgid "MKV (h.264 videotoolbox)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_webm_libvp9_lossless.xml
+msgid "WEBM (vp9) lossless"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mpeg_mpeg2.xml
+msgid "MPEG (mpeg2)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_ogg_flac.xml
+msgid "OGG (theora/flac)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/youtube_4K.xml
+msgid "YouTube (4K)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/instagram.xml
+msgid "Instagram"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/nokia_nHD.xml
+msgid "Nokia nHD"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/tiktok.xml
+msgid "TikTok"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/youtube_2K.xml
+msgid "YouTube (2K)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mov_prores.xml
+msgid "MOV (ProRes 422)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_mp4_x264_lossless.xml
+msgid "MP4 (h.264) lossless"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/avchd.xml
+msgid "Blu-Ray/AVCHD"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/avchd.xml
+msgid "AVCHD Disks"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_webm_libvp9.xml
+msgid "WEBM (vp9)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/wikipedia.xml
+msgid "Wikipedia"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/metacafe.xml
+msgid "Metacafe"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/youtube_8K.xml
+msgid "YouTube (8K)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/apple_tv.xml
+msgid "Apple TV"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/chromebook.xml
+msgid "Chromebook"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/format_webm_libvpx.xml
+msgid "WEBM (vpx)"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/vimeo_HD.xml
+msgid "Vimeo"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/flickr_HD.xml
+msgid "Flickr"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/picasa.xml
+msgid "Picasa"
+msgstr ""
+
+#: /home/jonathan/apps/openshot-qt-git/src/presets/snapchat.xml
+msgid "Snapchat"
 msgstr ""
 
 #: Settings for default-language
@@ -5725,7 +5777,7 @@ msgid "Use Blender GPU rendering for Animated Titles"
 msgstr ""
 
 #: Settings for actionPreferences
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:718
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:720
 msgid "Preferences"
 msgstr ""
 
@@ -5734,43 +5786,47 @@ msgid "Keyboard"
 msgstr ""
 
 #: Settings for actionQuit
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:691
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:693
 msgid "Quit"
 msgstr ""
 
 #: Settings for actionAbout
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/about.ui:20
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/about.ui:20
 msgid "About OpenShot"
 msgstr ""
 
+#: Settings for actionShareFeedback
+msgid "Share Feedback..."
+msgstr ""
+
 #: Settings for actionReportBug
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1173
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1175
 msgid "Report a Bug..."
 msgstr ""
 
 #: Settings for actionAskQuestion
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1182
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1184
 msgid "Ask a Question..."
 msgstr ""
 
 #: Settings for actionDiscord
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1221
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1223
 msgid "Join our Community..."
 msgstr ""
 
 #: Settings for actionTranslate
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1191
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1193
 msgid "Translate this Application..."
 msgstr ""
 
 #: Settings for actionDonate
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1200
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1202
 msgid "Donate"
 msgstr ""
 
 #: Settings for actionAddMarker
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:850
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:853
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:852
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:855
 msgid "Add Marker"
 msgstr ""
 
@@ -5779,59 +5835,59 @@ msgid "Razor Toggle"
 msgstr ""
 
 #: Settings for actionPreviousMarker
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:862
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:865
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:864
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:867
 msgid "Previous Marker"
 msgstr ""
 
 #: Settings for actionNextMarker
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:874
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:877
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:876
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:879
 msgid "Next Marker"
 msgstr ""
 
 #: Settings for actionCenterOnPlayhead
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:886
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:888
 msgid "Center on Playhead"
 msgstr ""
 
 #: Settings for actionAnimatedTitle
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1093
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1096
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1095
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1098
 msgid "Animated Title"
 msgstr ""
 
 #: Settings for actionExportFiles
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export-clips.ui:26
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export-clips.ui:26
 msgid "Export Files"
 msgstr ""
 
 #: Settings for actionNew
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:519
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:522
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:521
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:524
 msgid "New Project"
 msgstr ""
 
 #: Settings for actionRedo
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:628
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:631
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:630
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:633
 msgid "Redo"
 msgstr ""
 
 #: Settings for actionSave
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:543
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:546
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:545
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:548
 msgid "Save Project"
 msgstr ""
 
 #: Settings for actionSplitFile
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/cutting.ui:14
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:14
 msgid "Split File"
 msgstr ""
 
 #: Settings for actionUndo
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:555
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:558
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:557
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:560
 msgid "Undo"
 msgstr ""
 
@@ -5848,14 +5904,14 @@ msgid "Next Frame"
 msgstr ""
 
 #: Settings for actionRewind
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:754
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:757
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:756
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:759
 msgid "Rewind"
 msgstr ""
 
 #: Settings for actionFastForward
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:766
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:769
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:768
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:771
 msgid "Fast Forward"
 msgstr ""
 
@@ -5900,8 +5956,8 @@ msgid "Select None"
 msgstr ""
 
 #: Settings for actionAddTrack
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:703
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:706
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:705
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:708
 msgid "Add Track"
 msgstr ""
 
@@ -5914,26 +5970,26 @@ msgid "Timing Toggle"
 msgstr ""
 
 #: Settings for actionJumpStart
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:742
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:745
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:744
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:747
 msgid "Jump To Start"
 msgstr ""
 
 #: Settings for actionJumpEnd
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:778
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:781
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:780
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:783
 msgid "Jump To End"
 msgstr ""
 
 #: Settings for actionProperties
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:401
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1424
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:403
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1426
 msgid "Properties"
 msgstr ""
 
 #: Settings for actionSaveFrame
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:790
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:793
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:792
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:795
 msgid "Save Current Frame"
 msgstr ""
 
@@ -5958,12 +6014,12 @@ msgid "Clear All Cache"
 msgstr ""
 
 #: Settings for actionClearHistory
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1553
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1555
 msgid "Clear History"
 msgstr ""
 
 #: Settings for actionClearWaveformData
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1639
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1641
 msgid "Clear Waveform Display Data"
 msgstr ""
 
@@ -5972,22 +6028,22 @@ msgid "Delete Optimized Videos"
 msgstr ""
 
 #: Settings for actionSimple_View
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1230
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1232
 msgid "Simple View"
 msgstr ""
 
 #: Settings for actionView_Toolbar
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1125
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1127
 msgid "View Toolbar"
 msgstr ""
 
 #: Settings for actionTutorial
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1469
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1471
 msgid "Launch Tutorial"
 msgstr ""
 
 #: Settings for actionHelpContents
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1212
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1214
 msgid "Open Help Contents"
 msgstr ""
 
@@ -6135,689 +6191,689 @@ msgstr ""
 msgid "EfficientSAM: Small"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/about.ui:41
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/about.ui:41
 msgid "Create & Edit Amazing Videos and Movies"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/about.ui:62
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/about.ui:62
 msgid "Version Loading"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/about.ui:119
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/about.ui:119
 msgid "© 2024 OpenShot Studios, LLC"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/about.ui:140
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/license.ui:14
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/about.ui:140
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/license.ui:14
 msgid "License"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/about.ui:147
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/changelog.ui:14
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/about.ui:147
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/changelog.ui:14
 msgid "Changelog"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:14
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:14
 msgid "Add To Timeline"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:37
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:37
 msgid "Move Up"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:52
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:52
 msgid "Move Down"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:67
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:67
 msgid "Shuffle"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:119
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:119
 msgid "Timeline Location"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:140
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:140
 msgid "Start Time (seconds):"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:179
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:179
 msgid "Track:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:209
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:209
 msgid "Image Length (seconds):"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:255
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:255
 msgid "Fade:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:279
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:279
 msgid "Length (seconds):"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:319
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:319
 msgid "Zoom:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:356
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:356
 msgid "Transition:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:386
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:386
 msgid "Length:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:441
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:441
 msgid "Total Length (seconds):"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/add-to-timeline.ui:466
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/add-to-timeline.ui:466
 msgid "0.0"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animated-title.ui:14
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animated-title.ui:14
 msgid "Animated Titles (Powered by Blender)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animated-title.ui:63
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/title-editor.ui:69
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animated-title.ui:63
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/title-editor.ui:69
 msgid "<b>Choose a Template</b>"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animated-title.ui:103
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animated-title.ui:103
 msgid "Frame:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animated-title.ui:117
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animated-title.ui:117
 msgid "1/1"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animated-title.ui:124
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animated-title.ui:124
 msgid "Refresh"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animated-title.ui:204
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animated-title.ui:204
 msgid "Idle"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animation.ui:14
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animation.ui:14
 msgid "Animation"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animation.ui:46
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:153
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animation.ui:46
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:153
 msgid "Details"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animation.ui:60
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animation.ui:60
 msgid "Loop (Repeat)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animation.ui:77
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animation.ui:77
 msgid "# of Frames:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animation.ui:141
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/cutting.ui:131
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animation.ui:141
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:131
 msgid "Name:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animation.ui:148
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animation.ui:148
 msgid "YourAnimation"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animation.ui:165
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:680
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:413
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animation.ui:165
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:680
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:413
 msgid "Frame Rate:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animation.ui:235
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:516
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:517
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animation.ui:235
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:516
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:517
 msgid "Width:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animation.ui:273
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:549
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:222
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animation.ui:273
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:549
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:222
 msgid "Height:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animation.ui:318
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animation.ui:318
 msgid "Color:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/animation.ui:400
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/cutting.ui:76
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/region.ui:77
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/animation.ui:400
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:76
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/region.ui:77
 msgid "00:00:00:1"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/changelog.ui:44
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/changelog.ui:69
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/changelog.ui:91
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/changelog.ui:44
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/changelog.ui:69
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/changelog.ui:91
 msgid "Filter Changelog"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/credits.ui:31
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/credits.ui:31
 msgid "Developers"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/credits.ui:44
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/credits.ui:44
 msgid "Filter Developers"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/credits.ui:59
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/credits.ui:59
 msgid "Translators"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/credits.ui:69
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/credits.ui:69
 msgid "Filter Translators"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/credits.ui:81
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/credits.ui:81
 msgid "Supporters"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/credits.ui:91
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/credits.ui:91
 msgid "Filter Supporters"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/cutting.ui:44
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:44
 msgid "Choose the <b>start</b> and <b>end</b> of each file"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/cutting.ui:94
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:94
 msgid "Set the start"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/cutting.ui:113
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:113
 msgid "Set the end"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/cutting.ui:150
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:150
 msgid "Optional"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/cutting.ui:175
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:175
 msgid "Create"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/cutting.ui:196
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/cutting.ui:199
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/region.ui:94
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/region.ui:97
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:196
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/cutting.ui:199
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/region.ui:94
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/region.ui:97
 msgid "Play"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:93
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:93
 msgid "Simple"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:107
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:107
 msgid "<b>Select a Profile to start:</b>"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:131
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:489
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:131
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:489
 msgid "Profile:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:152
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:152
 msgid "<b>Select from the following options:</b>"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:180
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:180
 msgid "Target:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:225
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:225
 msgid "Video Profile:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:242
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:242
 msgid "Quality:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:311
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:311
 msgid "Advanced Options"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:328
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:328
 msgid "Export To:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:355
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:925
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:355
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:925
 msgid "Start Frame:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:378
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:378
 msgid "Start at First Clip"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:395
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:886
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:395
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:886
 msgid "End Frame:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:418
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:418
 msgid "End at Last Clip"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:445
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:445
 msgid "Profile"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:462
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:462
 msgid "360° / Spherical:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:582
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:264
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:582
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:264
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:631
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:325
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:631
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:325
 msgid "Pixel Ratio:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:731
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:464
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:731
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:464
 msgid "= 0.00"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:754
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:487
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:754
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:487
 msgid "Interlaced:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:782
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:782
 msgid "Image Sequence Settings"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:796
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:796
 msgid "Image Format:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:817
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:817
 msgid "Video Settings"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:831
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:574
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:831
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:574
 msgid "Video Format:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:851
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:604
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:851
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:604
 msgid "Video Codec:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:874
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:1025
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:637
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:760
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:874
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:1025
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:637
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:760
 msgid "Bit Rate / Quality:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:895
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:895
 msgid "Audio Settings"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:909
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:730
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:909
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:730
 msgid "Audio Codec:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:962
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:796
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:962
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:796
 msgid "# of Channels:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:998
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:841
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:998
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:841
 msgid "Channel Layout:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:1081
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:50
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:1081
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:50
 msgid "YourVideoName"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/export.ui:1098
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/export.ui:1098
 msgid "Folder Path:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:53
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:53
 msgid "Name of file"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:73
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:73
 msgid "Tags:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:80
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:80
 msgid "Search tags"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:100
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:100
 msgid "File Path:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:205
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:205
 msgid "Video Details"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:386
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:386
 msgid "Duration:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:560
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:560
 msgid "Video Format"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:587
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:617
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:587
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:617
 msgid "No video stream found"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:674
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:674
 msgid "Audio Format"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:743
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:743
 msgid "No audio stream found"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:872
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:872
 msgid "Frame Settings"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/file-properties.ui:955
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/file-properties.ui:955
 msgid "JSON"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:23
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:23
 msgid "OpenShot Video Editor"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:95
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:95
 msgid "&File"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:99
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:99
 msgid "Export Project"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:113
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:113
 msgid "Import Project"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:142
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:142
 msgid "&Edit"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:168
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:168
 msgid "View"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:184
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:184
 msgid "Help"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:207
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1122
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:209
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1124
 msgid "Toolbar"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:224
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:226
 msgid "Project Files"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:311
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:313
 msgid "Emojis"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:477
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1466
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:479
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1468
 msgid "Tutorial"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:534
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:536
 msgid "Open Project"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:583
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:585
 msgid "Export files"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:595
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:597
 msgid "Import Files"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:604
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:606
 msgid "Import Image Sequence..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:616
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:618
 msgid "Import New Transition..."
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:619
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:621
 msgid "Import New Transition"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:640
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:643
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:642
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:645
 msgid "Remove Clip"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:652
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:655
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:654
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:657
 msgid "Remove Transition"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:676
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:679
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:678
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:681
 msgid "Upload Video"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:688
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:690
 msgid "&Quit"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:715
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:717
 msgid "&Preferences"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:889
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:891
 msgid "Center the timeline on the Playhead"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:897
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:900
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:977
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:980
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1011
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1014
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:899
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:902
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:979
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:982
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1013
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1016
 msgid "Show All"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:908
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:911
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1022
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1025
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:910
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:913
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1024
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1027
 msgid "Video"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:930
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:933
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:932
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:935
 msgid "Image"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:954
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:957
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:956
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:959
 msgid "Remove Gap"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:966
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:969
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:968
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:971
 msgid "Remove All Gaps"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:988
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:991
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:990
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:993
 msgid "Common"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1209
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1211
 msgid "Contents"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1238
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1240
 msgid "Alt+Shift+2"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1250
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1252
 msgid "Recovery Placeholder"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1265
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1267
 msgid "Recent Placeholder"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1316
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1318
 msgid "Remove from "
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1349
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1352
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1351
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1354
 msgid "Remove Track"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1361
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1364
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1363
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1366
 msgid "Remove Marker"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1373
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1376
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1375
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1378
 msgid "Add Track Above"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1385
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1388
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1387
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1390
 msgid "Add Track Below"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1397
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1400
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1399
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1402
 msgid "Remove Effect"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1421
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1423
 msgid "&Properties"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1478
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1481
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1480
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1483
 msgid "Create Animation"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1490
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1493
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1492
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1495
 msgid "Lock Track"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1502
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1505
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1504
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1507
 msgid "Unlock Track"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1526
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1529
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1528
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1531
 msgid "Clear All"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1550
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1552
 msgid "History"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1562
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1564
 msgid "Import EDL"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1565
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1567
 msgid "Import Edit Decision List"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1574
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1577
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1576
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1579
 msgid "Import XML (Final Cut Pro)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1586
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1588
 msgid "Export EDL"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1589
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1591
 msgid "Export Edit Decision List"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1598
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1601
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1600
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1603
 msgid "Export XML (Final Cut Pro)"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1610
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1613
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1612
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1615
 msgid "Clear Recent Projects"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1622
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1625
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1624
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1627
 msgid "Insert Caption"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1648
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1650
 msgid "Optimized Videos"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/main-window.ui:1651
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/main-window.ui:1653
 msgid "Delete project optimized videos"
 msgstr ""
 
 #. Search for preference
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/preferences.ui:32
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/preferences.ui:32
 msgid "Search"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/process-effect.ui:20
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/process-effect.ui:20
 msgid "%s: Initialize Effect"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/profile-edit.ui:41
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/profile-edit.ui:41
 msgid "<b>~/.openshot_qt/profiles/...</b>"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/profile-edit.ui:126
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/profile-edit.ui:126
 msgid "Description:"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/profile.ui:25
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/profile.ui:25
 msgid "Filter Profiles"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/profile.ui:38
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/profile.ui:38
 msgid "0"
 msgstr ""
 
-#: /home/jonathan/apps/openshot-qt/src/windows/ui/title-editor.ui:14
+#: /home/jonathan/apps/openshot-qt-git/src/windows/ui/title-editor.ui:14
 msgid "Titles"
 msgstr ""
 

--- a/src/language/generate_translations.py
+++ b/src/language/generate_translations.py
@@ -103,7 +103,7 @@ log.info(" Using xgettext to generate .py POT files")
 log.info("-----------------------------------------------------")
 
 # Generate POT for Source Code strings (i.e. strings marked with a _("translate me"))
-subprocess.call(r'find %s -iname "*.py" -exec xgettext -j -o %s --keyword=_ --keyword=N_ --keyword=_tr {} \;' % (
+subprocess.call(r'find %s -iname "*.py" -exec xgettext --from-code=UTF-8 -j -o %s --keyword=_ --keyword=N_ --keyword=_tr {} \;' % (
     openshot_path, os.path.join(language_folder_path, 'OpenShot_source.pot')), shell=True)
 
 log.info("-----------------------------------------------------")

--- a/src/launch.py
+++ b/src/launch.py
@@ -152,9 +152,17 @@ def main():
         help='Debugging output (console only)')
     parser.add_argument('-V', '--version', action='store_true')
     parser.add_argument(
+        '--feedback-preview', action='store_true',
+        help='Show the feedback banner on launch without changing saved feedback state')
+    parser.add_argument(
+        '--update-preview', action='store_true',
+        help='Show the Update Available notice on launch')
+    parser.add_argument(
         'remain', nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
 
     args, extra_args = parser.parse_known_args()
+    info.FEEDBACK_PREVIEW = args.feedback_preview
+    info.UPDATE_PREVIEW = args.update_preview
 
     # Display version and exit (if requested)
     if args.version:

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -73,6 +73,27 @@
     "setting": "unique_install_id"
   },
   {
+    "value": false,
+    "title": "",
+    "type": "hidden",
+    "category": "General",
+    "setting": "feedback-shown"
+  },
+  {
+    "value": 0,
+    "title": "",
+    "type": "hidden",
+    "category": "General",
+    "setting": "feedback-use-seconds"
+  },
+  {
+    "value": "",
+    "title": "",
+    "type": "hidden",
+    "category": "General",
+    "setting": "dismissed-update-version"
+  },
+  {
     "value": true,
     "title": "",
     "type": "hidden",
@@ -734,6 +755,22 @@
     "restart": false,
     "setting": "actionAbout",
     "value": "Ctrl+H",
+    "type": "text"
+  },
+  {
+    "category": "Keyboard",
+    "title": "Update Available",
+    "restart": false,
+    "setting": "actionUpdate",
+    "value": "F9",
+    "type": "text"
+  },
+  {
+    "category": "Keyboard",
+    "title": "Share Feedback...",
+    "restart": false,
+    "setting": "actionShareFeedback",
+    "value": "F8",
     "type": "text"
   },
   {

--- a/src/tests/test_distribution.py
+++ b/src/tests/test_distribution.py
@@ -1,0 +1,133 @@
+"""Distribution detection must not promote downstream or source builds."""
+
+import os
+import sys
+import ctypes
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+import unittest
+
+PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+if PATH not in sys.path:
+    sys.path.append(PATH)
+
+from classes import distribution, info
+from classes.distribution import detect_distribution
+
+
+class DistributionTests(unittest.TestCase):
+    def detect(self, system="Linux", executable="/usr/bin/openshot-qt", frozen=True,
+               environ=None, package_name="", marked=True, flatpak=False):
+        return detect_distribution({"official_distribution": marked}, system, executable,
+                                   frozen, environ or {}, package_name, flatpak)
+
+    def test_official_packages(self):
+        cases = [
+            ({"environ": {"APPIMAGE": "/tmp/OpenShot.AppImage"}}, "appimage"),
+            ({"system": "Windows", "executable": "C:/OpenShot/openshot-qt.exe"}, "exe"),
+            ({"system": "Darwin", "executable": "/Applications/OpenShot.app/Contents/MacOS/openshot-qt"}, "appbundle"),
+            ({"system": "Windows", "package_name": "OpenShotStudios.OpenShotforWindows_4.0.0.0_x64__publisher"}, "msix"),
+        ]
+        for args, kind in cases:
+            with self.subTest(kind=kind):
+                self.assertEqual(self.detect(**args), {"package_type": kind, "official": True})
+                self.assertFalse(self.detect(marked=False, **args)["official"])
+
+    def test_downstream_wrappers_override_official_marker(self):
+        for env, flatpak in [({"SNAP": "/snap/openshot/1", "APPIMAGE": "app"}, False),
+                             ({"FLATPAK_ID": "org.openshot.OpenShot"}, False), ({}, True)]:
+            with self.subTest(env=env, flatpak=flatpak):
+                self.assertFalse(self.detect(environ=env, flatpak=flatpak)["official"])
+
+    def test_ppa_source_and_foreign_msix_are_not_official(self):
+        self.assertFalse(self.detect()["official"])
+        self.assertFalse(self.detect(frozen=False, environ={"APPIMAGE": "app"})["official"])
+        self.assertFalse(self.detect(system="Windows", package_name="Other.OpenShot_1_x64__id")["official"])
+
+    def test_source_copy_of_official_metadata_is_not_official(self):
+        for args in [dict(system="Windows", executable="C:/python.exe"),
+                     dict(system="Darwin", executable="/App.app/Contents/MacOS/python"),
+                     dict(system="Windows", package_name="OpenShotStudios.OpenShotforWindows_4.0.0.0_x64__publisher")]:
+            self.assertFalse(self.detect(frozen=False, **args)["official"])
+
+    def test_windows_api_uses_two_calls_and_returns_full_identity(self):
+        name = "OpenShotStudios.OpenShotforWindows_4.0.0.0_x64__publisher"
+        calls = []
+
+        def api(length, buffer):
+            calls.append(buffer is None)
+            if buffer is None:
+                length._obj.value = len(name) + 1
+                return 122
+            buffer.value = name
+            return 0
+
+        with patch.object(ctypes, "WinDLL", return_value=SimpleNamespace(GetCurrentPackageFullName=api), create=True):
+            self.assertEqual(distribution.windows_package_name(), name)
+        self.assertEqual(calls, [True, False])
+
+    def test_windows_api_fails_safely_without_identity_or_api(self):
+        for code, size in [(15700, 0), (5, 0), (122, 0), (122, 1000000)]:
+            def api(length, buffer):
+                length._obj.value = size
+                return code
+            with patch.object(ctypes, "WinDLL", return_value=SimpleNamespace(GetCurrentPackageFullName=api), create=True):
+                self.assertEqual(distribution.windows_package_name(), "")
+        for error in (OSError("unavailable"), AttributeError("unsupported")):
+            with patch.object(ctypes, "WinDLL", side_effect=error, create=True):
+                self.assertEqual(distribution.windows_package_name(), "")
+
+    def test_windows_api_second_call_failure_is_not_a_package(self):
+        def api(length, buffer):
+            length._obj.value = 100
+            return 122 if buffer is None else 5
+        with patch.object(ctypes, "WinDLL", return_value=SimpleNamespace(GetCurrentPackageFullName=api), create=True):
+            self.assertEqual(distribution.windows_package_name(), "")
+
+    def test_metadata_loading_and_runtime_version_payload(self):
+        with tempfile.TemporaryDirectory() as folder:
+            metadata = Path(folder, "settings", "version.json")
+            metadata.parent.mkdir()
+            with patch.object(info, "PATH", folder), \
+                    patch.object(distribution.platform, "system", return_value="Windows"), \
+                    patch.object(distribution.platform, "machine", return_value="AMD64"), \
+                    patch.object(distribution, "windows_package_name", return_value="OpenShotStudios.OpenShotforWindows_4.0.0.123_x64__publisher"), \
+                    patch.object(sys, "frozen", True, create=True), patch.dict(os.environ, {}, clear=True):
+                for content in [None, "{bad json", "[]", '{"official_distribution":"true"}']:
+                    if content is not None:
+                        metadata.write_text(content)
+                    distribution.get_distribution_info.cache_clear()
+                    self.assertFalse(distribution.get_distribution_info()["official"])
+                metadata.write_text(json.dumps({"official_distribution": True, "build_name": "OpenShot-v4.0.0-daily-123"}))
+                distribution.get_distribution_info.cache_clear()
+                data = distribution.get_distribution_info()
+                self.assertTrue(data["official"])
+                self.assertEqual(data["package_type"], "msix")
+                self.assertEqual(data["package_version"], "4.0.0.123")
+                self.assertEqual(data["app_version"], info.VERSION)
+                self.assertEqual(data["build_name"], "OpenShot-v4.0.0-daily-123")
+                self.assertEqual(data["architecture"], "AMD64")
+            distribution.get_distribution_info.cache_clear()
+
+
+class BuildProvenanceTests(unittest.TestCase):
+    def test_only_our_ci_project_marks_official_and_local_rebuild_clears_marker(self):
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+        self.addCleanup(sys.path.pop, 0)
+        from installer.version_parser import write_build_metadata
+        with tempfile.TemporaryDirectory() as folder:
+            target = Path(folder, "version.json")
+            official_env = {"CI_SERVER_HOST": "gitlab.openshot.org", "CI_PROJECT_PATH": "OpenShot/openshot-qt"}
+            source = {"build_name": "OpenShot-v4.0.0", "official_distribution": True}
+            write_build_metadata(target, source, official_env)
+            self.assertTrue(json.loads(target.read_text())["official_distribution"])
+            for env in [{}, dict(official_env, CI_SERVER_HOST="gitlab.com"),
+                        dict(official_env, CI_PROJECT_PATH="someone/openshot-qt")]:
+                write_build_metadata(target, source, env)
+                self.assertFalse(json.loads(target.read_text())["official_distribution"])
+            write_build_metadata(target, {}, {})
+            self.assertEqual(json.loads(target.read_text()), {"official_distribution": False})
+            self.assertTrue(source["official_distribution"])

--- a/src/tests/test_feedback.py
+++ b/src/tests/test_feedback.py
@@ -1,5 +1,7 @@
 """Survey persistence, routing, and actual Qt invitation behavior."""
 
+import base64
+import json
 import os
 import sys
 import tempfile
@@ -57,13 +59,51 @@ class FeedbackTests(unittest.TestCase):
                 policy.consume()
         self.assertFalse(policy.shown)
 
-    def test_url_encodes_metadata_and_id(self):
-        params = parse_qs(urlparse(survey_url(
-            {"official": False, "package_type": "unknown", "app_version": "4.0.0", "platform": "linux"},
-            "id&with spaces")).query)
-        self.assertEqual(params["guid"], ["id&with spaces"])
-        self.assertEqual(params["official"], ["0"])
-        self.assertEqual(params["app_version"], ["4.0.0"])
+    def decode_context(self, url):
+        parsed = urlparse(url)
+        self.assertEqual(parsed.scheme, "https")
+        self.assertEqual(parsed.netloc, "www.openshot.org")
+        self.assertEqual(parsed.path, "/feedback/")
+        params = parse_qs(parsed.query)
+        self.assertEqual(set(params), {"context"})
+        context, = params["context"]
+        self.assertRegex(context, r"^[A-Za-z0-9_-]+$")
+        return json.loads(base64.urlsafe_b64decode(context + "=" * (-len(context) % 4)))
+
+    def test_url_encodes_v1_context_and_unicode_id(self):
+        distribution = {"official": True, "package_type": "exe",
+                        "app_version": "4.0.1", "platform": "windows",
+                        "architecture": "AMD64", "build_name": "test-build"}
+        before = dict(distribution)
+        payload = self.decode_context(survey_url(distribution, "id&with spaces/é?"))
+        self.assertEqual(payload, {"v": 1, "version": "4.0.1", "os": "windows",
+                                   "source": "direct", "install_uuid": "id&with spaces/é?"})
+        self.assertEqual(distribution, before)
+
+    def test_context_source_and_os_mapping(self):
+        for kind, official, source in (
+                ("exe", True, "direct"), ("appimage", True, "direct"),
+                ("appbundle", True, "direct"), ("exe", False, "unknown"),
+                ("appimage", False, "unknown"), ("appbundle", False, "unknown"),
+                ("msix", True, "microsoft-store"), ("msix", False, "unknown"),
+                ("snap", False, "snap"), ("flatpak", False, "flatpak"),
+                ("unknown", False, "unknown")):
+            with self.subTest(kind=kind, official=official):
+                payload = self.decode_context(survey_url(
+                    {"official": official, "package_type": kind,
+                     "app_version": "4.0.1", "platform": "darwin"}, "test-id"))
+                self.assertEqual(payload["source"], source)
+                self.assertEqual(payload["os"], "macos")
+
+    def test_context_os_uses_only_supported_values(self):
+        for system, expected in (("windows", "windows"), ("Linux", "linux"),
+                                 ("darwin", "macos"), ("macos", "macos"),
+                                 ("FreeBSD", "unknown"), ("", "unknown")):
+            with self.subTest(system=system):
+                payload = self.decode_context(survey_url(
+                    {"app_version": "4.0.1", "platform": system}, "test-id"))
+                self.assertEqual(payload["os"], expected)
+                self.assertEqual(payload["source"], "unknown")
 
     def make_controller(self, settings, preview=False):
         window = QMainWindow()
@@ -90,7 +130,8 @@ class FeedbackTests(unittest.TestCase):
         self.assertTrue(actions[actions.index(controller.window.actionUpdate) + 1].isSeparator())
         with patch("windows.feedback.QDesktopServices.openUrl", return_value=True) as opened:
             controller.action.trigger()
-        self.assertIn("guid=test-install-id", opened.call_args[0][0].toString())
+        self.assertEqual(self.decode_context(opened.call_args[0][0].toString())["install_uuid"],
+                         "test-install-id")
         self.assertIsNone(controller.banner)
         self.assertTrue(settings.saved["feedback-shown"])
         self.assertTrue(controller.action.isEnabled())
@@ -159,7 +200,8 @@ class FeedbackTests(unittest.TestCase):
         self.assertFalse(controller.banner.isHidden())
         with patch("windows.feedback.QDesktopServices.openUrl", return_value=True) as opened:
             controller.open_survey()
-        self.assertIn("guid=test-install-id", opened.call_args[0][0].toString())
+        self.assertEqual(self.decode_context(opened.call_args[0][0].toString())["install_uuid"],
+                         "test-install-id")
         self.assertIsNone(controller.banner)
 
     def test_foreground_time_and_suspend_guard(self):

--- a/src/tests/test_feedback.py
+++ b/src/tests/test_feedback.py
@@ -1,0 +1,306 @@
+"""Survey persistence, routing, and actual Qt invitation behavior."""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+if PATH not in sys.path:
+    sys.path.append(PATH)
+
+from qt_api import QApplication, QMainWindow
+from classes.feedback import FeedbackPolicy, survey_url
+from windows.feedback import FeedbackController
+
+
+class Settings:
+    def __init__(self):
+        self.data = {"feedback-shown": False, "feedback-use-seconds": 0,
+                     "unique_install_id": "test-install-id"}
+        self.saved = {}
+
+    def get(self, key):
+        return self.data.get(key)
+
+    def set(self, key, value):
+        self.data[key] = value
+
+    def save(self):
+        self.saved = dict(self.data)
+
+
+class FeedbackTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_cumulative_use_and_one_time_consumption(self):
+        settings = Settings()
+        policy = FeedbackPolicy(settings)
+        self.assertFalse(policy.advance(900))
+        restarted = Settings()
+        restarted.data = dict(settings.saved)
+        policy = FeedbackPolicy(restarted)
+        self.assertTrue(policy.advance(900))
+        self.assertTrue(policy.consume())
+        self.assertTrue(restarted.saved["feedback-shown"])
+        self.assertFalse(FeedbackPolicy(restarted).consume())
+        self.assertFalse(policy.advance(1800))
+
+    def test_failed_persistence_does_not_consume_invitation(self):
+        policy = FeedbackPolicy(Settings())
+        with patch.object(policy.settings, "save", side_effect=OSError("disk full")):
+            with self.assertRaises(OSError):
+                policy.consume()
+        self.assertFalse(policy.shown)
+
+    def test_url_encodes_metadata_and_id(self):
+        params = parse_qs(urlparse(survey_url(
+            {"official": False, "package_type": "unknown", "app_version": "4.0.0", "platform": "linux"},
+            "id&with spaces")).query)
+        self.assertEqual(params["guid"], ["id&with spaces"])
+        self.assertEqual(params["official"], ["0"])
+        self.assertEqual(params["app_version"], ["4.0.0"])
+
+    def make_controller(self, settings, preview=False):
+        window = QMainWindow()
+        window.resize(1000, 700)
+        window.menuHelp = window.menuBar().addMenu("Help")
+        window.actionReportBug = window.menuHelp.addAction("Report a Bug…")
+        window.menuHelp.addSeparator()
+        window.actionUpdate = window.menuHelp.addAction("Update Available")
+        window.menuHelp.addSeparator()
+        window.actionAbout = window.menuHelp.addAction("About")
+        controller = FeedbackController(window, settings, lambda text: text, preview=preview)
+        self.addCleanup(window.deleteLater)
+        self.addCleanup(controller.timer.stop)
+        return controller
+
+    def test_help_opens_browser_directly_and_prevents_future_nag(self):
+        settings = Settings()
+        controller = self.make_controller(settings)
+        self.assertFalse(controller.action.icon().isNull())
+        actions = controller.window.menuHelp.actions()
+        self.assertEqual(actions.index(controller.action) + 1,
+                         actions.index(controller.window.actionUpdate))
+        self.assertTrue(actions[actions.index(controller.action) - 1].isSeparator())
+        self.assertTrue(actions[actions.index(controller.window.actionUpdate) + 1].isSeparator())
+        with patch("windows.feedback.QDesktopServices.openUrl", return_value=True) as opened:
+            controller.action.trigger()
+        self.assertIn("guid=test-install-id", opened.call_args[0][0].toString())
+        self.assertIsNone(controller.banner)
+        self.assertTrue(settings.saved["feedback-shown"])
+        self.assertTrue(controller.action.isEnabled())
+        self.assertFalse(controller.timer.isActive())
+        controller.show_invitation()
+        self.assertIsNone(controller.banner)
+        restarted = self.make_controller(settings)
+        self.assertTrue(restarted.action.isEnabled())
+        self.assertFalse(restarted.timer.isActive())
+
+    def test_help_browser_failure_allows_retry_without_nag(self):
+        controller = self.make_controller(Settings())
+        with patch("windows.feedback.QDesktopServices.openUrl", return_value=False), \
+                patch("windows.feedback.QMessageBox.warning") as warning:
+            controller.action.trigger()
+        warning.assert_called_once()
+        self.assertIsNone(controller.banner)
+        self.assertTrue(controller.action.isEnabled())
+        self.assertFalse(controller.policy.shown)
+
+    def test_help_remains_usable_after_dismissal_and_restart(self):
+        settings = Settings()
+        controller = self.make_controller(settings)
+        controller.show_invitation()
+        controller.banner.close_button.click()
+        restarted = self.make_controller(settings)
+        for current in (controller, restarted):
+            with self.subTest(restarted=current is restarted):
+                self.assertTrue(current.action.isEnabled())
+                with patch("windows.feedback.QDesktopServices.openUrl", return_value=True) as opened:
+                    current.action.trigger()
+                    current.action.trigger()
+                self.assertEqual(opened.call_count, 2)
+                current.show_invitation()
+                self.assertIsNone(current.banner)
+                self.assertFalse(current.timer.isActive())
+                self.assertTrue(settings.get("feedback-shown"))
+
+    def test_help_failure_after_completion_does_not_reset_banner_history(self):
+        settings = Settings()
+        settings.set("feedback-shown", True)
+        controller = self.make_controller(settings)
+        with patch("windows.feedback.QDesktopServices.openUrl", return_value=False), \
+                patch("windows.feedback.QMessageBox.warning") as warning:
+            controller.action.trigger()
+        warning.assert_called_once()
+        self.assertTrue(controller.action.isEnabled())
+        self.assertTrue(settings.get("feedback-shown"))
+        controller.show_invitation()
+        self.assertIsNone(controller.banner)
+
+    def test_dismissing_automatic_banner_prevents_repeat(self):
+        controller = self.make_controller(Settings())
+        controller.show_invitation()
+        controller.banner.close_button.click()
+        controller.show_invitation()
+        self.assertIsNone(controller.banner)
+        self.assertTrue(controller.area.toolbar.isHidden())
+        self.assertTrue(controller.settings.saved["feedback-shown"])
+
+    def test_browser_failure_keeps_banner_available_for_retry(self):
+        controller = self.make_controller(Settings())
+        controller.show_invitation()
+        with patch("windows.feedback.QDesktopServices.openUrl", return_value=False):
+            controller.open_survey()
+        self.assertFalse(controller.banner.isHidden())
+        with patch("windows.feedback.QDesktopServices.openUrl", return_value=True) as opened:
+            controller.open_survey()
+        self.assertIn("guid=test-install-id", opened.call_args[0][0].toString())
+        self.assertIsNone(controller.banner)
+
+    def test_foreground_time_and_suspend_guard(self):
+        controller = self.make_controller(Settings())
+        controller.last_tick = 100
+        controller.was_active = True
+        with patch.object(controller.window, "isActiveWindow", return_value=True), \
+                patch.object(controller.window, "isVisible", return_value=True), \
+                patch("windows.feedback.time.monotonic", return_value=105):
+            controller.tick()
+        self.assertEqual(controller.settings.get("feedback-use-seconds"), 5)
+        with patch("windows.feedback.time.monotonic", return_value=3700):
+            controller.tick()
+        self.assertEqual(controller.settings.get("feedback-use-seconds"), 5)
+
+    def test_due_invitation_waits_for_modal_to_close(self):
+        controller = self.make_controller(Settings())
+        controller.settings.set("feedback-use-seconds", 1800)
+        with patch.object(controller.window, "isActiveWindow", return_value=True), \
+                patch.object(controller.window, "isVisible", return_value=True):
+            with patch("windows.feedback.QApplication.activeModalWidget", return_value=object()):
+                controller.tick()
+            self.assertFalse(controller.policy.shown)
+            controller.tick()
+            self.assertIsNotNone(controller.banner)
+            self.assertFalse(controller.policy.shown)
+
+    def test_preview_bypasses_saved_nag_without_modifying_settings(self):
+        settings = Settings()
+        settings.set("feedback-shown", True)
+        before = dict(settings.data)
+        controller = self.make_controller(settings, preview=True)
+        with patch.object(controller.window, "isVisible", return_value=True):
+            controller.tick()
+        self.assertIsNotNone(controller.banner)
+        self.assertFalse(controller.timer.isActive())
+        self.assertEqual(settings.data, before)
+        self.assertEqual(settings.saved, {})
+
+    def test_banner_preview_close_collapses_toolbar_and_does_not_repeat(self):
+        controller = self.make_controller(Settings(), preview=True)
+        controller.show_invitation()
+        controller.banner.close_button.click()
+        self.assertTrue(controller.area.toolbar.isHidden())
+        controller.show_invitation()
+        self.assertTrue(controller.area.toolbar.isHidden())
+        self.assertFalse(controller.policy.shown)
+
+    def test_preview_survey_does_not_consume_real_invitation(self):
+        controller = self.make_controller(Settings(), preview=True)
+        controller.show_invitation()
+        with patch("windows.feedback.QDesktopServices.openUrl", return_value=True):
+            controller.open_survey()
+        self.assertFalse(controller.policy.shown)
+        self.assertEqual(controller.settings.saved, {})
+        self.assertTrue(controller.area.toolbar.isHidden())
+
+    def test_unanswered_banner_returns_on_next_session(self):
+        settings = Settings()
+        controller = self.make_controller(settings)
+        controller.policy.advance(1800)
+        controller.show_invitation()
+        self.assertFalse(settings.get("feedback-shown"))
+        restarted_settings = Settings()
+        restarted_settings.data = dict(settings.saved)
+        restarted = self.make_controller(restarted_settings)
+        with patch.object(restarted.window, "isActiveWindow", return_value=True), \
+                patch.object(restarted.window, "isVisible", return_value=True):
+            restarted.tick()
+        self.assertIsNotNone(restarted.banner)
+        restarted.banner.close_button.click()
+        self.assertTrue(restarted_settings.saved["feedback-shown"])
+
+    def test_help_can_complete_a_visible_banner(self):
+        controller = self.make_controller(Settings())
+        controller.show_invitation()
+        self.assertTrue(controller.action.isEnabled())
+        with patch("windows.feedback.QDesktopServices.openUrl", return_value=True):
+            controller.action.trigger()
+        self.assertIsNone(controller.banner)
+        self.assertTrue(controller.policy.shown)
+
+    def test_invalid_elapsed_settings_do_not_disable_feedback(self):
+        for value in ("invalid", float("nan"), float("inf"), -10, {}):
+            settings = Settings()
+            settings.set("feedback-use-seconds", value)
+            self.assertFalse(FeedbackPolicy(settings).advance(5))
+            self.assertEqual(settings.get("feedback-use-seconds"), 5)
+
+    def test_background_and_popup_time_does_not_count(self):
+        controller = self.make_controller(Settings())
+        controller.last_tick = 100
+        controller.was_active = True
+        with patch.object(controller.window, "isActiveWindow", return_value=True), \
+                patch.object(controller.window, "isVisible", return_value=True), \
+                patch("windows.feedback.QApplication.activePopupWidget", return_value=object()), \
+                patch("windows.feedback.time.monotonic", return_value=105):
+            controller.tick()
+        self.assertEqual(controller.settings.get("feedback-use-seconds"), 0)
+
+    def test_persistence_failure_still_dismisses_for_this_session(self):
+        controller = self.make_controller(Settings())
+        controller.show_invitation()
+        with patch.object(controller.settings, "save", side_effect=OSError("disk full")):
+            controller.banner.close_button.click()
+        controller.show_invitation()
+        self.assertIsNone(controller.banner)
+        self.assertTrue(controller.completed)
+        self.assertTrue(controller.action.isEnabled())
+
+    def test_browser_exception_keeps_visible_banner_for_retry(self):
+        controller = self.make_controller(Settings())
+        controller.show_invitation()
+        with patch("windows.feedback.QDesktopServices.openUrl", side_effect=OSError("no browser")):
+            controller.open_survey()
+        self.assertIsNotNone(controller.banner)
+        self.assertFalse(controller.policy.shown)
+
+    def test_real_settings_reload_and_reset_preserve_notification_history(self):
+        from classes import info
+        from classes.settings import SettingStore
+
+        with tempfile.TemporaryDirectory() as profile, patch.object(info, "USER_PATH", profile):
+            settings = SettingStore()
+            settings.load()
+            settings.set("unique_install_id", "persistent-test-id")
+            self.assertFalse(FeedbackPolicy(settings).advance(900))
+            restarted = SettingStore()
+            restarted.load()
+            self.assertEqual(restarted.get("feedback-use-seconds"), 900)
+            policy = FeedbackPolicy(restarted)
+            self.assertTrue(policy.advance(900))
+            self.assertTrue(policy.consume())
+            restarted.set("dismissed-update-version", "4.1.0")
+            restarted.save()
+            restarted.restore("General")
+            restored = SettingStore()
+            restored.load()
+            self.assertTrue(restored.get("feedback-shown"))
+            self.assertEqual(restored.get("feedback-use-seconds"), 1800)
+            self.assertEqual(restored.get("dismissed-update-version"), "4.1.0")
+            self.assertEqual(restored.get("unique_install_id"), "persistent-test-id")
+            self.assertEqual(restored.get("actionShareFeedback"), "F8")
+            self.assertEqual(restored.get("actionUpdate"), "F9")

--- a/src/tests/test_notification_startup.py
+++ b/src/tests/test_notification_startup.py
@@ -1,0 +1,97 @@
+"""Exercise notification wiring in a real application with an isolated profile."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+
+
+class NotificationStartupTests(unittest.TestCase):
+    def test_help_shortcuts_and_three_themes(self):
+        # A subprocess isolates OpenShotApp from other tests' QApplication stubs.
+        script = r'''
+import importlib
+import os
+import tempfile
+import traceback
+from unittest.mock import patch
+from classes import info, version
+
+profile_dir = tempfile.TemporaryDirectory(prefix="openshot-notification-test-")
+original = info.USER_PATH
+profile = os.path.join(profile_dir.name, ".openshot_qt")
+for key, value in list(vars(info).items()):
+    if isinstance(value, str) and value.startswith(original):
+        setattr(info, key, profile + value[len(original):])
+info._path_defaults = {key: profile + value[len(original):]
+                       for key, value in info._path_defaults.items()}
+info.setup_userdirs()
+info.FEEDBACK_PREVIEW = True
+info.UPDATE_PREVIEW = True
+version.get_current_Version = lambda: None
+from classes.app import OpenShotApp
+from qt_api import QTimer, Qt, QT_API
+binding = {"pyqt5": "PyQt5", "pyqt6": "PyQt6", "pyside6": "PySide6"}[QT_API]
+QTest = importlib.import_module(binding + ".QtTest").QTest
+app = OpenShotApp([], mode="unittest")
+app.settings.set("tutorial_enabled", False)
+app.settings.set("unique_install_id", "preview-only")
+app.settings.set("send_metrics", False)
+passed = False
+
+def verify():
+    global passed
+    try:
+        window = app.window
+        area = window.notification_area
+        assert set(area.banners) == {"feedback", "update"}
+        assert window.actionShareFeedback.shortcut().toString() == "F8"
+        assert window.actionUpdate.shortcut().toString() == "F9"
+        actions = window.menuHelp.actions()
+        start = actions.index(window.actionShareFeedback)
+        assert actions[start - 1].isSeparator()
+        assert actions[start + 1] is window.actionUpdate
+        assert actions[start + 2].isSeparator()
+        assert actions[start + 3] is window.actionAbout
+        for theme in ("Cosmic Dusk", "Humanity: Dark", "Retro"):
+            app.theme_manager.apply_theme(theme)
+            app.processEvents()
+            app.processEvents()
+            assert area.toolbar.width() >= window.width() * .95, theme
+            assert area.toolbar.y() >= window.toolBar.geometry().bottom(), theme
+            for action in (window.actionShareFeedback, window.actionUpdate):
+                assert not action.icon().pixmap(24, 24).isNull(), theme
+        window.activateWindow()
+        app.processEvents()
+        with patch("windows.feedback.QDesktopServices.openUrl", return_value=True) as opened:
+            QTest.keyClick(window, Qt.Key_F8)
+            app.processEvents()
+            assert opened.call_count == 1
+        assert set(area.banners) == {"update"}
+        with patch("windows.main_window.webbrowser.open", return_value=True) as opened:
+            QTest.keyClick(window, Qt.Key_F9)
+            app.processEvents()
+            assert opened.call_count == 1
+        assert not area.banners
+        assert area.toolbar.isHidden()
+        assert not app.settings.get("feedback-shown")
+        assert not app.settings.get("dismissed-update-version")
+        passed = True
+    except Exception:
+        traceback.print_exc()
+    finally:
+        app.quit()
+
+QTimer.singleShot(4000, verify)
+assert app.gui()
+app.exec_()
+assert passed, "Notification startup checks failed"
+'''
+        source = str(Path(__file__).resolve().parents[1])
+        env = dict(os.environ, PYTHONPATH=source, QT_QPA_PLATFORM="offscreen",
+                   QT_QUICK_BACKEND="software")
+        result = subprocess.run([sys.executable, "-c", script], env=env,
+                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                text=True, timeout=60)
+        self.assertEqual(result.returncode, 0, result.stdout[-16000:])

--- a/src/tests/test_notifications.py
+++ b/src/tests/test_notifications.py
@@ -1,0 +1,183 @@
+"""Shared notification layout, release dismissal, and theme behavior."""
+
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+if PATH not in sys.path:
+    sys.path.append(PATH)
+
+from qt_api import QApplication, QMainWindow, QAction, QColor, Qt
+from classes.notifications import should_notify_update
+from windows.notifications import NotificationBanner, notification_area, UpdateNotificationController, banner_colors
+
+
+class Settings:
+    def __init__(self):
+        self.data = {"dismissed-update-version": ""}
+        self.saved = {}
+
+    def get(self, key):
+        return self.data.get(key)
+
+    def set(self, key, value):
+        self.data[key] = value
+
+    def save(self):
+        self.saved = dict(self.data)
+
+
+class NotificationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QApplication.instance() or QApplication([])
+
+    def make_window(self):
+        window = QMainWindow()
+        window.resize(1100, 650)
+        window.addToolBar("Main").addAction("Open")
+        window.actionUpdate = QAction("Update", window)
+        self.addCleanup(window.deleteLater)
+        return window
+
+    def test_numeric_release_order_and_dismissed_release(self):
+        self.assertTrue(should_notify_update("4.10.0", "4.9.0", "4.9.1"))
+        self.assertFalse(should_notify_update("4.9.0", "4.10.0", ""))
+        self.assertFalse(should_notify_update("4.1.0", "4.0.0", "4.1"))
+        self.assertFalse(should_notify_update("4.1.0", "4.0.0", "4.2.0"))
+        self.assertFalse(should_notify_update("<invalid>", "4.0.0", ""))
+
+    def test_dismissal_survives_restart_and_next_release_reappears(self):
+        settings = Settings()
+        controller = UpdateNotificationController(self.make_window(), settings, str, "4.0.0", lambda: True)
+        controller.offer("4.1.0")
+        controller.banner.close_button.click()
+        self.assertEqual(settings.saved["dismissed-update-version"], "4.1.0")
+        controller.offer("4.1.0")
+        self.assertIsNone(controller.banner)
+        restarted_settings = Settings()
+        restarted_settings.data = dict(settings.saved)
+        restarted = UpdateNotificationController(self.make_window(), restarted_settings, str, "4.0.0", lambda: True)
+        restarted.offer("4.1.0")
+        self.assertIsNone(restarted.banner)
+        restarted.offer("4.2.0")
+        self.assertIsNotNone(restarted.banner)
+        self.assertEqual(restarted.version, "4.2.0")
+
+    def test_preview_can_be_dismissed_without_saving(self):
+        settings = Settings()
+        controller = UpdateNotificationController(self.make_window(), settings, str, "4.0.0", lambda: True, preview=True)
+        controller.offer("4.0.0")
+        controller.banner.close_button.click()
+        controller.offer("4.1.0")
+        self.assertIsNone(controller.banner)
+        self.assertEqual(settings.saved, {})
+
+    def test_duplicate_response_and_failed_browser_keep_existing_banner(self):
+        controller = UpdateNotificationController(self.make_window(), Settings(), str, "4.0.0", lambda: False)
+        controller.offer("4.2.0")
+        original = controller.banner
+        controller.offer("4.2.0")
+        controller.offer("4.1.0")
+        self.assertIs(controller.banner, original)
+        controller.banner.primary.click()
+        self.assertIs(controller.banner, original)
+        self.assertEqual(controller.settings.saved, {})
+
+    def test_stale_response_does_not_change_menu_version(self):
+        controller = UpdateNotificationController(self.make_window(), Settings(), str, "4.0.0", lambda: True)
+        controller.offer("4.2.0")
+        tooltip = controller.window.actionUpdate.toolTip()
+        controller.offer("4.1.0")
+        self.assertEqual(controller.window.actionUpdate.toolTip(), tooltip)
+        self.assertEqual(controller.version, "4.2.0")
+
+    def test_equivalent_releases_do_not_duplicate_banner(self):
+        controller = UpdateNotificationController(self.make_window(), Settings(), str, "4.0.0", lambda: True)
+        controller.offer("4.1")
+        banner = controller.banner
+        controller.offer("4.1.0")
+        self.assertIs(controller.banner, banner)
+
+    def test_menu_navigation_after_saved_dismissal_and_failure_feedback(self):
+        settings = Settings()
+        settings.set("dismissed-update-version", "4.1.0")
+        open_download = Mock(return_value=False)
+        controller = UpdateNotificationController(self.make_window(), settings, str, "4.0.0", open_download)
+        controller.offer("4.1.0")
+        self.assertEqual(controller.version, "4.1.0")
+        self.assertIsNone(controller.banner)
+        with patch("windows.notifications.QMessageBox.warning") as warning:
+            self.assertFalse(controller.activate())
+        warning.assert_called_once()
+        open_download.return_value = True
+        self.assertTrue(controller.activate())
+
+    def test_browser_exception_does_not_escape_qt_slot(self):
+        controller = UpdateNotificationController(self.make_window(), Settings(), str, "4.0.0", Mock(side_effect=OSError("no browser")))
+        controller.offer("4.1.0")
+        controller.banner.primary.click()
+        self.assertIsNotNone(controller.banner)
+        self.assertEqual(controller.settings.saved, {})
+
+    def test_dismiss_does_not_overwrite_a_newer_saved_version(self):
+        settings = Settings()
+        controller = UpdateNotificationController(self.make_window(), settings, str, "4.0.0", lambda: True)
+        controller.offer("4.1.0")
+        settings.set("dismissed-update-version", "4.2.0")
+        controller.dismiss()
+        self.assertEqual(settings.get("dismissed-update-version"), "4.2.0")
+
+    def test_save_failure_still_suppresses_update_for_session(self):
+        settings = Settings()
+        controller = UpdateNotificationController(self.make_window(), settings, str, "4.0.0", lambda: True)
+        controller.offer("4.1.0")
+        with patch.object(settings, "save", side_effect=OSError("disk full")):
+            controller.dismiss()
+        controller.offer("4.1")
+        self.assertIsNone(controller.banner)
+
+    def test_shared_area_order_collapse_and_theme_switches(self):
+        window = self.make_window()
+        area = notification_area(window)
+        for key in ("update", "feedback"):
+            banner = NotificationBanner(window, key, "Open", lambda: None,
+                                        lambda checked=False, k=key: area.remove(k), str)
+            area.add(key, banner)
+        self.assertIs(area.layout.itemAt(0).widget(), area.banners["feedback"])
+        self.assertIs(area.layout.itemAt(1).widget(), area.banners["update"])
+        window.show()
+        self.app.processEvents()
+        window.removeToolBarBreak(area.toolbar)
+        self.app.processEvents()
+        self.app.processEvents()
+        self.assertTrue(window.toolBarBreak(area.toolbar))
+        for theme in ("Cosmic Dusk", "Humanity: Dark", "Retro"):
+            area.apply_theme(SimpleNamespace(name=theme))
+            for banner in area.banners.values():
+                self.assertIn(banner_colors(window, SimpleNamespace(name=theme))["surface"], banner.styleSheet())
+                self.assertLess(banner.close_button.geometry().right(), banner.width())
+        area.banners["feedback"].close_button.click()
+        self.assertFalse(area.toolbar.isHidden())
+        area.banners["update"].close_button.click()
+        self.assertTrue(area.toolbar.isHidden())
+        # A stored workspace's visible toolbar state cannot revive empty banners.
+        area.toolbar.show()
+        self.app.processEvents()
+        self.assertTrue(area.toolbar.isHidden())
+        window.close()
+
+    def test_theme_text_contrast(self):
+        def luminance(color):
+            c = QColor(color)
+            channels = [x / 12.92 if x <= 0.04045 else ((x + 0.055) / 1.055) ** 2.4
+                        for x in (c.redF(), c.greenF(), c.blueF())]
+            return sum(a * b for a, b in zip(channels, (0.2126, 0.7152, 0.0722)))
+        for name in ("Cosmic Dusk", "Humanity: Dark", "Retro"):
+            colors = banner_colors(self.make_window(), SimpleNamespace(name=name))
+            for role in ("text", "action", "close"):
+                values = sorted([luminance(colors["surface"]), luminance(colors[role])])
+                self.assertGreaterEqual((values[1] + 0.05) / (values[0] + 0.05), 4.5)

--- a/src/themes/cosmic/images/feedback.svg
+++ b/src/themes/cosmic/images/feedback.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <path d="M5.5 3h9A2.5 2.5 0 0 1 17 5.5v6a2.5 2.5 0 0 1-2.5 2.5H8l-4 3v-3.5a2.5 2.5 0 0 1-1-2v-6A2.5 2.5 0 0 1 5.5 3Z" stroke="#91C3FF" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M6.5 7h7M6.5 10h4.5" stroke="#91C3FF" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/src/themes/cosmic/images/update.svg
+++ b/src/themes/cosmic/images/update.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <circle cx="10" cy="10" r="7" stroke="#91C3FF" stroke-width="1.2"/>
+  <path d="M10 13.5v-7M7 9.5l3-3 3 3" stroke="#91C3FF" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/themes/cosmic/theme.py
+++ b/src/themes/cosmic/theme.py
@@ -935,7 +935,6 @@ QMessageBox QPushButton[dialogRole="destructive"] {{
             {"action": self.app.window.actionSave, "icon": "themes/cosmic/images/tool-save-project.svg", "style": Qt.ToolButtonTextBesideIcon},
             {"action": self.app.window.actionExportVideo, "icon": "themes/cosmic/images/tool-export.svg",
              "style": Qt.ToolButtonTextBesideIcon, "stylesheet": "QToolButton { background-color: #0078FF; color: #FFFFFF; border: none; } QToolButton:hover { background-color: #0a82ff; } QToolButton:focus { background-color: #0a82ff; } QToolButton:pressed { background-color: #3d9bff; }"},
-            {"action": self.app.window.actionUpdate, "icon": "themes/cosmic/images/warning.svg", "visible": False, "style": Qt.ToolButtonTextBesideIcon, "stylesheet": "QToolButton {  background-color: #141923; color: #FABE0A; }"}
         ]
         self.set_toolbar_buttons(self.app.window.toolBar, icon_size=20, settings=toolbar_buttons)
 

--- a/src/themes/humanity/images/feedback-dark.svg
+++ b/src/themes/humanity/images/feedback-dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <path d="M5.5 3h9A2.5 2.5 0 0 1 17 5.5v6a2.5 2.5 0 0 1-2.5 2.5H8l-4 3v-3.5a2.5 2.5 0 0 1-1-2v-6A2.5 2.5 0 0 1 5.5 3Z" stroke="#9BC8FF" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M6.5 7h7M6.5 10h4.5" stroke="#9BC8FF" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/src/themes/humanity/images/feedback-retro.svg
+++ b/src/themes/humanity/images/feedback-retro.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <path d="M5.5 3h9A2.5 2.5 0 0 1 17 5.5v6a2.5 2.5 0 0 1-2.5 2.5H8l-4 3v-3.5a2.5 2.5 0 0 1-1-2v-6A2.5 2.5 0 0 1 5.5 3Z" stroke="#155DA6" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M6.5 7h7M6.5 10h4.5" stroke="#155DA6" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/src/themes/humanity/images/update-dark.svg
+++ b/src/themes/humanity/images/update-dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <circle cx="10" cy="10" r="7" stroke="#9BC8FF" stroke-width="1.2"/>
+  <path d="M10 13.5v-7M7 9.5l3-3 3 3" stroke="#9BC8FF" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/themes/humanity/images/update-retro.svg
+++ b/src/themes/humanity/images/update-retro.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <circle cx="10" cy="10" r="7" stroke="#155DA6" stroke-width="1.2"/>
+  <path d="M10 13.5v-7M7 9.5l3-3 3 3" stroke="#155DA6" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/windows/about.py
+++ b/src/windows/about.py
@@ -267,6 +267,8 @@ class About(QDialog):
 
         version_line = f"Version: {info.VERSION} | libopenshot: {openshot.OPENSHOT_VERSION_FULL}"
         lines.append(version_line)
+        from classes.distribution import distribution_label
+        lines.append("Distribution: " + distribution_label())
 
         build_name, release_date = self.get_build_details()
         build_parts = []

--- a/src/windows/feedback.py
+++ b/src/windows/feedback.py
@@ -1,0 +1,111 @@
+"""One-time feedback invitation using the shared notification banners."""
+
+import time
+
+from qt_api import QAction, QApplication, QDesktopServices, QTimer, QUrl, QObject, QMessageBox
+
+from classes.distribution import get_distribution_info
+from classes.feedback import FeedbackPolicy, survey_url
+from classes.logger import log
+from windows.notifications import NotificationBanner, notification_area, notification_icon
+
+
+class FeedbackController(QObject):
+    def __init__(self, window, settings, translate, preview=False):
+        super().__init__(window)
+        self.window = window
+        self.settings = settings
+        self.translate = translate
+        self.policy = FeedbackPolicy(settings)
+        self.preview = preview
+        self.presented = False
+        self.completed = False
+        self.area = notification_area(window)
+        self.banner = None
+        self.action = QAction(translate("Share Feedback…"), window)
+        self.action.setObjectName("actionShareFeedback")
+        window.actionShareFeedback = self.action
+        self.refresh_icon(self.area.theme)
+        if hasattr(window, "ThemeChangedSignal"):
+            window.ThemeChangedSignal.connect(self.refresh_icon)
+        self.action.setIconVisibleInMenu(True)
+        self.action.triggered.connect(self.open_from_menu)
+        window.menuHelp.insertAction(window.actionUpdate, self.action)
+        self.last_tick = time.monotonic()
+        self.was_active = False
+        self.timer = QTimer(self)
+        self.timer.setInterval(5000)
+        self.timer.timeout.connect(self.tick)
+        if preview:
+            self.timer.setInterval(250)
+            self.timer.start()
+        elif not self.policy.shown:
+            self.timer.start()
+
+    def refresh_icon(self, theme=None):
+        self.action.setIcon(notification_icon(self.window, "feedback", theme))
+
+    def tick(self):
+        if self.preview:
+            if self.window.isVisible() and not QApplication.activeModalWidget():
+                self.show_invitation()
+            return
+        now = time.monotonic()
+        seconds = now - self.last_tick
+        self.last_tick = now
+        active = (self.window.isActiveWindow() and self.window.isVisible()
+                  and not self.window.isMinimized() and not QApplication.activeModalWidget()
+                  and not QApplication.activePopupWidget()
+                  and not getattr(self.window, "shutting_down", False))
+        # Ignore suspended/event-loop-blocked intervals instead of counting idle hours.
+        elapsed = seconds if active and self.was_active and seconds <= 10 else 0
+        self.was_active = active
+        try:
+            if self.policy.advance(elapsed) and active:
+                self.show_invitation()
+        except Exception:
+            log.warning("Unable to save feedback invitation state", exc_info=True)
+            self.timer.stop()
+
+    def show_invitation(self, checked=False):
+        if self.presented or self.completed or (not self.preview and self.policy.shown):
+            return
+        _ = self.translate
+        self.banner = NotificationBanner(
+            self.window, _("Help us make OpenShot even better!"), _("Share feedback"),
+            self.open_survey, self.dismiss, _)
+        self.area.add("feedback", self.banner)
+        self.presented = True
+        self.timer.stop()
+
+    def open_from_menu(self, checked=False):
+        # Voluntary feedback remains available after the one-time invitation ends.
+        self.open_survey()
+
+    def dismiss(self):
+        self.completed = True
+        if not self.preview:
+            try:
+                self.policy.consume()
+            except Exception:
+                log.warning("Unable to save feedback invitation state", exc_info=True)
+        self.timer.stop()
+        if self.banner:
+            self.area.remove("feedback")
+            self.banner = None
+
+    def open_survey(self):
+        url = survey_url(get_distribution_info(), self.settings.get("unique_install_id"))
+        try:
+            opened = QDesktopServices.openUrl(QUrl(url))
+        except Exception:
+            opened = False
+        if opened:
+            self.dismiss()
+        elif self.banner:
+            self.banner.show_error(self.translate("Couldn’t open your browser. Please try again."))
+        else:
+            QMessageBox.warning(self.window, self.translate("Unable to open browser"),
+                                self.translate("Couldn’t open your browser. Please try again."))
+            log.warning("Unable to open feedback survey in browser")
+        return opened

--- a/src/windows/feedback.py
+++ b/src/windows/feedback.py
@@ -13,6 +13,7 @@ from windows.notifications import NotificationBanner, notification_area, notific
 class FeedbackController(QObject):
     def __init__(self, window, settings, translate, preview=False):
         super().__init__(window)
+        _ = translate
         self.window = window
         self.settings = settings
         self.translate = translate
@@ -22,7 +23,7 @@ class FeedbackController(QObject):
         self.completed = False
         self.area = notification_area(window)
         self.banner = None
-        self.action = QAction(translate("Share Feedback…"), window)
+        self.action = QAction(_("Share Feedback…"), window)
         self.action.setObjectName("actionShareFeedback")
         window.actionShareFeedback = self.action
         self.refresh_icon(self.area.theme)
@@ -95,6 +96,7 @@ class FeedbackController(QObject):
             self.banner = None
 
     def open_survey(self):
+        _ = self.translate
         url = survey_url(get_distribution_info(), self.settings.get("unique_install_id"))
         try:
             opened = QDesktopServices.openUrl(QUrl(url))
@@ -103,9 +105,9 @@ class FeedbackController(QObject):
         if opened:
             self.dismiss()
         elif self.banner:
-            self.banner.show_error(self.translate("Couldn’t open your browser. Please try again."))
+            self.banner.show_error(_("Couldn’t open your browser. Please try again."))
         else:
-            QMessageBox.warning(self.window, self.translate("Unable to open browser"),
-                                self.translate("Couldn’t open your browser. Please try again."))
+            QMessageBox.warning(self.window, _("Unable to open browser"),
+                                _("Couldn’t open your browser. Please try again."))
             log.warning("Unable to open feedback survey in browser")
         return opened

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -1208,13 +1208,11 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             log.error(error_msg, exc_info=1)
 
     def actionUpdate_trigger(self, checked=True):
+        return self.update_notifications.activate()
+
+    def open_update_download(self):
         url = "https://www.openshot.org/%sdownload/?app-toolbar" % info.website_language()
-        try:
-            webbrowser.open(url, new=1)
-        except Exception:
-            error_msg = f"Unable to open the Download url: {url}"
-            QMessageBox.information(self, "Error", error_msg)
-            log.error(error_msg, exc_info=1)
+        return webbrowser.open(url, new=1)
 
     def should_play(self, requested_speed=0):
         """Determine if we should start playback, based on the current frame
@@ -4319,38 +4317,16 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
 
     def foundCurrentVersion(self, version):
         """Handle the callback for detecting the current version on openshot.org"""
-        _ = get_app()._tr
-
-        # Compare versions (alphabetical compare of version strings should work fine)
-        if info.VERSION < version:
-            # Update text for QAction
-            self.actionUpdate.setVisible(True)
-            self.actionUpdate.setText(_("Update Available"))
-            self.actionUpdate.setToolTip(_("Update Available: <b>%s</b>") % version)
-
-            # Add toolbar button for non-cosmic dusk themes
-            # Cosmic dusk has a hidden toolbar button which is made visible
-            # by the setVisible() call above this
-            if get_app().theme_manager:
-                from themes.manager import ThemeName
-                theme = get_app().theme_manager.get_current_theme()
-                if theme and theme.name != ThemeName.COSMIC.value:
-                    # Add spacer and 'New Version Available' toolbar button (default hidden)
-                    spacer = QWidget(self)
-                    spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
-                    self.toolBar.addWidget(spacer)
-
-                    # Add update available button (with icon and text)
-                    updateButton = QToolButton(self)
-                    updateButton.setDefaultAction(self.actionUpdate)
-                    updateButton.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
-                    self.toolBar.addWidget(updateButton)
-            else:
-                log.warning("No ThemeManager loaded yet. Skip update available button.")
+        self.show_update_notice(version)
 
         # Initialize sentry exception tracing (now that we know the current version)
         from classes import sentry
         sentry.init_tracing()
+
+    def show_update_notice(self, version):
+        """Show updates in the shared banner area, without a duplicate toolbar button."""
+        if hasattr(self, "update_notifications"):
+            self.update_notifications.offer(version)
 
     def handleSeek(self, frame, _start_preroll=True):
         """ Always update the property view when we seek to a new position """
@@ -5384,6 +5360,10 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         # Add window as watcher to receive undo/redo status updates
         app.updates.add_watcher(self)
 
+        from windows.notifications import UpdateNotificationController
+        self.update_notifications = UpdateNotificationController(
+            self, s, _, info.VERSION, self.open_update_download, preview=info.UPDATE_PREVIEW)
+
         # Get current version of OpenShot via HTTP
         self.FoundVersionSignal.connect(self.foundCurrentVersion)
         get_current_Version()
@@ -5715,6 +5695,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         self.initialized = True
 
         # Init all Keyboard shortcuts
+        from windows.feedback import FeedbackController
+        self.feedback_controller = FeedbackController(self, s, _, preview=info.FEEDBACK_PREVIEW)
         self.initShortcuts()
 
         # Apply accessibility-friendly tab order after layout settles
@@ -5726,6 +5708,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
         )
         self._schedule_initial_focus()
         self._install_focus_debugger()
+        if info.UPDATE_PREVIEW:
+            QTimer.singleShot(0, lambda: self.show_update_notice(info.VERSION))
 
     def _init_ui_trace_recorder(self):
         """Enable env-configured UI trace recording for automated test capture."""

--- a/src/windows/notifications.py
+++ b/src/windows/notifications.py
@@ -1,0 +1,273 @@
+"""Shared, dismissible notification banners below the main toolbar."""
+
+import os
+
+from qt_api import (
+    QObject, Qt, QEvent, QFrame, QHBoxLayout, QLabel, QPushButton, QToolBar,
+    QVBoxLayout, QWidget, QSizePolicy, QPalette, QTimer, QIcon, QMessageBox,
+)
+
+from classes.notifications import release_version, should_notify_update
+from classes.logger import log
+from classes import info
+
+
+def notification_icon(window, name, theme=None):
+    """Matching outline menu icons with each theme's foreground color."""
+    theme_name = getattr(theme, "name", "")
+    if not theme_name:
+        background = window.palette().color(QPalette.Window)
+        theme_name = "Retro" if background.lightness() >= 128 else "Cosmic Dusk"
+    path = {
+        "Cosmic Dusk": "cosmic/images/{}.svg",
+        "Humanity: Dark": "humanity/images/{}-dark.svg",
+        "Retro": "humanity/images/{}-retro.svg",
+    }.get(theme_name, "cosmic/images/{}.svg").format(name)
+    return QIcon(os.path.join(info.PATH, "themes", path))
+
+
+def banner_colors(window, theme=None):
+    """Explicit contrast pairs for OpenShot's three themes, with a palette fallback."""
+    name = getattr(theme, "name", "")
+    background = window.palette().color(QPalette.Window)
+    if name == "Retro" or (not name and background.lightness() >= 128):
+        return dict(backdrop="#ededed", surface="#ffffff", border="#c4cbd3", text="#805800",
+                    action="#155da6", close="#536579", hover="#e4edf6")
+    if name == "Cosmic Dusk" or (not name and background.blue() > background.red() + 10):
+        return dict(backdrop="#192332", surface="#141923", border="#303c4d", text="#fabe0a",
+                    action="#91c3ff", close="#91a5bc", hover="#283241")
+    return dict(backdrop="#303030", surface="#252525", border="#505050", text="#f5c451",
+                action="#9bc8ff", close="#b0b8c2", hover="#3d3d3d")
+
+
+class NotificationBanner(QFrame):
+    def __init__(self, parent, message, action_text, on_action, on_dismiss, translate):
+        super().__init__(parent)
+        self.setObjectName("notificationBanner")
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        self.setAccessibleName(message)
+        self._dismiss = on_dismiss
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(12, 4, 8, 4)
+        layout.setSpacing(10)
+        # Native text/shape styling keeps the glyph sharp at every UI scale.
+        self.symbol = QLabel("!", self)
+        self.symbol.setObjectName("notificationSymbol")
+        self.symbol.setAlignment(Qt.AlignCenter)
+        self.symbol.setFixedSize(20, 20)
+        layout.addWidget(self.symbol)
+        self.message = QLabel(message, self)
+        self.message.setObjectName("notificationMessage")
+        self.message.setWordWrap(True)
+        layout.addWidget(self.message, 1)
+        self.primary = QPushButton(action_text, self)
+        self.primary.setObjectName("notificationAction")
+        self.primary.clicked.connect(on_action)
+        layout.addWidget(self.primary)
+        self.close_button = QPushButton("×", self)
+        self.close_button.setObjectName("notificationClose")
+        self.close_button.setAccessibleName(translate("Dismiss notification"))
+        self.close_button.setToolTip(translate("Dismiss notification"))
+        self.close_button.setFixedWidth(28)
+        self.close_button.clicked.connect(on_dismiss)
+        layout.addWidget(self.close_button)
+
+    def apply_colors(self, colors):
+        self.setStyleSheet("""
+            QFrame#notificationBanner {
+                background: %(surface)s; border: 1px solid %(border)s; border-radius: 6px;
+            }
+            QFrame#notificationBanner QLabel {
+                background: transparent; color: %(text)s; border: none; font-weight: 600;
+            }
+            QFrame#notificationBanner QLabel#notificationSymbol {
+                border: 2px solid %(text)s; border-radius: 10px;
+            }
+            QFrame#notificationBanner QPushButton {
+                background: transparent; color: %(action)s; border: none;
+                border-radius: 4px; padding: 4px 8px; font-weight: 600;
+            }
+            QFrame#notificationBanner QPushButton#notificationClose { color: %(close)s; padding: 4px; }
+            QFrame#notificationBanner QPushButton:hover,
+            QFrame#notificationBanner QPushButton:focus { background: %(hover)s; }
+        """ % colors)
+
+    def show_error(self, message):
+        self.message.setText(message)
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key_Escape:
+            self._dismiss()
+            event.accept()
+        else:
+            super().keyPressEvent(event)
+
+
+class NotificationArea(QObject):
+    """One shared row of stacked banners; collapses when the last one is removed."""
+
+    def __init__(self, window):
+        super().__init__(window)
+        self.window = window
+        self.toolbar = None
+        self.banners = {}
+        self.theme = None
+        self.sync_timer = QTimer(self)
+        self.sync_timer.setSingleShot(True)
+        self.sync_timer.timeout.connect(self.sync_visibility)
+        if hasattr(window, "ThemeChangedSignal"):
+            window.ThemeChangedSignal.connect(self.apply_theme)
+
+    def _create_toolbar(self):
+        if self.toolbar:
+            return
+        self.toolbar = QToolBar(self.window)
+        self.toolbar.setObjectName("notificationToolbar")
+        self.toolbar.setMovable(False)
+        self.toolbar.setFloatable(False)
+        self.toolbar.setAllowedAreas(Qt.TopToolBarArea)
+        self.toolbar.toggleViewAction().setVisible(False)
+        self.toolbar.setStyleSheet("QToolBar { background: transparent; border: none; padding: 0; spacing: 0; }")
+        self.container = QWidget(self.toolbar)
+        self.container.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        self.container.setObjectName("notificationContainer")
+        self.layout = QVBoxLayout(self.container)
+        self.layout.setContentsMargins(12, 8, 12, 6)
+        self.layout.setSpacing(6)
+        self.toolbar.addWidget(self.container)
+        self.window.addToolBarBreak(Qt.TopToolBarArea)
+        self.window.addToolBar(Qt.TopToolBarArea, self.toolbar)
+        self.toolbar.installEventFilter(self)
+
+    def add(self, key, banner):
+        self._create_toolbar()
+        self.remove(key)
+        self.banners[key] = banner
+        # Feedback stays above updates, independent of asynchronous response order.
+        self.layout.insertWidget(0 if key == "feedback" else self.layout.count(), banner)
+        self.apply_theme(self.theme)
+        banner.show()
+        self.toolbar.show()
+
+    def remove(self, key):
+        banner = self.banners.pop(key, None)
+        if banner:
+            self.layout.removeWidget(banner)
+            banner.hide()
+            banner.deleteLater()
+        if self.toolbar and not self.banners:
+            self.toolbar.hide()
+
+    def apply_theme(self, theme=None):
+        self.theme = theme
+        colors = banner_colors(self.window, theme)
+        if self.toolbar:
+            self.toolbar.setStyleSheet(
+                "QToolBar { background: %s; border: none; padding: 0; spacing: 0; }" % colors["backdrop"])
+            self.container.setStyleSheet(
+                "QWidget#notificationContainer { background: %s; }" % colors["backdrop"])
+        for banner in self.banners.values():
+            banner.apply_colors(colors)
+
+    def sync_visibility(self):
+        if self.toolbar:
+            # restoreState() can merge a newly introduced toolbar into the main row.
+            # Notices must retain their own full-width row after workspace changes.
+            if not self.window.toolBarBreak(self.toolbar):
+                self.window.insertToolBarBreak(self.toolbar)
+            self.toolbar.setVisible(bool(self.banners))
+
+    def eventFilter(self, watched, event):
+        # Saved workspace layouts must not resurrect a dismissed notification row.
+        if watched is self.toolbar and event.type() in (
+                QEvent.Show, QEvent.Hide, QEvent.Move, QEvent.Resize):
+            self.sync_timer.start(0)
+        return super().eventFilter(watched, event)
+
+
+def notification_area(window):
+    if not hasattr(window, "notification_area"):
+        window.notification_area = NotificationArea(window)
+    return window.notification_area
+
+
+class UpdateNotificationController(QObject):
+    def __init__(self, window, settings, translate, current_version, open_download, preview=False):
+        super().__init__(window)
+        self.window = window
+        self.settings = settings
+        self.translate = translate
+        self.current_version = current_version
+        self.open_download = open_download
+        self.preview = preview
+        self.area = notification_area(window)
+        self.version = None
+        self.dismissed = set()
+        self.banner = None
+        self.refresh_icon(self.area.theme)
+        if hasattr(window, "ThemeChangedSignal"):
+            window.ThemeChangedSignal.connect(self.refresh_icon)
+
+    def refresh_icon(self, theme=None):
+        self.window.actionUpdate.setIcon(notification_icon(self.window, "update", theme))
+        self.window.actionUpdate.setIconVisibleInMenu(True)
+
+    def offer(self, version):
+        if self.preview:
+            version = self.current_version
+        elif not should_notify_update(version, self.current_version, ""):
+            return
+        version_key = release_version(version)
+        if self.version and version_key < release_version(self.version):
+            return
+        previous_version = self.version
+        self.version = version
+        # Keep the explicit Help action available even when its banner was dismissed.
+        if hasattr(self.window, "actionUpdate"):
+            self.window.actionUpdate.setVisible(True)
+            self.window.actionUpdate.setText(self.translate("Update Available"))
+            self.window.actionUpdate.setToolTip(self.translate("Update Available: %s") % version)
+        if (version_key in self.dismissed or (not self.preview and not should_notify_update(
+                version, self.current_version, self.settings.get("dismissed-update-version")))):
+            self.area.remove("update")
+            self.banner = None
+            return
+        if self.banner and version_key == release_version(previous_version):
+            return
+        _ = self.translate
+        self.banner = NotificationBanner(
+            self.window, _("Upgrade to the latest version of OpenShot."), _("Upgrade"),
+            self.activate, self.dismiss, _)
+        self.banner.setToolTip(_("Update Available: %s") % (_("Preview") if self.preview else version))
+        self.area.add("update", self.banner)
+
+    def dismiss(self):
+        if not self.version:
+            return
+        version_key = release_version(self.version)
+        self.dismissed.add(version_key)
+        previous = release_version(self.settings.get("dismissed-update-version"))
+        if not self.preview and (previous is None or version_key > previous):
+            self.settings.set("dismissed-update-version", self.version)
+            try:
+                self.settings.save()
+            except Exception:
+                log.warning("Unable to save dismissed update version", exc_info=True)
+        self.area.remove("update")
+        self.banner = None
+
+    def activate(self):
+        try:
+            opened = self.open_download()
+        except Exception:
+            opened = False
+            log.warning("Unable to open update download page", exc_info=True)
+        if opened:
+            self.dismiss()
+        elif self.banner:
+            self.banner.show_error(self.translate("Couldn’t open your browser. Please try again."))
+        else:
+            QMessageBox.warning(self.window, self.translate("Unable to open browser"),
+                                self.translate("Couldn’t open your browser. Please try again."))
+        return opened

--- a/src/windows/notifications.py
+++ b/src/windows/notifications.py
@@ -43,6 +43,7 @@ def banner_colors(window, theme=None):
 class NotificationBanner(QFrame):
     def __init__(self, parent, message, action_text, on_action, on_dismiss, translate):
         super().__init__(parent)
+        _ = translate
         self.setObjectName("notificationBanner")
         self.setAttribute(Qt.WA_StyledBackground, True)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
@@ -67,8 +68,8 @@ class NotificationBanner(QFrame):
         layout.addWidget(self.primary)
         self.close_button = QPushButton("×", self)
         self.close_button.setObjectName("notificationClose")
-        self.close_button.setAccessibleName(translate("Dismiss notification"))
-        self.close_button.setToolTip(translate("Dismiss notification"))
+        self.close_button.setAccessibleName(_("Dismiss notification"))
+        self.close_button.setToolTip(_("Dismiss notification"))
         self.close_button.setFixedWidth(28)
         self.close_button.clicked.connect(on_dismiss)
         layout.addWidget(self.close_button)
@@ -214,6 +215,7 @@ class UpdateNotificationController(QObject):
         self.window.actionUpdate.setIconVisibleInMenu(True)
 
     def offer(self, version):
+        _ = self.translate
         if self.preview:
             version = self.current_version
         elif not should_notify_update(version, self.current_version, ""):
@@ -226,8 +228,8 @@ class UpdateNotificationController(QObject):
         # Keep the explicit Help action available even when its banner was dismissed.
         if hasattr(self.window, "actionUpdate"):
             self.window.actionUpdate.setVisible(True)
-            self.window.actionUpdate.setText(self.translate("Update Available"))
-            self.window.actionUpdate.setToolTip(self.translate("Update Available: %s") % version)
+            self.window.actionUpdate.setText(_("Update Available"))
+            self.window.actionUpdate.setToolTip(_("Update Available: %s") % version)
         if (version_key in self.dismissed or (not self.preview and not should_notify_update(
                 version, self.current_version, self.settings.get("dismissed-update-version")))):
             self.area.remove("update")
@@ -235,7 +237,6 @@ class UpdateNotificationController(QObject):
             return
         if self.banner and version_key == release_version(previous_version):
             return
-        _ = self.translate
         self.banner = NotificationBanner(
             self.window, _("Upgrade to the latest version of OpenShot."), _("Upgrade"),
             self.activate, self.dismiss, _)
@@ -258,6 +259,7 @@ class UpdateNotificationController(QObject):
         self.banner = None
 
     def activate(self):
+        _ = self.translate
         try:
             opened = self.open_download()
         except Exception:
@@ -266,8 +268,8 @@ class UpdateNotificationController(QObject):
         if opened:
             self.dismiss()
         elif self.banner:
-            self.banner.show_error(self.translate("Couldn’t open your browser. Please try again."))
+            self.banner.show_error(_("Couldn’t open your browser. Please try again."))
         else:
-            QMessageBox.warning(self.window, self.translate("Unable to open browser"),
-                                self.translate("Couldn’t open your browser. Please try again."))
+            QMessageBox.warning(self.window, _("Unable to open browser"),
+                                _("Couldn’t open your browser. Please try again."))
         return opened

--- a/src/windows/ui/main-window.ui
+++ b/src/windows/ui/main-window.ui
@@ -183,7 +183,6 @@
     <property name="title">
      <string>Help</string>
     </property>
-    <addaction name="actionUpdate"/>
     <addaction name="actionHelpContents"/>
     <addaction name="actionTutorial"/>
     <addaction name="separator"/>
@@ -193,6 +192,9 @@
     <addaction name="actionTranslate"/>
     <addaction name="separator"/>
     <addaction name="actionDonate"/>
+    <addaction name="separator"/>
+    <addaction name="actionUpdate"/>
+    <addaction name="separator"/>
     <addaction name="actionAbout"/>
    </widget>
    <addaction name="menuFile"/>


### PR DESCRIPTION
Adds compact, dismissible banners styled for all three themes. Feedback appears after 30 minutes of use and is dismissed permanently; update dismissals apply only to that version.

Help includes Share Feedback (F8) and Update Available (F9). Feedback links pass version, platform, install source, and installation ID to the website.


<img width="1222" height="516" alt="image" src="https://github.com/user-attachments/assets/350d70b9-3609-4835-8b50-2b560f474bf5" />
