### PR TITLE
Trigger feedback banner after editing experience and release usage

### DIFF
--- a/src/classes/feedback.py
+++ b/src/classes/feedback.py
@@ -1,12 +1,18 @@
-"""One-time survey policy and URL metadata (no automatic network requests)."""
+"""Feedback eligibility and survey URL metadata (no automatic network requests)."""
 
 import base64
 import json
 import math
+from copy import deepcopy
+from contextvars import ContextVar
+from functools import wraps
+from inspect import signature
 from urllib.parse import urlencode
 
 SURVEY_URL = "https://www.openshot.org/{language}feedback/"
-FEEDBACK_DELAY_SECONDS = 30 * 60
+FEEDBACK_DELAY_SECONDS = 20 * 60
+FEEDBACK_ACTION_CATEGORIES = frozenset(("structure", "adjustments", "effects", "titles", "profile", "export"))
+_feedback_command_active = ContextVar("feedback_command_active", default=False)
 
 
 def survey_url(distribution, install_id, website_language=""):
@@ -45,17 +51,133 @@ def survey_url(distribution, install_id, website_language=""):
     return SURVEY_URL.format(language=website_language) + "?" + urlencode({"context": context})
 
 
-class FeedbackPolicy:
-    """Persist use across sessions; consume only on dismissal or survey navigation."""
+def record_feedback_action(category):
+    """Called after a committed user command; feedback must never break editing."""
+    from classes.app import get_app
+    from classes.logger import log
 
-    def __init__(self, settings):
+    try:
+        controller = getattr(getattr(get_app(), "window", None), "feedback_controller", None)
+        if controller:
+            controller.record_action(category)
+    except Exception:
+        log.warning("Unable to record feedback activity", exc_info=True)
+
+
+def _feedback_clip_snapshot(clip_ids):
+    """Read only the affected clips, and only while action milestones are needed."""
+    from classes.app import get_app
+    from classes.query import Clip
+    from classes.logger import log
+
+    try:
+        controller = getattr(getattr(get_app(), "window", None), "feedback_controller", None)
+        if not controller or controller.preview or controller.policy.experienced:
+            return {}
+        return {clip_id: deepcopy(clip.data) for clip_id in clip_ids
+                if (clip := Clip.get(id=clip_id)) is not None}
+    except Exception:
+        log.warning("Unable to inspect feedback activity", exc_info=True)
+        return {}
+
+
+def record_feedback_changes(category, originals, fields=None):
+    """Count a committed multi-clip operation once, excluding unchanged values."""
+    current = _feedback_clip_snapshot(originals)
+    for clip_id, data in current.items():
+        before = originals[clip_id]
+        if fields:
+            changed = any(before.get(key) != data.get(key) for key in fields)
+        else:
+            # Reader serialization is not an editing action.
+            changed = ({key: value for key, value in before.items() if key != "reader"}
+                       != {key: value for key, value in data.items() if key != "reader"})
+        if changed:
+            record_feedback_action(category)
+            break
+
+
+def feedback_command(category):
+    """Annotate a user command with a clip_ids argument, never a low-level update.
+
+    Snapshot once before the command and compare after it returns successfully.
+    This excludes no-ops and exceptions and counts multi-selection only once.
+    """
+    def decorate(command):
+        arguments = signature(command)
+        positional_count = sum(parameter.kind in (parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD)
+                               for parameter in arguments.parameters.values())
+
+        @wraps(command)
+        def tracked(*args, **kwargs):
+            # QAction adds checked(bool). A *args wrapper must discard this extra
+            # argument itself, as Qt did for the original fixed-arity handler.
+            if len(args) == positional_count + 1 and type(args[-1]) is bool:
+                args = args[:-1]
+            # Some presets delegate to other commands (e.g. volume fade in + out).
+            if _feedback_command_active.get():
+                return command(*args, **kwargs)
+            clip_ids = arguments.bind(*args, **kwargs).arguments.get("clip_ids", ())
+            before = _feedback_clip_snapshot(clip_ids)
+            token = _feedback_command_active.set(True)
+            try:
+                result = command(*args, **kwargs)
+            finally:
+                _feedback_command_active.reset(token)
+            if before:
+                record_feedback_changes(category, before)
+            return result
+        return tracked
+    return decorate
+
+
+class FeedbackPolicy:
+    """Require 3 committed actions in 2 categories, plus 20 minutes this release.
+
+    Actions survive upgrades. Only time and banner acknowledgement reset.
+    """
+
+    def __init__(self, settings, release):
         self.settings = settings
         self.unsaved_seconds = 0
+        self.dirty = False
+        previous_release = settings.get("feedback-release")
+        if release is not None and previous_release != release:
+            settings.set("feedback-release", release)
+            settings.set("feedback-use-seconds", 0)
+            # Preserve a legacy dismissal for the first release using this policy.
+            if previous_release:
+                settings.set("feedback-shown", False)
+            self.dirty = True
 
     @property
     def shown(self):
-        # Keep the original settings key so previously dismissed prompts stay dismissed.
         return bool(self.settings.get("feedback-shown"))
+
+    @property
+    def categories(self):
+        values = self.settings.get("feedback-action-categories")
+        if not isinstance(values, list):
+            return set()
+        return {value for value in values if isinstance(value, str) and value in FEEDBACK_ACTION_CATEGORIES}
+
+    @property
+    def action_count(self):
+        value = self.settings.get("feedback-action-count")
+        return min(3, max(0, value)) if type(value) is int else 0
+
+    @property
+    def experienced(self):
+        return self.action_count >= 3 and len(self.categories) >= 2
+
+    def record_action(self, category):
+        if category not in FEEDBACK_ACTION_CATEGORIES or self.experienced:
+            return
+        if self.action_count == 3 and category in self.categories:
+            return
+        self.settings.set("feedback-action-count", min(3, self.action_count + 1))
+        self.settings.set("feedback-action-categories", sorted(self.categories | {category}))
+        self.settings.save()
 
     def advance(self, seconds):
         if self.shown:
@@ -66,16 +188,24 @@ class FeedbackPolicy:
             elapsed = 0
         if not math.isfinite(elapsed) or elapsed < 0:
             elapsed = 0
+        elapsed = min(FEEDBACK_DELAY_SECONDS, elapsed)
         previous = elapsed
-        elapsed = min(FEEDBACK_DELAY_SECONDS, elapsed + max(0, seconds))
+        seconds = seconds if math.isfinite(seconds) and seconds > 0 else 0
+        elapsed = min(FEEDBACK_DELAY_SECONDS, elapsed + seconds)
         self.settings.set("feedback-use-seconds", elapsed)
-        self.unsaved_seconds += max(0, seconds)
+        self.unsaved_seconds += elapsed - previous
         if self.unsaved_seconds >= 60 or previous < FEEDBACK_DELAY_SECONDS <= elapsed:
+            self.flush()
+        return elapsed >= FEEDBACK_DELAY_SECONDS and self.experienced
+
+    def flush(self):
+        if self.unsaved_seconds or self.dirty:
             self.settings.save()
             self.unsaved_seconds = 0
-        return elapsed >= FEEDBACK_DELAY_SECONDS
+            self.dirty = False
 
     def consume(self):
+        """Acknowledge this release's banner, independently of the survey URL."""
         if self.shown:
             return False
         self.settings.set("feedback-shown", True)

--- a/src/classes/feedback.py
+++ b/src/classes/feedback.py
@@ -112,7 +112,7 @@ def feedback_command(category):
         def tracked(*args, **kwargs):
             # QAction adds checked(bool). A *args wrapper must discard this extra
             # argument itself, as Qt did for the original fixed-arity handler.
-            if len(args) == positional_count + 1 and type(args[-1]) is bool:
+            if len(args) == positional_count + 1 and isinstance(args[-1], bool):
                 args = args[:-1]
             # Some presets delegate to other commands (e.g. volume fade in + out).
             if _feedback_command_active.get():
@@ -164,7 +164,7 @@ class FeedbackPolicy:
     @property
     def action_count(self):
         value = self.settings.get("feedback-action-count")
-        return min(3, max(0, value)) if type(value) is int else 0
+        return min(3, max(0, value)) if isinstance(value, int) and not isinstance(value, bool) else 0
 
     @property
     def experienced(self):

--- a/src/classes/settings.py
+++ b/src/classes/settings.py
@@ -168,7 +168,8 @@ class SettingStore(JsonDataStore):
         log.info(f"Restoring defaults for category: {category_filter or 'all categories'}")
         preserve_keys = [
             'unique_install_id', 'tutorial_ids', 'tutorial_enabled', 'send_metrics',
-            'feedback-shown', 'feedback-use-seconds',
+            'feedback-shown', 'feedback-use-seconds', 'feedback-release',
+            'feedback-action-count', 'feedback-action-categories',
             'dismissed-update-version',
             'recent_projects', 'custom_views', 'active_custom_view', 'active_builtin_view',
         ]

--- a/src/settings/_default.settings
+++ b/src/settings/_default.settings
@@ -91,6 +91,27 @@
     "title": "",
     "type": "hidden",
     "category": "General",
