### PR TITLE
Fix Sentry errors and stabilize undo/redo, slicing, and project saves

### DIFF
--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -294,6 +294,9 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
         else:
 
+            # Keep live project edits from changing values retained in history.
+            values = copy.deepcopy(values)
+
             # Add or Full Update
             # For adds to list perform an insert to index or the end if not specified
             if add and isinstance(parent, list):
@@ -306,7 +309,6 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                     and isinstance(obj.get("objects"), dict)
                     and isinstance(values.get("objects"), dict)
                 ):
-                    values = copy.deepcopy(values)
                     object_updates = values.pop("objects", {})
                     tracked_objects = obj.setdefault("objects", {})
                     for object_id, object_values in object_updates.items():
@@ -1298,6 +1300,54 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             if os.path.exists(temporary_path):
                 os.remove(temporary_path)
 
+    def _relocate_history_assets(self, asset_roots):
+        """Keep detached undo/redo snapshots usable after assets move on save."""
+        path_keys = {"image", "path", "resource", "protobuf_data_path", "lut_path"}
+
+        def relocate(value, key=None):
+            if isinstance(value, dict):
+                for child_key, child in value.items():
+                    value[child_key] = relocate(child, child_key)
+            elif isinstance(value, list):
+                for index, child in enumerate(value):
+                    value[index] = relocate(child)
+            elif key in path_keys and isinstance(value, str) and os.path.isabs(value):
+                for source_root, target_root in asset_roots:
+                    relative = self._path_relative_to_root(value, source_root)
+                    if relative is None:
+                        continue
+                    destination = os.path.join(target_root, relative)
+                    if self._paths_match(value, destination):
+                        return value
+                    # Deleted/undone recordings may exist only in history, so
+                    # preserve those too. Never remove the history's source.
+                    try:
+                        self._copy_recording_asset(value, destination)
+                    except OSError:
+                        log.warning("Unable to copy history asset %s", value, exc_info=True)
+                    return destination if os.path.exists(destination) else value
+            return value
+
+        # History serialized before saving is independent of the active manager.
+        for actions in self._data.get("history", {}).values():
+            for action in actions:
+                key = action.get("key", [])
+                path_key = key[-1] if key and isinstance(key[-1], str) else None
+                for field in ("value", "old_values"):
+                    if field in action:
+                        action[field] = relocate(action[field], path_key)
+
+        app = get_app()
+        if app.project is self:
+            updates = app.updates
+            actions = list(updates.actionHistory) + list(updates.redoHistory)
+            if updates.pending_action is not None:
+                actions.append(updates.pending_action)
+            for action in actions:
+                path_key = action.key[-1] if action.key and isinstance(action.key[-1], str) else None
+                action.values = relocate(action.values, path_key)
+                action.old_values = relocate(action.old_values, path_key)
+
     def move_temp_paths_to_project_folder(self, file_path, previous_path=None):
         """ Move all temp files (such as Thumbnails, Titles, and Blender animations) to the project asset folder. """
         # Fail the save before relocating media or writing the project when its
@@ -1305,6 +1355,7 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
         asset_path = get_assets_path(file_path)
         if not asset_path:
             raise OSError("Unable to create project assets for %s" % file_path)
+        history_asset_roots = []
         try:
             # Resolve destination folders before moving assets.
             target_thumb_path = os.path.join(asset_path, "thumbnail")
@@ -1356,6 +1407,16 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
                     get_assets_path(previous_path), "recordings")
                 if not self._paths_match(previous_recording_path, recording_roots[0][0]):
                     recording_roots.append((previous_recording_path, False))
+
+            history_asset_roots = [
+                (info.THUMBNAIL_PATH, target_thumb_path),
+                (info.TITLE_PATH, target_title_path),
+                (info.BLENDER_PATH, target_blender_path),
+                (info.PROTOBUF_DATA_PATH, target_protobuf_path),
+                (info.CLIPBOARD_PATH, target_clipboard_path),
+                (info.COMFYUI_OUTPUT_PATH, target_comfy_output_path),
+                (info.PROXY_PATH, target_proxy_path),
+            ] + [(root, target_recording_path) for root, _move in recording_roots]
 
             def relocate_effect_protobuf(effect):
                 if not isinstance(effect, dict) or "protobuf_data_path" not in effect:
@@ -1550,6 +1611,9 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
             log.error(
                 "Error while moving temp paths to project assets folder %s",
                 asset_path, exc_info=1)
+        finally:
+            # Some assets may already have moved even if a later copy failed.
+            self._relocate_history_assets(history_asset_roots)
 
     def add_to_recent_files(self, file_path):
         """ Add this project to the recent files list """

--- a/src/classes/project_data.py
+++ b/src/classes/project_data.py
@@ -1300,9 +1300,13 @@ class ProjectDataStore(JsonDataStore, UpdateInterface):
 
     def move_temp_paths_to_project_folder(self, file_path, previous_path=None):
         """ Move all temp files (such as Thumbnails, Titles, and Blender animations) to the project asset folder. """
+        # Fail the save before relocating media or writing the project when its
+        # asset directory cannot be created (permissions, disk full, etc.).
+        asset_path = get_assets_path(file_path)
+        if not asset_path:
+            raise OSError("Unable to create project assets for %s" % file_path)
         try:
-            # Get or generate asset folder name, max 30 chars of filename + "_assets"
-            asset_path = get_assets_path(file_path)
+            # Resolve destination folders before moving assets.
             target_thumb_path = os.path.join(asset_path, "thumbnail")
             target_title_path = os.path.join(asset_path, "title")
             target_blender_path = os.path.join(asset_path, "blender")

--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -128,6 +128,13 @@ class TimelineSync(UpdateInterface):
         except Exception as e:
             log.error("Error applying JSON to timeline object in libopenshot: %s. %s" %
                      (e, action.json(is_array=True)))
+        finally:
+            # Refresh borrowed clip/effect pointers before another update listener
+            # can process UI events, including between actions in an undo/redo.
+            if action.key and action.key[0] == "clips":
+                preview = getattr(self.window, "videoPreview", None)
+                if preview is not None:
+                    preview.refreshTriggered()
 
         # Cache stays off — re-enabled when the user seeks or starts playback
 

--- a/src/classes/timeline.py
+++ b/src/classes/timeline.py
@@ -134,7 +134,9 @@ class TimelineSync(UpdateInterface):
             if action.key and action.key[0] == "clips":
                 preview = getattr(self.window, "videoPreview", None)
                 if preview is not None:
-                    preview.refreshTriggered()
+                    # ProjectDataStore has not applied this action yet. Reading
+                    # queries here would cache old data under the new version.
+                    preview.refreshTriggered(refresh_project=False)
 
         # Cache stays off — re-enabled when the user seeks or starts playback
 

--- a/src/tests/test_sentry_sep12.py
+++ b/src/tests/test_sentry_sep12.py
@@ -215,7 +215,7 @@ class SentrySeptemberTests(unittest.TestCase):
             win=window, transforming_clips=[], transforming_clip_objects=[],
             transforming_clip=None, transforming_clip_object=None,
             transforming_effect=None, transforming_effect_object=None)
-        preview.refreshTriggered = lambda: self.video.VideoWidget.refreshTriggered(preview)
+        preview.refreshTriggered = lambda **kw: self.video.VideoWidget.refreshTriggered(preview, **kw)
         window.videoPreview = preview
         manager = UpdateManager()
         manager.add_listener(types.SimpleNamespace(changed=lambda action: TimelineSync.changed(sync, action)))
@@ -315,3 +315,97 @@ class SentrySeptemberTests(unittest.TestCase):
             self.assertIsNone(preview.transforming_clip_object)
             self.assertIsNone(preview.transforming_effect)
         timeline.Clear()
+
+    def test_repeated_splits_keep_clip_edges_adjacent(self):
+        from classes.timeline import TimelineSync
+        from classes.updates import UpdateManager
+        store = make_store()
+        reader = openshot.DummyReader(openshot.Fraction(24, 1), 320, 180, 44100, 2, 600.0)
+        source = openshot.Clip(reader)
+        source.Id('long-clip')
+        source.Position(10)
+        source.Start(30)
+        source.End(530)
+        data = json.loads(source.Json())
+        store._data = {'clips': [data], 'effects': [], 'layers': [], 'fps': {'num': 24, 'den': 1}}
+        manager = UpdateManager()
+        manager.add_listener(store)
+        window = Mock()
+        native = openshot.Timeline(320, 180, openshot.Fraction(24, 1), 44100, 2, openshot.LAYOUT_STEREO)
+        native.ApplyJsonDiff(json.dumps([{'type': 'insert', 'key': ['clips'], 'value': data}]))
+        sync = types.SimpleNamespace(timeline=native, window=window)
+        window.timeline_sync = sync
+        window.proxy_service = None
+        preview = types.SimpleNamespace(win=window, transforming_clips=[], transforming_clip_objects=[],
+                                        transforming_clip=None, transforming_clip_object=None,
+                                        transforming_effect=None, transforming_effect_object=None)
+        preview.refreshTriggered = lambda **kw: self.video.VideoWidget.refreshTriggered(preview, **kw)
+        window.videoPreview = preview
+        manager.add_listener(types.SimpleNamespace(changed=lambda action: TimelineSync.changed(sync, action)), 0)
+        helper = Mock(window=window, show_wait_spinner=False)
+        helper.delete_invalid_timeline_item.side_effect = lambda item: self.timeline.TimelineView.delete_invalid_timeline_item(helper, item)
+        helper.update_clip_data.side_effect = lambda data, **kw: self.timeline.TimelineView.update_clip_data(helper, data, **kw)
+        helper.get_uuid.side_effect = ['cut-1', 'cut-2', 'cut-3', 'keep-left']
+        with patch.object(self.app, 'project', store), patch.object(self.app, 'updates', manager), \
+                patch.object(self.app, 'window', window):
+            for cut in (110, 210, 310):
+                target = max(store._data['clips'], key=lambda clip: clip['position'])
+                preview.transforming_clips = [Clip.get(id=target['id'])]
+                preview.refreshTriggered()
+                self.timeline.TimelineView.Slice_Triggered(helper, self.timeline.MenuSlice.KEEP_BOTH,
+                                                         [target['id']], [], cut)
+                clips = sorted(store._data['clips'], key=lambda clip: clip['position'])
+                self.assertEqual([c.data for c in Clip.filter()], store._data['clips'])
+                for left, right in zip(clips, clips[1:]):
+                    self.assertAlmostEqual(left['position'] + left['end'] - left['start'], right['position'])
+                    self.assertAlmostEqual(left['end'], right['start'])
+                self.assertAlmostEqual(sum(c['end'] - c['start'] for c in clips), 500)
+            # Keeping ten seconds and dragging between tracks must not restore
+            # source duration from a query cached before the trim was committed.
+            first = clips[0]
+            preview.transforming_clips = [Clip.get(id=first['id'])]
+            preview.refreshTriggered()
+            self.timeline.TimelineView.Slice_Triggered(helper, self.timeline.MenuSlice.KEEP_LEFT,
+                                                     [first['id']], [], 20)
+            expected_end = 40 + 1 / 24  # KEEP_LEFT includes the playhead frame.
+            for layer in (1, 0):
+                moved = Clip.get(id=first['id'])
+                moved.data['layer'] = layer
+                helper.update_clip_data(moved.data, only_basic_props=True, ignore_reader=True)
+                saved = next(c for c in store._data['clips'] if c['id'] == first['id'])
+                self.assertAlmostEqual(saved['end'], expected_end)
+                self.assertEqual(saved['start'], 30)
+                self.assertEqual(saved['position'], 10)
+                self.assertEqual(saved['layer'], layer)
+                self.assertEqual(Clip.get(id=first['id']).data, saved)
+        native.Clear()
+
+    def test_razor_consumes_title_and_body_clicks_without_menus_or_drag_release(self):
+        from qt_api import QPointF, QRectF, Qt
+        from windows.views.timeline_backend.qwidget.base import TimelineWidgetBase
+        for item_type in ('clip', 'transition'):
+            for y in (20, 80):
+                with self.subTest(item_type=item_type, y=y):
+                    item = types.SimpleNamespace(id='item')
+                    helper = Mock(enable_razor=True, _press_hit=None)
+                    helper._is_timeline_content_pos.return_value = True
+                    helper.geometry.iter_items.return_value = [(QRectF(10, 10, 200, 100), item, False, item_type)]
+                    helper._seconds_from_x.return_value = 10.0
+                    helper._handle_razor_press.side_effect = lambda pos: TimelineWidgetBase._handle_razor_press(helper, pos)
+                    helper._clear_pending_clip_menu_click.side_effect = lambda: TimelineWidgetBase._clear_pending_clip_menu_click(helper)
+                    helper._clear_pending_transition_menu_click.side_effect = lambda: TimelineWidgetBase._clear_pending_transition_menu_click(helper)
+                    helper._playhead_time_panel_rect.return_value = QRectF()
+                    helper._track_toolbar_button_at.return_value = None
+                    helper._handle_menu_icon_clicks.return_value = False
+                    event = types.SimpleNamespace(pos=lambda: QPointF(50, y), button=lambda: Qt.LeftButton,
+                                                  accept=Mock())
+                    TimelineWidgetBase.mousePressEvent(helper, event)
+                    helper.RazorSliceAtCursor.assert_called_once_with(
+                        'item' if item_type == 'clip' else '',
+                        'item' if item_type == 'transition' else '', 10.0)
+                    helper._begin_pending_clip_menu_click.assert_not_called()
+                    helper._begin_pending_transition_menu_click.assert_not_called()
+                    helper._handle_menu_icon_clicks.assert_not_called()
+                    TimelineWidgetBase.mouseReleaseEvent(helper, event)
+                    helper.events.released.emit.assert_not_called()
+                    self.assertIsNone(helper._press_hit)