+    "setting": "feedback-release"
+  },
+  {
+    "value": 0,
+    "title": "",
+    "type": "hidden",
+    "category": "General",
+    "setting": "feedback-action-count"
+  },
+  {
+    "value": [],
+    "title": "",
+    "type": "hidden",
+    "category": "General",
+    "setting": "feedback-action-categories"
+  },
+  {
+    "value": "",
+    "title": "",
+    "type": "hidden",
+    "category": "General",
     "setting": "dismissed-update-version"
   },
   {

--- a/src/tests/test_feedback.py
+++ b/src/tests/test_feedback.py
@@ -6,22 +6,24 @@ import os
 import sys
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
+from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
 
 PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 if PATH not in sys.path:
     sys.path.append(PATH)
 
-from qt_api import QApplication, QMainWindow
-from classes.feedback import FeedbackPolicy, survey_url
+from qt_api import QApplication, QMainWindow, isdeleted
+from classes.feedback import FeedbackPolicy, survey_url, FEEDBACK_DELAY_SECONDS
+from classes import info
 from windows.feedback import FeedbackController
 
 
 class Settings:
     def __init__(self):
         self.data = {"feedback-shown": False, "feedback-use-seconds": 0,
-                     "unique_install_id": "test-install-id"}
+                     "unique_install_id": "test-install-id", "feedback-release": info.VERSION}
         self.saved = {}
 
     def get(self, key):
@@ -41,19 +43,21 @@ class FeedbackTests(unittest.TestCase):
 
     def test_cumulative_use_and_one_time_consumption(self):
         settings = Settings()
-        policy = FeedbackPolicy(settings)
+        policy = FeedbackPolicy(settings, info.VERSION)
+        for category in ("structure", "structure", "adjustments"):
+            policy.record_action(category)
         self.assertFalse(policy.advance(900))
         restarted = Settings()
         restarted.data = dict(settings.saved)
-        policy = FeedbackPolicy(restarted)
+        policy = FeedbackPolicy(restarted, info.VERSION)
         self.assertTrue(policy.advance(900))
         self.assertTrue(policy.consume())
         self.assertTrue(restarted.saved["feedback-shown"])
-        self.assertFalse(FeedbackPolicy(restarted).consume())
+        self.assertFalse(FeedbackPolicy(restarted, info.VERSION).consume())
         self.assertFalse(policy.advance(1800))
 
     def test_failed_persistence_does_not_consume_invitation(self):
-        policy = FeedbackPolicy(Settings())
+        policy = FeedbackPolicy(Settings(), info.VERSION)
         with patch.object(policy.settings, "save", side_effect=OSError("disk full")):
             with self.assertRaises(OSError):
                 policy.consume()
@@ -115,11 +119,15 @@ class FeedbackTests(unittest.TestCase):
         window.menuHelp.addSeparator()
         window.actionAbout = window.menuHelp.addAction("About")
         controller = FeedbackController(window, settings, lambda text: text, preview=preview)
-        self.addCleanup(window.deleteLater)
-        self.addCleanup(controller.timer.stop)
+        self.addCleanup(lambda: window.deleteLater() if not isdeleted(window) else None)
+        self.addCleanup(lambda: controller.timer.stop() if not isdeleted(controller.timer) else None)
+        for method in ("has_timeline_content", "playback_active"):
+            mock = patch.object(controller, method, return_value=method == "has_timeline_content")
+            mock.start()
+            self.addCleanup(mock.stop)
         return controller
 
-    def test_help_opens_browser_directly_and_prevents_future_nag(self):
+    def test_help_opens_browser_without_acknowledging_banner(self):
         settings = Settings()
         controller = self.make_controller(settings)
         self.assertFalse(controller.action.icon().isNull())
@@ -133,14 +141,9 @@ class FeedbackTests(unittest.TestCase):
         self.assertEqual(self.decode_context(opened.call_args[0][0].toString())["install_uuid"],
                          "test-install-id")
         self.assertIsNone(controller.banner)
-        self.assertTrue(settings.saved["feedback-shown"])
+        self.assertFalse(settings.get("feedback-shown"))
         self.assertTrue(controller.action.isEnabled())
-        self.assertFalse(controller.timer.isActive())
-        controller.show_invitation()
-        self.assertIsNone(controller.banner)
-        restarted = self.make_controller(settings)
-        self.assertTrue(restarted.action.isEnabled())
-        self.assertFalse(restarted.timer.isActive())
+        self.assertTrue(controller.timer.isActive())
 
     def test_help_browser_failure_allows_retry_without_nag(self):
         controller = self.make_controller(Settings())
@@ -222,20 +225,23 @@ class FeedbackTests(unittest.TestCase):
         self.assertTrue(controller.area.toolbar.isHidden())
         self.assertTrue(controller.settings.saved["feedback-shown"])
 
-    def test_browser_failure_keeps_banner_available_for_retry(self):
-        controller = self.make_controller(Settings())
-        controller.show_invitation()
-        with patch("windows.feedback.QDesktopServices.openUrl", return_value=False):
-            controller.open_survey()
-        self.assertFalse(controller.banner.isHidden())
-        with patch("windows.feedback.QDesktopServices.openUrl", return_value=True) as opened:
-            controller.open_survey()
-        self.assertEqual(self.decode_context(opened.call_args[0][0].toString())["install_uuid"],
-                         "test-install-id")
-        self.assertIsNone(controller.banner)
+    def test_banner_click_acknowledges_even_when_browser_fails(self):
+        for outcome in (False, OSError("no browser")):
+            with self.subTest(outcome=outcome):
+                controller = self.make_controller(Settings())
+                controller.show_invitation()
+                with patch("windows.feedback.QDesktopServices.openUrl", return_value=False,
+                           side_effect=outcome if isinstance(outcome, Exception) else None), \
+                        patch("windows.feedback.QMessageBox.warning") as warning:
+                    controller.banner.primary.click()
+                warning.assert_called_once()
+                self.assertIsNone(controller.banner)
+                self.assertTrue(controller.policy.shown)
+                self.assertTrue(controller.action.isEnabled())
 
     def test_foreground_time_and_suspend_guard(self):
         controller = self.make_controller(Settings())
+        controller.last_input = 100
         controller.last_tick = 100
         controller.was_active = True
         with patch.object(controller.window, "isActiveWindow", return_value=True), \
@@ -249,7 +255,10 @@ class FeedbackTests(unittest.TestCase):
 
     def test_due_invitation_waits_for_modal_to_close(self):
         controller = self.make_controller(Settings())
-        controller.settings.set("feedback-use-seconds", 1800)
+        controller.settings.set("feedback-use-seconds", FEEDBACK_DELAY_SECONDS)
+        for category in ("structure", "structure", "adjustments"):
+            controller.record_action(category)
+        controller.last_input = 0
         with patch.object(controller.window, "isActiveWindow", return_value=True), \
                 patch.object(controller.window, "isVisible", return_value=True):
             with patch("windows.feedback.QApplication.activeModalWidget", return_value=object()):
@@ -284,7 +293,7 @@ class FeedbackTests(unittest.TestCase):
         controller = self.make_controller(Settings(), preview=True)
         controller.show_invitation()
         with patch("windows.feedback.QDesktopServices.openUrl", return_value=True):
-            controller.open_survey()
+            controller.open_from_banner()
         self.assertFalse(controller.policy.shown)
         self.assertEqual(controller.settings.saved, {})
         self.assertTrue(controller.area.toolbar.isHidden())
@@ -292,12 +301,15 @@ class FeedbackTests(unittest.TestCase):
     def test_unanswered_banner_returns_on_next_session(self):
         settings = Settings()
         controller = self.make_controller(settings)
-        controller.policy.advance(1800)
+        for category in ("structure", "structure", "adjustments"):
+            controller.record_action(category)
+        controller.policy.advance(FEEDBACK_DELAY_SECONDS)
         controller.show_invitation()
         self.assertFalse(settings.get("feedback-shown"))
         restarted_settings = Settings()
         restarted_settings.data = dict(settings.saved)
         restarted = self.make_controller(restarted_settings)
+        restarted.last_input = 0
         with patch.object(restarted.window, "isActiveWindow", return_value=True), \
                 patch.object(restarted.window, "isVisible", return_value=True):
             restarted.tick()
@@ -305,24 +317,25 @@ class FeedbackTests(unittest.TestCase):
         restarted.banner.close_button.click()
         self.assertTrue(restarted_settings.saved["feedback-shown"])
 
-    def test_help_can_complete_a_visible_banner(self):
+    def test_help_does_not_acknowledge_a_visible_banner(self):
         controller = self.make_controller(Settings())
         controller.show_invitation()
         self.assertTrue(controller.action.isEnabled())
         with patch("windows.feedback.QDesktopServices.openUrl", return_value=True):
             controller.action.trigger()
-        self.assertIsNone(controller.banner)
-        self.assertTrue(controller.policy.shown)
+        self.assertIsNotNone(controller.banner)
+        self.assertFalse(controller.policy.shown)
 
     def test_invalid_elapsed_settings_do_not_disable_feedback(self):
         for value in ("invalid", float("nan"), float("inf"), -10, {}):
             settings = Settings()
             settings.set("feedback-use-seconds", value)
-            self.assertFalse(FeedbackPolicy(settings).advance(5))
+            self.assertFalse(FeedbackPolicy(settings, info.VERSION).advance(5))
             self.assertEqual(settings.get("feedback-use-seconds"), 5)
 
     def test_background_and_popup_time_does_not_count(self):
         controller = self.make_controller(Settings())
+        controller.last_input = 100
         controller.last_tick = 100
         controller.was_active = True
         with patch.object(controller.window, "isActiveWindow", return_value=True), \
@@ -342,14 +355,6 @@ class FeedbackTests(unittest.TestCase):
         self.assertTrue(controller.completed)
         self.assertTrue(controller.action.isEnabled())
 