--- a/src/tests/test_sentry_sep12.py
+++ b/src/tests/test_sentry_sep12.py
@@ -1,0 +1,203 @@
+"""Regression coverage for the September 12 Sentry fixes."""
+
+import copy
+import importlib
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+import openshot
+from qt_api import QComboBox, QLabel, QRect
+from classes.query import Clip
+from tests.qt_test_app import get_or_create_app
+from tests.test_project_data import DummyApp, ensure_app_state, make_store
+
+
+class SentrySeptemberTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app, _ = get_or_create_app(DummyApp)
+        ensure_app_state(cls.app)
+        metrics = types.ModuleType("classes.metrics")
+        metrics.track_metric_screen = Mock()
+        metrics.track_metric_error = Mock()
+        with patch.dict(sys.modules, {"classes.metrics": metrics}):
+            cls.export = importlib.import_module("windows.export")
+            cls.title = importlib.import_module("windows.title_editor")
+            cls.video = importlib.import_module("windows.video_widget")
+            cls.timeline = importlib.import_module("windows.views.timeline")
+
+    def test_preview_title_before_worker_start_and_after_shutdown(self):
+        dock = Mock()
+        helper = Mock()
+        helper.centeredViewport.return_value = QRect(0, 0, 320, 180)
+        helper.devicePixelRatioF.return_value = 1
+        helper.parent.return_value.parent.return_value = dock
+        helper.settings = {"preview-fps": False}
+        helper.region_enabled = False
+        helper.transforming_effect = False
+        helper.transforming_clips = False
+        player = Mock()
+        player.Mode.return_value = openshot.PLAYBACK_PLAY
+        player.Speed.return_value = 2.0
+        app = types.SimpleNamespace(_tr=lambda text: text)
+        with patch.object(self.video, "get_app", return_value=app):
+            for window in (types.SimpleNamespace(), types.SimpleNamespace(preview_thread=None)):
+                helper.win = window
+                self.video.VideoWidget.update_title(helper)
+                dock.setWindowTitle.assert_called_with("Video Preview")
+            helper.win = types.SimpleNamespace(preview_thread=types.SimpleNamespace(player=player))
+            self.video.VideoWidget.update_title(helper)
+            dock.setWindowTitle.assert_called_with("Video Preview (2.0x)")
+            player.Mode.return_value = openshot.PLAYBACK_PAUSED
+            self.video.VideoWidget.update_title(helper)
+            dock.setWindowTitle.assert_called_with("Video Preview")
+
+    def test_channel_layout_combo_clear_preserves_native_layout(self):
+        combo = QComboBox()
+        timeline = openshot.Timeline(320, 180, openshot.Fraction(30, 1),
+                                     44100, 2, openshot.LAYOUT_STEREO)
+        helper = Mock()
+        helper.timeline = timeline
+        helper.cboChannelLayout = combo
+        for name, value in {"Width": 320, "Height": 180, "FrameRateNum": 30,
+                            "FrameRateDen": 1, "SampleRate": 44100, "Channels": 2}.items():
+            getattr(helper, "txt" + name).value.return_value = value
+        errors = []
+
+        def changed(index):
+            try:
+                self.export.Export.updateFrameRate(helper, False)
+            except Exception as ex:
+                errors.append(ex)
+
+        app = types.SimpleNamespace(project={"fps": {"num": 30, "den": 1}})
+        with patch.object(self.export, "get_app", return_value=app):
+            combo.currentIndexChanged.connect(changed)
+            combo.addItem("Mono", openshot.LAYOUT_MONO)
+            self.assertEqual(timeline.info.channel_layout, openshot.LAYOUT_MONO)
+            combo.clear()
+            self.assertEqual(timeline.info.channel_layout, openshot.LAYOUT_MONO)
+            combo.addItem("Stereo", openshot.LAYOUT_STEREO)
+            self.assertEqual(timeline.info.channel_layout, openshot.LAYOUT_STEREO)
+        self.assertEqual(errors, [])
+
+    def test_failed_asset_creation_aborts_save_before_mutating_project(self):
+        store = make_store()
+        store._data = {"clips": [], "files": []}
+        store.current_filepath = "original.osp"
+        store.has_unsaved_changes = True
+        original = copy.deepcopy(store._data)
+        with tempfile.TemporaryDirectory() as root:
+            destination = os.path.join(root, "new.osp")
+            with patch("classes.assets.os.mkdir", side_effect=PermissionError("denied")), \
+                    patch.object(store, "write_to_file") as write, \
+                    patch.object(store, "_sync_asset_root") as sync:
+                with self.assertRaisesRegex(OSError, "Unable to create project assets"):
+                    store.save(destination)
+                write.assert_not_called()
+                sync.assert_not_called()
+            self.assertEqual(store._data, original)
+            self.assertEqual(store.current_filepath, "original.osp")
+            self.assertTrue(store.has_unsaved_changes)
+            # The user can retry in a writable location; no poisoned save state.
+            with patch.object(store, "_sync_asset_root"), \
+                    patch("classes.project_data.log.error") as error:
+                store.move_temp_paths_to_project_folder(destination)
+                error.assert_not_called()
+            self.assertTrue(os.path.isdir(os.path.join(root, "new_assets", "title")))
+
+    def test_late_clip_update_does_not_reinsert_deleted_clip(self):
+        helper = Mock()
+        helper.delete_invalid_timeline_item.return_value = False
+        helper.show_wait_spinner = False
+        partial = {"id": "deleted", "layer": 3000000, "position": 0.0,
+                   "start": 0.0, "end": 115.593, "duration": 115.593}
+        with patch.object(Clip, "get", return_value=None), \
+                patch.object(Clip, "save") as save:
+            self.timeline.TimelineView.update_clip_data(helper, json.dumps(partial))
+            save.assert_not_called()
+            helper.window.IgnoreUpdates.emit.assert_not_called()
+
+    def test_new_clip_keeps_reader_and_existing_clip_uses_partial_update(self):
+        helper = Mock()
+        helper.delete_invalid_timeline_item.return_value = False
+        helper.show_wait_spinner = False
+        reader = openshot.DummyReader(openshot.Fraction(30, 1), 320, 180, 44100, 2, 10.0)
+        native_clip = openshot.Clip(reader)
+        data = json.loads(native_clip.Json())
+        data["id"] = "clip"
+        saved = []
+        with patch.object(Clip, "get", return_value=None), \
+                patch.object(Clip, "save", autospec=True,
+                             side_effect=lambda clip: saved.append(copy.deepcopy(clip.data))):
+            self.timeline.TimelineView.update_clip_data(helper, copy.deepcopy(data),
+                                                        only_basic_props=True, ignore_reader=True)
+        self.assertEqual(saved[0]["reader"], data["reader"])
+        self.assertIn("alpha", saved[0])
+        existing = Clip()
+        existing.id, existing.type, existing.data = "clip", "update", data
+        with patch.object(Clip, "get", return_value=existing), \
+                patch.object(Clip, "save", autospec=True,
+                             side_effect=lambda clip: saved.append(copy.deepcopy(clip.data))):
+            self.timeline.TimelineView.update_clip_data(helper, copy.deepcopy(data))
+        self.assertNotIn("reader", saved[1])
+        self.assertEqual(saved[1]["id"], "clip")
+        self.assertEqual(saved[1]["end"], data["end"])
+
+    def test_svg_preview_recovers_after_unreadable_title(self):
+        label = QLabel()
+        label.resize(320, 180)
+        helper = types.SimpleNamespace(lblPreviewLabel=label, thumbnailReady=Mock())
+        app = types.SimpleNamespace(devicePixelRatio=lambda: 1)
+        with tempfile.TemporaryDirectory() as root, \
+                patch.object(self.title, "get_app", return_value=app):
+            helper.filename = os.path.join(root, "title.svg")
+            for contents in (None, "<svg", '<svg xmlns="http://www.w3.org/2000/svg" '
+                             'width="320" height="180"><rect width="320" height="180" '
+                             'fill="red"/></svg>'):
+                if contents is not None:
+                    with open(helper.filename, "w") as svg:
+                        svg.write(contents)
+                self.title.TitleEditor.display_svg(helper)
+                pixmap = helper.thumbnailReady.emit.call_args[0][0]
+                if contents is None or contents == "<svg":
+                    self.assertTrue(pixmap.isNull())
+                else:
+                    self.assertFalse(pixmap.isNull())
+                    self.assertGreater(pixmap.toImage().pixelColor(160, 90).red(), 200)
+
+    def test_title_worker_is_reusable_after_failure(self):
+        helper = types.SimpleNamespace(filename="title.svg", xmldoc=object(),
+                                       is_thread_busy=False, writeToFile=Mock(),
+                                       display_svg=Mock(side_effect=RuntimeError("render failed")))
+        with self.assertRaisesRegex(RuntimeError, "render failed"):
+            self.title.TitleEditor.save_and_reload_thread(helper)
+        self.assertFalse(helper.is_thread_busy)
+        helper.display_svg.side_effect = None
+        self.title.TitleEditor.save_and_reload_thread(helper)
+        self.assertFalse(helper.is_thread_busy)
+        self.assertEqual(helper.display_svg.call_count, 2)
+
+    def test_svg_thumbnail_failure_closes_reader_and_removes_temp_file(self):
+        label = QLabel()
+        label.resize(320, 180)
+        helper = types.SimpleNamespace(filename="title.svg", lblPreviewLabel=label,
+                                       thumbnailReady=Mock())
+        reader = Mock()
+        reader.info = types.SimpleNamespace(width=320, height=180)
+        reader.GetFrame.return_value.Thumbnail.side_effect = RuntimeError("render failed")
+        app = types.SimpleNamespace(devicePixelRatio=lambda: 1)
+        with tempfile.TemporaryDirectory() as root:
+            descriptor, path = tempfile.mkstemp(dir=root)
+            with patch.object(self.title.openshot, "QtImageReader", return_value=reader), \
+                    patch.object(self.title, "get_app", return_value=app), \
+                    patch.object(self.title.tempfile, "mkstemp", return_value=(descriptor, path)):
+                self.title.TitleEditor.display_svg(helper)
+            reader.Close.assert_called_once_with()
+            self.assertFalse(os.path.exists(path))
+            self.assertTrue(helper.thumbnailReady.emit.call_args[0][0].isNull())

--- a/src/tests/test_sentry_sep12.py
+++ b/src/tests/test_sentry_sep12.py
@@ -201,3 +201,117 @@ class SentrySeptemberTests(unittest.TestCase):
             reader.Close.assert_called_once_with()
             self.assertFalse(os.path.exists(path))
             self.assertTrue(helper.thumbnailReady.emit.call_args[0][0].isNull())
+
+    def test_redo_title_delete_refreshes_native_selection_before_next_listener(self):
+        from classes.timeline import TimelineSync
+        from classes.updates import UpdateAction, UpdateManager
+
+        timeline = openshot.Timeline(320, 180, openshot.Fraction(30, 1),
+                                     44100, 2, openshot.LAYOUT_STEREO)
+        window = types.SimpleNamespace(proxy_service=None, IgnoreUpdates=Mock(), verifySelections=Mock())
+        sync = types.SimpleNamespace(timeline=timeline, window=window)
+        window.timeline_sync = sync
+        preview = types.SimpleNamespace(
+            win=window, transforming_clips=[], transforming_clip_objects=[],
+            transforming_clip=None, transforming_clip_object=None,
+            transforming_effect=None, transforming_effect_object=None)
+        preview.refreshTriggered = lambda: self.video.VideoWidget.refreshTriggered(preview)
+        window.videoPreview = preview
+        manager = UpdateManager()
+        manager.add_listener(types.SimpleNamespace(changed=lambda action: TimelineSync.changed(sync, action)))
+        observed = []
+        manager.add_listener(types.SimpleNamespace(changed=lambda action: observed.append(
+            [clip.id for clip in preview.transforming_clips])))
+        rows = {}
+        with tempfile.TemporaryDirectory() as root:
+            path = os.path.join(root, 'title.svg')
+            with open(path, 'w') as stream:
+                stream.write('<svg xmlns="http://www.w3.org/2000/svg" width="32" height="18">'
+                             '<rect width="32" height="18" fill="red"/></svg>')
+            source = openshot.Clip(path)
+            source.Id('title')
+            source.End(10)
+            value = json.loads(source.Json())
+            survivor = copy.deepcopy(value)
+            survivor['id'] = 'survivor'
+            for data in (value, survivor):
+                timeline.ApplyJsonDiff(json.dumps([{
+                    'type': 'insert', 'key': ['clips'], 'value': data}]))
+                rows[data['id']] = types.SimpleNamespace(id=data['id'], data=data)
+            preview.transforming_clips = list(rows.values())
+            preview.transforming_clip_objects = [timeline.GetClip(cid) for cid in rows]
+            preview.transforming_clip = rows['title']
+            preview.transforming_clip_object = timeline.GetClip('title')
+            with patch.object(self.video.Clip, 'get', side_effect=lambda id: rows.get(id)), \
+                    patch('classes.updates.get_app', return_value=types.SimpleNamespace(window=window)):
+                # Move five times, undo those moves, then redo through deletion.
+                # Keep the project rows stale until after dispatch, matching the
+                # native listener running ahead of the project-data listener.
+                for position in range(1, 6):
+                    action = UpdateAction('update', ['clips', {'id': 'title'}],
+                                          {'position': position}, {'position': position - 1})
+                    manager.actionHistory.append(action)
+                    manager.dispatch_action(action)
+                    self.assertEqual(preview.transforming_clip_object.Position(), position)
+                deleted_value = dict(value, position=5)
+                action = UpdateAction('delete', ['clips', {'id': 'title'}], None, deleted_value)
+                manager.actionHistory.append(action)
+                manager.dispatch_action(action)
+                self.assertEqual(observed[-1], ['survivor'])
+                manager.undo()
+                # Select the restored title, then undo/redo its five moves.
+                preview.transforming_clips = list(rows.values())
+                preview.refreshTriggered()
+                for position in range(4, -1, -1):
+                    manager.undo()
+                    self.assertEqual(preview.transforming_clip_object.Position(), position)
+                for position in range(1, 6):
+                    manager.redo()
+                    self.assertEqual(preview.transforming_clip_object.Position(), position)
+                manager.redo()
+                self.assertIsNone(timeline.GetClip('title'))
+                self.assertEqual(observed[-1], ['survivor'])
+                self.assertEqual([c.id for c in preview.transforming_clips], ['survivor'])
+                self.assertEqual(len(preview.transforming_clip_objects), 1)
+                self.assertEqual(preview.transforming_clip_object.Id(), 'survivor')
+                self.assertEqual(preview.transforming_clip_objects[0].Id(), 'survivor')
+                # Deleting the remaining selected clip clears every borrowed pointer.
+                manager.dispatch_action(UpdateAction('delete', ['clips', {'id': 'survivor'}]))
+                self.assertEqual(preview.transforming_clip_objects, [])
+                self.assertIsNone(preview.transforming_clip_object)
+                self.assertIsNone(preview.transforming_clip)
+        timeline.Clear()
+
+    def test_refresh_rebinds_replaced_effect_and_clears_deleted_effect(self):
+        timeline = openshot.Timeline(320, 180, openshot.Fraction(30, 1),
+                                     44100, 2, openshot.LAYOUT_STEREO)
+        reader = openshot.DummyReader(openshot.Fraction(30, 1), 320, 180, 44100, 2, 10.0)
+        source = openshot.Clip(reader)
+        source.Id('clip')
+        effect = openshot.Crop()
+        effect.Id('crop')
+        source.AddEffect(effect)
+        value = json.loads(source.Json())
+        timeline.ApplyJsonDiff(json.dumps([{'type': 'insert', 'key': ['clips'], 'value': value}]))
+        clip_row = types.SimpleNamespace(id='clip')
+        effect_row = types.SimpleNamespace(id='crop')
+        preview = types.SimpleNamespace(
+            win=types.SimpleNamespace(timeline_sync=types.SimpleNamespace(timeline=timeline)),
+            transforming_clips=[], transforming_clip_objects=[],
+            transforming_clip=clip_row, transforming_clip_object=timeline.GetClip('clip'),
+            transforming_effect=effect_row, transforming_effect_object=timeline.GetClipEffect('crop'))
+        with patch.object(self.video.Clip, 'get', return_value=clip_row), \
+                patch.object(self.video.Effect, 'get', return_value=effect_row):
+            # Full clip updates replace the effect even when its ID is unchanged.
+            timeline.ApplyJsonDiff(json.dumps([{
+                'type': 'update', 'key': ['clips', {'id': 'clip'}], 'value': value}]))
+            self.video.VideoWidget.refreshTriggered(preview)
+            self.assertEqual(int(preview.transforming_effect_object.this),
+                             int(timeline.GetClipEffect('crop').this))
+            timeline.ApplyJsonDiff(json.dumps([{
+                'type': 'delete', 'key': ['clips', {'id': 'clip'}], 'value': None}]))
+            self.video.VideoWidget.refreshTriggered(preview)
+            self.assertIsNone(preview.transforming_effect_object)
+            self.assertIsNone(preview.transforming_clip_object)
+            self.assertIsNone(preview.transforming_effect)
+        timeline.Clear()