-    def test_browser_exception_keeps_visible_banner_for_retry(self):
-        controller = self.make_controller(Settings())
-        controller.show_invitation()
-        with patch("windows.feedback.QDesktopServices.openUrl", side_effect=OSError("no browser")):
-            controller.open_survey()
-        self.assertIsNotNone(controller.banner)
-        self.assertFalse(controller.policy.shown)
-
     def test_real_settings_reload_and_reset_preserve_notification_history(self):
         from classes import info
         from classes.settings import SettingStore
@@ -358,11 +363,14 @@ class FeedbackTests(unittest.TestCase):
             settings = SettingStore()
             settings.load()
             settings.set("unique_install_id", "persistent-test-id")
-            self.assertFalse(FeedbackPolicy(settings).advance(900))
+            policy = FeedbackPolicy(settings, info.VERSION)
+            for category in ("structure", "titles", "profile"):
+                policy.record_action(category)
+            self.assertFalse(policy.advance(900))
             restarted = SettingStore()
             restarted.load()
             self.assertEqual(restarted.get("feedback-use-seconds"), 900)
-            policy = FeedbackPolicy(restarted)
+            policy = FeedbackPolicy(restarted, info.VERSION)
             self.assertTrue(policy.advance(900))
             self.assertTrue(policy.consume())
             restarted.set("dismissed-update-version", "4.1.0")
@@ -371,8 +379,340 @@ class FeedbackTests(unittest.TestCase):
             restored = SettingStore()
             restored.load()
             self.assertTrue(restored.get("feedback-shown"))
-            self.assertEqual(restored.get("feedback-use-seconds"), 1800)
+            self.assertEqual(restored.get("feedback-use-seconds"), FEEDBACK_DELAY_SECONDS)
+            self.assertEqual(restored.get("feedback-release"), info.VERSION)
+            self.assertEqual(restored.get("feedback-action-count"), 3)
+            self.assertEqual(restored.get("feedback-action-categories"), ["profile", "structure", "titles"])
             self.assertEqual(restored.get("dismissed-update-version"), "4.1.0")
             self.assertEqual(restored.get("unique_install_id"), "persistent-test-id")
             self.assertEqual(restored.get("actionShareFeedback"), "F8")
             self.assertEqual(restored.get("actionUpdate"), "F9")