--- a/src/tests/test_sentry_workflow_audit.py
+++ b/src/tests/test_sentry_workflow_audit.py
@@ -24,7 +24,7 @@ class SentryWorkflowAuditTests(unittest.TestCase):
     def setUpClass(cls):
         test_sentry_sep12.SentrySeptemberTests.setUpClass.__func__(cls)
 
-    def test_clip_effect_edit_and_deletion_round_trip(self):
+    def test_insert_edit_effect_delete_and_history_keep_all_layers_consistent(self):
         store = make_store()
         store._data = {'clips': [], 'effects': [], 'layers': [], 'fps': {'num': 30, 'den': 1}}
         manager = UpdateManager()
@@ -76,6 +76,11 @@ class SentryWorkflowAuditTests(unittest.TestCase):
             self.assertEqual(native.GetClip(cid).End(), 25)
             self.assertAlmostEqual(json.loads(native.GetClipEffect('crop').PropertiesJSON(1))['left']['value'], 0.2)
             self.assertEqual(int(preview.transforming_effect_object.this), int(native.GetClipEffect('crop').this))
+            crop = Effect.get(id='crop')
+            crop.data['left']['Points'][0]['co']['Y'] = 0.4
+            crop.save()
+            after_effect = copy.deepcopy(store._data['clips'])
+            self.assertAlmostEqual(json.loads(native.GetClipEffect('crop').PropertiesJSON(1))['left']['value'], 0.4)
             Clip.get(id=cid).delete()
             self.assertIsNone(preview.transforming_clip_object)
             self.assertIsNone(preview.transforming_effect_object)
@@ -83,12 +88,14 @@ class SentryWorkflowAuditTests(unittest.TestCase):
             # A queued partial edit must not resurrect the deleted clip.
             helper.update_clip_data(dict(id=cid, position=12, start=7, end=25, duration=18, layer=2))
             self.assertEqual(store._data['clips'], [])
-            self.assertEqual(len(manager.actionHistory), 3)
-            for expected in (after_edit, baseline):
+            self.assertEqual(len(manager.actionHistory), 4)
+            self.assertEqual(manager.actionHistory[0].values, baseline[0])
+            self.assertEqual(manager.actionHistory[1].values['effects'], after_edit[0]['effects'])
+            for expected in (after_effect, after_edit, baseline, []):
                 manager.undo()
                 self.assertEqual(store._data['clips'], expected)
                 self.assertEqual(bool(native.GetClip(cid)), bool(expected))
-            for expected in (after_edit, []):
+            for expected in (baseline, after_edit, after_effect, []):
                 manager.redo()
                 self.assertEqual(store._data['clips'], expected)
                 self.assertEqual(bool(native.GetClip(cid)), bool(expected))
@@ -108,6 +115,7 @@ class SentryWorkflowAuditTests(unittest.TestCase):
                 path = os.path.join(user_path, name.lower())
                 os.makedirs(path)
                 stack.enter_context(patch.object(info, name, path))
+                stack.enter_context(patch.dict(info._path_defaults, {name: path}))
             title_path = os.path.join(info.TITLE_PATH, 'title.svg')
             svg = '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="18"><rect width="32" height="18" fill="red"/></svg>'
             with open(title_path, 'w') as stream:
@@ -126,12 +134,31 @@ class SentryWorkflowAuditTests(unittest.TestCase):
                                      {'id': 'generated', 'reader': {}, 'effects': [{'protobuf_data_path': tracking_path}]}]}
             stack.enter_context(patch.object(store, 'add_to_recent_files'))
             stack.enter_context(patch.object(self.app, 'project', store))
+            manager = UpdateManager()
+            manager.add_listener(store)
+            stack.enter_context(patch.object(self.app, 'updates', manager))
+            stack.enter_context(patch.object(self.app, 'window', Mock()))
+            initial = store._data
+            store._data = {'files': [], 'clips': [], 'history': {'undo': [], 'redo': []}}
+            for collection in ('files', 'clips'):
+                for value in initial[collection]:
+                    manager.insert([collection], value)
+            # This recording has no live file/clip record when the project saves.
+            history_only_path = os.path.join(user_path, 'recordings', 'undone.mov')
+            with open(history_only_path, 'wb') as stream:
+                stream.write(b'undone recording')
+            manager.insert(['files'], {'id': 'undone', 'path': history_only_path})
+            manager.undo()
             reopened = []
             for name in ('first', 'second'):
                 destination = os.path.join(root, name + '.osp')
+                manager.save_history(store, 100)
                 store.save(destination)
                 data = store.read_from_file(destination, path_mode='absolute')
                 reopened.append(data)
+                if name == 'first':
+                    self.assertFalse(os.path.exists(title_path))
+                    self.assertFalse(os.path.exists(recording_path))
                 for record in data['files']:
                     self.assertTrue(os.path.isfile(record['path']))
                     self.assertTrue(record['path'].startswith(os.path.join(root, name + '_assets')))
@@ -149,8 +176,79 @@ class SentryWorkflowAuditTests(unittest.TestCase):
                     self.assertEqual(restored_title.GetFrame(1).GetWidth(), 32)
                 finally:
                     restored_title.Close()
+                # Active history and reopened history must both restore usable
+                # media, without changing the original clip's trim or position.
+                for active in (True, False):
+                    replay_store = store if active else make_store()
+                    replay_manager = manager if active else UpdateManager()
+                    if not active:
+                        replay_store._data = copy.deepcopy(data)
+                        replay_manager.add_listener(replay_store)
+                        replay_manager.load_history(replay_store)
+                    with patch.object(self.app, 'project', replay_store), \
+                            patch.object(self.app, 'updates', replay_manager):
+                        replay_manager.redo()
+                        undone = replay_store._data['files'][-1]
+                        self.assertEqual(undone['id'], 'undone')
+                        self.assertTrue(undone['path'].startswith(os.path.join(root, name + '_assets')))
+                        with open(undone['path'], 'rb') as stream:
+                            self.assertEqual(stream.read(), b'undone recording')
+                        replay_manager.undo()
+                        for _ in range(3):
+                            replay_manager.undo()
+                        self.assertEqual(replay_store._data['clips'], [])
+                        for _ in range(3):
+                            replay_manager.redo()
+                        restored = replay_store._data['clips'][0]
+                        self.assertEqual((restored['start'], restored['end'], restored['position']), (0, 10, 10))
+                        self.assertEqual(restored['reader']['path'], data['clips'][0]['reader']['path'])
+                        self.assertTrue(os.path.exists(restored['reader']['path']))
+                        self.assertTrue(os.path.exists(replay_store._data['clips'][1]['reader']['path']))
             # Save As must leave the first project's media intact and independent.
             self.assertNotEqual(reopened[0]['files'][1]['path'], reopened[1]['files'][1]['path'])
             for data in reopened:
                 with open(data['files'][1]['path'], 'rb') as stream:
                     self.assertEqual(stream.read(), recording_bytes)
+
+    def test_history_asset_relocation_preserves_external_paths_and_failed_copies(self):
+        from classes.updates import UpdateAction
+        store = make_store()
+        store._data = {'history': {'undo': [], 'redo': []}}
+        manager = UpdateManager()
+        manager.add_listener(store)
+        with tempfile.TemporaryDirectory() as root, \
+                patch.object(self.app, 'project', store), patch.object(self.app, 'updates', manager):
+            source = os.path.join(root, 'assets')
+            target = os.path.join(root, 'saved_assets')
+            os.makedirs(source)
+            paths = [os.path.join(source, name) for name in ('new.svg', 'old.svg')]
+            for path in paths:
+                with open(path, 'w') as stream:
+                    stream.write(path)
+            external = os.path.join(root, 'assets-other', 'external.svg')
+            payload = {'reader': {'path': paths[0]}, 'title': paths[0], 'position': 12,
+                       'effects': [{'resource': external}]}
+            manager.actionHistory = [UpdateAction('update', ['clips', {'id': 'clip'}], copy.deepcopy(payload))]
+            manager.redoHistory = [UpdateAction('update', ['files', {'id': 'file'}, 'path'], paths[0], paths[1])]
+            manager.save_history(store, 100)
+            original_copy = store._copy_recording_asset
+
+            def copy_asset(source_path, destination):
+                if source_path == paths[1]:
+                    raise PermissionError('inaccessible source')
+                return original_copy(source_path, destination)
+
+            with patch.object(store, '_copy_recording_asset', side_effect=copy_asset), \
+                    patch('classes.project_data.log.warning') as warning:
+                store._relocate_history_assets([(source, target)])
+            self.assertTrue(warning.called)
+            updated = manager.actionHistory[0].values
+            self.assertEqual(updated['reader']['path'], os.path.join(target, 'new.svg'))
+            self.assertEqual(updated['title'], paths[0])
+            self.assertEqual(updated['position'], 12)
+            self.assertEqual(updated['effects'][0]['resource'], external)
+            self.assertEqual(manager.redoHistory[0].values, os.path.join(target, 'new.svg'))
+            self.assertEqual(manager.redoHistory[0].old_values, paths[1])
+            self.assertEqual(store._data['history']['redo'][0]['old_values'], paths[1])
+            self.assertTrue(all(os.path.isfile(path) for path in paths))
+            self.assertFalse(os.path.exists(os.path.join(target, 'old.svg')))

--- a/src/tests/test_sentry_workflow_audit.py
+++ b/src/tests/test_sentry_workflow_audit.py
@@ -1,0 +1,156 @@
+"""Cross-layer coverage for the committed September Sentry fixes."""
+
+import copy
+import json
+import os
+import tempfile
+import types
+import unittest
+from contextlib import ExitStack
+from unittest.mock import Mock, patch
+
+import openshot
+from classes import info
+from classes.json_data import JsonDataStore
+from classes.query import Clip, Effect, QueryObject
+from classes.timeline import TimelineSync
+from classes.updates import UpdateManager
+from tests.test_project_data import make_store
+from tests import test_sentry_sep12
+
+
+class SentryWorkflowAuditTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        test_sentry_sep12.SentrySeptemberTests.setUpClass.__func__(cls)
+
+    def test_clip_effect_edit_and_deletion_round_trip(self):
+        store = make_store()
+        store._data = {'clips': [], 'effects': [], 'layers': [], 'fps': {'num': 30, 'den': 1}}
+        manager = UpdateManager()
+        native = openshot.Timeline(320, 180, openshot.Fraction(30, 1), 44100, 2, openshot.LAYOUT_STEREO)
+        self.addCleanup(native.Clear)
+        window = Mock(proxy_service=None)
+        sync = types.SimpleNamespace(timeline=native, window=window)
+        window.timeline_sync = sync
+        preview = types.SimpleNamespace(win=window, transforming_clips=[], transforming_clip_objects=[],
+                                        transforming_clip=None, transforming_clip_object=None,
+                                        transforming_effect=None, transforming_effect_object=None)
+        preview.refreshTriggered = lambda **kw: self.video.VideoWidget.refreshTriggered(preview, **kw)
+        window.videoPreview = preview
+        manager.add_listener(types.SimpleNamespace(changed=lambda action: TimelineSync.changed(sync, action)))
+        manager.add_listener(store)
+        # Query consumers run after the store, as geometry/properties listeners do.
+        observations = []
+        manager.add_listener(types.SimpleNamespace(changed=lambda action: observations.append(
+            (copy.deepcopy([c.data for c in Clip.filter()]), copy.deepcopy(store._data['clips'])))))
+        helper = Mock(window=window, show_wait_spinner=False)
+        helper.update_clip_data.side_effect = lambda data, **kw: self.timeline.TimelineView.update_clip_data(helper, data, **kw)
+        helper.delete_invalid_timeline_item.side_effect = lambda item: self.timeline.TimelineView.delete_invalid_timeline_item(helper, item)
+        reader = openshot.DummyReader(openshot.Fraction(30, 1), 320, 180, 44100, 2, 60.0)
+        source = openshot.Clip(reader)
+        source.Start(5)
+        source.End(35)
+        effect = openshot.Crop()
+        effect.Id('crop')
+        source.AddEffect(effect)
+        with patch.object(self.app, 'project', store), patch.object(self.app, 'updates', manager), \
+                patch.object(self.app, 'window', window):
+            QueryObject._cache_version = -1
+            # Import through the changed insertion path, including a complete reader.
+            helper.update_clip_data(json.loads(source.Json()), ignore_reader=True)
+            cid = store._data['clips'][0]['id']
+            preview.transforming_clips = [Clip.get(id=cid)]
+            preview.refreshTriggered()
+            preview.transforming_effect = Effect.get(id='crop')
+            preview.transforming_effect_object = native.GetClipEffect('crop')
+            baseline = copy.deepcopy(store._data['clips'])
+            edited = copy.deepcopy(Clip.get(id=cid).data)
+            edited.update(position=12.0, start=7.0, end=25.0, duration=18.0, layer=2)
+            edited['scale_x']['Points'][0]['co']['Y'] = 0.75
+            edited['effects'][0]['left']['Points'][0]['co']['Y'] = 0.2
+            helper.update_clip_data(edited, only_basic_props=False, ignore_reader=True)
+            after_edit = copy.deepcopy(store._data['clips'])
+            self.assertEqual(native.GetClip(cid).Position(), 12)
+            self.assertEqual(native.GetClip(cid).Start(), 7)
+            self.assertEqual(native.GetClip(cid).End(), 25)
+            self.assertAlmostEqual(json.loads(native.GetClipEffect('crop').PropertiesJSON(1))['left']['value'], 0.2)
+            self.assertEqual(int(preview.transforming_effect_object.this), int(native.GetClipEffect('crop').this))
+            Clip.get(id=cid).delete()
+            self.assertIsNone(preview.transforming_clip_object)
+            self.assertIsNone(preview.transforming_effect_object)
+            self.assertEqual(store._data['clips'], [])
+            # A queued partial edit must not resurrect the deleted clip.
+            helper.update_clip_data(dict(id=cid, position=12, start=7, end=25, duration=18, layer=2))
+            self.assertEqual(store._data['clips'], [])
+            self.assertEqual(len(manager.actionHistory), 3)
+            for expected in (after_edit, baseline):
+                manager.undo()
+                self.assertEqual(store._data['clips'], expected)
+                self.assertEqual(bool(native.GetClip(cid)), bool(expected))
+            for expected in (after_edit, []):
+                manager.redo()
+                self.assertEqual(store._data['clips'], expected)
+                self.assertEqual(bool(native.GetClip(cid)), bool(expected))
+            self.assertTrue(observations)
+            for query_data, stored_data in observations:
+                self.assertEqual(query_data, stored_data)
+
+    def test_save_and_save_as_reopen_title_recording_and_generated_clip_assets(self):
+        store = make_store()
+        JsonDataStore.__init__(store)
+        with tempfile.TemporaryDirectory() as root, ExitStack() as stack:
+            user_path = os.path.join(root, 'runtime')
+            os.makedirs(os.path.join(user_path, 'recordings'))
+            stack.enter_context(patch.object(info, 'USER_PATH', user_path))
+            for name in ('THUMBNAIL_PATH', 'TITLE_PATH', 'BLENDER_PATH', 'PROTOBUF_DATA_PATH',
+                         'CLIPBOARD_PATH', 'COMFYUI_OUTPUT_PATH', 'PROXY_PATH'):
+                path = os.path.join(user_path, name.lower())
+                os.makedirs(path)
+                stack.enter_context(patch.object(info, name, path))
+            title_path = os.path.join(info.TITLE_PATH, 'title.svg')
+            svg = '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="18"><rect width="32" height="18" fill="red"/></svg>'
+            with open(title_path, 'w') as stream:
+                stream.write(svg)
+            recording_path = os.path.join(user_path, 'recordings', 'capture.mov')
+            recording_bytes = b'recording payload for relocation verification'
+            with open(recording_path, 'wb') as stream:
+                stream.write(recording_bytes)
+            tracking_path = os.path.join(info.PROTOBUF_DATA_PATH, 'tracking.data')
+            with open(tracking_path, 'wb') as stream:
+                stream.write(b'tracking payload')
+            title = json.loads(openshot.Clip(title_path).Json())
+            title.update(id='title', file_id='F1', position=10, start=0, end=10, duration=10, layer=2)
+            store._data = {'files': [{'id': 'F1', 'path': title_path}, {'id': 'F2', 'path': recording_path}],
+                           'clips': [title, {'id': 'recording', 'file_id': 'F2', 'reader': {'path': recording_path}, 'effects': []},
+                                     {'id': 'generated', 'reader': {}, 'effects': [{'protobuf_data_path': tracking_path}]}]}
+            stack.enter_context(patch.object(store, 'add_to_recent_files'))
+            stack.enter_context(patch.object(self.app, 'project', store))
+            reopened = []
+            for name in ('first', 'second'):
+                destination = os.path.join(root, name + '.osp')
+                store.save(destination)
+                data = store.read_from_file(destination, path_mode='absolute')
+                reopened.append(data)
+                for record in data['files']:
+                    self.assertTrue(os.path.isfile(record['path']))
+                    self.assertTrue(record['path'].startswith(os.path.join(root, name + '_assets')))
+                self.assertEqual(data['clips'][0]['reader']['path'], data['files'][0]['path'])
+                self.assertEqual(data['clips'][1]['reader']['path'], data['files'][1]['path'])
+                self.assertEqual(data['clips'][0]['end'], 10)
+                with open(data['clips'][1]['reader']['path'], 'rb') as stream:
+                    self.assertEqual(stream.read(), recording_bytes)
+                with open(data['clips'][2]['effects'][0]['protobuf_data_path'], 'rb') as stream:
+                    self.assertEqual(stream.read(), b'tracking payload')
+                restored_title = openshot.Clip()
+                restored_title.SetJson(json.dumps(data['clips'][0]))
+                restored_title.Open()
+                try:
+                    self.assertEqual(restored_title.GetFrame(1).GetWidth(), 32)
+                finally:
+                    restored_title.Close()
+            # Save As must leave the first project's media intact and independent.
+            self.assertNotEqual(reopened[0]['files'][1]['path'], reopened[1]['files'][1]['path'])
+            for data in reopened:
+                with open(data['files'][1]['path'], 'rb') as stream:
+                    self.assertEqual(stream.read(), recording_bytes)

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -450,7 +450,10 @@ class Export(QDialog):
         self.timeline.info.fps.den = self.txtFrameRateDen.value()
         self.timeline.info.sample_rate = self.txtSampleRate.value()
         self.timeline.info.channels = self.txtChannels.value()