+
+    def test_idle_empty_background_and_playback_time(self):
+        for active, content, playing, idle, expected in (
+                (True, True, False, 20, 5), (True, True, False, 61, 0),
+                (True, False, False, 20, 0), (False, True, False, 20, 0),
+                (True, True, True, 120, 5), (False, True, True, 20, 0)):
+            with self.subTest(active=active, content=content, playing=playing, idle=idle):
+                controller = self.make_controller(Settings())
+                controller.last_tick = 200
+                controller.last_input = 205 - idle
+                controller.was_active = True
+                with patch.object(controller.window, "isActiveWindow", return_value=active), \
+                        patch.object(controller.window, "isVisible", return_value=True), \
+                        patch.object(controller, "has_timeline_content", return_value=content), \
+                        patch.object(controller, "playback_active", return_value=playing), \
+                        patch("windows.feedback.time.monotonic", return_value=205):
+                    controller.tick()
+                self.assertEqual(controller.settings.get("feedback-use-seconds"), expected)
+
+    def test_eligible_banner_waits_for_quiet_paused_input(self):
+        controller = self.make_controller(Settings())
+        for category in ("structure", "adjustments", "export"):
+            controller.record_action(category)
+        controller.policy.advance(FEEDBACK_DELAY_SECONDS)
+        controller.last_input = 100
+        controller.last_tick = 100
+        with patch.object(controller.window, "isActiveWindow", return_value=True), \
+                patch.object(controller.window, "isVisible", return_value=True):
+            with patch("windows.feedback.time.monotonic", return_value=105):
+                controller.tick()
+            self.assertIsNone(controller.banner)
+            with patch("windows.feedback.time.monotonic", return_value=110), \
+                    patch.object(controller, "playback_active", return_value=True):
+                controller.tick()
+            self.assertIsNone(controller.banner)
+            with patch("windows.feedback.time.monotonic", return_value=115):
+                controller.tick()
+            self.assertIsNotNone(controller.banner)
+            self.assertFalse(controller.policy.shown)
+
+    def test_input_filter_observes_only_our_window(self):
+        from qt_api import QEvent, QWidget
+        controller = self.make_controller(Settings())
+        other_window = QWidget()
+        self.addCleanup(other_window.deleteLater)
+        controller.last_input = 0
+        event = QEvent(QEvent.KeyPress)
+        with patch("windows.feedback.time.monotonic", return_value=42):
+            self.assertFalse(controller.eventFilter(other_window, event))
+            self.assertEqual(controller.last_input, 0)
+            self.assertFalse(controller.eventFilter(controller.window, event))
+            self.assertEqual(controller.last_input, 42)
+
+    def test_shutdown_removes_input_filter_and_flushes_time(self):
+        from qt_api import QEvent, QKeyEvent, Qt
+        controller = self.make_controller(Settings())
+        controller.policy.advance(25)
+        controller.shutdown()
+        self.assertFalse(controller.timer.isActive())
+        self.assertEqual(controller.settings.saved["feedback-use-seconds"], 25)
+        controller.last_input = 0
+        with patch("windows.feedback.time.monotonic", return_value=42):
+            QApplication.sendEvent(controller.window, QKeyEvent(QEvent.KeyPress, Qt.Key_A, Qt.NoModifier))
+        self.assertEqual(controller.last_input, 0)
+
+    def test_event_filter_does_not_access_deleted_main_window(self):
+        from qt_api import QEvent, QCoreApplication, QWidget, isdeleted
+        controller = self.make_controller(Settings())
+        controller.timer.stop()
+        window = controller.window
+        window.deleteLater()
+        QCoreApplication.sendPostedEvents(window, QEvent.DeferredDelete)
+        self.assertTrue(isdeleted(window))
+        other = QWidget()
+        with patch.object(sys, "excepthook") as errors:
+            self.assertFalse(controller.eventFilter(other, QEvent(QEvent.KeyPress)))
+        errors.assert_not_called()
+        other.deleteLater()
+
+
+class EligibilityPolicyTests(unittest.TestCase):
+    def test_requires_time_and_three_actions_in_two_categories(self):
+        for actions, expected in (([], False), (["structure"] * 3, False),
+                                  (["structure", "titles"], False),
+                                  (["structure", "structure", "titles"], True)):
+            with self.subTest(actions=actions):
+                policy = FeedbackPolicy(Settings(), info.VERSION)
+                for category in actions:
+                    policy.record_action(category)
+                self.assertFalse(policy.advance(FEEDBACK_DELAY_SECONDS - 1))
+                self.assertEqual(policy.advance(1), expected)
+
+    def test_time_can_complete_before_actions(self):
+        policy = FeedbackPolicy(Settings(), info.VERSION)
+        self.assertFalse(policy.advance(FEEDBACK_DELAY_SECONDS))
+        for category in ("effects", "profile", "export"):
+            policy.record_action(category)
+        self.assertTrue(policy.advance(0))
+
+    def test_new_release_resets_time_and_acknowledgement_only(self):
+        settings = Settings()
+        policy = FeedbackPolicy(settings, "4.0.0")
+        for category in ("structure", "titles", "export"):
+            policy.record_action(category)
+        policy.advance(FEEDBACK_DELAY_SECONDS)
+        policy.consume()
+        restarted = FeedbackPolicy(settings, "4.0.0")
+        self.assertTrue(restarted.shown)
+        upgraded = FeedbackPolicy(settings, "4.1.0")
+        self.assertFalse(upgraded.shown)
+        self.assertTrue(upgraded.experienced)
+        self.assertEqual(settings.get("feedback-use-seconds"), 0)
+        self.assertFalse(upgraded.advance(FEEDBACK_DELAY_SECONDS - 1))
+        self.assertTrue(upgraded.advance(1))
+
+    def test_partial_action_progress_survives_upgrade(self):
+        settings = Settings()
+        policy = FeedbackPolicy(settings, "4.0.0")
+        policy.record_action("structure")
+        policy.advance(300)
+        upgraded = FeedbackPolicy(settings, "4.1.0")
+        self.assertEqual(upgraded.action_count, 1)
+        self.assertEqual(upgraded.categories, {"structure"})
+        self.assertFalse(upgraded.advance(FEEDBACK_DELAY_SECONDS))
+        upgraded.record_action("titles")
+        upgraded.record_action("profile")
+        self.assertTrue(upgraded.advance(0))
+
+    def test_legacy_dismissal_is_preserved_but_foreground_timer_is_discarded(self):
+        settings = Settings()
+        settings.data.pop("feedback-release")
+        settings.set("feedback-shown", True)
+        settings.set("feedback-use-seconds", 1800)
+        policy = FeedbackPolicy(settings, "4.0.0")
+        self.assertTrue(policy.shown)
+        self.assertEqual(settings.get("feedback-use-seconds"), 0)
+        self.assertFalse(FeedbackPolicy(settings, "4.1.0").shown)
+
+    def test_counts_are_bounded_and_unknown_actions_ignored(self):
+        policy = FeedbackPolicy(Settings(), info.VERSION)
+        policy.record_action("open-properties")
+        self.assertEqual(policy.action_count, 0)
+        for _ in range(10):
+            policy.record_action("structure")
+        self.assertEqual(policy.action_count, 3)
+        self.assertFalse(policy.experienced)
+        policy.record_action("profile")
+        self.assertTrue(policy.experienced)
+        before = dict(policy.settings.data)
+        policy.record_action("export")
+        self.assertEqual(before, policy.settings.data)
+
+    def test_short_session_flush_preserves_progress(self):
+        settings = Settings()
+        policy = FeedbackPolicy(settings, info.VERSION)
+        policy.advance(25)
+        policy.flush()
+        restarted_settings = Settings()
+        restarted_settings.data = dict(settings.saved)
+        restarted = FeedbackPolicy(restarted_settings, info.VERSION)
+        restarted.advance(5)
+        self.assertEqual(restarted_settings.get("feedback-use-seconds"), 30)
+
+    def test_corrupt_action_state_is_not_eligibility(self):
+        for count, categories in (("3", ["structure", "titles"]),
+                                   (3, "structure"), (-1, []),
+                                   (3, [[], {}, "unknown", "structure"])):
+            settings = Settings()
+            settings.set("feedback-action-count", count)
+            settings.set("feedback-action-categories", categories)
+            policy = FeedbackPolicy(settings, info.VERSION)
+            self.assertFalse(policy.advance(FEEDBACK_DELAY_SECONDS))
+            policy.record_action("profile")
+
+    def test_actions_still_accumulate_after_banner_acknowledgement(self):
+        policy = FeedbackPolicy(Settings(), info.VERSION)
+        policy.consume()
+        for category in ("structure", "titles", "export"):
+            policy.record_action(category)
+        self.assertTrue(policy.experienced)
+        self.assertFalse(policy.advance(FEEDBACK_DELAY_SECONDS))
+
+
+class FeedbackActionHookTests(unittest.TestCase):
+    def setUp(self):
+        from classes.query import Clip
+        self.policy = FeedbackPolicy(Settings(), info.VERSION)
+        self.controller = SimpleNamespace(preview=False, policy=self.policy,
+                                          record_action=self.policy.record_action)
+        self.clips = {key: SimpleNamespace(data={"id": key, "start": 0, "end": 10})
+                      for key in ("one", "two")}
+        for mock in (patch("classes.app.get_app", return_value=SimpleNamespace(
+                window=SimpleNamespace(feedback_controller=self.controller))),
+                patch.object(Clip, "get", side_effect=lambda id: self.clips.get(id))):
+            mock.start()
+            self.addCleanup(mock.stop)
+
+    def test_command_counts_once_for_multiple_clips_and_skips_noops(self):
+        from classes.feedback import feedback_command
+
+        @feedback_command("structure")
+        def trim(clip_ids, end):
+            for clip_id in clip_ids:
+                self.clips[clip_id].data["end"] = end
+            return "committed"
+
+        self.assertEqual(trim(["one", "two"], 8), "committed")
+        self.assertEqual(self.policy.action_count, 1)
+        trim(clip_ids=["one", "two"], end=8)
+        trim([], 4)
+        self.assertEqual(self.policy.action_count, 1)
+        trim(["one"], 7)
+        self.assertEqual(self.policy.action_count, 2)
+        self.assertEqual(self.policy.categories, {"structure"})
+
+    def test_qt_checked_argument_is_ignored_but_real_arguments_are_preserved(self):
+        from functools import partial
+        from qt_api import QAction
+        from classes.feedback import feedback_command
+
+        class Commands:
+            @feedback_command("structure")
+            def trim(command_self, clip_ids, end):
+                self.clips["one"].data["end"] = end
+                return end
+
+        commands = Commands()
+        for checked, end in ((False, 8), (True, 7)):
+            with self.subTest(checked=checked):
+                action = QAction()
+                action.setCheckable(True)
+                action.triggered.connect(partial(commands.trim, ["one"], end))
+                with patch.object(sys, "excepthook") as errors:
+                    action.triggered.emit(checked)
+                errors.assert_not_called()
+                self.assertEqual(self.clips["one"].data["end"], end)
+        self.assertEqual(self.policy.action_count, 2)
+        # A legitimate boolean parameter must not be removed.
+        self.assertIs(commands.trim(["one"], False), False)
+        # Do not hide ordinary programming errors with other extra arguments.
+        with self.assertRaises(TypeError):
+            commands.trim(["one"], 7, "unexpected")
+
+    def test_cancelled_or_failed_command_does_not_count(self):
+        from classes.feedback import feedback_command
+
+        @feedback_command("adjustments")
+        def adjust(clip_ids, fail=False):
+            if fail:
+                raise ValueError("edit failed")
+            return False  # cancelled without mutation
+
+        self.assertFalse(adjust(["one"]))
+        with self.assertRaises(ValueError):
+            adjust(["one"], fail=True)
+        self.assertEqual(self.policy.action_count, 0)
+
+        @feedback_command("structure")
+        def next_command(clip_ids):
+            self.clips["one"].data["end"] = 6
+
+        next_command(["one"])
+        self.assertEqual(self.policy.action_count, 1)
+
+    def test_tracking_failure_does_not_break_user_command(self):
+        from classes.feedback import feedback_command
+
+        @feedback_command("structure")
+        def trim(clip_ids):
+            self.clips["one"].data["end"] = 5
+            return 17
+
+        self.controller.record_action = Mock(side_effect=OSError("settings unavailable"))
+        self.assertEqual(trim(["one"]), 17)
+        self.assertEqual(self.clips["one"].data["end"], 5)
+
+    def test_reader_serialization_and_transition_changes_do_not_count(self):
+        from classes.feedback import record_feedback_changes
+        before = {"one": dict(self.clips["one"].data, reader={"path": "media.mp4"})}
+        record_feedback_changes("adjustments", before)
+        record_feedback_changes("structure", {"transition-id": {"start": 0, "end": 1}})
+        self.assertEqual(self.policy.action_count, 0)
+
+    def test_resize_counts_bound_changes_but_not_movement(self):
+        from classes.feedback import record_feedback_changes
+        before = {key: dict(clip.data) for key, clip in self.clips.items()}
+        self.clips["one"].data["position"] = 4
+        record_feedback_changes("structure", before, fields=("start", "end"))
+        self.assertEqual(self.policy.action_count, 0)
+        self.clips["one"].data["end"] = 8
+        self.clips["two"].data["end"] = 9
+        record_feedback_changes("structure", before, fields=("start", "end"))
+        self.assertEqual(self.policy.action_count, 1)
+
+    def test_completed_milestones_skip_clip_queries(self):
+        from classes.feedback import feedback_command
+        from classes.query import Clip
+        for category in ("structure", "effects", "titles"):
+            self.policy.record_action(category)
+
+        @feedback_command("adjustments")
+        def adjust(clip_ids):
+            return "done"
+
+        with patch.object(Clip, "get") as query:
+            self.assertEqual(adjust(["one"]), "done")
+            query.assert_not_called()
+
+    def test_property_transaction_counts_once_and_cancel_does_not_count(self):
+        from windows.views.properties_tableview import PropertiesTableView
+        originals = {key: {"type": "clip", "data": dict(clip.data)}
+                     for key, clip in self.clips.items()}
+        for clip in self.clips.values():
+            clip.save = Mock()
+            clip.data["end"] = 8
+        app = SimpleNamespace(updates=Mock())
+        view = SimpleNamespace(transaction_id="drag", original_data_map=originals,
+                               update_in_progress=True)
+        with patch("windows.views.properties_tableview.get_app", return_value=app):
+            PropertiesTableView.finalize_transaction(view)
+            PropertiesTableView.finalize_transaction(view)
+        self.assertEqual(self.policy.action_count, 1)
+        self.assertEqual(self.policy.categories, {"adjustments"})
+        view.transaction_id = "cancelled-drag"
+        view.original_data_map = originals
+        view._restore_original_objects = Mock()
+        with patch("windows.views.properties_tableview.get_app", return_value=app):
+            PropertiesTableView.cancel_transaction(view)
+        self.assertEqual(self.policy.action_count, 1)

--- a/src/tests/test_feedback.py
+++ b/src/tests/test_feedback.py
@@ -453,7 +453,7 @@ class FeedbackTests(unittest.TestCase):
         self.assertEqual(controller.last_input, 0)
 
     def test_event_filter_does_not_access_deleted_main_window(self):
-        from qt_api import QEvent, QCoreApplication, QWidget, isdeleted
+        from qt_api import QEvent, QCoreApplication, QWidget
         controller = self.make_controller(Settings())
         controller.timer.stop()
         window = controller.window
@@ -578,9 +578,12 @@ class FeedbackActionHookTests(unittest.TestCase):
                                           record_action=self.policy.record_action)
         self.clips = {key: SimpleNamespace(data={"id": key, "start": 0, "end": 10})
                       for key in ("one", "two")}
+        def get_clip(id):
+            return self.clips.get(id)
+
         for mock in (patch("classes.app.get_app", return_value=SimpleNamespace(
                 window=SimpleNamespace(feedback_controller=self.controller))),
-                patch.object(Clip, "get", side_effect=lambda id: self.clips.get(id))):
+                patch.object(Clip, "get", side_effect=get_clip)):
             mock.start()
             self.addCleanup(mock.stop)
 
@@ -607,10 +610,12 @@ class FeedbackActionHookTests(unittest.TestCase):
         from qt_api import QAction
         from classes.feedback import feedback_command
 
+        clips = self.clips
+
         class Commands:
             @feedback_command("structure")
-            def trim(command_self, clip_ids, end):
-                self.clips["one"].data["end"] = end
+            def trim(self, clip_ids, end):
+                clips["one"].data["end"] = end
                 return end
 
         commands = Commands()