-        self.timeline.info.channel_layout = self.cboChannelLayout.currentData()
+        channel_layout = self.cboChannelLayout.currentData()
+        # Clearing/repopulating the combo emits changes without a selection.
+        if channel_layout is not None:
+            self.timeline.info.channel_layout = channel_layout
 
         # Disable audio (if not needed)
         if self.timeline.info.sample_rate == 0 or self.timeline.info.channels == 0:

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -260,44 +260,48 @@ class TitleEditor(QDialog):
         self.update_timer.start()
 
     def display_svg(self):
-        # Create a temp file for the thumbnail image
-        new_file, tmp_filename = tempfile.mkstemp(suffix=".png")
-        os.close(new_file)
+        # Select the SVG reader explicitly so an unreadable title reports the
+        # original image error instead of leaving a Clip without a reader.
+        reader = openshot.QtImageReader(self.filename, False)
+        tmp_filename = None
+        try:
+            reader.Open()
 
-        # Create a clip object and get the reader
-        clip = openshot.Clip(self.filename)
-        reader = clip.Reader()
+            # Get the device pixel ratio (for high DPI)
+            scale = get_app().devicePixelRatio()
 
-        # Get the device pixel ratio (for high DPI)
-        scale = get_app().devicePixelRatio()
+            # Get the available size (logical) and the original title size
+            avail_size = self.lblPreviewLabel.rect().size()
+            orig_size = QSize(reader.info.width, reader.info.height)
 
-        # Get the available size (logical) and the original title size
-        avail_size = self.lblPreviewLabel.rect().size()
-        orig_size = QSize(reader.info.width, reader.info.height)
+            # Compute the target rectangle that preserves the title's aspect ratio
+            target_size = orig_size.scaled(avail_size, Qt.KeepAspectRatio)
+            target_rect = QRect(QPoint(0, 0), target_size)
+            target_rect.moveCenter(self.lblPreviewLabel.rect().center())
 
-        # Compute the target rectangle that preserves the title's aspect ratio
-        target_size = orig_size.scaled(avail_size, Qt.KeepAspectRatio)
-        target_rect = QRect(QPoint(0, 0), target_size)
-        target_rect.moveCenter(self.lblPreviewLabel.rect().center())
+            # Determine thumbnail dimensions in physical pixels
+            thumb_width = round(target_rect.width() * scale)
+            thumb_height = round(target_rect.height() * scale)
 
-        # Determine thumbnail dimensions in physical pixels
-        thumb_width = round(target_rect.width() * scale)
-        thumb_height = round(target_rect.height() * scale)
+            # Generate the thumbnail.
+            new_file, tmp_filename = tempfile.mkstemp(suffix=".png")
+            os.close(new_file)
+            reader.GetFrame(1).Thumbnail(
+                tmp_filename,
+                thumb_width,
+                thumb_height,
+                "", "", "#00000000", False, "png", 85, 0.0)
 
-        # Generate the thumbnail.
-        reader.Open()
-        reader.GetFrame(1).Thumbnail(
-            tmp_filename,
-            thumb_width,
-            thumb_height,
-            "", "", "#00000000", False, "png", 85, 0.0)
-        reader.Close()
-        clip.Close()
-
-        # Load the thumbnail pixmap and set its device pixel ratio
-        preview_pixmap = QIcon(tmp_filename).pixmap(thumb_width, thumb_height)
-        preview_pixmap.setDevicePixelRatio(scale)
-        os.unlink(tmp_filename)
+            preview_pixmap = QIcon(tmp_filename).pixmap(thumb_width, thumb_height)
+            preview_pixmap.setDevicePixelRatio(scale)
+        except RuntimeError as ex:
+            log.warning("Unable to preview SVG title %s: %s", self.filename, ex)
+            self.thumbnailReady.emit(QPixmap())
+            return
+        finally:
+            reader.Close()
+            if tmp_filename is not None:
+                os.unlink(tmp_filename)
 
         # Create the final pixmap filled with the label's background color
         final_pixmap = QPixmap(avail_size * scale)
@@ -590,9 +594,11 @@ class TitleEditor(QDialog):
             return
 
         self.is_thread_busy = True
-        self.writeToFile(self.xmldoc)
-        self.display_svg()
-        self.is_thread_busy = False
+        try:
+            self.writeToFile(self.xmldoc)
+            self.display_svg()
+        finally:
+            self.is_thread_busy = False
 
     @pyqtSlot(QColor)
     def color_callback(self, save_fn, refresh_fn, color):

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -2610,16 +2610,36 @@ class VideoWidget(QWidget, updates.UpdateInterface):
     def refreshTriggered(self):
         """Signal to refresh viewport (i.e. a property might have changed that effects the preview)"""
 
-        # Update reference to clip(s)
-        if self.transforming_clips:
-            self.transforming_clips = [Clip.get(id=c.id) for c in self.transforming_clips if Clip.get(id=c.id)]
-            if self.transforming_clips:
-                self.transforming_clip = self.transforming_clips[0]
-            else:
-                self.transforming_clip = None
+        # SWIG references do not keep timeline-owned objects alive. Undo/redo
+        # can delete or replace them, so resolve both sides by their Python IDs.
+        timeline = self.win.timeline_sync.timeline
+        clips, objects = [], []
+        for selected in self.transforming_clips:
+            clip = Clip.get(id=selected.id)
+            obj = timeline.GetClip(selected.id)
+            if clip and obj:
+                clips.append(clip)
+                objects.append(obj)
+        self.transforming_clips = clips
+        self.transforming_clip_objects = objects
 
         if self.transforming_effect:
-            self.transforming_effect = Effect.get(id=self.transforming_effect.id)
+            clip_id = self.transforming_clip.id if self.transforming_clip else None
+            effect_id = self.transforming_effect.id
+            clip = Clip.get(id=clip_id) if clip_id else None
+            obj = timeline.GetClip(clip_id) if clip_id else None
+            effect = Effect.get(id=effect_id)
+            effect_obj = timeline.GetClipEffect(effect_id)
+            if clip and obj and effect and effect_obj:
+                self.transforming_clip = clip
+                self.transforming_clip_object = obj
+                self.transforming_effect = effect
+                self.transforming_effect_object = effect_obj
+                return
+        self.transforming_effect = None
+        self.transforming_effect_object = None
+        self.transforming_clip = clips[0] if clips else None
+        self.transforming_clip_object = objects[0] if objects else None
 
     def transformTriggered(self, clip_ids):
         """Handle the transform signal when it's emitted. Supports multiple clip IDs."""

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -2607,7 +2607,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
                 return object_id, object_props
         return None, None
 
-    def refreshTriggered(self):
+    def refreshTriggered(self, refresh_project=True):
         """Signal to refresh viewport (i.e. a property might have changed that effects the preview)"""
 
         # SWIG references do not keep timeline-owned objects alive. Undo/redo
@@ -2615,7 +2615,7 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         timeline = self.win.timeline_sync.timeline
         clips, objects = [], []
         for selected in self.transforming_clips:
-            clip = Clip.get(id=selected.id)
+            clip = Clip.get(id=selected.id) if refresh_project else selected
             obj = timeline.GetClip(selected.id)
             if clip and obj:
                 clips.append(clip)
@@ -2626,9 +2626,9 @@ class VideoWidget(QWidget, updates.UpdateInterface):
         if self.transforming_effect:
             clip_id = self.transforming_clip.id if self.transforming_clip else None
             effect_id = self.transforming_effect.id
-            clip = Clip.get(id=clip_id) if clip_id else None
+            clip = (Clip.get(id=clip_id) if refresh_project else self.transforming_clip) if clip_id else None
             obj = timeline.GetClip(clip_id) if clip_id else None
-            effect = Effect.get(id=effect_id)
+            effect = Effect.get(id=effect_id) if refresh_project else self.transforming_effect
             effect_obj = timeline.GetClipEffect(effect_id)
             if clip and obj and effect and effect_obj:
                 self.transforming_clip = clip

--- a/src/windows/video_widget.py
+++ b/src/windows/video_widget.py
@@ -488,9 +488,9 @@ class VideoWidget(QWidget, updates.UpdateInterface):
 
         # Display the playback speed in widget title
         speed = 0.0
-        mode = self.win.preview_thread.player.Mode()
-        if mode != openshot.PLAYBACK_PAUSED:
-            speed = self.win.preview_thread.player.Speed()
+        preview_thread = getattr(self.win, "preview_thread", None)
+        if preview_thread and preview_thread.player.Mode() != openshot.PLAYBACK_PAUSED:
+            speed = preview_thread.player.Speed()
 
         # Find parent dockWidget (if any)
         dock = None

--- a/src/windows/views/timeline.py
+++ b/src/windows/views/timeline.py
@@ -872,7 +872,12 @@ class TimelineView(updates.UpdateInterface, ViewClass):
 
         # Search for matching clip in project data (if any)
         existing_clip = Clip.get(id=clip_data.get("id"))
-        if not existing_clip:
+        is_new_clip = existing_clip is None
+        if is_new_clip:
+            # Delayed edits can arrive after a clip has been deleted. A partial
+            # update cannot recreate its reader or other media properties.
+            if not clip_data.get("reader"):
+                return
             # Create a new clip (if not exists)
             log.debug("Create new clip object from clip_data: %s" % clip_data)
             existing_clip = Clip()
@@ -884,7 +889,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
         existing_clip.data = clip_data
 
         # Remove unneeded properties (since they don't change here... this is a performance boost)
-        if only_basic_props:
+        if only_basic_props and not is_new_clip:
             existing_clip.data = {}
             existing_clip.data["id"] = clip_data["id"]
             existing_clip.data["layer"] = clip_data["layer"]
@@ -899,7 +904,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
 
         # Always remove the Reader attribute (since nothing updates it,
         # and we are wrapping clips in FrameMappers anyway)
-        if ignore_reader and "reader" in existing_clip.data:
+        if ignore_reader and not is_new_clip and "reader" in existing_clip.data:
             existing_clip.data.pop("reader")
 
         # Set transaction id (if any)

--- a/src/windows/views/timeline_backend/qwidget/base.py
+++ b/src/windows/views/timeline_backend/qwidget/base.py
@@ -3167,6 +3167,14 @@ class TimelineWidgetBase(QWidget):
 
         self.geometry.ensure()
 
+        # Razor clicks own the whole item, including its title and effect badges.
+        # Consume the release too, so it cannot open a menu or finish an old drag.
+        if content_pos and self.enable_razor and event.button() == Qt.LeftButton:
+            if self._handle_razor_press(pos):
+                self._press_hit = "razor"
+                event.accept()
+                return
+
         if event.button() == Qt.LeftButton:
             if self._playhead_time_panel_rect().contains(pos):
                 if self._start_playhead_time_edit():
@@ -3192,11 +3200,6 @@ class TimelineWidgetBase(QWidget):
             and self._handle_menu_icon_clicks(pos)
         ):
             return
-
-        if content_pos and self.enable_razor and event.button() == Qt.LeftButton:
-            if self._handle_razor_press(pos):
-                event.accept()
-                return
 
         self._assign_press_target(event)
 
@@ -3503,6 +3506,11 @@ class TimelineWidgetBase(QWidget):
     def mouseReleaseEvent(self, event):
         self._last_event = event
         posf = _event_posf(event)
+
+        if event.button() == Qt.LeftButton and self._press_hit == "razor":
+            self._press_hit = None
+            event.accept()
+            return
 
         if event.button() == Qt.LeftButton and self._toolbar_pressed_key:
             button = self._get_toolbar_button(*self._toolbar_pressed_key)


### PR DESCRIPTION
Fix several OpenShot 4.0.0 Sentry reports and editing problems found during manual testing.

**Sentry fixes:**
- OPENSHOT-F3Z0: Handle preview titles when the playback worker is unavailable.
- OPENSHOT-69HH: Preserve the audio channel layout while export options refresh.
- OPENSHOT-GZ: Abort saving safely when the project asset folder cannot be created.
- OPENSHOT-DJWP: Handle unreadable SVG titles, clean up preview resources, and allow retries.
- OPENSHOT-FJMK: Ignore delayed partial edits to deleted clips and preserve reader data when inserting new clips.

**Additional fixes:**
- Refresh borrowed native clip/effect references after edits to avoid accessing deleted objects.
- Prevent stale query data from causing overlapping slices or restoring a trimmed clip’s original length.
- Give razor clicks priority over clip-title menus.
- Keep undo snapshots independent so later edits cannot rewrite insertion history or earlier effect settings.
- Preserve asset paths in active and saved undo/redo history across Save,
Save As, and reopening, including recordings present only in undone actions.