@@ -627,8 +632,7 @@ class FeedbackActionHookTests(unittest.TestCase):
         # A legitimate boolean parameter must not be removed.
         self.assertIs(commands.trim(["one"], False), False)
         # Do not hide ordinary programming errors with other extra arguments.
-        with self.assertRaises(TypeError):
-            commands.trim(["one"], 7, "unexpected")
+        self.assertRaises(TypeError, commands.trim, ["one"], 7, "unexpected")
 
     def test_cancelled_or_failed_command_does_not_count(self):
         from classes.feedback import feedback_command

--- a/src/tests/test_feedback_commands.py
+++ b/src/tests/test_feedback_commands.py
@@ -131,7 +131,7 @@ class FeedbackCommandTests(unittest.TestCase):
                 dialog.export_fps_factor = 1.0
                 dialog.old_cache_object = None
                 dialog.s = Mock(get=lambda key: False)
-                app = SimpleNamespace(_tr=lambda text: text, get_settings=lambda: Mock(),
+                app = SimpleNamespace(_tr=lambda text: text, get_settings=Mock,
                     project=SimpleNamespace(), window=SimpleNamespace(timeline_sync=Mock()))
                 writer = Mock()
                 if outcome == "cancel":

--- a/src/tests/test_feedback_commands.py
+++ b/src/tests/test_feedback_commands.py
@@ -1,0 +1,152 @@
+"""Feedback hooks exercise real command handlers with external work stubbed out."""
+
+import os
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+if PATH not in sys.path:
+    sys.path.append(PATH)
+
+from qt_api import QApplication, QDialog
+
+
+class FeedbackCommandTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from tests.qt_test_app import ensure_app_state
+        cls.app = ensure_app_state(QApplication.instance() or QApplication([]),
+                                   lambda: SimpleNamespace(get=lambda key: None))
+
+    def test_profile_changes_count_once_but_same_profile_and_cancel_do_not(self):
+        from windows.main_window import MainWindow
+
+        data = {"profile": "Old", "width": 640, "height": 480, "fps": {"num": 24, "den": 1}}
+        project = SimpleNamespace(get=lambda key: data.get(key[0] if isinstance(key, list) else key))
+        app = SimpleNamespace(project=project, updates=SimpleNamespace(
+            transaction_id=None, update=lambda key, value: data.__setitem__(key[0], value)))
+        ratio = SimpleNamespace(num=1, den=1)
+        profile = SimpleNamespace(info=SimpleNamespace(description="New", width=1280, height=720,
+            fps=SimpleNamespace(num=24, den=1, ToFloat=lambda: 24), pixel_ratio=ratio, display_ratio=ratio))
+        window = SimpleNamespace(clearSelections=Mock(), preview_thread=SimpleNamespace(current_frame=1),
+            SeekSignal=Mock(), refreshFrameSignal=Mock(), MaxSizeChanged=Mock(), videoPreview=Mock())
+        with patch("windows.main_window.get_app", return_value=app), \
+                patch("windows.main_window.record_feedback_action") as record, \
+                patch("windows.main_window.QTimer.singleShot"), \
+                patch("windows.main_window.openshot.Settings"):
+            MainWindow.actionProfile_trigger(window, profile)
+            MainWindow.actionProfile_trigger(window, profile)
+            with patch("windows.profile.Profile", return_value=SimpleNamespace(
+                    exec_=lambda: QDialog.Rejected, selected_profile=profile)):
+                MainWindow.actionProfile_trigger(window)
+            record.assert_called_once_with("profile")
+
+    def test_regular_title_counts_only_a_successful_creation(self):
+        from windows.title_editor import TitleEditor
+        for saved, editing, expected in ((True, False, 1), (False, False, 0), (True, True, 0)):
+            with self.subTest(saved=saved, editing=editing):
+                dialog = TitleEditor.__new__(TitleEditor)
+                QDialog.__init__(dialog)
+                self.addCleanup(dialog.deleteLater)
+                dialog.edit_file_path = "existing.svg" if editing else None
+                dialog.duplicate = False
+                dialog.txtFileName = Mock(text=lambda: "test-feedback-title")
+                dialog.xmldoc = Mock()
+                dialog.writeToFile = Mock(return_value=saved)
+                app = SimpleNamespace(_tr=lambda text: text, window=SimpleNamespace(files_model=Mock()))
+                with patch("windows.title_editor.get_app", return_value=app), \
+                        patch("windows.title_editor.os.path.exists", return_value=False), \
+                        patch("windows.title_editor.record_feedback_action") as record:
+                    dialog.accept()
+                self.assertEqual(record.call_count, expected)
+
+    def test_title_write_failure_reports_failure(self):
+        from windows.title_editor import TitleEditor
+        with patch("builtins.open", side_effect=OSError("disk full")):
+            self.assertFalse(TitleEditor.writeToFile(SimpleNamespace(filename="title.svg"), Mock()))
+
+    def test_animated_title_excludes_previews_cancelled_and_failed_renders(self):
+        from windows.views.blender_listview import BlenderListView
+        for final, cancelled, exit_code, expected in (
+                (True, False, 0, 1), (False, False, 0, 0),
+                (True, True, 0, 0), (True, False, 1, 0)):
+            with self.subTest(final=final, cancelled=cancelled, exit_code=exit_code):
+                view = SimpleNamespace(final_render=final, params={"file_name": "Title"},
+                    unique_folder_name="test", fps={"num": 24, "den": 1}, win=Mock(),
+                    worker=SimpleNamespace(canceled=cancelled, process=SimpleNamespace(returncode=exit_code)))
+                app = SimpleNamespace(window=SimpleNamespace(files_model=Mock()))
+                with patch("windows.views.blender_listview.get_app", return_value=app), \
+                        patch("windows.views.blender_listview.record_feedback_action") as record:
+                    BlenderListView.render_finished(view)
+                self.assertEqual(record.call_count, expected)
+
+    def test_effect_drop_counts_success_but_not_cancelled_processing(self):
+        import json
+        from windows.views.timeline import TimelineView
+        effect = SimpleNamespace(Id=Mock(), Json=lambda: json.dumps({"id": "effect", "class_name": "Blur"}))
+        clip = SimpleNamespace(id="clip", data={"effects": []})
+        view = SimpleNamespace(update_clip_data=Mock())
+        app = SimpleNamespace(project=SimpleNamespace(generate_id=lambda: "effect"), updates=Mock())
+        with patch("windows.views.timeline.get_app", return_value=app), \
+                patch("windows.views.timeline.record_feedback_action") as record:
+            with patch("windows.views.timeline.effect_options", {}), \
+                    patch("windows.views.timeline.openshot.EffectInfo", return_value=SimpleNamespace(
+                        CreateEffect=lambda name: effect)):
+                TimelineView._apply_effect_to_clip(view, clip, "Blur")
+            record.assert_called_once_with("effects")
+            record.reset_mock()
+            with patch("windows.views.timeline.effect_options", {"Tracker": {}}), \
+                    patch("windows.process_effect.ProcessEffect", return_value=SimpleNamespace(
+                        exec_=lambda: QDialog.Rejected)):
+                TimelineView._apply_effect_to_clip(view, clip, "Tracker")
+            record.assert_not_called()
+
+    def test_export_counts_only_after_writer_success_not_cancel_or_failure(self):
+        from windows.export import Export
+        for outcome in ("success", "cancel", "write-error", "close-error"):
+            with self.subTest(outcome=outcome), tempfile.TemporaryDirectory() as folder:
+                dialog = Export.__new__(Export)
+                QDialog.__init__(dialog)
+                self.addCleanup(dialog.deleteLater)
+                for name in ("save_settings", "enableControls", "disableControls", "updateFrameRate",
+                             "progressExportVideo", "timeline", "cache_thread"):
+                    setattr(dialog, name, Mock())
+                for name, value in {"txtStartFrame": 1, "txtEndFrame": 3,
+                        "txtFrameRateNum": 24, "txtFrameRateDen": 1, "txtWidth": 16, "txtHeight": 16,
+                        "txtPixelRatioNum": 1, "txtPixelRatioDen": 1,
+                        "txtSampleRate": 48000, "txtChannels": 2}.items():
+                    setattr(dialog, name, Mock(value=lambda value=value: value))
+                for name, text in {"txtFileName": "feedback-export", "txtVideoFormat": "mp4",
+                        "txtVideoCodec": "mpeg4", "txtExportFolder": folder,
+                        "txtVideoBitRate": "1000", "txtAudioCodec": "aac", "txtAudioBitrate": "128"}.items():
+                    setattr(dialog, name, Mock(text=lambda text=text: text))
+                dialog.cboExportTo = Mock(currentText=lambda: "Video Only")
+                dialog.cboInterlaced = Mock(currentIndex=lambda: 0)
+                dialog.cboSpherical = Mock(currentIndex=lambda: 0)
+                dialog.cboChannelLayout = Mock(currentData=lambda: 3)
+                dialog.convert_to_bytes = int
+                dialog.export_fps_factor = 1.0
+                dialog.old_cache_object = None
+                dialog.s = Mock(get=lambda key: False)
+                app = SimpleNamespace(_tr=lambda text: text, get_settings=lambda: Mock(),
+                    project=SimpleNamespace(), window=SimpleNamespace(timeline_sync=Mock()))
+                writer = Mock()
+                if outcome == "cancel":
+                    writer.WriteFrame.side_effect = lambda frame: setattr(dialog, "exporting", False)
+                elif outcome == "write-error":
+                    writer.WriteFrame.side_effect = RuntimeError("write failed")
+                elif outcome == "close-error":
+                    writer.Close.side_effect = RuntimeError("close failed")
+                with patch("windows.export.get_app", return_value=app), \
+                        patch("windows.export.File.get", return_value=None), \
+                        patch("windows.export.openshot.FFmpegWriter", return_value=writer), \
+                        patch("windows.export.openshot.CacheMemory"), \
+                        patch("windows.export.openshot.Settings"), \
+                        patch("windows.export.QMessageBox"), \
+                        patch("windows.export.open", Mock()), \
+                        patch("windows.export.record_feedback_action") as record:
+                    dialog.accept()
+                self.assertEqual(record.call_count, int(outcome == "success"))

--- a/src/tests/test_feedback_menu_startup.py
+++ b/src/tests/test_feedback_menu_startup.py
@@ -1,0 +1,131 @@
+"""Exercise generated Qt menus, undo/redo, and shutdown in a real OpenShot app."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+class FeedbackMenuStartupTests(unittest.TestCase):
+    @unittest.skipUnless(shutil.which("ffmpeg"), "ffmpeg is needed to generate a tiny audio/video fixture")
+    def test_clip_menus_and_undo_redo_preserve_edits_and_count_once(self):
+        # A subprocess isolates real Qt, project data, and player threads from unit-test stubs.
+        script = r'''
+
+import importlib
+import os
+import tempfile
+import traceback
+from unittest.mock import patch
+from classes import info, version
+
+profile_dir = tempfile.TemporaryDirectory(prefix="openshot-notification-test-")
+original = info.USER_PATH
+profile = os.path.join(profile_dir.name, ".openshot_qt")
+for key, value in list(vars(info).items()):
+    if isinstance(value, str) and value.startswith(original):
+        setattr(info, key, profile + value[len(original):])
+info._path_defaults = {key: profile + value[len(original):]
+                       for key, value in info._path_defaults.items()}
+info.setup_userdirs()
+info.FEEDBACK_PREVIEW = False
+info.CMDLINE_LANGUAGE = "en_US"
+info.UPDATE_PREVIEW = False
+version.get_current_Version = lambda: None
+from classes.app import OpenShotApp
+from qt_api import QTimer, Qt, QT_API
+binding = {"pyqt5": "PyQt5", "pyqt6": "PyQt6", "pyside6": "PySide6"}[QT_API]
+QTest = importlib.import_module(binding + ".QtTest").QTest
+app = OpenShotApp([], mode="unittest")
+app.settings.set("tutorial_enabled", False)
+app.settings.set("unique_install_id", "preview-only")
+app.settings.set("send_metrics", False)
+passed = False
+
+
+import copy
+import json
+import sys
+import openshot
+from classes.query import Clip
+
+def verify():
+    global passed
+    try:
+        window = app.window
+        controller = window.feedback_controller
+        controller.timer.stop()
+        media = openshot.Clip(os.environ['FEEDBACK_TEST_MEDIA'])
+        media.Open()
+        clip = Clip()
+        clip.data = json.loads(media.Json())
+        clip.data.update(start=0.0, end=2.0, duration=2.0, position=0.0,
+                         layer=app.project.get('layers')[-1]['number'])
+        clip.save()
+        original = copy.deepcopy(clip.data)
+        window.selected_items = [{'id': clip.id, 'type': 'clip'}]
+        window.preview_thread.current_frame = 24
+        app.clipboard().setText("feedback audit")
+        app.processEvents()
+        window.preview_thread.current_frame = 24
+        with patch('windows.views.timeline.StyledContextMenu.show_at', lambda menu, pos: menu):
+            menu = window.timeline.ShowClipMenu(clip.id)
+        targets=[]
+        def collect(menu, path=()):
+            for action in menu.actions():
+                current=path+(action.text().replace('&',''),)
+                if action.menu(): collect(action.menu(), current)
+                elif path and (path[0] in ('Fade','Motion','Look','Slice') or path[:2] == ('Audio','Volume')) and not action.isSeparator() and current[-1] not in ('Adjust Colors','Analyze Colors'):
+                    targets.append((current,action))
+        collect(menu)
+        assert len(targets) >= 20, 'Expected the full clip menu'
+        assert any(path[-1] == 'Super 8' for path, _ in targets)
+        for path,action in targets:
+            for other in Clip.filter():
+                if other.id != clip.id: other.delete()
+            current=Clip.get(id=clip.id);current.data=copy.deepcopy(original);current.save()
+            app.settings.set('feedback-action-count',0)
+            app.settings.set('feedback-action-categories',[])
+            with patch.object(sys,'excepthook') as errors:
+                action.trigger()
+            assert not errors.called,(path, errors.call_args)
+            assert app.settings.get('feedback-action-count') <= 1, (path,'double counted')
+            count = app.settings.get('feedback-action-count')
+            if count:
+                result = copy.deepcopy(Clip.get(id=clip.id).data)
+                app.updates.undo()
+                assert app.settings.get('feedback-action-count') == count, (path,'undo counted')
+                app.updates.redo()
+                assert app.settings.get('feedback-action-count') == count, (path,'redo counted')
+                assert Clip.get(id=clip.id).data == result, (path,'redo changed edit')
+        print('Verified menu actions:', len(targets), flush=True)
+        passed=True
+    except Exception:
+        traceback.print_exc()
+    finally:
+        app.quit()
+QTimer.singleShot(4000,verify)
+assert app.gui()
+app.exec_()
+assert passed
+'''
+        with tempfile.TemporaryDirectory(prefix="openshot-feedback-menu-") as folder:
+            media = str(Path(folder) / "clip.mp4")
+            subprocess.run([
+                "ffmpeg", "-hide_banner", "-loglevel", "error",
+                "-f", "lavfi", "-i", "color=c=blue:s=160x90:r=24",
+                "-f", "lavfi", "-i", "anullsrc=r=48000:cl=stereo",
+                "-t", "2", "-c:v", "mpeg4", "-c:a", "aac", "-y", media,
+            ], check=True, capture_output=True, timeout=30)
+            env = dict(os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[1]),
+                       QT_QPA_PLATFORM="offscreen", QT_QUICK_BACKEND="software",
+                       FEEDBACK_TEST_MEDIA=media)
+            result = subprocess.run([sys.executable, "-c", script], env=env,
+                                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                    text=True, timeout=90)
+        self.assertEqual(result.returncode, 0, result.stdout[-16000:])
+        # Qt callbacks can report exceptions without a nonzero process exit.
+        self.assertNotIn("Traceback (most recent call last)", result.stdout, result.stdout[-16000:])

--- a/src/tests/test_feedback_menu_startup.py
+++ b/src/tests/test_feedback_menu_startup.py
@@ -3,7 +3,7 @@
 import os
 from pathlib import Path
 import shutil
-import subprocess
+import subprocess  # nosec B404 - Isolate the real Qt app in a test process.
 import sys
 import tempfile
 import unittest
@@ -114,7 +114,8 @@ assert passed
 '''
         with tempfile.TemporaryDirectory(prefix="openshot-feedback-menu-") as folder:
             media = str(Path(folder) / "clip.mp4")
-            subprocess.run([
+            # Fixed fixture arguments, a temporary output path, and no shell.
+            subprocess.run([  # nosec B603
                 "ffmpeg", "-hide_banner", "-loglevel", "error",
                 "-f", "lavfi", "-i", "color=c=blue:s=160x90:r=24",
                 "-f", "lavfi", "-i", "anullsrc=r=48000:cl=stereo",
@@ -123,7 +124,8 @@ assert passed
             env = dict(os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[1]),
                        QT_QPA_PLATFORM="offscreen", QT_QUICK_BACKEND="software",
                        FEEDBACK_TEST_MEDIA=media)
-            result = subprocess.run([sys.executable, "-c", script], env=env,
+            # Execute only the literal test script above, using this Python interpreter.
+            result = subprocess.run([sys.executable, "-c", script], env=env,  # nosec B603
                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                     text=True, timeout=90)
         self.assertEqual(result.returncode, 0, result.stdout[-16000:])

--- a/src/tests/test_notification_startup.py
+++ b/src/tests/test_notification_startup.py
@@ -68,6 +68,9 @@ def verify():
             QTest.keyClick(window, Qt.Key_F8)
             app.processEvents()
             assert opened.call_count == 1
+            assert set(area.banners) == {"feedback", "update"}
+            area.banners["feedback"].primary.click()
+            assert opened.call_count == 2
         assert set(area.banners) == {"update"}
         with patch("windows.main_window.webbrowser.open", return_value=True) as opened:
             QTest.keyClick(window, Qt.Key_F9)

--- a/src/tests/test_timeline_helpers.py
+++ b/src/tests/test_timeline_helpers.py
@@ -2378,6 +2378,29 @@ class TimelineHelperTests(unittest.TestCase):
             helper.updated,
         )
 
+    def test_feedback_volume_command_counts_once_for_multiselection_and_skips_noop(self):
+        helper = self.make_time_helper()
+        clips = {key: types.SimpleNamespace(id=key, data={
+            "id": key, "start": 0.0, "end": 4.0, "duration": 4.0,
+            "volume": {"Points": [{"co": {"X": 1, "Y": 1.0}, "interpolation": openshot.LINEAR}]},
+        }) for key in ("C1", "C2")}
+        controller = types.SimpleNamespace(preview=False,
+            policy=types.SimpleNamespace(experienced=False), record_action=MagicMock())
+        app = types.SimpleNamespace(project={"fps": {"num": 24, "den": 1}},
+            updates=types.SimpleNamespace(transaction_id=None),
+            window=types.SimpleNamespace(feedback_controller=controller))
+        with patch.object(self.timeline_module.Clip, "get", side_effect=lambda id: clips.get(id)), \
+                patch.object(self.timeline_module, "get_app", return_value=app), \
+                patch("classes.app.get_app", return_value=app):
+            for _ in range(2):
+                self.timeline_module.TimelineView.Volume_Triggered(
+                    helper, self.timeline_module.MenuVolume.LEVEL, list(clips), level=0.5)
+            controller.record_action.assert_called_once_with("adjustments")
+            controller.record_action.reset_mock()
+            helper.Volume_Triggered = types.MethodType(self.timeline_module.TimelineView.Volume_Triggered, helper)
+            helper.Volume_Triggered(self.timeline_module.MenuVolume.FADE_IN_OUT_FAST, list(clips))
+            controller.record_action.assert_called_once_with("adjustments")
+
     def test_fast_fade_in_out_keeps_four_keyframes_on_four_second_clip(self):
         helper = self.make_time_helper()
         clip = types.SimpleNamespace(
@@ -5426,6 +5449,9 @@ class TimelineHelperTests(unittest.TestCase):
         self.assertFalse(self.timeline_module.TimelineView._clip_has_audio(helper, clip))
 
     def test_film_grain_trigger_adds_preset_effect(self):
+        from functools import partial
+        from qt_api import QMenu
+
         timeline_module = self.timeline_module
         clip = types.SimpleNamespace(id="C1", data={
             "id": "C1",
@@ -5450,20 +5476,28 @@ class TimelineHelperTests(unittest.TestCase):
                 self.updates.append((copy.deepcopy(clip_data), dict(kwargs)))
 
         history = []
+        controller = types.SimpleNamespace(preview=False,
+            policy=types.SimpleNamespace(experienced=False), record_action=MagicMock())
         fake_app = types.SimpleNamespace(
+            window=types.SimpleNamespace(feedback_controller=controller),
             updates=types.SimpleNamespace(
                 apply_last_action_to_history=lambda original: history.append(copy.deepcopy(original))
             )
         )
         helper = Helper()
 
+        # Exercise QAction.triggered(bool), not just a direct Python call.
+        menu = QMenu()
+        action = menu.addAction("Super 8")
+        handler = types.MethodType(timeline_module.TimelineView.Film_Grain_Triggered, helper)
+        action.triggered.connect(partial(handler, timeline_module.FILM_GRAIN_PRESET_SUPER_8, ["C1"]))
         with patch.object(timeline_module.Clip, "get", return_value=clip), \
-             patch.object(timeline_module, "get_app", return_value=fake_app):
-            timeline_module.TimelineView.Film_Grain_Triggered(
-                helper,
-                timeline_module.FILM_GRAIN_PRESET_SUPER_8,
-                ["C1"],
-            )
+             patch.object(timeline_module, "get_app", return_value=fake_app), \
+             patch("classes.app.get_app", return_value=fake_app), \
+             patch.object(sys, "excepthook") as errors:
+            action.trigger()
+        errors.assert_not_called()
+        controller.record_action.assert_called_once_with("adjustments")
 
         self.assertEqual(len(clip.data["effects"]), 1)
         effect = clip.data["effects"][0]

--- a/src/windows/export.py
+++ b/src/windows/export.py
@@ -54,6 +54,7 @@ from classes import ui_util
 from classes import openshot_rc  # noqa
 from classes.logger import log
 from classes.app import get_app
+from classes.feedback import record_feedback_action
 from classes.metrics import track_metric_screen, track_metric_error
 from classes.query import File
 
@@ -1315,6 +1316,8 @@ class Export(QDialog):
 
             # Close writer
             w.Close()
+            if self.exporting and max_frame == end_frame_export:
+                record_feedback_action("export")
 
             # Emit final exported frame (with elapsed time)
             seconds_run = round((end_time_export - start_time_export))

--- a/src/windows/feedback.py
+++ b/src/windows/feedback.py
@@ -2,13 +2,19 @@
 
 import time
 
-from qt_api import QAction, QApplication, QDesktopServices, QTimer, QUrl, QObject, QMessageBox
+import openshot
+
+from qt_api import QAction, QApplication, QDesktopServices, QTimer, QUrl, QObject, QMessageBox, QEvent, QWidget, Qt, isdeleted
 
 from classes import info
+from classes.app import get_app
 from classes.distribution import get_distribution_info
 from classes.feedback import FeedbackPolicy, survey_url
 from classes.logger import log
 from windows.notifications import NotificationBanner, notification_area, notification_icon
+
+IDLE_SECONDS = 60
+QUIET_SECONDS = 10
 
 
 class FeedbackController(QObject):
@@ -18,7 +24,7 @@ class FeedbackController(QObject):
         self.window = window
         self.settings = settings
         self.translate = translate
-        self.policy = FeedbackPolicy(settings)
+        self.policy = FeedbackPolicy(settings, None if preview else info.VERSION)
         self.preview = preview
         self.presented = False
         self.completed = False
@@ -34,10 +40,12 @@ class FeedbackController(QObject):
         self.action.triggered.connect(self.open_from_menu)
         window.menuHelp.insertAction(window.actionUpdate, self.action)
         self.last_tick = time.monotonic()
+        self.last_input = self.last_tick
         self.was_active = False
         self.timer = QTimer(self)
         self.timer.setInterval(5000)
         self.timer.timeout.connect(self.tick)
+        QApplication.instance().installEventFilter(self)
         if preview:
             self.timer.setInterval(250)
             self.timer.start()
@@ -46,6 +54,42 @@ class FeedbackController(QObject):
 
     def refresh_icon(self, theme=None):
         self.action.setIcon(notification_icon(self.window, "feedback", theme))
+
+    def record_action(self, category):
+        if not self.preview:
+            self.policy.record_action(category)
+        self.last_input = time.monotonic()
+
+    def eventFilter(self, watched, event):
+        if isdeleted(self.window):
+            return False
+        # Observe input without swallowing it or treating passive mouse movement as editing.
+        if isinstance(watched, QWidget) and (watched is self.window or self.window.isAncestorOf(watched)):
+            if event.type() in (QEvent.KeyPress, QEvent.MouseButtonPress, QEvent.MouseButtonRelease,
+                                QEvent.Wheel, QEvent.TouchBegin, QEvent.TouchUpdate, QEvent.WindowActivate):
+                self.last_input = time.monotonic()
+            elif event.type() == QEvent.MouseMove and event.buttons() != Qt.NoButton:
+                self.last_input = time.monotonic()
+        return False
+
+    def playback_active(self):
+        preview = getattr(self.window, "preview_thread", None)
+        player = getattr(preview, "player", None)
+        return bool(player and player.Mode() == openshot.PLAYBACK_PLAY and player.Speed() != 0)
+
+    def has_timeline_content(self):
+        return bool(get_app().project.get("clips"))
+
+    def shutdown(self):
+        self.timer.stop()
+        QApplication.instance().removeEventFilter(self)
+        self.flush()
+
+    def flush(self):
+        try:
+            self.policy.flush()
+        except Exception:
+            log.warning("Unable to save feedback editing time", exc_info=True)
 
     def tick(self):
         if self.preview:
@@ -60,10 +104,14 @@ class FeedbackController(QObject):
                   and not QApplication.activePopupWidget()
                   and not getattr(self.window, "shutting_down", False))
         # Ignore suspended/event-loop-blocked intervals instead of counting idle hours.
-        elapsed = seconds if active and self.was_active and seconds <= 10 else 0
-        self.was_active = active
+        playing = self.playback_active() if active else False
+        idle_seconds = now - self.last_input
+        editing = active and self.has_timeline_content() and (playing or idle_seconds <= IDLE_SECONDS)
+        elapsed = seconds if editing and self.was_active and seconds <= 10 else 0
+        self.was_active = editing
         try:
-            if self.policy.advance(elapsed) and active:
+            if (self.policy.advance(elapsed) and active and not playing and idle_seconds >= QUIET_SECONDS
+                    and seconds <= 10 and QApplication.mouseButtons() == Qt.NoButton):
                 self.show_invitation()
         except Exception:
             log.warning("Unable to save feedback invitation state", exc_info=True)
@@ -75,10 +123,15 @@ class FeedbackController(QObject):
         _ = self.translate
         self.banner = NotificationBanner(
             self.window, _("Help us make OpenShot even better!"), _("Share feedback"),
-            self.open_survey, self.dismiss, _)
+            self.open_from_banner, self.dismiss, _)
         self.area.add("feedback", self.banner)
         self.presented = True
         self.timer.stop()
+
+    def open_from_banner(self):
+        # A click acknowledges the banner even if the browser fails or the survey is abandoned.
+        self.dismiss()
+        self.open_survey()
 
     def open_from_menu(self, checked=False):
         # Voluntary feedback remains available after the one-time invitation ends.
@@ -104,11 +157,7 @@ class FeedbackController(QObject):
             opened = QDesktopServices.openUrl(QUrl(url))
         except Exception:
             opened = False
-        if opened:
-            self.dismiss()
-        elif self.banner:
-            self.banner.show_error(_("Couldn’t open your browser. Please try again."))
-        else:
+        if not opened:
             QMessageBox.warning(self.window, _("Unable to open browser"),
                                 _("Couldn’t open your browser. Please try again."))
             log.warning("Unable to open feedback survey in browser")

--- a/src/windows/main_window.py
+++ b/src/windows/main_window.py
@@ -59,6 +59,7 @@ from qt_api import (
 
 from classes import exceptions, info, qt_types, sentry, ui_util, updates, tabstops
 from classes.app import get_app
+from classes.feedback import record_feedback_action
 from classes.exporters.edl import export_edl
 from classes.exporters.final_cut_pro import export_xml
 from classes.importers.edl import import_edl
@@ -203,6 +204,8 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             log.debug("Already shutting down, skipping the shutdown routine")
             return
         self.shutting_down = True
+        if getattr(self, "feedback_controller", None):
+            self.feedback_controller.shutdown()
 
         # Log the exit routine
         log.info('---------------- Shutting down -----------------')
@@ -2538,6 +2541,7 @@ class MainWindow(updates.UpdateWatcher, QMainWindow):
             if profile_changed:
                 # Export dialog settings are profile-dependent; reset cache on profile changes.
                 get_app().updates.update(["export_settings"], None)
+                record_feedback_action("profile")
 
             # Clear transaction id
             get_app().updates.transaction_id = None

--- a/src/windows/title_editor.py
+++ b/src/windows/title_editor.py
@@ -54,6 +54,7 @@ import openshot
 from classes import info, ui_util, tabstops
 from classes.logger import log
 from classes.app import get_app
+from classes.feedback import record_feedback_action
 from classes.metrics import track_metric_screen
 from windows.color_picker import ColorPicker, draw_checkerboard
 from classes.style_tools import style_to_dict, dict_to_style, set_if_existing
@@ -574,6 +575,8 @@ class TitleEditor(QDialog):
             file.close()
         except IOError as inst:
             log.error("Error writing SVG title: {}".format(inst))
+            return False
+        return True
 
     def save_and_reload(self):
         """Something changed, so update temp SVG and redisplay"""
@@ -843,10 +846,12 @@ class TitleEditor(QDialog):
                 self.filename = file_path
 
                 # Save title
-                self.writeToFile(self.xmldoc)
+                title_saved = self.writeToFile(self.xmldoc)
 
                 # Add file to project
                 app.window.files_model.add_files(self.filename, prevent_image_seq=True, prevent_recent_folder=True)
+                if title_saved:
+                    record_feedback_action("titles")
 
         # Close window
         super().accept()

--- a/src/windows/views/blender_listview.py
+++ b/src/windows/views/blender_listview.py
@@ -54,6 +54,7 @@ from classes import info
 from classes.logger import log
 from classes.query import File
 from classes.app import get_app
+from classes.feedback import record_feedback_action
 
 from windows.models.blender_model import BlenderModel
 from windows.color_picker import ColorPicker
@@ -342,6 +343,8 @@ class BlenderListView(QListView):
 
         # Add to project files
         get_app().window.files_model.add_files(seq_params.get("path"), seq_params, prevent_recent_folder=True)
+        if not self.worker.canceled and self.worker.process.returncode == 0:
+            record_feedback_action("titles")
 
         # We're done here
         self.win.close()

--- a/src/windows/views/properties_tableview.py
+++ b/src/windows/views/properties_tableview.py
@@ -48,6 +48,7 @@ from qt_api import (
 
 from classes.logger import log
 from classes.app import get_app
+from classes.feedback import record_feedback_changes
 from classes import info
 from classes.query import Clip, Effect, Transition, File
 from classes.thumbnail import GetThumbPath
@@ -543,6 +544,9 @@ class PropertiesTableView(QTableView):
 
         get_app().updates.transaction_id = None
         self.transaction_id = None
+        record_feedback_changes("adjustments", {
+            item_id: item["data"] for item_id, item in self.original_data_map.items()
+            if item["type"] == "clip"})
         self.original_data_map = {}
         self.update_in_progress = False
 

--- a/src/windows/views/timeline.py
+++ b/src/windows/views/timeline.py
@@ -44,6 +44,7 @@ from qt_api import QDialog
 
 from classes import info, updates
 from classes.app import get_app
+from classes.feedback import feedback_command, record_feedback_action
 from classes.color_presets import (
     COLOR_GRADE_CLASS_NAME,
     COLOR_PRESET_AUTO_CONTRAST,
@@ -2737,6 +2738,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
         elif property_name in effect_json:
             effect_json[property_name] = value
 
+    @feedback_command("adjustments")
     def _apply_effect_preset(self, class_name, preset_name, clip_ids):
         """Apply a simple Look effect preset, or remove the effect for the none preset."""
         presets = LOOK_EFFECT_PRESETS.get(class_name, {})
@@ -2796,6 +2798,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
             self.update_clip_data(clip.data, only_basic_props=False, ignore_reader=True)
             get_app().updates.apply_last_action_to_history(original_clip_data)
 
+    @feedback_command("adjustments")
     def Reset_Look_Triggered(self, clip_ids):
         """Remove all effects managed by the clip Look menu."""
         for clip_id in clip_ids:
@@ -2840,6 +2843,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
         effects.append(effect_json)
         return effect_json, True
 
+    @feedback_command("adjustments")
     def Color_Triggered(self, preset_name, clip_ids):
         """Apply or reset Color Grade presets for selected clips."""
         for clip_id in clip_ids:
@@ -2889,6 +2893,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
             self.update_clip_data(clip.data, only_basic_props=False, ignore_reader=True)
             get_app().updates.apply_last_action_to_history(original_clip_data)
 
+    @feedback_command("adjustments")
     def Film_Grain_Triggered(self, preset_name, clip_ids):
         """Apply Film Grain presets for selected clips."""
         for clip_id in clip_ids:
@@ -3041,6 +3046,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
             # Save changes
             self.update_clip_data(clip.data, only_basic_props=False, ignore_reader=True)
 
+    @feedback_command("adjustments")
     def Animate_Triggered(self, action, clip_ids, transaction_id=None):
         """Apply one-click motion presets to selected clips.
 
@@ -3933,6 +3939,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
             # Save changes
             self.update_transition_data(tran.data, only_basic_props=False)
 
+    @feedback_command("adjustments")
     def Fade_Triggered(self, action, clip_ids, position="Entire Clip", transaction_id=None):
         """Callback for fade context menus — fades both alpha (video) and volume (audio)"""
         log.debug(action)
@@ -4105,6 +4112,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
             # Slice transitions
             QTimer.singleShot(0, partial(self.Slice_Triggered, slice_mode, [], [trans_id], cursor_position))
 
+    @feedback_command("structure")
     def Slice_Triggered(self, action, clip_ids, trans_ids, playhead_position=0, ripple=False):
         """Callback for slice context menus"""
         # Get FPS from project
@@ -4297,6 +4305,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
             trans.data["position"] -= ripple_gap
             trans.save()
 
+    @feedback_command("adjustments")
     def Volume_Triggered(self, action, clip_ids, position="Entire Clip", level=1.0, transaction_id=None):
         """Callback for volume context menus"""
         log.debug(action)
@@ -5814,6 +5823,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
 
         # Callback function, to actually add the effect object
         def callback(self, effect_names, callback_data):
+            feedback_changed = False
             js_position = callback_data.get('position', 0.0)
             js_nearest_track = callback_data.get('track', 0)
 
@@ -5880,6 +5890,9 @@ class TimelineView(updates.UpdateInterface, ViewClass):
                     # Update clip data for project
                     self.update_clip_data(clip.data, only_basic_props=False, ignore_reader=True)
                     get_app().updates.apply_last_action_to_history(original_clip_data)
+                    feedback_changed = True
+            if feedback_changed:
+                record_feedback_action("effects")
 
         # Find position from javascript
         self.run_js(JS_SCOPE_SELECTOR + ".getJavaScriptPosition({}, {});"
@@ -5948,6 +5961,7 @@ class TimelineView(updates.UpdateInterface, ViewClass):
         effects.append(effect_json)
         self.update_clip_data(clip.data, only_basic_props=False, ignore_reader=True)
         get_app().updates.apply_last_action_to_history(original_clip_data)
+        record_feedback_action("effects")
 
     # Without defining this method, the 'copy' action doesn't show with cursor
     def dragMoveEvent(self, event):

--- a/src/windows/views/timeline_backend/qwidget/clip.py
+++ b/src/windows/views/timeline_backend/qwidget/clip.py
@@ -31,6 +31,7 @@ import uuid
 from qt_api import Qt, QRectF, QPointF
 from qt_api import QApplication
 from classes.app import get_app
+from classes.feedback import record_feedback_changes
 from classes.clip_utils import is_single_image_media
 from classes.query import Clip, Transition
 from classes.waveform import waveform_sample_rate
@@ -1580,6 +1581,9 @@ class ClipInteractionMixin:
         self._update_project_duration()
         if waveform_clips and hasattr(self, "Show_Waveform_Triggered"):
             self.Show_Waveform_Triggered(waveform_clips, transaction_id=transaction_id)
+        record_feedback_changes("structure", {
+            item_id: context["initial"] for item_id, context in resize_initial_map.items()
+            if isinstance(context.get("item"), Clip)}, fields=("start", "end"))
         self._finalize_resize_preview_state(resize_items, requested_backend_refresh)
         if hasattr(self, "_refresh_keyframe_markers") and not self._dragging_panel_keyframes and not self._dragging_keyframe:
             self._refresh_keyframe_markers()


### PR DESCRIPTION
Require three lifetime actions across two categories and 20 minutes of active editing per release. Show the banner during a quiet moment and acknowledge clicks or dismissal for that release.

Keep editing hooks small, preserve Qt signal behavior, and remove the input filter on shutdown. Cover eligibility, editing commands, 154 live menu actions, undo/redo, and shutdown with regression tests.